### PR TITLE
Generate proper JSON Schema for nullable properties

### DIFF
--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -724,6 +724,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
         field_type = field_type.__pydantic_model__
 
     if issubclass(field_type, BaseModel):
+        schema_ref: Dict[str, Any]
         model_name = model_name_map[field_type]
         if field_type not in known_models:
             sub_schema, sub_definitions, sub_nested_models = model_process_schema(

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -560,7 +560,7 @@ def field_singleton_sub_fields_schema(
     schema_overrides: bool = False,
     ref_prefix: Optional[str] = None,
     known_models: TypeModelSet,
-    allow_none: bool = False
+    allow_none: bool = False,
 ) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
     """
     This function is indirectly used by ``field_schema()``, you probably should be using that function.
@@ -678,7 +678,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
             schema_overrides=schema_overrides,
             ref_prefix=ref_prefix,
             known_models=known_models,
-            allow_none=field.allow_none if field.shape == SHAPE_SINGLETON else False
+            allow_none=field.allow_none if field.shape == SHAPE_SINGLETON else False,
         )
     if field.type_ is Any or field.type_.__class__ == TypeVar:
         return {}, definitions, nested_models  # no restrictions

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -469,7 +469,7 @@ def test_schema():
                 'type': 'object',
                 'additionalProperties': {'type': 'string'},
             },
-            'signup_ts': {'title': 'Signup Ts', 'type': 'string', 'format': 'date-time'},
+            'signup_ts': {'title': 'Signup Ts', 'anyOf': [{'type': 'string', 'format': 'date-time'}, {'type': 'null'}]},
         },
         'required': ['id'],
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -153,7 +153,7 @@ def test_sub_model():
         },
         'properties': {
             'a': {'type': 'integer', 'title': 'A'},
-            'b': {'anyOf': [{'$ref': '#/definitions/Foo'}, {'type': 'null'}]}
+            'b': {'anyOf': [{'$ref': '#/definitions/Foo'}, {'type': 'null'}]},
         },
         'required': ['a'],
     }
@@ -279,8 +279,9 @@ def test_optional():
         a: Optional[str]
 
     assert Model.schema() == {
-        'title': 'Model', 'type': 'object',
-        'properties': {'a': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'title': 'A'}}
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'title': 'A'}},
     }
 
 
@@ -497,11 +498,7 @@ def test_date_types(field_type, expected_schema):
         (NoneStr, {'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'string'}, {'type': 'null'}]}}}),
         (
             NoneBytes,
-            {
-                'properties': {
-                    'a': {'title': 'A', 'anyOf': [{'type': 'string', 'format': 'binary'}, {'type': 'null'}]}
-                }
-            }
+            {'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'string', 'format': 'binary'}, {'type': 'null'}]}}},
         ),
         (
             StrBytes,
@@ -518,9 +515,7 @@ def test_date_types(field_type, expected_schema):
                 'properties': {
                     'a': {
                         'title': 'A',
-                        'anyOf': [
-                            {'type': 'string'}, {'type': 'string', 'format': 'binary'}, {'type': 'null'}
-                        ]
+                        'anyOf': [{'type': 'string'}, {'type': 'string', 'format': 'binary'}, {'type': 'null'}],
                     }
                 }
             },
@@ -980,7 +975,7 @@ def test_schema_overrides():
             'Baz': {
                 'title': 'Baz',
                 'type': 'object',
-                'properties': {'c': {'anyOf': [{'$ref': '#/definitions/Bar'}, {'type': 'null'}]}}
+                'properties': {'c': {'anyOf': [{'$ref': '#/definitions/Bar'}, {'type': 'null'}]}},
             },
         },
         'properties': {'d': {'$ref': '#/definitions/Baz'}},
@@ -1633,7 +1628,7 @@ def test_model_with_extra_forbidden():
         (
             Optional[int],
             dict(gt=0),
-            {'title': 'A', 'exclusiveMinimum': 0, 'anyOf': [{'type': 'integer'}, {'type': 'null'}]}
+            {'title': 'A', 'exclusiveMinimum': 0, 'anyOf': [{'type': 'integer'}, {'type': 'null'}]},
         ),
         (
             Tuple[int, ...],
@@ -1743,9 +1738,10 @@ def test_conlist():
             'bar': {
                 'title': 'Bar',
                 'anyOf': [
-                    {'type': 'array', 'items': {'type': 'string'}, 'minItems': 1, 'maxItems': 4}, {'type': 'null'}
-                ]
-            }
+                    {'type': 'array', 'items': {'type': 'string'}, 'minItems': 1, 'maxItems': 4},
+                    {'type': 'null'},
+                ],
+            },
         },
         'required': ['foo'],
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -280,7 +280,7 @@ def test_optional():
 
     assert Model.schema() == {
         'title': 'Model', 'type': 'object',
-        'properties': {'a': {'anyOf': [{'type': 'string'},  {'type': 'null'}], 'title': 'A'}}
+        'properties': {'a': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'title': 'A'}}
     }
 
 
@@ -454,7 +454,7 @@ class Foo(BaseModel):
                         'required': ['a'],
                     }
                 },
-                'properties': {'a': {'anyOf': [{'$ref': '#/definitions/Foo'},  {'type': 'null'}]}},
+                'properties': {'a': {'anyOf': [{'$ref': '#/definitions/Foo'}, {'type': 'null'}]}},
             },
         ),
         (Dict[str, Any], {'properties': {'a': {'title': 'A', 'type': 'object'}}, 'required': ['a']}),
@@ -494,12 +494,12 @@ def test_date_types(field_type, expected_schema):
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
-        (NoneStr, {'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'string'},  {'type': 'null'}]}}}),
+        (NoneStr, {'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'string'}, {'type': 'null'}]}}}),
         (
             NoneBytes,
             {
                 'properties': {
-                    'a': {'title': 'A', 'anyOf': [{'type': 'string', 'format': 'binary'},  {'type': 'null'}]}
+                    'a': {'title': 'A', 'anyOf': [{'type': 'string', 'format': 'binary'}, {'type': 'null'}]}
                 }
             }
         ),
@@ -519,7 +519,7 @@ def test_date_types(field_type, expected_schema):
                     'a': {
                         'title': 'A',
                         'anyOf': [
-                            {'type': 'string'}, {'type': 'string', 'format': 'binary'},  {'type': 'null'}
+                            {'type': 'string'}, {'type': 'string', 'format': 'binary'}, {'type': 'null'}
                         ]
                     }
                 }
@@ -980,7 +980,7 @@ def test_schema_overrides():
             'Baz': {
                 'title': 'Baz',
                 'type': 'object',
-                'properties': {'c': {'anyOf': [{'$ref': '#/definitions/Bar'},  {'type': 'null'}]}}
+                'properties': {'c': {'anyOf': [{'$ref': '#/definitions/Bar'}, {'type': 'null'}]}}
             },
         },
         'properties': {'d': {'$ref': '#/definitions/Baz'}},
@@ -1338,7 +1338,7 @@ def test_optional_dict():
     assert Model.schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'something': {'title': 'Something', 'anyOf': [{'type': 'object'},  {'type': 'null'}]}},
+        'properties': {'something': {'title': 'Something', 'anyOf': [{'type': 'object'}, {'type': 'null'}]}},
     }
 
     assert Model().dict() == {'something': None}
@@ -1357,7 +1357,7 @@ def test_optional_validator():
     assert Model.schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'something': {'title': 'Something', 'anyOf': [{'type': 'string'},  {'type': 'null'}]}},
+        'properties': {'something': {'title': 'Something', 'anyOf': [{'type': 'string'}, {'type': 'null'}]}},
     }
 
     assert Model().dict() == {'something': None}
@@ -1376,7 +1376,7 @@ def test_field_with_validator():
     assert Model.schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'something': {'anyOf': [{'type': 'integer'},  {'type': 'null'}], 'title': 'Something'}},
+        'properties': {'something': {'anyOf': [{'type': 'integer'}, {'type': 'null'}], 'title': 'Something'}},
     }
 
 
@@ -1633,7 +1633,7 @@ def test_model_with_extra_forbidden():
         (
             Optional[int],
             dict(gt=0),
-            {'title': 'A', 'exclusiveMinimum': 0, 'anyOf': [{'type': 'integer'},  {'type': 'null'}]}
+            {'title': 'A', 'exclusiveMinimum': 0, 'anyOf': [{'type': 'integer'}, {'type': 'null'}]}
         ),
         (
             Tuple[int, ...],


### PR DESCRIPTION
## Change Summary

Generate `'anyOf: [{'type': <field_type>}, {'type': 'null'}]` for optional fields of a pydantic model.

## Related issue number

#1270

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
