### PR TITLE
feat: add computed fields

### DIFF
--- a/changes/2625-PrettyWood.md
+++ b/changes/2625-PrettyWood.md
@@ -1,1 +1,1 @@
-Allow to create fields based on `property`-like descriptors.
+Allow to create computed fields based on other fields. See [the doc](https://pydantic-docs.helpmanual.io/usage/models/#field-with-computed-value-based-on-other-fields) for more information.

--- a/changes/2625-PrettyWood.md
+++ b/changes/2625-PrettyWood.md
@@ -1,1 +1,1 @@
-Allow to create computed fields based on other fields. See [the doc](https://pydantic-docs.helpmanual.io/usage/models/#field-with-computed-value-based-on-other-fields) for more information.
+Allow creating computed fields based on other fields. See [the doc](https://pydantic-docs.helpmanual.io/usage/models/#field-with-computed-value-based-on-other-fields) for more information.

--- a/changes/2625-PrettyWood.md
+++ b/changes/2625-PrettyWood.md
@@ -1,0 +1,1 @@
+Allow to create fields based on `property`-like descriptors.

--- a/docs/examples/models_computed_field_annotation.py
+++ b/docs/examples/models_computed_field_annotation.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, ComputedField
+
+
+class Rectangle(BaseModel):
+    width: int
+    length: int
+    area: int = ComputedField(lambda self: self.width * self.length)
+
+
+print(Rectangle(width=3, length=2).dict())

--- a/docs/examples/models_computed_field_decorator.py
+++ b/docs/examples/models_computed_field_decorator.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, computed_field
+
+
+class Rectangle(BaseModel):
+    width: int
+    length: int
+
+    @computed_field
+    def area(self) -> int:
+        return self.width * self.length
+
+
+print(Rectangle(width=3, length=2).dict())

--- a/docs/examples/models_computed_field_decorator_details.py
+++ b/docs/examples/models_computed_field_decorator_details.py
@@ -16,18 +16,21 @@ class Square(BaseModel):
     def area(self, new_area: float) -> None:
         self.width = new_area ** .5
 
-    @computed_field(alias='the magic number')
+    @computed_field(alias='the magic number', repr=False)
     @cached_property
     def random_number(self) -> int:
         """An awesome number"""
         return random.randint(0, 1_000)
 
-    @computed_field(exclude=True)
+    @computed_field(exclude=True)  # exclude it in serialization
     def is_dot(self) -> bool:
         return self.width == 0
 
 
 square = Square(width=1.3)
+
+# `random_number` does not appear in representation
+print(repr(square))
 
 print(square.random_number)
 

--- a/docs/examples/models_computed_field_decorator_details.py
+++ b/docs/examples/models_computed_field_decorator_details.py
@@ -1,0 +1,42 @@
+import random
+from functools import cached_property
+
+from pydantic import BaseModel, computed_field
+
+
+class Square(BaseModel):
+    width: float
+
+    @computed_field(title='The area', description='the area of the square')
+    @property  # can be omitted as explained above
+    def area(self) -> float:
+        return round(self.width ** 2, 2)
+
+    @area.setter
+    def area(self, new_area: float) -> None:
+        self.width = new_area ** .5
+
+    @computed_field(alias='the magic number')
+    @cached_property
+    def random_number(self) -> int:
+        """An awesome number"""
+        return random.randint(0, 1_000)
+
+    @computed_field(exclude=True)
+    def is_dot(self) -> bool:
+        return self.width == 0
+
+
+square = Square(width=1.3)
+
+print(square.random_number)
+
+# same random number as before (cached as expected) and `is_dot` is excluded
+print(square.dict())
+
+square.area = 4
+
+print(square.json(by_alias=True))
+
+# Computed fields that don't have a setter have `readOnly` attribute
+print(Square.schema_json(indent=2))

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -574,7 +574,7 @@ _(This script is complete, it should run "as is")_
     If `computed_field` decorator doesn't wrap a decorator like `property`, `cached_property`, ...,
     it will fallback and create `property` itself. This is shorter and may be what you want, but you
     will probably lose IntelliSense in your IDE and have some warnings.
-    This is why it is recommanded to combine `computed_field` with `property`<br>
+    This is why it is recommended to combine `computed_field` with `property`<br>
     **Warning for _mypy_**: Even with this, _mypy_ won't be happy because of [this issue](https://github.com/python/mypy/issues/1362)
 
 ```py

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -554,6 +554,34 @@ Where `Field` refers to the [field function](schema.md#field-customisation).
 !!! warning
     The `default_factory` expects the field type to be set.
 
+## Field with computed value based on other fields
+
+You have two ways of writing a computed field, either with a `property`-like syntax
+
+```py
+{!.tmp_examples/models_computed_field_decorator.py!}
+```
+_(This script is complete, it should run "as is")_
+
+or a `Field`-like one
+
+```py
+{!.tmp_examples/models_computed_field_annotation.py!}
+```
+_(This script is complete, it should run "as is")_
+
+!!! note
+    If `computed_field` decorator doesn't wrap a decorator like `property`, `cached_property`, ...,
+    it will fallback and create `property` itself. This is shorter and may be what you want, but you
+    will probably lose IntelliSense in your IDE and have some warnings.
+    This is why it is recommanded to combine `computed_field` with `property`<br>
+    **Warning for _mypy_**: Even with this, _mypy_ won't be happy because of [this issue](https://github.com/python/mypy/issues/1362)
+
+```py
+{!.tmp_examples/models_computed_field_decorator_details.py!}
+```
+_(This script is complete, it should run "as is")_
+
 ## Automatically excluded attributes
 
 Class variables which begin with an underscore and attributes annotated with `typing.ClassVar` will be

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -6,7 +6,7 @@ from .decorator import validate_arguments
 from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
 from .errors import *
-from .fields import Field, PrivateAttr, Required, field
+from .fields import ComputedField, Field, PrivateAttr, Required, field
 from .main import *
 from .networks import *
 from .parse import Protocol
@@ -35,6 +35,7 @@ __all__ = [
     'ValidationError',
     # fields
     'field',
+    'ComputedField',
     'Field',
     'Required',
     # main

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -6,7 +6,7 @@ from .decorator import validate_arguments
 from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
 from .errors import *
-from .fields import ComputedField, Field, PrivateAttr, Required, field
+from .fields import ComputedField, Field, PrivateAttr, Required, computed_field
 from .main import *
 from .networks import *
 from .parse import Protocol
@@ -34,7 +34,7 @@ __all__ = [
     # error_wrappers
     'ValidationError',
     # fields
-    'field',
+    'computed_field',
     'ComputedField',
     'Field',
     'Required',

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -6,7 +6,7 @@ from .decorator import validate_arguments
 from .env_settings import BaseSettings
 from .error_wrappers import ValidationError
 from .errors import *
-from .fields import Field, PrivateAttr, Required
+from .fields import Field, PrivateAttr, Required, field
 from .main import *
 from .networks import *
 from .parse import Protocol
@@ -32,6 +32,7 @@ __all__ = [
     # error_wrappers
     'ValidationError',
     # fields
+    'field',
     'Field',
     'Required',
     # main

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -339,7 +339,7 @@ def _get_descriptor_infos(descriptor: Any) -> Tuple[Any, 'FGet', Optional['FSet'
 
 
 @overload
-def field(
+def computed_field(
     *,
     alias: Optional[str] = None,
     title: Optional[str] = None,
@@ -351,7 +351,7 @@ def field(
 
 
 @overload
-def field(
+def computed_field(
     func: Any,
     *,
     alias: Optional[str] = None,
@@ -363,7 +363,7 @@ def field(
     ...
 
 
-def field(
+def computed_field(
     func: Optional[Any] = None,
     *,
     alias: Optional[str] = None,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -82,7 +82,6 @@ if TYPE_CHECKING:
 
     FGet = Callable[[Optional[BaseModel], str], Any]
     FSet = Callable[[Optional[BaseModel], Any], None]
-    FDel = Callable[[Optional[BaseModel], str], None]
 
 
 class FieldInfo(Representation):
@@ -293,8 +292,8 @@ def _get_descriptor_infos(descriptor: Any) -> Tuple[Any, 'FGet', Optional['FSet'
     fset = None
 
     if isinstance(descriptor, property):
-        fget = descriptor.fget
-        fset = descriptor.fset
+        fget = cast('FGet', descriptor.fget)
+        fset = cast('FSet', descriptor.fset)
     else:
         _self_param, getter_param, *set_del_params = inspect.signature(
             descriptor.__class__.__init__
@@ -308,7 +307,7 @@ def _get_descriptor_infos(descriptor: Any) -> Tuple[Any, 'FGet', Optional['FSet'
     if type_ is sig.empty:
         type_ = Any
 
-    return type_, cast('FGet', fget), cast('FSet', fset)
+    return type_, fget, fset
 
 
 @overload
@@ -323,7 +322,7 @@ def field(
 
 @overload
 def field(
-    func: T,
+    func: Any,
     *,
     alias: Optional[str] = None,
     title: Optional[str] = None,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -349,7 +349,6 @@ class ComputedField(Representation):
         'config',
         'model_field',
         'required',
-        'descriptor',
     )
 
     def __init__(

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -21,6 +21,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload,
 )
 
 from typing_extensions import Annotated
@@ -308,6 +309,27 @@ def _get_descriptor_infos(descriptor: Any) -> Tuple[Any, 'FGet', Optional['FSet'
         type_ = Any
 
     return type_, cast('FGet', fget), cast('FSet', fset)
+
+
+@overload
+def field(
+    *,
+    alias: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+) -> 'Callable[[Any], ComputedField]':
+    ...
+
+
+@overload
+def field(
+    func: T,
+    *,
+    alias: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Any:
+    ...
 
 
 def field(

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -302,8 +302,9 @@ def _get_descriptor_infos(descriptor: Any) -> Tuple[Any, 'FGet', Optional['FSet'
         if len(set_del_params) > 0:
             fset = getattr(descriptor, set_del_params[0].name)
 
-    type_ = inspect.signature(fget).return_annotation
-    if type_ is inspect._empty:  # type: ignore[attr-defined]
+    sig = inspect.signature(fget)
+    type_ = sig.return_annotation
+    if type_ is sig.empty:
         type_ = Any
 
     return type_, cast('FGet', fget), cast('FSet', fset)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -320,11 +320,9 @@ class ComputedField(Representation):
         'fget',
         'fset',
         'class_validators',
-
         'alias',
         'title',
         'description',
-
         'config',
         'model_field',
         'required',
@@ -336,7 +334,7 @@ class ComputedField(Representation):
         name: str,
         type_: type,
         fget: Callable[[Optional['BaseModel']], Any],
-        fset: Any = None,
+        fset: 'Optional[Callable[[Optional[BaseModel], Any], None]]' = None,
         alias: Optional[str] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
@@ -347,7 +345,7 @@ class ComputedField(Representation):
         self.type_: type = type_
         self.outer_type_: type = type_
         self.fget: Callable[[Optional['BaseModel']], Any] = fget
-        self.fset: Any = fset
+        self.fset: 'Optional[Callable[[Optional[BaseModel], Any], None]]' = fset
         self.class_validators: Optional[Dict[str, 'Validator']] = None
 
         self.alias: str = alias or name
@@ -361,9 +359,7 @@ class ComputedField(Representation):
     @property
     def field_info(self) -> FieldInfo:
         return FieldInfo(
-            alias=self.alias,
-            title=self.title,
-            description=self.description or self.fget.__doc__, read_only=True
+            alias=self.alias, title=self.title, description=self.description or self.fget.__doc__, read_only=True
         )
 
     def __get__(self, instance: Optional['BaseModel'], owner: Any) -> Any:
@@ -371,12 +367,12 @@ class ComputedField(Representation):
             return self
         return self.fget(instance)
 
-    def __set__(self, obj, value):
+    def __set__(self, instance: Optional['BaseModel'], value: Any) -> None:
         if self.fset is None:
             raise AttributeError("can't set attribute")
-        self.fset(obj, value)
+        self.fset(instance, value)
 
-    def setter(self, fset):
+    def setter(self, fset: Callable[[Optional['BaseModel'], Any], None]) -> 'ComputedField':
         return type(self)(
             name=self.name,
             type_=self.type_,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     ValidateReturn = Tuple[Optional[Any], Optional[ErrorList]]
     LocStr = Union[Tuple[Union[int, str], ...], str]
     BoolUndefined = Union[bool, UndefinedType]
+    ExcludeInclude = Union[AbstractSetIntStr, MappingIntStrAny, Any]
 
     FGet = Callable[[Optional[BaseModel], str], Any]
     FSet = Callable[[Optional[BaseModel], Any], None]
@@ -195,8 +196,8 @@ def Field(
     alias: str = None,
     title: str = None,
     description: str = None,
-    exclude: Union['AbstractSetIntStr', 'MappingIntStrAny', Any] = None,
-    include: Union['AbstractSetIntStr', 'MappingIntStrAny', Any] = None,
+    exclude: 'ExcludeInclude' = None,
+    include: 'ExcludeInclude' = None,
     const: bool = None,
     gt: float = None,
     ge: float = None,
@@ -332,6 +333,8 @@ def field(
     alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
+    exclude: Optional['ExcludeInclude'] = None,
+    include: Optional['ExcludeInclude'] = None,
 ) -> 'Callable[[Any], ComputedField]':
     ...
 
@@ -343,6 +346,8 @@ def field(
     alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
+    exclude: Optional['ExcludeInclude'] = None,
+    include: Optional['ExcludeInclude'] = None,
 ) -> Any:
     ...
 
@@ -353,6 +358,8 @@ def field(
     alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
+    exclude: Optional['ExcludeInclude'] = None,
+    include: Optional['ExcludeInclude'] = None,
 ) -> 'Union[Callable[[Any], ComputedField], ComputedField]':
     def wrap(func_: Any) -> 'ComputedField':
         from inspect import isdatadescriptor, ismethoddescriptor
@@ -365,6 +372,8 @@ def field(
             alias=alias,
             title=title,
             description=description,
+            exclude=exclude,
+            include=include,
         )
 
     if func is None:
@@ -384,6 +393,8 @@ class ComputedField(Representation):
         'alias',
         'title',
         'description',
+        'exclude',
+        'include',
         'config',
         'model_field',
         'required',
@@ -397,6 +408,8 @@ class ComputedField(Representation):
         alias: Optional[str] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        exclude: Optional['ExcludeInclude'] = None,
+        include: Optional['ExcludeInclude'] = None,
         config: Optional[Type['BaseConfig']] = None,
         model_field: Optional['ModelField'] = None,
     ) -> None:
@@ -411,6 +424,8 @@ class ComputedField(Representation):
         self.alias: str = alias or self.name
         self.title: Optional[str] = title
         self.description: Optional[str] = description
+        self.exclude: Optional['ExcludeInclude'] = exclude
+        self.include: Optional['ExcludeInclude'] = include
 
         self.config: Optional[Type['BaseConfig']] = config
         self.model_field: Optional[ModelField] = model_field
@@ -423,6 +438,8 @@ class ComputedField(Representation):
             title=self.title,
             description=self.description or self.descriptor.__doc__,
             read_only=self.fset is None,
+            exclude=self.exclude,
+            include=self.include,
         )
 
     def __get__(self, instance: Optional['BaseModel'], owner: Any = None) -> Any:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -351,6 +351,7 @@ def computed_field(
     description: Optional[str] = None,
     exclude: Optional['ExcludeInclude'] = None,
     include: Optional['ExcludeInclude'] = None,
+    repr: bool = True,
 ) -> 'Callable[[Any], ComputedField]':
     ...
 
@@ -364,6 +365,7 @@ def computed_field(
     description: Optional[str] = None,
     exclude: Optional['ExcludeInclude'] = None,
     include: Optional['ExcludeInclude'] = None,
+    repr: bool = True,
 ) -> Any:
     ...
 
@@ -376,6 +378,7 @@ def computed_field(
     description: Optional[str] = None,
     exclude: Optional['ExcludeInclude'] = None,
     include: Optional['ExcludeInclude'] = None,
+    repr: bool = True,
 ) -> 'Union[Callable[[Any], ComputedField], ComputedField]':
     def wrap(func_: Any) -> 'ComputedField':
         return ComputedField(
@@ -385,6 +388,7 @@ def computed_field(
             description=description,
             exclude=exclude,
             include=include,
+            repr=repr,
         )
 
     if func is None:
@@ -424,6 +428,7 @@ class ComputedField(Representation):
         'config',
         'model_field',
         'required',
+        'repr',
     )
 
     def __init__(
@@ -438,6 +443,7 @@ class ComputedField(Representation):
         include: Optional['ExcludeInclude'] = None,
         config: Optional[Type['BaseConfig']] = None,
         model_field: Optional['ModelField'] = None,
+        repr: bool = True,
     ) -> None:
         from inspect import isdatadescriptor, ismethoddescriptor
 
@@ -461,6 +467,7 @@ class ComputedField(Representation):
         self.config: Optional[Type['BaseConfig']] = config
         self.model_field: Optional[ModelField] = model_field
         self.required: bool = False
+        self.repr = repr
 
     @property
     def name(self) -> str:
@@ -475,6 +482,7 @@ class ComputedField(Representation):
             read_only=self.fset is None,
             exclude=self.exclude,
             include=self.include,
+            repr=self.repr,
         )
 
     def __get__(self, instance: Optional['BaseModel'], owner: Any = None) -> Any:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -892,7 +892,17 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             return self.dict() == other
 
     def __repr_args__(self) -> 'ReprArgs':
-        return [(k, v) for k, v in self.__dict__.items() if self.__fields__[k].field_info.repr]
+        if not self.__computed_fields__:
+            return [(k, v) for k, v in self.__dict__.items() if self.__fields__[k].field_info.repr]
+        else:
+            all_values = {
+                **{k: v for k, v in self.__dict__.items()},
+                **{
+                    computed_field.name: computed_field.__get__(self)
+                    for computed_field in self.__computed_fields__.values()
+                },
+            }
+            return [(k, v) for k, v in all_values.items() if self.__all_fields__[k].field_info.repr]
 
 
 _is_base_model_class_defined = True

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -425,7 +425,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         if name in self.__private_attributes__:
             return object_setattr(self, name, value)
         elif name in self.__computed_fields__:
-            self.__computed_fields__[name].descriptor.__set__(self, value)
+            self.__computed_fields__[name].__set__(self, value)
         elif self.__config__.extra is not Extra.allow and name not in self.__fields__:
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
         elif not self.__config__.allow_mutation or self.__config__.frozen:
@@ -894,7 +894,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 
         for computed_field in self.__computed_fields__.values():
             dict_key = computed_field.alias if by_alias else computed_field.name
-            yield dict_key, computed_field.descriptor.__get__(self)
+            yield dict_key, computed_field.__get__(self)
 
     def _calculate_keys(
         self,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -405,7 +405,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         # populated by the metaclass, defined here to help IDEs only
         __fields__: Dict[str, ModelField] = {}
         __computed_fields__: Dict[str, ComputedField] = {}
-        __all_fields__: Dict[str, Union[ModelField, ComputedField]]
+        __all_fields__: Mapping[str, Union[ModelField, ComputedField]]
         __include_fields__: Optional[Mapping[str, Any]] = None
         __exclude_fields__: Optional[Mapping[str, Any]] = None
         __validators__: Dict[str, AnyCallable] = {}
@@ -901,10 +901,19 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         value_exclude = ValueItems(self, exclude) if exclude is not None else None
         value_include = ValueItems(self, include) if include is not None else None
 
-        all_values = ChainMap(
-            {computed_field.name: computed_field.__get__(self) for computed_field in self.__computed_fields__.values()},
-            self.__dict__,
-        )
+        if not self.__computed_fields__:
+            all_values = self.__dict__
+        else:
+            # In python 3.6, `ChainMap` deserialization is not consistent with newer versions.
+            # We hence recreate a whole dictionary.
+            # If 3.6 is dropped, we should probably use a `ChainMap` instead for perf reasons
+            all_values = {
+                **{k: v for k, v in self.__dict__.items()},
+                **{
+                    computed_field.name: computed_field.__get__(self)
+                    for computed_field in self.__computed_fields__.values()
+                },
+            }
 
         for field_key, v in all_values.items():
             if (allowed_keys is not None and field_key not in allowed_keys) or (exclude_none and v is None):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -276,7 +276,8 @@ class ModelMetaclass(ABCMeta):
 
             return (
                 isinstance(v, untouched_types)
-                or (ismethoddescriptor(v) or isdatadescriptor(v))  # ignore `property`, `cached_property`, ...
+                # ignore `property`, `cached_property`, `singledispatchmethod`, ...
+                or (ismethoddescriptor(v) or isdatadescriptor(v))
                 or v.__class__.__name__ == 'cython_function_or_method'
             )
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -504,6 +504,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_computed: bool = False,
     ) -> 'DictStrAny':
         """
         Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.
@@ -525,6 +526,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 exclude_unset=exclude_unset,
                 exclude_defaults=exclude_defaults,
                 exclude_none=exclude_none,
+                exclude_computed=exclude_computed,
             )
         )
 
@@ -538,6 +540,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_computed: bool = False,
         encoder: Optional[Callable[[Any], Any]] = None,
         **dumps_kwargs: Any,
     ) -> str:
@@ -560,6 +563,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
+            exclude_computed=exclude_computed,
         )
         if self.__custom_root_type__:
             data = data[ROOT_KEY]
@@ -855,6 +859,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_computed: bool = False,
     ) -> 'TupleGenerator':
 
         allowed_keys = self._calculate_keys(include=include, exclude=exclude, exclude_unset=exclude_unset)
@@ -866,17 +871,40 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         value_exclude = ValueItems(self, exclude) if exclude else None
         value_include = ValueItems(self, include) if include else None
 
-        for field_key, v in self.__dict__.items():
+        all_values: Mapping[str, Any]
+        all_fields: Mapping[str, 'Union[ModelField, ComputedField]']
+        # Case 1: no computed fields -> just reference for max speed
+        if not self.__computed_fields__:
+            all_fields = self.__fields__
+            all_values = self.__dict__
+        # Case 2: we have computed fields but want to ignore them
+        # In this case we need to remove some extra values in self.__dict__ that may have been added by
+        # descriptors (e.g. `cached_property`)
+        elif exclude_computed:
+            all_fields = self.__fields__
+            all_values = {k: v for k, v in self.__dict__.items() if k not in self.__computed_fields__}
+        # Case 3: we have computed fields and want to add them
+        else:
+            all_fields = {**self.__fields__, **self.__computed_fields__}
+            all_values = {
+                **{k: v for k, v in self.__dict__.items() if k not in self.__computed_fields__},
+                **{
+                    computed_field.name: computed_field.__get__(self)
+                    for computed_field in self.__computed_fields__.values()
+                },
+            }
+
+        for field_key, v in all_values.items():
             if (allowed_keys is not None and field_key not in allowed_keys) or (exclude_none and v is None):
                 continue
 
             if exclude_defaults:
-                model_field = self.__fields__.get(field_key)
+                model_field = all_fields.get(field_key)
                 if not getattr(model_field, 'required', True) and getattr(model_field, 'default', _missing) == v:
                     continue
 
-            if by_alias and field_key in self.__fields__:
-                dict_key = self.__fields__[field_key].alias
+            if by_alias and field_key in all_fields:
+                dict_key = all_fields[field_key].alias
             else:
                 dict_key = field_key
 
@@ -893,10 +921,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 )
             yield dict_key, v
 
-        for computed_field in self.__computed_fields__.values():
-            dict_key = computed_field.alias if by_alias else computed_field.name
-            yield dict_key, computed_field.__get__(self)
-
     def _calculate_keys(
         self,
         include: Optional[Union['AbstractSetIntStr', 'MappingIntStrAny']],
@@ -912,6 +936,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             keys = self.__fields_set__.copy()
         else:
             keys = self.__dict__.keys()
+        keys |= set(self.__computed_fields__)
 
         if include is not None:
             if isinstance(include, Mapping):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -2,6 +2,7 @@ import json
 import sys
 import warnings
 from abc import ABCMeta
+from collections import ChainMap
 from copy import deepcopy
 from enum import Enum
 from functools import partial
@@ -358,16 +359,23 @@ class ModelMetaclass(ABCMeta):
             hash_func = generate_hash_function(config.frozen)
 
         exclude_from_namespace = fields | private_attributes.keys() | {'__slots__'}
+
+        all_fields = ChainMap(fields, computed_fields)
         new_namespace = {
             '__config__': config,
             '__fields__': fields,
             '__computed_fields__': computed_fields,
+            '__all_fields__': all_fields,
             '__exclude_fields__': {
-                name: field.field_info.exclude for name, field in fields.items() if field.field_info.exclude is not None
+                name: field.field_info.exclude
+                for name, field in all_fields.items()
+                if field.field_info.exclude is not None
             }
             or None,
             '__include_fields__': {
-                name: field.field_info.include for name, field in fields.items() if field.field_info.include is not None
+                name: field.field_info.include
+                for name, field in all_fields.items()
+                if field.field_info.include is not None
             }
             or None,
             '__validators__': vg.validators,
@@ -397,6 +405,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         # populated by the metaclass, defined here to help IDEs only
         __fields__: Dict[str, ModelField] = {}
         __computed_fields__: Dict[str, ComputedField] = {}
+        __all_fields__: Dict[str, Union[ModelField, ComputedField]]
         __include_fields__: Optional[Mapping[str, Any]] = None
         __exclude_fields__: Optional[Mapping[str, Any]] = None
         __validators__: Dict[str, AnyCallable] = {}
@@ -520,7 +529,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
-        exclude_computed: bool = False,
     ) -> 'DictStrAny':
         """
         Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.
@@ -542,7 +550,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 exclude_unset=exclude_unset,
                 exclude_defaults=exclude_defaults,
                 exclude_none=exclude_none,
-                exclude_computed=exclude_computed,
             )
         )
 
@@ -556,7 +563,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
-        exclude_computed: bool = False,
         encoder: Optional[Callable[[Any], Any]] = None,
         **dumps_kwargs: Any,
     ) -> str:
@@ -579,7 +585,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
-            exclude_computed=exclude_computed,
         )
         if self.__custom_root_type__:
             data = data[ROOT_KEY]
@@ -875,7 +880,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
-        exclude_computed: bool = False,
     ) -> 'TupleGenerator':
 
         # Merge field set excludes with explicit exclude parameter with explicit overriding field set options.
@@ -897,40 +901,22 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         value_exclude = ValueItems(self, exclude) if exclude is not None else None
         value_include = ValueItems(self, include) if include is not None else None
 
-        all_values: Mapping[str, Any]
-        all_fields: Mapping[str, 'Union[ModelField, ComputedField]']
-        # Case 1: no computed fields -> just reference for max speed
-        if not self.__computed_fields__:
-            all_fields = self.__fields__
-            all_values = self.__dict__
-        # Case 2: we have computed fields but want to ignore them
-        # In this case we need to remove some extra values in self.__dict__ that may have been added by
-        # descriptors (e.g. `cached_property`)
-        elif exclude_computed:
-            all_fields = self.__fields__
-            all_values = {k: v for k, v in self.__dict__.items() if k not in self.__computed_fields__}
-        # Case 3: we have computed fields and want to add them
-        else:
-            all_fields = {**self.__fields__, **self.__computed_fields__}
-            all_values = {
-                **{k: v for k, v in self.__dict__.items() if k not in self.__computed_fields__},
-                **{
-                    computed_field.name: computed_field.__get__(self)
-                    for computed_field in self.__computed_fields__.values()
-                },
-            }
+        all_values = ChainMap(
+            {computed_field.name: computed_field.__get__(self) for computed_field in self.__computed_fields__.values()},
+            self.__dict__,
+        )
 
         for field_key, v in all_values.items():
             if (allowed_keys is not None and field_key not in allowed_keys) or (exclude_none and v is None):
                 continue
 
             if exclude_defaults:
-                model_field = all_fields.get(field_key)
+                model_field = self.__all_fields__.get(field_key)
                 if not getattr(model_field, 'required', True) and getattr(model_field, 'default', _missing) == v:
                     continue
 
-            if by_alias and field_key in all_fields:
-                dict_key = all_fields[field_key].alias
+            if by_alias and field_key in self.__all_fields__:
+                dict_key = self.__all_fields__[field_key].alias
             else:
                 dict_key = field_key
 

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -193,7 +193,10 @@ def get_field_info_schema(field: ModelField) -> Tuple[Dict[str, Any], bool]:
         schema['description'] = field.field_info.description
         schema_overrides = True
 
-    if (
+    if field.field_info.read_only:
+        schema['readOnly'] = True
+        schema_overrides = True
+    elif (
         not field.required
         and not field.field_info.const
         and field.default is not None
@@ -584,7 +587,12 @@ def model_type_schema(
     required = []
     definitions: Dict[str, Any] = {}
     nested_models: Set[str] = set()
-    for k, f in model.__fields__.items():
+    all_fields: Dict[str, ModelField] = {
+        **model.__fields__,
+        **{k: cast(ModelField, m.model_field) for k, m in model.__computed_fields__.items()},
+    }
+
+    for k, f in all_fields.items():
         try:
             f_schema, f_definitions, f_nested_models = field_schema(
                 f,

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -289,6 +289,19 @@ if sys.version_info < (3, 8):  # noqa: C901 (ignore complexity)
         return type_ in NONE_TYPES
 
 
+elif sys.version_info[:2] == (3, 8):
+    # We can use the fast implementation for 3.8 but using directly `NONE_TYPES` like above
+    # fails for `Literal[None]` because of defined methods `ComputedField.__get__`
+    # or `ComputedField.__set__` in module `fields.py`.
+    # This is why we repeat the value of `NONE_TYPES` here
+
+    def is_none_type(type_: Any) -> bool:
+        for none_type in (None, NoneType, Literal[None]):
+            if type_ is none_type:
+                return True
+        return False
+
+
 else:
 
     def is_none_type(type_: Any) -> bool:

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -31,6 +31,7 @@ from pydantic import (
     StrictFloat,
     StrictInt,
     StrictStr,
+    field,
     root_validator,
     validate_arguments,
     validator,
@@ -234,3 +235,22 @@ validated.my_file_path.absolute()
 validated.my_file_path_str.absolute()
 validated.my_dir_path.absolute()
 validated.my_dir_path_str.absolute()
+
+
+# Decorated property is not yet supported
+# https://github.com/python/mypy/issues/1362
+class Square(BaseModel):
+    side: float
+
+    @field(alias='the area')  # type: ignore[misc]
+    @property
+    def area(self) -> float:
+        return self.side ** 2
+
+    @area.setter
+    def area(self, area: float) -> None:
+        self.side = area ** 0.5
+
+
+sq = Square(side=10)
+sq.area = 13

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -31,7 +31,7 @@ from pydantic import (
     StrictFloat,
     StrictInt,
     StrictStr,
-    field,
+    computed_field,
     root_validator,
     validate_arguments,
     validator,
@@ -242,7 +242,7 @@ validated.my_dir_path_str.absolute()
 class Square(BaseModel):
     side: float
 
-    @field(alias='the area')  # type: ignore[misc]
+    @computed_field(alias='the area')  # type: ignore[misc]
     @property
     def area(self) -> float:
         return self.side ** 2

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -2,7 +2,7 @@ import random
 
 import pytest
 
-from pydantic import BaseModel, ComputedField, Field, ValidationError, field, validator
+from pydantic import BaseModel, ComputedField, Field, ValidationError, computed_field, validator
 
 try:
     from functools import cached_property
@@ -15,13 +15,13 @@ def test_computed_fields_get():
         width: int
         length: int
 
-        @field
+        @computed_field
         @property
         def area(self) -> int:
             """An awesome area"""
             return self.width * self.length
 
-        @field(title='Pikarea', description='Another area')
+        @computed_field(title='Pikarea', description='Another area')
         @property
         def area2(self) -> int:
             return self.width * self.length
@@ -72,7 +72,7 @@ def test_computed_fields_set():
     class Square(BaseModel):
         side: float
 
-        @field
+        @computed_field
         def area(self) -> float:
             return self.side ** 2
 
@@ -106,7 +106,7 @@ def test_computed_fields_del():
         first: str
         last: str
 
-        @field
+        @computed_field
         def fullname(self) -> str:
             return f'{self.first} {self.last}'
 
@@ -133,7 +133,7 @@ def test_cached_property():
         minimum: int = Field(alias='min')
         maximum: int = Field(alias='max')
 
-        @field(alias='the magic number')
+        @computed_field(alias='the magic number')
         @cached_property
         def random_number(self) -> int:
             """An awesome area"""
@@ -170,7 +170,7 @@ def test_custom_descriptor():
         first: str
         last: str
 
-        @field
+        @computed_field
         @MyCustomProperty
         def fullname(self) -> str:
             return f'{self.first} {self.last}'
@@ -187,7 +187,7 @@ def test_custom_descriptor():
         first: str
         last: str
 
-        @field
+        @computed_field
         @MyCustomProperty
         def fullname(self) -> str:
             return f'{self.first} {self.last}'
@@ -208,7 +208,7 @@ def test_computed_fields_no_return_type():
         first: str
         last: str
 
-        @field
+        @computed_field
         def fullname(self):
             return f'{self.first} {self.last}'
 
@@ -228,7 +228,7 @@ def test_properties_and_computed_fields():
         def public_int(self, v: float) -> None:
             self._private_float = v
 
-        @field
+        @computed_field
         @property
         def public_str(self) -> str:
             return f'public {self.public_int}'
@@ -246,12 +246,12 @@ def test_exclude():
     class Model(BaseModel):
         x: float = Field(...)
 
-        @field(exclude=True)
+        @computed_field(exclude=True)
         @property
         def double(self) -> float:
             return self.x * 2
 
-        @field
+        @computed_field
         @property
         def quadruple(self) -> float:
             return self.double * 2
@@ -265,7 +265,7 @@ def test_validation():
         first_name: str
         surname: str
 
-        @field
+        @computed_field
         @property
         def full_name(self) -> str:
             return f'{self.first_name} {self.surname}'
@@ -327,7 +327,7 @@ def test_more_validation():
     class M(BaseModel):
         value: int
 
-        @field
+        @computed_field
         @property
         def plus_one(self) -> int:
             return self.value + 1

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -408,3 +408,20 @@ def test_computed_field_syntax():
             'type': 'value_error',
         }
     ]
+
+
+def test_computed_fields_repr():
+    class Model(BaseModel):
+        x: int
+
+        @computed_field(repr=False)
+        @property
+        def double(self) -> int:
+            return self.x * 2
+
+        @computed_field  # repr=True by default
+        @property
+        def triple(self) -> int:
+            return self.x * 3
+
+    assert repr(Model(x=2)) == 'Model(x=2, triple=6)'

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -39,7 +39,6 @@ def test_computed_fields_get():
     assert rect.area == 50
     assert rect.double_width == 20
     assert rect.dict() == {'width': 10, 'length': 5, 'area': 50, 'area2': 50}
-    assert rect.dict(exclude_computed=True) == {'width': 10, 'length': 5}
     assert rect.json() == '{"width": 10, "length": 5, "area": 50, "area2": 50}'
     assert Rectangle.schema() == {
         'title': 'Rectangle',
@@ -146,7 +145,6 @@ def test_cached_property():
     second_n = rect.random_number
     assert first_n == second_n
     assert rect.dict() == {'minimum': 10, 'maximum': 10_000, 'random_number': first_n}
-    assert rect.dict(exclude_computed=True) == {'minimum': 10, 'maximum': 10_000}
     assert rect.dict(by_alias=True) == {'min': 10, 'max': 10_000, 'the magic number': first_n}
     assert rect.dict(by_alias=True, exclude={'random_number'}) == {'min': 10, 'max': 10000}
 
@@ -243,3 +241,21 @@ def test_properties_and_computed_fields():
     m.public_int = 2
     assert m._private_float == 2.0
     assert m.dict() == {'x': 'pika', 'public_str': 'public 2'}
+
+
+def test_exclude():
+    class Model(BaseModel):
+        x: float = Field(...)
+
+        @field(exclude=True)
+        @property
+        def double(self) -> float:
+            return self.x * 2
+
+        @field
+        @property
+        def quadruple(self) -> float:
+            return self.double * 2
+
+    m = Model(x=3)
+    assert m.dict() == {'x': 3.0, 'quadruple': 12.0}

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -39,6 +39,7 @@ def test_computed_fields_get():
     assert rect.area == 50
     assert rect.double_width == 20
     assert rect.dict() == {'width': 10, 'length': 5, 'area': 50, 'area2': 50}
+    assert rect.dict(exclude_computed=True) == {'width': 10, 'length': 5}
     assert rect.json() == '{"width": 10, "length": 5, "area": 50, "area2": 50}'
     assert Rectangle.schema() == {
         'title': 'Rectangle',
@@ -145,7 +146,9 @@ def test_cached_property():
     second_n = rect.random_number
     assert first_n == second_n
     assert rect.dict() == {'minimum': 10, 'maximum': 10_000, 'random_number': first_n}
-    assert rect.dict(by_alias=True, exclude={'random_number'}) == {'min': 10, 'max': 10000, 'the magic number': first_n}
+    assert rect.dict(exclude_computed=True) == {'minimum': 10, 'maximum': 10_000}
+    assert rect.dict(by_alias=True) == {'min': 10, 'max': 10_000, 'the magic number': first_n}
+    assert rect.dict(by_alias=True, exclude={'random_number'}) == {'min': 10, 'max': 10000}
 
 
 def test_custom_descriptor():

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -1,0 +1,60 @@
+from pydantic import BaseModel
+from pydantic.fields import field
+
+
+def test_computed_fields():
+    class Rectangle(BaseModel):
+        width: int
+        length: int
+
+        @field
+        @property
+        def area(self) -> int:
+            """An awesome area"""
+            return self.width * self.length
+
+        @field(title='Pikarea', description='Another area')
+        @property
+        def area2(self) -> int:
+            return self.width * self.length
+
+        @property
+        def double_width(self) -> int:
+            return self.width * 2
+
+    rect = Rectangle(width=10, length=5)
+    assert set(rect.__fields__) == {'width', 'length'}
+    assert set(rect.__computed_fields__) == {'area', 'area2'}
+    assert rect.__dict__ == {'width': 10, 'length': 5}
+
+    assert rect.area == 50
+    assert rect.double_width == 20
+    assert rect.dict() == {'width': 10, 'length': 5, 'area': 50, 'area2': 50}
+    assert rect.json() == '{"width": 10, "length": 5, "area": 50, "area2": 50}'
+    assert rect.schema() == {
+        'title': 'Rectangle',
+        'type': 'object',
+        'properties': {
+            'width': {
+                'title': 'Width',
+                'type': 'integer',
+            },
+            'length': {
+                'title': 'Length',
+                'type': 'integer',
+            },
+            'area': {
+                'title': 'Area',
+                'description': 'An awesome area',
+                'type': 'integer',
+                'readOnly': True,
+            },
+            'area2': {
+                'title': 'Pikarea',
+                'description': 'Another area',
+                'type': 'integer',
+                'readOnly': True,
+            },
+        },
+        'required': ['width', 'length'],
+    }

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 from pydantic.fields import field
 
 
-def test_computed_fields():
+def test_computed_fields_get():
     class Rectangle(BaseModel):
         width: int
         length: int
@@ -58,3 +58,21 @@ def test_computed_fields():
         },
         'required': ['width', 'length'],
     }
+
+
+def test_computed_fields_set():
+    class Square(BaseModel):
+        side: float
+
+        @field
+        def area(self) -> float:
+            return self.side ** 2
+
+        @area.setter
+        def area(self, new_area: int):
+            self.side = new_area ** 0.5
+
+    r = Square(side=10)
+    assert r.dict() == {'side': 10.0, 'area': 100.0}
+    r.area = 64
+    assert r.dict() == {'side': 8.0, 'area': 64.0}

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -40,7 +40,7 @@ def test_computed_fields_get():
     assert rect.double_width == 20
     assert rect.dict() == {'width': 10, 'length': 5, 'area': 50, 'area2': 50}
     assert rect.json() == '{"width": 10, "length": 5, "area": 50, "area2": 50}'
-    assert rect.schema() == {
+    assert Rectangle.schema() == {
         'title': 'Rectangle',
         'type': 'object',
         'properties': {
@@ -81,10 +81,25 @@ def test_computed_fields_set():
         def area(self, new_area: int):
             self.side = new_area ** 0.5
 
-    r = Square(side=10)
-    assert r.dict() == {'side': 10.0, 'area': 100.0}
-    r.area = 64
-    assert r.dict() == {'side': 8.0, 'area': 64.0}
+    s = Square(side=10)
+    assert s.dict() == {'side': 10.0, 'area': 100.0}
+    s.area = 64
+    assert s.dict() == {'side': 8.0, 'area': 64.0}
+    assert Square.schema() == {
+        'title': 'Square',
+        'type': 'object',
+        'properties': {
+            'side': {
+                'title': 'Side',
+                'type': 'number',
+            },
+            'area': {
+                'title': 'Area',
+                'type': 'number',
+            },
+        },
+        'required': ['side'],
+    }
 
 
 def test_computed_fields_del():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1270,9 +1270,23 @@ def test_parse_obj_nested_root():
     assert tournament.players.__root__['Jane'].pokemons.__root__[0].name == 'Pikachu'
 
 
-def test_untouched_types():
-    from pydantic import BaseModel
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='singledispatchmethod is not available')
+def test_descriptors_work_without_keep_untouched():
+    from functools import singledispatchmethod
 
+    class Model(BaseModel):
+        x: int
+
+        @singledispatchmethod
+        def add_to_x(self, y):
+            raise NotImplementedError()
+
+    m = Model(x=1)
+    with pytest.raises(NotImplementedError):
+        m.add_to_x(3)
+
+
+def test_descriptors_work_without_keep_untouched_2():
     class _ClassPropertyDescriptor:
         def __init__(self, getter):
             self.getter = getter
@@ -1283,9 +1297,6 @@ def test_untouched_types():
     classproperty = _ClassPropertyDescriptor
 
     class Model(BaseModel):
-        class Config:
-            keep_untouched = (classproperty,)
-
         @classproperty
         def class_name(cls) -> str:
             return cls.__name__
@@ -1294,22 +1305,20 @@ def test_untouched_types():
     assert Model().class_name == 'Model'
 
 
-def test_descriptors_work_without_keep_untouched():
-    class _ClassPropertyDescriptor:
-        def __init__(self, getter):
-            self.getter = getter
-
-        def __get__(self, instance, owner):
-            return self.getter(owner)
-
-    classproperty = _ClassPropertyDescriptor
+def test_keep_untouched():
+    class decorator:
+        def __init__(self, func):
+            self.func = func
 
     class Model(BaseModel):
-        @classproperty
+        class Config:
+            keep_untouched = (decorator,)
+
+        @decorator
         def class_name(cls) -> str:
             return cls.__name__
 
-    assert Model.class_name == 'Model'
+    assert Model.class_name.func(Model) == 'Model'
 
 
 def test_other_classes_fail_without_keep_untouched():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1294,9 +1294,7 @@ def test_untouched_types():
     assert Model().class_name == 'Model'
 
 
-def test_custom_types_fail_without_keep_untouched():
-    from pydantic import BaseModel
-
+def test_descriptors_work_without_keep_untouched():
     class _ClassPropertyDescriptor:
         def __init__(self, getter):
             self.getter = getter
@@ -1306,31 +1304,30 @@ def test_custom_types_fail_without_keep_untouched():
 
     classproperty = _ClassPropertyDescriptor
 
-    with pytest.raises(RuntimeError) as e:
-
-        class Model(BaseModel):
-            @classproperty
-            def class_name(cls) -> str:
-                return cls.__name__
-
-        Model.class_name
-
-    assert str(e.value) == (
-        "no validator found for <class 'tests.test_main.test_custom_types_fail_without_keep_untouched.<locals>."
-        "_ClassPropertyDescriptor'>, see `arbitrary_types_allowed` in Config"
-    )
-
     class Model(BaseModel):
-        class Config:
-            arbitrary_types_allowed = True
-
         @classproperty
         def class_name(cls) -> str:
             return cls.__name__
 
-    with pytest.raises(AttributeError) as e:
-        Model.class_name
-    assert str(e.value) == "type object 'Model' has no attribute 'class_name'"
+    assert Model.class_name == 'Model'
+
+
+def test_other_classes_fail_without_keep_untouched():
+    class decorator:
+        def __init__(self, func):
+            self.func = func
+
+    with pytest.raises(RuntimeError) as e:
+
+        class Model(BaseModel):
+            @decorator
+            def class_name(cls) -> str:
+                return cls.__name__
+
+    assert str(e.value) == (
+        "no validator found for <class 'tests.test_main.test_other_classes_fail_without_keep_untouched.<locals>."
+        "decorator'>, see `arbitrary_types_allowed` in Config"
+    )
 
 
 def test_model_iteration():

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -160,8 +160,8 @@ def test_slots_are_ignored():
     m = Model()
     for attr in Model.__slots__:
         assert object.__getattribute__(m, attr) == 'spam'
-        with pytest.raises(ValueError, match=f'"Model" object has no field "{attr}"'):
-            setattr(m, attr, 'not spam')
+        setattr(m, attr, 'not spam')
+        assert object.__getattribute__(m, attr) == 'not spam'
 
 
 def test_default_and_default_factory_used_error():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
I'm waiting for feedback on the API and [doc](https://smokeshow.helpmanual.io/3h0m1f4t2i5e2b26723a/usage/models/#field-with-computed-value-based-on-other-fields) 🙏  

### `property`-like syntax

```py
from functools import cached_property
from random import randint

from pydantic import BaseModel, computed_field


class Square(BaseModel, underscore_attrs_are_private=True):
    side: float
    _private_attr: int = 1

    @computed_field(title='The area')
    @property
    def area(self) -> float:
        return self.side ** 2

    @area.setter
    def area(self, area: float) -> None:
        self.side = area ** .5

    @area.deleter
    def area(self) -> None:
        self.side = 0

    @computed_field(alias='The random number')
    @cached_property
    def random_n(self) -> int:
        return randint(0, 1_000)

    @property
    def public_attr(self) -> int:
        return self._private_attr + 1

    @public_attr.setter
    def public_attr(self, v: int) -> None:
        self._private_attr = v - 1


sq = Square(side=10)
assert sq._private_attr == 1
assert sq.public_attr == 2
sq.public_attr = 5
assert sq._private_attr == 4
assert sq.public_attr == 5
the_random_n = sq.random_n
assert sq.dict(by_alias=True) == {'side': 10, 'area': 100, 'The random number': the_random_n}
sq.area = 49
assert sq.dict() == {'side': 7, 'area': 49, 'random_n': the_random_n}
del sq.area
assert sq.dict() == {'side': 0, 'area': 0, 'random_n': the_random_n}
assert sq.dict(exclude={'random_n'}) == {'side': 0, 'area': 0}
```

### `ComputedField` syntax

```py
from pydantic import BaseModel, ComputedField, ValidationError, validator


class User(BaseModel, validate_assignment=True):
    first_name: str
    surname: str
    full_name: str = ComputedField(lambda self: f'{self.first_name} {self.surname}')

    @validator('full_name')
    def should_not_have_pika(cls, v: str) -> str:
        if 'pika' in v.lower():
            raise ValueError('We love pika but not that much!')
        return v


u = User(first_name='John', surname='Smith')
assert u.dict() == {'first_name': 'John', 'surname': 'Smith', 'full_name': 'John Smith'}
u.first_name = 'Mike'
assert u.dict()['full_name'] == 'Mike Smith'

try:
    User(first_name='Pika', surname='Chu')
    assert False
except ValidationError:
    # pydantic.error_wrappers.ValidationError: 1 validation error for User
    # full_name
    #   We love pika but not that much! (type=value_error)
    assert True
```

See [the tests](https://github.com/PrettyWood/pydantic/blob/field-property/tests/test_computed_fields.py) for more examples

## Related issue number
closes #935
closes #1241
closes #2313

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
