### PR TITLE
Ensure type correctness when using `EmailStr`

### DIFF
--- a/changes/2688-gherx.md
+++ b/changes/2688-gherx.md
@@ -1,0 +1,1 @@
+Using `EmailStr` in a model now always returns an `EmailStr`

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -446,7 +446,7 @@ _(This script is complete, it should run "as is")_
 
 `EmailStr`
 : requires [email-validator](https://github.com/JoshData/python-email-validator) to be installed;
-  the input string must be a valid email address, and the output is a simple string
+  the input string must be a valid email address, and the output is an `EmailStr` object which is also a simple string
 
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -359,8 +359,8 @@ class EmailStr(str):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value: Union[str]) -> str:
-        return validate_email(value)[1]
+    def validate(cls, value: Union[str]) -> 'EmailStr':
+        return cls(validate_email(value)[1])
 
 
 class NameEmail(Representation):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -484,6 +484,17 @@ def test_email_str():
 
 
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
+def test_email_str_type():
+    class Model(BaseModel):
+        v: EmailStr
+
+    assert isinstance(Model(v=EmailStr('foo@example.org')).v, EmailStr)
+    assert isinstance(Model(v=EmailStr('foo@example.org')).v, str)
+    assert isinstance(Model(v='foo@example.org').v, EmailStr)
+    assert isinstance(Model(v='foo@example.org').v, str)
+
+
+@pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 def test_name_email():
     class Model(BaseModel):
         v: NameEmail


### PR DESCRIPTION
## Change Summary

Hi,

Currently `EmailStr` is always converted to a `str` which leads to false-negatives during type checking, e.g. using mypy, and may cause non-obvious bugs when using `isinstance`, which is useful in combination with `Union`-types, e.g.:

```python
import pydantic as pyd

class Model(pyd.BaseModel):
  v: pyd.EmailStr

m = Model(v=pyd.EmailStr("test@example.com"))
# reveal_type(m.v) == `'pydantic.networks.EmailStr`
assert isinstance(m.v, pyd.EmailStr)  # this raises
```

This change always makes `EmailStr` an `EmailStr` and should be fully backward-compatible, as `EmailStr` is still an instance of `str`.

## Related issue number

None that I know of

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
