### PR TITLE
Allow user-defined loaders for parse.py logic

### DIFF
--- a/changes/3025-nowanilfideme.md
+++ b/changes/3025-nowanilfideme.md
@@ -1,0 +1,1 @@
+Add ability to define custom loaders for non-JSON file formats/MIME types.

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -10,7 +10,7 @@ from .errors import *
 from .fields import Field, PrivateAttr, Required
 from .main import *
 from .networks import *
-from .parse import Protocol
+from .parse import Protocol, register_loader
 from .tools import *
 from .types import *
 from .version import VERSION
@@ -60,6 +60,7 @@ __all__ = [
     'validate_email',
     # parse
     'Protocol',
+    'register_loader',
     # tools
     'parse_file_as',
     'parse_obj_as',

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -144,6 +144,14 @@ def test_bad_proto():
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'Unknown protocol: foobar', 'type': 'type_error'}]
 
 
+def test_user_proto():
+    from pydantic.parse import register_loader
+
+    register_loader(json.loads, proto_name='foobar')
+
+    assert Model.parse_raw('{"a": 12, "b": 8}', proto='foobar') == Model(a=12, b=8)
+
+
 def test_file_json(tmpdir):
     p = tmpdir.join('test.json')
     p.write('{"a": 12, "b": 8}')


### PR DESCRIPTION
## Change Summary

This is a draft request (with updated imports and unit tests, but not yet docs). It doesn't affect existing logic, only allows additional functionality by hooking external "loaders". The new API function is `pydantic.parse.register_loader()`, which allows the user to define a custom "proto" and, optionally, MIME types or file extensions, to parse to any Pydantic model. The loaders themselves are not added to Pydantic, only the flexibility to define your own types.

## Related issue number

Implements discussion https://github.com/samuelcolvin/pydantic/discussions/3025, including #136  and #2335 as special cases to be implemented by external libraries.

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
