### PR TITLE
Include types during model equality check

### DIFF
--- a/changes/3066-JacobHayes.md
+++ b/changes/3066-JacobHayes.md
@@ -1,0 +1,1 @@
+Include types during model equality check

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -822,7 +822,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, BaseModel):
-            return self.dict() == other.dict()
+            return (self.__class__, self.dict()) == (other.__class__, other.dict())
         else:
             return self.dict() == other
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1077,7 +1077,7 @@ def test_generic_recursive_models(create_module):
     Model1 = module.Model1
     Model2 = module.Model2
     result = Model1[str].parse_obj(dict(ref=dict(ref=dict(ref=dict(ref=123)))))
-    assert result == Model1(ref=Model2(ref=Model1(ref=Model2(ref='123'))))
+    assert result == Model1[str](ref=Model2(ref=Model1(ref=Model2(ref='123'))))
 
 
 @skip_36

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2047,11 +2047,19 @@ def test_new_union_origin():
 
 
 def test_equality():
-    class A(BaseModel):
-        description: str = ''
+    class Animal(BaseModel):
+        name: str = ''
 
-    class B(BaseModel):
-        description: str = ''
+    class Dog(Animal):
+        pass
 
-    assert A() == A()
-    assert A() != B()
+    class Cat(Animal):
+        pass
+
+    class Owner(BaseModel):
+        name: str = ''
+        pet: Animal
+
+    assert Dog() == Dog()
+    assert Dog() != Cat()
+    assert Owner(pet=Dog()) != Owner(pet=Cat())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2048,10 +2048,10 @@ def test_new_union_origin():
 
 def test_equality():
     class A(BaseModel):
-        description: str = ""
+        description: str = ''
 
     class B(BaseModel):
-        description: str = ""
+        description: str = ''
 
     assert A() == A()
     assert A() != B()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2044,3 +2044,14 @@ def test_new_union_origin():
         'properties': {'x': {'title': 'X', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}},
         'required': ['x'],
     }
+
+
+def test_equality():
+    class A(BaseModel):
+        description: str = ""
+
+    class B(BaseModel):
+        description: str = ""
+
+    assert A() == A()
+    assert A() != B()


### PR DESCRIPTION
Currently, `BaseModel.__eq__` only considers the _dict_ representation of the two models. This leads to incorrect (imo) equality for models of different types but the same fields. For example (not contrived, ~real code I wrote):

```python3
from pydantic import BaseModel

class Type(BaseModel):
    description: str = ""
    class Config:
        frozen = True  # Only relevant for hash comparison below

class Int8(Type):
    pass

class Int16(Type):
    pass

# then...

>>> i8, i16 = Int8(), Int16()
>>> i8 == i16
True
>>> hash(i8) == hash(i16)
False
```

## Change Summary

This PR adds the model classes into the equality check to distinguish on type+content. Note that this new behavior more closely matches `__hash__` (for frozen models), which mixes the class + the values (not sure why the keys aren't included :shrug:)

@samuelcolvin suggests a very similar change in https://github.com/samuelcolvin/pydantic/issues/1494#issuecomment-630144720. I avoided most of the "breaking change" described there - we're still converting the models to dicts. However, the class check may still be a breaking change for some esoteric uses, including 1 (fixed) test: `test_generic_recursive_models`, which was arguably incorrect in the first place (comparing an instance with the TypeVar against one without).

## Related issue number

Tangentially: #1494

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
