### PR TITLE
Copy ModelField.outer_type_ to subclass field

### DIFF
--- a/changes/3621-JacobHayes.md
+++ b/changes/3621-JacobHayes.md
@@ -1,0 +1,1 @@
+Copy ModelField.outer_type_ to subclass field with new default

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -229,6 +229,7 @@ class ModelMetaclass(ABCMeta):
                     if var_name in fields:
                         if lenient_issubclass(inferred.type_, fields[var_name].type_):
                             inferred.type_ = fields[var_name].type_
+                            inferred.outer_type_ = fields[var_name].outer_type_
                         else:
                             raise TypeError(
                                 f'The type of {name}.{var_name} differs from the new default value; '

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -180,6 +180,12 @@ def lenient_isinstance(o: Any, class_or_tuple: Union[Type[Any], Tuple[Type[Any],
 
 
 def lenient_issubclass(cls: Any, class_or_tuple: Union[Type[Any], Tuple[Type[Any], ...], None]) -> bool:
+    if class_or_tuple is not None:
+        if isinstance(class_or_tuple, tuple):
+            return any(lenient_issubclass(cls, subtype) for subtype in class_or_tuple)
+        # NOTE: py <3.10 doesn't support issubclass with Unions (eg: `issubclass(str, str | int)`), so recurse by hand.
+        if get_origin(class_or_tuple) is Union:
+            return any(lenient_issubclass(cls, subtype) for subtype in get_args(class_or_tuple))
     try:
         return isinstance(cls, type) and issubclass(cls, class_or_tuple)  # type: ignore[arg-type]
     except TypeError:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -885,20 +885,37 @@ def test_inheritance_subclass_default():
     # Confirm hint supports a subclass default
     class Simple(BaseModel):
         x: str = MyStr('test')
+        y: Union[int, str] = MyStr('test')
+
+    assert Simple.__fields__['x'].type_ == str
+    assert Simple.__fields__['x'].outer_type_ == str
+    assert Simple.__fields__['y'].type_ == Union[int, str]
+    assert Simple.__fields__['y'].outer_type_ == Union[int, str]
 
     # Confirm hint on a base can be overridden with a subclass default on a subclass
     class Base(BaseModel):
         x: str
         y: str
+        z: Union[int, str]
+
+    assert Base.__fields__['x'].type_ == str
+    assert Base.__fields__['x'].outer_type_ == str
+    assert Base.__fields__['y'].type_ == str
+    assert Base.__fields__['y'].outer_type_ == str
+    assert Base.__fields__['z'].type_ == Union[int, str]
+    assert Base.__fields__['z'].outer_type_ == Union[int, str]
 
     class Sub(Base):
         x = MyStr('test')
-        y: MyStr = MyStr('test')  # force subtype
+        y: MyStr = MyStr('test')  # override subtype
+        z = MyStr('test')  # confirm a subclass of one of the Union members is allowed
 
     assert Sub.__fields__['x'].type_ == str
     assert Sub.__fields__['x'].outer_type_ == str
     assert Sub.__fields__['y'].type_ == MyStr
     assert Sub.__fields__['y'].outer_type_ == MyStr
+    assert Sub.__fields__['z'].type_ == Union[int, str]
+    assert Sub.__fields__['z'].outer_type_ == Union[int, str]
 
 
 def test_invalid_type():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -896,7 +896,9 @@ def test_inheritance_subclass_default():
         y: MyStr = MyStr('test')  # force subtype
 
     assert Sub.__fields__['x'].type_ == str
+    assert Sub.__fields__['x'].outer_type_ == str
     assert Sub.__fields__['y'].type_ == MyStr
+    assert Sub.__fields__['y'].outer_type_ == MyStr
 
 
 def test_invalid_type():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,9 @@ def test_lenient_issubclass():
         pass
 
     assert lenient_issubclass(A, str) is True
+    assert lenient_issubclass(A, (float, str)) is True
+    assert lenient_issubclass(A, Union[int, str]) is True
+    assert lenient_issubclass(A, (float, Union[int, str])) is True
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason='generic aliases are not available in python < 3.9')


### PR DESCRIPTION
## Change Summary

Copy ModelField.outer_type_ to subclass field with new default

In https://github.com/samuelcolvin/pydantic/pull/3018, I tried to support setting defaults in a subclass that were a subtype of the base class's type hint *without repeating the type hint*. To do so, we copy over `ModelField.type_`, but I forgot to update `ModelField.outer_type_` as well.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
