### PR TITLE
fix ability to mix/merge json env variables with env_nested_delimiter…

### DIFF
--- a/changes/3640-Air-Mark.md
+++ b/changes/3640-Air-Mark.md
@@ -1,0 +1,1 @@
+fix ability to mix/merge json env variables with variables defined according to env_nested_delimiter

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -93,6 +93,8 @@ def test_merge_dict(env):
 def test_nested_env_delimiter(env):
     class SubSubValue(BaseSettings):
         v6: str
+        v7: str
+        v8: int
 
     class SubValue(BaseSettings):
         v4: str
@@ -113,6 +115,7 @@ def test_nested_env_delimiter(env):
         class Config:
             env_nested_delimiter = '__'
 
+    env.set('top__sub', '{"sub_sub": {"v7": 7}}')
     env.set('top', '{"v1": "json-1", "v2": "json-2", "sub": {"v5": "xx"}}')
     env.set('top__sub__v5', '5')
     env.set('v0', '0')
@@ -120,6 +123,7 @@ def test_nested_env_delimiter(env):
     env.set('top__v3', '3')
     env.set('v0_union', '0')
     env.set('top__sub__sub_sub__v6', '6')
+    env.set('top__sub__sub_sub', '{"v8": 8}')
     env.set('top__sub__v4', '4')
     cfg = Cfg()
     assert cfg.dict() == {
@@ -129,7 +133,7 @@ def test_nested_env_delimiter(env):
             'v1': 'json-1',
             'v2': '2',
             'v3': '3',
-            'sub': {'v4': '4', 'v5': 5, 'sub_sub': {'v6': '6'}},
+            'sub': {'v4': '4', 'v5': 5, 'sub_sub': {'v6': '6', 'v7': '7', 'v8': 8}},
         },
     }
 


### PR DESCRIPTION
## Change Summary
fix ability to mix/merge json env variables with variables defined according to env_nested_delimiter

## Related issue number
Found a corner-case when we are mixing 2 types of nested environment variables definition.
#3159

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
