### PR TITLE
support `kw_only` on dataclasses

### DIFF
--- a/changes/3670-detachhead.md
+++ b/changes/3670-detachhead.md
@@ -1,0 +1,1 @@
+Support `kw_only` in dataclasses

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1356,7 +1356,7 @@ def test_kw_only():
         a: int | None = None
         b: str
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match='takes 1 positional argument but 3 were given'):
         A(1, '')
 
     assert A(b='hi').b == 'hi'

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,6 +1,7 @@
 import dataclasses
 import pickle
 import re
+import sys
 from collections.abc import Hashable
 from datetime import datetime
 from pathlib import Path
@@ -1346,3 +1347,16 @@ def test_self_reference_dataclass():
         self_reference: 'MyDataclass'
 
     assert MyDataclass.__pydantic_model__.__fields__['self_reference'].type_ is MyDataclass
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='kw_only is not available in python < 3.10')
+def test_kw_only():
+    @pydantic.dataclasses.dataclass(kw_only=True)
+    class A:
+        a: int | None = None
+        b: str
+
+    with pytest.raises(TypeError):
+        A(1, '')
+
+    assert A(b='hi').b == 'hi'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #3670 (it's a discussion tho because the issue template didn't let me raise a feature request)
## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
