### PR TITLE
fix: support local refs natively in future annotation mode

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1,5 +1,5 @@
-import warnings
 import sys
+import warnings
 from abc import ABCMeta
 from copy import deepcopy
 from enum import Enum
@@ -291,17 +291,7 @@ class ModelMetaclass(ABCMeta):
         # set __signature__ attr only for model class, but not for its instances
         cls.__signature__ = ClassAttribute('__signature__', generate_model_signature(cls.__init__, fields, config))
 
-        localns = {}
-
-        # Pull in the currently defined local namespace and any namespaces above 
-        if hasattr(sys, "_getframe"):
-            frame = sys._getframe(1)
-            while frame is not None:
-                for k, v in frame.f_locals.items():
-                    if k not in localns:
-                        localns[k] = v
-                frame = frame.f_back
-
+        localns = sys._getframe(1).f_locals if hasattr(sys, '_getframe') else {}
         cls.__try_update_forward_refs__(**localns)
 
         return cls

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -71,6 +71,27 @@ class Bar(BaseModel):
     assert module.Bar.__fields__['b'].type_ is module.Foo
 
 
+def test_postponed_annotations_local(create_module):
+    module = create_module(
+        # language=Python
+        """
+from __future__ import annotations
+from pydantic import BaseModel
+
+def main():
+    from pydantic import PositiveInt
+
+    class Model(BaseModel):
+        a: PositiveInt
+
+    return Model
+
+Model = main()
+"""
+    )
+    assert module.Model(a='123').dict() == {'a': 123}
+
+
 def test_forward_ref_one_of_fields_not_defined(create_module):
     @create_module
     def module():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This is trying out the suggestion in #2678. When the class is instantiated, type annotations are resolved using the enclosing scopes, enabling locally defined types to be used.

Performance should be checked. This should only affect class creation, though - not usage. This could be optimized, perhaps, by trying to resolve first, maybe with the inmost locals, and then trying again with the full locals construction only if some annotations remain unresolved.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Improves the situation in #2678 by supporting local type annotation, or annotations in an enclosing scope, but not global.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
