### PR TITLE
New type StrLimited

### DIFF
--- a/changes/2104-lucastosetto.md
+++ b/changes/2104-lucastosetto.md
@@ -1,1 +1,1 @@
-Added simplified length limited string type, declared as StrLimited[max_length].
+Added simplified length limited string type, declared as `StrLimited[max_length]`.

--- a/changes/2104-lucastosetto.md
+++ b/changes/2104-lucastosetto.md
@@ -1,0 +1,1 @@
+Added simplified length limited string type, declared as StrLimited[max_length].

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -73,6 +73,7 @@ __all__ = [
     'NoneStr',
     'NoneBytes',
     'StrBytes',
+    'StrLimited',
     'NoneStrBytes',
     'StrictStr',
     'ConstrainedBytes',

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -97,6 +97,7 @@ __all__ = [
     'StrictBytes',
     'StrictInt',
     'StrictFloat',
+    'StrLimited',
     'PaymentCardNumber',
     'ByteSize',
     'PastDate',
@@ -434,6 +435,12 @@ def constr(
         regex=regex and re.compile(regex),
     )
     return _registered(type('ConstrainedStrValue', (ConstrainedStr,), namespace))
+
+
+class StrLimited:
+    @classmethod
+    def __class_getitem__(cls, max_length: int) -> Type[str]:
+        return constr(max_length=max_length, strip_whitespace=True)
 
 
 if TYPE_CHECKING:

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -439,7 +439,7 @@ def constr(
 
 class StrLimited:
     @classmethod
-    def __class_getitem__(cls, max_length: int) -> Type[str]:
+    def __class_getitem__(cls, max_length: int) -> Type[ConstrainedStr]:
         return constr(max_length=max_length, strip_whitespace=True)
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -738,7 +738,7 @@ def test_str_limited_good():
     max_length = 5
 
     class Model(BaseModel):
-        v: StrLimited[max_length]
+        v: StrLimited[5]
 
     m = Model(v='abcde')
     assert m.v == 'abcde'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -61,6 +61,7 @@ from pydantic import (
     StrictFloat,
     StrictInt,
     StrictStr,
+    StrLimited,
     ValidationError,
     conbytes,
     condecimal,
@@ -729,6 +730,34 @@ def test_constrained_str_max_length_0():
             'msg': 'ensure this value has at most 0 characters',
             'type': 'value_error.any_str.max_length',
             'ctx': {'limit_value': 0},
+        }
+    ]
+
+
+def test_str_limited_good():
+    max_length = 5
+
+    class Model(BaseModel):
+        v: StrLimited[max_length]
+
+    m = Model(v='abcde')
+    assert m.v == 'abcde'
+
+
+def test_str_limited_too_long():
+    max_length = 5
+
+    class Model(BaseModel):
+        v: StrLimited[max_length]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v='abcdef')
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('v',),
+            'msg': f'ensure this value has at most {max_length} characters',
+            'type': 'value_error.any_str.max_length',
+            'ctx': {'limit_value': max_length},
         }
     ]
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -740,7 +740,7 @@ def test_str_limited_good():
     class Model(BaseModel):
         v: StrLimited[5]
 
-    m = Model(v='abcde')
+    m = Model(v='abcde ')
     assert m.v == 'abcde'
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -748,7 +748,7 @@ def test_str_limited_too_long():
     max_length = 5
 
     class Model(BaseModel):
-        v: StrLimited[max_length]
+        v: StrLimited[5]
 
     with pytest.raises(ValidationError) as exc_info:
         Model(v='abcdef')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

This represents a simplified length limited string and is an alias for the following syntax:

`StrLimited[max_length]` = `constr(max_length=max_length, strip_whitespace=True)`

Usage example:

```
class Foo:
    bar: StrLimited[10] # bar is a str with maximum length of 10 characters
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

fix #2104

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
