### PR TITLE
Fix(BaseModel.copy) Do not ignore Extra.ignore configuration in copy with update #3732

### DIFF
--- a/changes/3732-rglsk.md
+++ b/changes/3732-rglsk.md
@@ -1,0 +1,1 @@
+Do not ignore Extra.ignore configuration in BaseModel.copy().

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -632,7 +632,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         )
 
         # new `__fields_set__` can have unset optional fields with a set value in `update` kwarg
-        if update:
+        extra_ignore = self.__config__.extra == Extra.ignore
+        if update and extra_ignore:
+            fields_set = set(self.__fields__.keys())
+            pop_values = update.keys() - self.__fields__.keys()
+            list(map(values.pop, pop_values))
+        elif update:
             fields_set = self.__fields_set__ | update.keys()
         else:
             fields_set = set(self.__fields_set__)

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -222,6 +222,19 @@ def test_copy_update_unset():
     assert Foo(foo='hello').copy(update={'bar': 'world'}).json(exclude_unset=True) == '{"foo": "hello", "bar": "world"}'
 
 
+def test_copy_update_extra_allow():
+    class Model(BaseModel):
+        a: int
+        b: int
+
+        class Config:
+            extra = Extra.allow
+
+    model = Model(a=2, b=3)
+    copied_model = model.copy(update={'b': 1, 'c': 2})
+    assert copied_model.dict() == {'a': 2, 'b': 1, 'c': 2}
+
+
 def test_copy_update_extra_ignore():
     class Model(BaseModel):
         a: float

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional
 
 import pytest
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Extra, Field, PrivateAttr
 from pydantic.fields import Undefined
 
 
@@ -220,6 +220,25 @@ def test_copy_update_unset():
         bar: Optional[str]
 
     assert Foo(foo='hello').copy(update={'bar': 'world'}).json(exclude_unset=True) == '{"foo": "hello", "bar": "world"}'
+
+
+def test_copy_update_extra_ignore():
+    class Model(BaseModel):
+        a: float
+        b: float
+
+        class Config:
+            extra = Extra.ignore
+
+    model = Model(a=0.2, b=0.3)
+
+    copied_model = model.copy(update={'b': 3.5, 'c': 2.5})
+    assert model.a == model.a == 0.2
+    assert copied_model.b == 3.5
+    assert not hasattr(copied_model, 'c')
+
+    with pytest.raises(ValueError, match='"Model" object has no field "c"'):
+        copied_model.c = 1
 
 
 def test_copy_set_fields():


### PR DESCRIPTION
## Change Summary

Do not add extra fields to the model on copy with update method once Config.extra = Extra.ignore is set.

## Related issue number

Fix: #3732 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
