### PR TITLE
Fix mypy version check

### DIFF
--- a/changes/3783-KotlinIsland.md
+++ b/changes/3783-KotlinIsland.md
@@ -1,0 +1,1 @@
+Fix mypy version checking.

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -76,7 +76,8 @@ BASEMODEL_FULLNAME = 'pydantic.main.BaseModel'
 BASESETTINGS_FULLNAME = 'pydantic.env_settings.BaseSettings'
 FIELD_FULLNAME = 'pydantic.fields.Field'
 DATACLASS_FULLNAME = 'pydantic.dataclasses.dataclass'
-BUILTINS_NAME = 'builtins' if float(mypy_version) >= 0.930 else '__builtins__'
+MYPY_VERSION = tuple(int(part) for part in mypy_version.split('+')[0].split('.'))
+BUILTINS_NAME = 'builtins' if MYPY_VERSION >= (0, 930) else '__builtins__'
 
 
 def plugin(version: str) -> 'TypingType[Plugin]':

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -61,7 +61,6 @@ from mypy.types import (
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 from mypy.version import __version__ as mypy_version
-from typing_extensions import Literal
 
 from pydantic.utils import is_valid_field
 
@@ -77,15 +76,13 @@ BASEMODEL_FULLNAME = 'pydantic.main.BaseModel'
 BASESETTINGS_FULLNAME = 'pydantic.env_settings.BaseSettings'
 FIELD_FULLNAME = 'pydantic.fields.Field'
 DATACLASS_FULLNAME = 'pydantic.dataclasses.dataclass'
-MYPY_VERSION: Tuple[int, ...]
-BUILTINS_NAME: Literal['builtins', '__builtins__'] = 'builtins'
 
 
-def _parse_version(version: str) -> Tuple[Tuple[int, ...], Literal['builtins', '__builtins__']]:
-    return (
-        tuple(int(part) for part in version.split('+', 1)[0].split('.')),
-        'builtins' if MYPY_VERSION >= (0, 930) else '__builtins__',
-    )
+def parse_mypy_version(version: str) -> Tuple[int, ...]:
+    return tuple(int(part) for part in version.split('+', 1)[0].split('.'))
+
+
+BUILTINS_NAME = 'builtins' if parse_mypy_version(mypy_version) >= (0, 930) else '__builtins__'
 
 
 def plugin(version: str) -> 'TypingType[Plugin]':
@@ -95,8 +92,6 @@ def plugin(version: str) -> 'TypingType[Plugin]':
     We might want to use this to print a warning if the mypy version being used is
     newer, or especially older, than we expect (or need).
     """
-    global MYPY_VERSION, BUILTINS_NAME
-    MYPY_VERSION, BUILTINS_NAME = _parse_version(version)
     return PydanticPlugin
 
 

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -61,6 +61,7 @@ from mypy.types import (
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 from mypy.version import __version__ as mypy_version
+from typing_extensions import Literal
 
 from pydantic.utils import is_valid_field
 
@@ -76,8 +77,15 @@ BASEMODEL_FULLNAME = 'pydantic.main.BaseModel'
 BASESETTINGS_FULLNAME = 'pydantic.env_settings.BaseSettings'
 FIELD_FULLNAME = 'pydantic.fields.Field'
 DATACLASS_FULLNAME = 'pydantic.dataclasses.dataclass'
-MYPY_VERSION = tuple(int(part) for part in mypy_version.split('+')[0].split('.'))
-BUILTINS_NAME = 'builtins' if MYPY_VERSION >= (0, 930) else '__builtins__'
+MYPY_VERSION: Tuple[int, ...]
+BUILTINS_NAME: Literal['builtins', '__builtins__'] = 'builtins'
+
+
+def _parse_version(version: str) -> Tuple[Tuple[int, ...], Literal['builtins', '__builtins__']]:
+    return (
+        tuple(int(part) for part in version.split('+', 1)[0].split('.')),
+        'builtins' if MYPY_VERSION >= (0, 930) else '__builtins__',
+    )
 
 
 def plugin(version: str) -> 'TypingType[Plugin]':
@@ -87,6 +95,8 @@ def plugin(version: str) -> 'TypingType[Plugin]':
     We might want to use this to print a warning if the mypy version being used is
     newer, or especially older, than we expect (or need).
     """
+    global MYPY_VERSION, BUILTINS_NAME
+    MYPY_VERSION, BUILTINS_NAME = _parse_version(version)
     return PydanticPlugin
 
 

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -7,10 +7,11 @@ import pytest
 
 try:
     from mypy import api as mypy_api
-    from mypy.version import __version__ as mypy_version
+
+    from pydantic.mypy import MYPY_VERSION
 except ImportError:
     mypy_api = None  # type: ignore
-    mypy_version = '0'
+    MYPY_VERSION = (0,)
 
 try:
     import dotenv
@@ -78,7 +79,7 @@ def test_mypy_results(config_filename: str, python_filename: str, output_filenam
     expected_out = Path(output_path).read_text().rstrip('\n') if output_path else ''
 
     # fix for compatibility between mypy versions: (this can be dropped once we drop support for mypy<0.930)
-    if actual_out and float(mypy_version) < 0.930:
+    if actual_out and MYPY_VERSION < (0, 930):
         actual_out = actual_out.lower()
         expected_out = expected_out.lower()
         actual_out = actual_out.replace('variant:', 'variants:')

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -5,13 +5,14 @@ from pathlib import Path
 
 import pytest
 
+from pydantic.mypy import parse_mypy_version
+
 try:
     from mypy import api as mypy_api
-
-    from pydantic.mypy import MYPY_VERSION
+    from mypy.version import __version__ as mypy_version
 except ImportError:
     mypy_api = None  # type: ignore
-    MYPY_VERSION = (0,)
+    mypy_version = '0'
 
 try:
     import dotenv
@@ -79,7 +80,7 @@ def test_mypy_results(config_filename: str, python_filename: str, output_filenam
     expected_out = Path(output_path).read_text().rstrip('\n') if output_path else ''
 
     # fix for compatibility between mypy versions: (this can be dropped once we drop support for mypy<0.930)
-    if actual_out and MYPY_VERSION < (0, 930):
+    if actual_out and parse_mypy_version(mypy_version) < (0, 930):
         actual_out = actual_out.lower()
         expected_out = expected_out.lower()
         actual_out = actual_out.replace('variant:', 'variants:')
@@ -123,3 +124,15 @@ def test_explicit_reexports() -> None:
     for name, export_all in [('main', main), ('network', networks), ('tools', tools), ('types', types)]:
         for export in export_all:
             assert export in root_all, f'{export} is in {name}.__all__ but missing from re-export in __init__.py'
+
+
+@pytest.mark.parametrize(
+    'v_str,v_tuple',
+    [
+        ('0', (0,)),
+        ('0.930', (0, 930)),
+        ('0.940+dev.04cac4b5d911c4f9529e6ce86a27b44f28846f5d.dirty', (0, 940)),
+    ],
+)
+def test_parse_mypy_version(v_str, v_tuple):
+    assert parse_mypy_version(v_str) == v_tuple


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Basically the mypy plugin is broken with any dev version of mypy, I changed how the version number is parsed.

```
>mypy --version 
mypy 0.940+dev.04cac4b5d911c4f9529e6ce86a27b44f28846f5d.dirty

>mypy test.py       
pyproject.toml:1: error: Error importing plugin "pydantic.mypy": could not convert string to float: 
Found 1 error in 1 file (errors prevented further checking)
```

Also mypy will switch to a version number like `x.y.z` which the current check will fail on. It will be better to future proof this check to prevent a sudden wave of reports of "could not convert string to float".

## Related issue number

N/A
<!-- Are there any issues opened that will be resolved by merging this change? --> 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [N/A] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
