### PR TITLE
Don't override `__init__` method in MyPy plugin if it already exists

### DIFF
--- a/changes/3824-patrick91.md
+++ b/changes/3824-patrick91.md
@@ -1,0 +1,1 @@
+Fix MyPy plugin to not override pre-existing `__init__` method in models.

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -392,7 +392,9 @@ class PydanticModelTransformer:
         if not self.should_init_forbid_extra(fields, config):
             var = Var('kwargs')
             init_arguments.append(Argument(var, AnyType(TypeOfAny.explicit), None, ARG_STAR2))
-        add_method(ctx, '__init__', init_arguments, NoneType())
+
+        if '__init__' not in ctx.cls.info.names:
+            add_method(ctx, '__init__', init_arguments, NoneType())
 
     def add_construct_method(self, fields: List['PydanticModelField']) -> None:
         """
@@ -708,7 +710,7 @@ def add_method(
     if name in info.names:
         sym = info.names[name]
         if sym.plugin_generated and isinstance(sym.node, FuncDef):
-            ctx.cls.defs.body.remove(sym.node)
+            ctx.cls.defs.body.remove(sym.node)  # pragma: no cover
 
     self_type = self_type or fill_typevars(info)
     if is_classmethod or is_new:

--- a/tests/mypy/modules/custom_constructor.py
+++ b/tests/mypy/modules/custom_constructor.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class Person(BaseModel):
+    id: int
+    name: str
+    birth_year: int
+
+    def __init__(self, id: int) -> None:
+        super().__init__(id=id, name='Patrick', birth_year=1991)
+
+
+Person(1)
+Person(id=1)
+Person(name='Patrick')

--- a/tests/mypy/outputs/custom_constructor.txt
+++ b/tests/mypy/outputs/custom_constructor.txt
@@ -1,0 +1,2 @@
+9: note: "Person" defined here
+15: error: Unexpected keyword argument "name" for "Person"  [call-arg]

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -23,6 +23,7 @@ os.chdir(Path(__file__).parent.parent.parent)
 cases = [
     ('mypy-plugin.ini', 'plugin_success.py', None),
     ('mypy-plugin.ini', 'plugin_fail.py', 'plugin-fail.txt'),
+    ('mypy-plugin.ini', 'custom_constructor.py', 'custom_constructor.txt'),
     ('mypy-plugin-strict.ini', 'plugin_success.py', 'plugin-success-strict.txt'),
     ('mypy-plugin-strict.ini', 'plugin_fail.py', 'plugin-fail-strict.txt'),
     ('mypy-plugin-strict.ini', 'fail_defaults.py', 'fail_defaults.txt'),


### PR DESCRIPTION
## Change Summary

This PR updates the MyPy plugin to not override the `__init__` method if there's already one in the model.

Here's an example of the current issue:

https://replit.com/@patrick91/AngryThoseMath#main.py

running `mypy main.py` returns the following:

```
main.py:13: error: Too many positional arguments for "Person"
main.py:13: error: Missing named argument "name" for "Person"
main.py:13: error: Missing named argument "birth_year" for "Person"
main.py:15: note: Revealed type is "def (*, id: Any, name: Any, birth_year: Any, **kwargs: Any) -> main.Person"
main.py:16: note: Revealed type is "def (__pydantic_self__: main.Person, *, id: Any, name: Any, birth_year: Any, **kwargs: Any)"
```

while the code works since we have a custom constructor:

```python
from pydantic import BaseModel


class Person(BaseModel):
    id: int
    name: str
    birth_year: int

    def __init__(self, id: int) -> None:
        super().__init__(id=id, name="Patrick", birth_year=1991)


print(Person(1))

reveal_type(Person)
reveal_type(Person.__init__)

```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
