### PR TITLE
speed up __eq__

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -870,6 +870,9 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         return keys
 
     def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+
         if isinstance(other, BaseModel):
             return self.dict() == other.dict()
         else:


### PR DESCRIPTION
Please don't merge right away I think I can speed up a lot more. 

__eq__ is written really simple and can be greatly speed up. This one line resulted in about 5000x times faster comparison for cases of is the same object. Breaking up the .dict() into generators and checking keys one at a time would results in significantly faster code for one of the most common expressions used. I have to verify order integrity and a few other things but there is likely a lot that can be done for this method and result in MUCH faster code. Including but not limited to, tracking len, smart search optimization (simple types first), and some other hash based fuckery. 