### PR TITLE
Fix mypy version number parsing.

### DIFF
--- a/changes/3845-danalbert.md
+++ b/changes/3845-danalbert.md
@@ -1,0 +1,2 @@
+Fixed mypy version parsing in the plugin. Ordering is now correct and compatible
+with development versions of mypy.

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -62,13 +62,23 @@ except ImportError:  # pragma: no cover
     # Backward-compatible with TypeVarDef from Mypy 0.910.
     from mypy.types import TypeVarType as TypeVarDef
 
+
+def _parse_mypy_version(mypy_version: str) -> Tuple[int, ...]:
+    # mypy release versions are . separated. Development versions are suffixed
+    # with +dev, and development versions from git are further suffixed with a
+    # git SHA. A full example:
+    # 0.940+dev.2d30dbaa34eab9d7519e440480f360fc9a1e65c3
+    non_dev_version = mypy_version.split('+')[0]
+    return tuple(int(c) for c in non_dev_version.split('.'))
+
+
 CONFIGFILE_KEY = 'pydantic-mypy'
 METADATA_KEY = 'pydantic-mypy-metadata'
 BASEMODEL_FULLNAME = 'pydantic.main.BaseModel'
 BASESETTINGS_FULLNAME = 'pydantic.env_settings.BaseSettings'
 FIELD_FULLNAME = 'pydantic.fields.Field'
 DATACLASS_FULLNAME = 'pydantic.dataclasses.dataclass'
-BUILTINS_NAME = 'builtins' if float(mypy_version) >= 0.930 else '__builtins__'
+BUILTINS_NAME = 'builtins' if _parse_mypy_version(mypy_version) >= (0, 930) else '__builtins__'
 
 
 def plugin(version: str) -> 'TypingType[Plugin]':

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -120,3 +120,12 @@ def test_explicit_reexports() -> None:
     for name, export_all in [('main', main), ('network', networks), ('tools', tools), ('types', types)]:
         for export in export_all:
             assert export in root_all, f'{export} is in {name}.__all__ but missing from re-export in __init__.py'
+
+
+@pytest.mark.skipif(not (dotenv and mypy_api), reason='dotenv or mypy are not installed')
+def test_version_parsing() -> None:
+    from pydantic.mypy import _parse_mypy_version
+
+    assert _parse_mypy_version('0.930') == (0, 930)
+    assert _parse_mypy_version('0.930.1') == (0, 930, 1)
+    assert _parse_mypy_version('0.940+dev.2d30dbaa34eab9d7519e440480f360fc9a1e65c3') == (0, 940)


### PR DESCRIPTION
## Change Summary

This fixes the parsing for mypy version numbers. Float parsing is not correct for comparing version numbers (1.10 should
be greater than 1.2). Python's tuple comparison works well for version comparison.

Unreleased versions of mypy (which must be tested before filing mypy bugs) contain further information as well. Strip off the excess, convert to a tuple of ints, and compare.

## Related issue number

None, trivial?

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
