### PR TITLE
fix: access discriminator field on BaseModel instance using key

### DIFF
--- a/changes/3846-chornsby.md
+++ b/changes/3846-chornsby.md
@@ -1,0 +1,1 @@
+Fix validation of discriminated union fields with an alias when passing a model instance

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1086,7 +1086,7 @@ class ModelField(Representation):
         except TypeError:
             try:
                 # BaseModel or dataclass
-                discriminator_value = getattr(v, self.discriminator_alias)
+                discriminator_value = getattr(v, self.discriminator_key)
             except (AttributeError, TypeError):
                 return v, ErrorWrapper(MissingDiscriminator(discriminator_key=self.discriminator_key), loc)
 

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -267,6 +267,24 @@ def test_discriminated_union_basemodel_instance_value():
     assert isinstance(t, Top)
 
 
+def test_discriminated_union_basemodel_instance_value_with_alias():
+    class A(BaseModel):
+        literal: Literal['a'] = Field(alias='lit')
+
+    class B(BaseModel):
+        literal: Literal['b'] = Field(alias='lit')
+
+        class Config:
+            allow_population_by_field_name = True
+
+    class Top(BaseModel):
+        sub: Union[A, B] = Field(..., discriminator='literal')
+
+    assert Top(sub=A(lit='a')).sub.literal == 'a'
+    assert Top(sub=B(lit='b')).sub.literal == 'b'
+    assert Top(sub=B(literal='b')).sub.literal == 'b'
+
+
 def test_discriminated_union_int():
     class A(BaseModel):
         l: Literal[1]


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

When validating a discriminated union where the union value has been passed as a Pydantic model instance, it appears that the _validate_discriminated_union function is trying to access the value of the discriminator field via its alias. Since the alias does not exist on the model as an attribute, the validation fails.

I believe this is the result of a tiny mistake when setting up the _validate_discriminated_union function and that whenever a BaseModel or dataclass is detected then we should use the discriminator key and not the alias to access the discriminator value.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #3846

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
