### PR TITLE
Fix StrictBool etc. constructors should return base types

### DIFF
--- a/changes/2329-spookylukey.md
+++ b/changes/2329-spookylukey.md
@@ -1,0 +1,1 @@
+Fix StrictBool, StrictInt, StrictFloat, StrictStr, StrictBytes constructors to return instances of the base class

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -167,6 +167,9 @@ else:
         StrictBool to allow for bools which are not type-coerced.
         """
 
+        def __new__(self, value=False):
+            return bool(value)
+
         @classmethod
         def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
             field_schema.update(type='boolean')
@@ -246,6 +249,12 @@ else:
     class StrictInt(ConstrainedInt):
         strict = True
 
+        def __new__(cls, value=0):
+            if cls is StrictInt:
+                return int(value)
+            else:
+                return super().__new__(cls, value)
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FLOAT TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -322,6 +331,12 @@ else:
     class StrictFloat(ConstrainedFloat):
         strict = True
 
+        def __new__(cls, value=0.0):
+            if cls is StrictFloat:
+                return float(value)
+            else:
+                return super().__new__(cls, value)
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ BYTES TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -370,6 +385,12 @@ else:
 
     class StrictBytes(ConstrainedBytes):
         strict = True
+
+        def __new__(cls, value=b''):
+            if cls is StrictBytes:
+                return bytes(value)
+            else:
+                return super().__new__(cls, value)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ STRING TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -442,6 +463,12 @@ else:
 
     class StrictStr(ConstrainedStr):
         strict = True
+
+        def __new__(cls, value=''):
+            if cls is StrictStr:
+                return str(value)
+            else:
+                return super().__new__(cls, value)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SET TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3206,3 +3206,43 @@ def test_future_date_validation_fails(value):
             'type': 'value_error.date.not_in_the_future',
         }
     ]
+
+
+# Issue 2329 - Strict* types should be drop in replacements for normal types,
+# so their constructors should produce the same type of objects.
+# 'isinstance' is weakest test, so comes first.
+# 'type' check is next.
+# 'is' check on values is tightest, only possible for some.
+# '==' check is for default values
+
+
+def test_strict_bool_constructor():
+    assert isinstance(StrictBool(bool), bool)
+    assert type(StrictBool(bool)) is bool
+    assert StrictBool(True) is True
+    assert StrictBool(False) is False
+    assert StrictBool() == bool()
+
+
+def test_strict_float_constructor():
+    assert isinstance(StrictFloat(1), float)
+    assert type(StrictFloat(1)) is float
+    assert StrictFloat() == float()
+
+
+def test_strict_int_constructor():
+    assert isinstance(StrictInt(1), int)
+    assert type(StrictInt(1)) is int
+    assert StrictInt() == int()
+
+
+def test_strict_bytes_constructor():
+    assert isinstance(StrictBytes(b''), bytes)
+    assert type(StrictBytes(b'')) is bytes
+    assert StrictBytes() == bytes()
+
+
+def test_strict_str_constructor():
+    assert isinstance(StrictStr(''), str)
+    assert type(StrictStr('')) is str
+    assert StrictStr() == str()


### PR DESCRIPTION
This PR changes the constructors of `StrictBool`, `StrictInt`, `StrictFloat`, `StrictBytes` and `StrictStr` so that they return the base types instead of a subclass. The motivation for this is on #2329 

In terms of implementation. For `StrictInt` etc, there were tests that ensured that subclassing worked: https://github.com/samuelcolvin/pydantic/blob/d7a8272d7e0c151b0bd43df596be02e0d436ebdf/tests/test_types.py#L1682

I'm not sure why this is needed, but to preserve that behaviour the implementation was constrained such that the change only affects `StrictInt`, and not further subclasses. The logic here is that if you go from `int` to `StrictInt`, the only behaviour change you expect is stricter validation, as mentioned in the ticket. If you have your own further subclass, you presumably have other behaviour you want, and you are responsible for that yourself.

`StrictBool` is a slight exception to this:
- it doesn't inherit from `bool`, but `int` (it seems it's not possible to inherit from `bool`)
- there were no tests for subclassing `StrictBool`
- it's difficult to imagine a use case for subclassing bool

So for `StrictBool.__new__` only, we unconditionally defer to `bool.__new__`.


## Checks

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable - not needed
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review