### PR TITLE
Fix #3899: add correct handling for negative time deltas

### DIFF
--- a/changes/3899-07pepa.md
+++ b/changes/3899-07pepa.md
@@ -1,0 +1,2 @@
+Fix incorrect deserialization of python timedelta object to ISO 8601 for negative time deltas.
+Minus was serialized in incorrect place ("P-1DT23H59M59.888735S" instead of correct "-P1DT23H59M59.888735S")

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -105,8 +105,8 @@ def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]]
 
 def timedelta_isoformat(td: datetime.timedelta) -> str:
     """
-    ISO 8601 encoding for timedeltas.
+    ISO 8601 encoding for Python timedelta object.
     """
     minutes, seconds = divmod(td.seconds, 60)
     hours, minutes = divmod(minutes, 60)
-    return f'P{td.days}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S'
+    return f'{"-" if td.days < 0 else ""}P{abs(td.days)}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -46,6 +46,7 @@ class MyEnum(Enum):
         (datetime.datetime(2032, 1, 1), '"2032-01-01T00:00:00"'),
         (datetime.time(12, 34, 56), '"12:34:56"'),
         (datetime.timedelta(days=12, seconds=34, microseconds=56), '1036834.000056'),
+        (datetime.timedelta(seconds=-1), '-1.0'),
         ({1, 2, 3}, '[1, 2, 3]'),
         (frozenset([1, 2, 3]), '[1, 2, 3]'),
         ((v for v in range(4)), '[0, 1, 2, 3]'),
@@ -142,6 +143,8 @@ def test_invalid_model():
     [
         (datetime.timedelta(days=12, seconds=34, microseconds=56), 'P12DT0H0M34.000056S'),
         (datetime.timedelta(days=1001, hours=1, minutes=2, seconds=3, microseconds=654_321), 'P1001DT1H2M3.654321S'),
+        (datetime.timedelta(seconds=-1), '-P1DT23H59M59.000000S'),
+        (datetime.timedelta(), 'P0DT0H0M0.000000S'),
     ],
 )
 def test_iso_timedelta(input, output):


### PR DESCRIPTION
## Change Summary
* make [timedelta_isoformat](https://github.com/samuelcolvin/pydantic/blob/d7a8272d7e0c151b0bd43df596be02e0d436ebdf/pydantic/json.py#L106) ISO 8601 compilant for negative values
* add test to verify functionality

## Related issue number
fix #3899 

## Checklist
* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
