### PR TITLE
Fix #3807: matching characters in nested env delimeter and env prefix

### DIFF
--- a/changes/3975-arsenron.md
+++ b/changes/3975-arsenron.md
@@ -1,1 +1,1 @@
-fix 3807 - Remove undefined behaviour when `env_prefix` had characters in common with `env_nested_delimiter`
+Remove undefined behaviour when `env_prefix` had characters in common with `env_nested_delimiter`

--- a/changes/3975-arsenron.md
+++ b/changes/3975-arsenron.md
@@ -1,0 +1,1 @@
+fix 3807 - Remove undefined behaviour when `env_prefix` had characters in common with `env_nested_delimiter`

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -63,6 +63,7 @@ class BaseSettings(BaseModel):
             env_nested_delimiter=(
                 _env_nested_delimiter if _env_nested_delimiter is not None else self.__config__.env_nested_delimiter
             ),
+            env_prefix=self.__config__.env_prefix,
         )
         file_secret_settings = SecretsSettingsSource(secrets_dir=_secrets_dir or self.__config__.secrets_dir)
         # Provide a hook to set built-in sources priority and add / remove sources
@@ -142,14 +143,19 @@ class InitSettingsSource:
 
 
 class EnvSettingsSource:
-    __slots__ = ('env_file', 'env_file_encoding', 'env_nested_delimiter')
+    __slots__ = ('env_file', 'env_file_encoding', 'env_nested_delimiter', 'env_prefix')
 
     def __init__(
-        self, env_file: Optional[StrPath], env_file_encoding: Optional[str], env_nested_delimiter: Optional[str] = None
+        self,
+        env_file: Optional[StrPath],
+        env_file_encoding: Optional[str],
+        env_nested_delimiter: Optional[str] = None,
+        env_prefix: str = '',
     ):
         self.env_file: Optional[StrPath] = env_file
         self.env_file_encoding: Optional[str] = env_file_encoding
         self.env_nested_delimiter: Optional[str] = env_nested_delimiter
+        self.env_prefix: str = env_prefix
 
     def __call__(self, settings: BaseSettings) -> Dict[str, Any]:  # noqa C901
         """
@@ -228,7 +234,8 @@ class EnvSettingsSource:
         for env_name, env_val in env_vars.items():
             if not any(env_name.startswith(prefix) for prefix in prefixes):
                 continue
-            _, *keys, last_key = env_name.split(self.env_nested_delimiter)
+            env_name_without_prefix = env_name[len(self.env_prefix) :]
+            _, *keys, last_key = env_name_without_prefix.split(self.env_nested_delimiter)
             env_var = result
             for key in keys:
                 env_var = env_var.setdefault(key, {})

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -234,6 +234,7 @@ class EnvSettingsSource:
         for env_name, env_val in env_vars.items():
             if not any(env_name.startswith(prefix) for prefix in prefixes):
                 continue
+            # we remove the prefix before splitting in case the prefix has characters in common with the delimiter
             env_name_without_prefix = env_name[self.env_prefix_len :]
             _, *keys, last_key = env_name_without_prefix.split(self.env_nested_delimiter)
             env_var = result

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -63,7 +63,7 @@ class BaseSettings(BaseModel):
             env_nested_delimiter=(
                 _env_nested_delimiter if _env_nested_delimiter is not None else self.__config__.env_nested_delimiter
             ),
-            env_prefix=self.__config__.env_prefix,
+            env_prefix_len=len(self.__config__.env_prefix),
         )
         file_secret_settings = SecretsSettingsSource(secrets_dir=_secrets_dir or self.__config__.secrets_dir)
         # Provide a hook to set built-in sources priority and add / remove sources
@@ -143,19 +143,19 @@ class InitSettingsSource:
 
 
 class EnvSettingsSource:
-    __slots__ = ('env_file', 'env_file_encoding', 'env_nested_delimiter', 'env_prefix')
+    __slots__ = ('env_file', 'env_file_encoding', 'env_nested_delimiter', 'env_prefix_len')
 
     def __init__(
         self,
         env_file: Optional[StrPath],
         env_file_encoding: Optional[str],
         env_nested_delimiter: Optional[str] = None,
-        env_prefix: str = '',
+        env_prefix_len: int = 0,
     ):
         self.env_file: Optional[StrPath] = env_file
         self.env_file_encoding: Optional[str] = env_file_encoding
         self.env_nested_delimiter: Optional[str] = env_nested_delimiter
-        self.env_prefix: str = env_prefix
+        self.env_prefix_len: int = env_prefix_len
 
     def __call__(self, settings: BaseSettings) -> Dict[str, Any]:  # noqa C901
         """
@@ -234,7 +234,7 @@ class EnvSettingsSource:
         for env_name, env_val in env_vars.items():
             if not any(env_name.startswith(prefix) for prefix in prefixes):
                 continue
-            env_name_without_prefix = env_name[len(self.env_prefix) :]
+            env_name_without_prefix = env_name[self.env_prefix_len :]
             _, *keys, last_key = env_name_without_prefix.split(self.env_nested_delimiter)
             env_var = result
             for key in keys:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -134,6 +134,33 @@ def test_nested_env_delimiter(env):
     }
 
 
+def test_nested_env_delimiter_with_prefix(env):
+    class Subsettings(BaseSettings):
+        banana: str
+
+    class Settings(BaseSettings):
+        subsettings: Subsettings
+
+        class Config:
+            env_nested_delimiter = '_'
+            env_prefix = 'myprefix_'
+
+    env.set('myprefix_subsettings_banana', 'banana')
+    s = Settings()
+    assert s.subsettings.banana == 'banana'
+
+    class Settings(BaseSettings):
+        subsettings: Subsettings
+
+        class Config:
+            env_nested_delimiter = '_'
+            env_prefix = 'myprefix__'
+
+    env.set('myprefix__subsettings_banana', 'banana')
+    s = Settings()
+    assert s.subsettings.banana == 'banana'
+
+
 def test_nested_env_delimiter_complex_required(env):
     class Cfg(BaseSettings):
         v: str = 'default'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
Hi! It is my first pull request to the project which I really, really appreciate :) The problem is when characters in ```env_prefix``` and ```env_nested_delimiter``` match, it occurs an unexpected behaviour as the initial splitting was wrong in this case.

I added a new ```env_prefix``` field to ```EnvSettingsSource``` to fix the issue without parsing ```ModelField``` which I think can create a little "code mess".

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #3807

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
