### PR TITLE
Fix #1458 - Allow for custom parsing of environment variables via env_parse

### DIFF
--- a/changes/3977-acmiyaguchi.md
+++ b/changes/3977-acmiyaguchi.md
@@ -1,0 +1,1 @@
+Allow for custom parsing of environment variables via `env_parse` in `Field`.

--- a/docs/examples/settings_with_custom_parsing.py
+++ b/docs/examples/settings_with_custom_parsing.py
@@ -1,0 +1,17 @@
+# output-json
+import os
+from typing import List
+
+from pydantic import BaseSettings, Field
+
+
+def parse_list(s: str) -> List[int]:
+    return [int(x.strip()) for x in s.split(',')]
+
+
+class Settings(BaseSettings):
+    numbers: List[int] = Field(env_parse=parse_list)
+
+
+os.environ['numbers'] = '1,2,3'
+print(Settings().dict())

--- a/docs/examples/settings_with_custom_parsing_validator.py
+++ b/docs/examples/settings_with_custom_parsing_validator.py
@@ -1,0 +1,17 @@
+# output-json
+import os
+from typing import List
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    numbers: List[int] = Field(env_parse=str)
+
+    @validator('numbers', pre=True)
+    def validate_numbers(cls, s):
+        return [int(x.strip()) for x in s.split(',')]
+
+
+os.environ['numbers'] = '1,2,3'
+print(Settings().dict())

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -99,16 +99,12 @@ Nested environment variables take precedence over the top-level environment vari
 You may also populate a complex type by providing your own parsing function to
 `env_parse` in the field extras.
 
-```py
 {!.tmp_examples/settings_with_custom_parsing.py!}
-```
 
 You might choose to pass the environment string value through to pydantic and
 transform in a validator instead.
 
-```py
 {!.tmp_examples/settings_with_custom_parsing_validator.py!}
-```
 
 
 ## Dotenv (.env) support

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -99,12 +99,12 @@ Nested environment variables take precedence over the top-level environment vari
 You may also populate a complex type by providing your own parsing function to
 `env_parse` in the field extras.
 
-{!.tmp_examples/settings_with_custom_parsing.py!}
+{!.tmp_examples/settings_with_custom_parsing.md!}
 
 You might choose to pass the environment string value through to pydantic and
 transform in a validator instead.
 
-{!.tmp_examples/settings_with_custom_parsing_validator.py!}
+{!.tmp_examples/settings_with_custom_parsing_validator.md!}
 
 
 ## Dotenv (.env) support

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -87,7 +87,7 @@ export SUB_MODEL__DEEP__V4=v4
 You could load a settings module thus:
 {!.tmp_examples/settings_nested_env.md!}
 
-`env_nested_delimiter` can be configured via the `Config` class as shown above, or via the 
+`env_nested_delimiter` can be configured via the `Config` class as shown above, or via the
 `_env_nested_delimiter` keyword argument on instantiation.
 
 JSON is only parsed in top-level fields, if you need to parse JSON in sub-models, you will need to implement
@@ -95,6 +95,21 @@ validators on those models.
 
 Nested environment variables take precedence over the top-level environment variable JSON
 (e.g. in the example above, `SUB_MODEL__V2` trumps `SUB_MODEL`).
+
+You may also populate a complex type by providing your own parsing function to
+`env_parse` in the field extras.
+
+```py
+{!.tmp_examples/settings_with_custom_parsing.py!}
+```
+
+You might choose to pass the environment string value through to pydantic and
+transform in a validator instead.
+
+```py
+{!.tmp_examples/settings_with_custom_parsing_validator.py!}
+```
+
 
 ## Dotenv (.env) support
 
@@ -178,7 +193,7 @@ see [python-dotenv's documentation](https://saurabh-kumar.com/python-dotenv/#usa
 
 Placing secret values in files is a common pattern to provide sensitive configuration to an application.
 
-A secret file follows the same principal as a dotenv file except it only contains a single value and the file name 
+A secret file follows the same principal as a dotenv file except it only contains a single value and the file name
 is used as the key. A secret file will look like the following:
 
 `/var/run/database_password`:
@@ -231,7 +246,7 @@ class Settings(BaseSettings):
         secrets_dir = '/run/secrets'
 ```
 !!! note
-    By default Docker uses `/run/secrets` as the target mount point. If you want to use a different location, change 
+    By default Docker uses `/run/secrets` as the target mount point. If you want to use a different location, change
     `Config.secrets_dir` accordingly.
 
 Then, create your secret via the Docker CLI

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -195,7 +195,6 @@ class EnvSettingsSource:
                         'env_parse', settings.__config__.json_loads
                     )
                     try:
-                        print(parse_func)
                         env_val = parse_func(env_val)
                     except ValueError as e:
                         if not allow_json_failure:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This PR adds an `env_parse` extra into Fields to allow for custom parsing of the environment within Settings. This is useful when specifying a custom format in environment strings e.g. lists (`1,2,3`) or key-value pairs (`a=1,b=2,c=3`). String-encoded JSON is not ideal in certain situations, such as when the environment is specified inside of a YAML file (leading to string-escaped string-encoded JSON). 

## Related issue number

fixes #1458

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
