### PR TITLE
Adds reserved word check to signature generation logic.

### DIFF
--- a/changes/4011-strue36.md
+++ b/changes/4011-strue36.md
@@ -1,0 +1,1 @@
+Adds reserved word check to signature generation logic.

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -1,3 +1,4 @@
+import keyword
 import warnings
 import weakref
 from collections import OrderedDict, defaultdict, deque
@@ -56,6 +57,7 @@ __all__ = (
     'lenient_isinstance',
     'lenient_issubclass',
     'in_ipython',
+    'is_valid_identifier',
     'deep_update',
     'update_not_none',
     'almost_equal_floats',
@@ -192,6 +194,15 @@ def in_ipython() -> bool:
         return True
 
 
+def is_valid_identifier(identifier: str) -> bool:
+    """
+    Checks that a string is a valid identifier and not a reserved word.
+    :param identifier: The identifier to test.
+    :return: True if the identifier is valid.
+    """
+    return identifier.isidentifier() and not keyword.iskeyword(identifier)
+
+
 KeyType = TypeVar('KeyType')
 
 
@@ -244,8 +255,8 @@ def generate_model_signature(
             param_name = field.alias
             if field_name in merged_params or param_name in merged_params:
                 continue
-            elif not param_name.isidentifier():
-                if allow_names and field_name.isidentifier():
+            elif not is_valid_identifier(param_name):
+                if allow_names and is_valid_identifier(field_name):
                     param_name = field_name
                 else:
                     use_var_kw = True

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -196,7 +196,7 @@ def in_ipython() -> bool:
 
 def is_valid_identifier(identifier: str) -> bool:
     """
-    Checks that a string is a valid identifier and not a reserved word.
+    Checks that a string is a valid identifier and not a Python keyword.
     :param identifier: The identifier to test.
     :return: True if the identifier is valid.
     """

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -84,6 +84,16 @@ def test_use_field_name():
     assert _equals(str(signature(Foo)), '(*, foo: str) -> None')
 
 
+def test_does_not_use_reserved_word():
+    class Foo(BaseModel):
+        from_: str = Field(..., alias='from')
+
+        class Config:
+            allow_population_by_field_name = True
+
+    assert _equals(str(signature(Foo)), '(*, from_: str) -> None')
+
+
 def test_extra_allow_no_conflict():
     class Model(BaseModel):
         spam: str


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Adds a check within `utils.generate_model_signature()` to treat reserved words as invalid identifiers.

## Related issue number

fix #4011"

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
