### PR TITLE
fix corner case for NoneType in __root__

### DIFF
--- a/changes/4066-mike0sv.md
+++ b/changes/4066-mike0sv.md
@@ -1,0 +1,1 @@
+Fix edge case with `NoneType` as `__root__` field type

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -839,7 +839,12 @@ class ModelField(Representation):
                 return v, errors
 
         if v is None:
-            if is_none_type(self.type_):
+            if (
+                is_none_type(self.type_)
+                or hasattr(self.type_, '__fields__')
+                and '__root__' in self.type_.__fields__
+                and is_none_type(self.type_.__fields__['__root__'].type_)
+            ):
                 # keep validating
                 pass
             elif self.allow_none:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -16,6 +16,7 @@ from pydantic import (
     ValidationError,
     constr,
     errors,
+    parse_obj_as,
     validate_model,
     validator,
 )
@@ -1932,3 +1933,16 @@ def test_int_subclass():
 
     m = MyModel(my_int=IntSubclass(123))
     assert m.my_int.__class__ == IntSubclass
+
+
+def test_none_type_root():
+    class NoneModel(BaseModel):
+        __root__: type(None)
+
+    class MyModel(BaseModel):
+        my_none: NoneModel
+
+    m = MyModel(my_none=None)
+    assert m.dict()['my_none'] is None
+    m = parse_obj_as(MyModel, {'my_none': None})
+    assert m.dict()['my_none'] is None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

I faced this edge case where I need to use a Model with `NoneType` for `__root__` field. It failed validation since `None` value is not allowed for this field. I fixed this check to allow it.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
