### PR TITLE
Support cross-process pickling of Pydantic-wrapped built-in dataclasses

### DIFF
--- a/changes/4084-iammaart.md
+++ b/changes/4084-iammaart.md
@@ -1,0 +1,1 @@
+Support cross-process pickling of built-in dataclasses wrapped by Pydantic

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -927,13 +927,13 @@ def test_cross_process_picklability_of_overriden_builtin_dataclasses(create_modu
 
     source_obj = ModelForCrossProcessPickle(dataclass=BuiltinDataclassForCrossProcessPickle(value=123))
 
-    # Fix multiprocessing start method for cross platforms consistency
-    # testing 'spawn' is most rigorous in this case
+    # Prescribe the multiprocessing start method for cross-platforms consistency.
+    # 'spawn' makes for the most rigorous as well as compatible test in this case
     mp_context = multiprocessing.get_context('spawn')
     with ProcessPoolExecutor(mp_context=mp_context) as executor:
         # Pickle the source_obj in a different process (a worker of the executor)
         # (transmitting source_obj to the worker happens through pickle, so it
-        # this happens to test both directions)
+        # happens to test both directions)
         serialized_obj = executor.submit(pickle.dumps, source_obj).result()
 
     revived = pickle.loads(serialized_obj)


### PR DESCRIPTION
## Change Summary

Pull request https://github.com/samuelcolvin/pydantic/pull/2114 has added support for picking built-in dataclasses that are used as fields in Pydantic models (or ones that are directly wrapped by `pydantic.dataclasses.dataclass`). However, the currently implemented solution only works within a single Python process.

The problem is that Pydantic dynamically creates wrapper classes for the built-in dataclasses and assigns names to them based on `id(origninal_class)`. These generated names will be different for each invocation of the Python interpreter. In a multiprocessing setting, or even for different runs of the same code, pickle won't be able to find the right class to unpickle to as a result.

This change adds support for cross-process pickling by making the generated class names deterministic.

As explained in [my analysis of issue #3453](https://github.com/samuelcolvin/pydantic/issues/3453#issuecomment-1126065386), pickling will still not work properly across different processes in some scenarios. This could either be considered a separate issue, or this PR is only a partial fix for https://github.com/samuelcolvin/pydantic/issues/3453.

## Related issue number

Fix #3453

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
