### PR TITLE
mypy plugin: More precisely detect when fields are required.

### DIFF
--- a/changes/4086-richardxia.md
+++ b/changes/4086-richardxia.md
@@ -1,0 +1,1 @@
+Improve mypy plugin's ability to detect required fields.

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -435,8 +435,15 @@ class PydanticModelTransformer:
             return True
         if isinstance(expr, CallExpr) and isinstance(expr.callee, RefExpr) and expr.callee.fullname == FIELD_FULLNAME:
             # The "default value" is a call to `Field`; at this point, the field is
-            # only required if default is Ellipsis (i.e., `field_name: Annotation = Field(...)`)
-            return len(expr.args) > 0 and expr.args[0].__class__ is EllipsisExpr
+            # only required if default is Ellipsis (i.e., `field_name: Annotation = Field(...)`) or if default_factory
+            # is specified.
+            for arg, name in zip(expr.args, expr.arg_names):
+                # If name is None, then this arg is the default because it is the only positonal argument.
+                if name is None or name == 'default':
+                    return arg.__class__ is EllipsisExpr
+                if name == 'default_factory':
+                    return False
+            return True
         # Only required if the "default value" is Ellipsis (i.e., `field_name: Annotation = ...`)
         return isinstance(expr, EllipsisExpr)
 

--- a/tests/mypy/modules/fail_defaults.py
+++ b/tests/mypy/modules/fail_defaults.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field
+
+
+class Model(BaseModel):
+    # Required
+    undefined_default_no_args: int = Field()
+    undefined_default: int = Field(description='my desc')
+    positional_ellipsis_default: int = Field(...)
+    named_ellipsis_default: int = Field(default=...)
+
+    # Not required
+    positional_default: int = Field(1)
+    named_default: int = Field(default=2)
+    named_default_factory: int = Field(default_factory=lambda: 3)
+
+
+Model()

--- a/tests/mypy/outputs/fail_defaults.txt
+++ b/tests/mypy/outputs/fail_defaults.txt
@@ -1,0 +1,4 @@
+17: error: Missing named argument "undefined_default_no_args" for "Model"  [call-arg]
+17: error: Missing named argument "undefined_default" for "Model"  [call-arg]
+17: error: Missing named argument "positional_ellipsis_default" for "Model"  [call-arg]
+17: error: Missing named argument "named_ellipsis_default" for "Model"  [call-arg]

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -25,6 +25,7 @@ cases = [
     ('mypy-plugin.ini', 'plugin_fail.py', 'plugin-fail.txt'),
     ('mypy-plugin-strict.ini', 'plugin_success.py', 'plugin-success-strict.txt'),
     ('mypy-plugin-strict.ini', 'plugin_fail.py', 'plugin-fail-strict.txt'),
+    ('mypy-plugin-strict.ini', 'fail_defaults.py', 'fail_defaults.txt'),
     ('mypy-default.ini', 'success.py', None),
     ('mypy-default.ini', 'fail1.py', 'fail1.txt'),
     ('mypy-default.ini', 'fail2.py', 'fail2.txt'),
@@ -40,6 +41,7 @@ cases = [
     ('pyproject-plugin.toml', 'plugin_fail.py', 'plugin-fail.txt'),
     ('pyproject-plugin-strict.toml', 'plugin_success.py', 'plugin-success-strict.txt'),
     ('pyproject-plugin-strict.toml', 'plugin_fail.py', 'plugin-fail-strict.txt'),
+    ('pyproject-plugin-strict.toml', 'fail_defaults.py', 'fail_defaults.txt'),
 ]
 executable_modules = list({fname[:-3] for _, fname, out_fname in cases if out_fname is None})
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->
The mypy plugin would previously incorrectly determine that a field was
not required in a few scenarios where the field really is required. This
specifically affected cases when the `Field()` function is used, where
the plugin assumed that the first argument would always be `default`.

This changes the code to examine each argument more closely, and it now
properly handles several more scenarios where the default is explicitly
named or when the default_factory named argument is used.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100% (Coverage was not at 100% to begin with for me, but the coverage did not drop after I made my changes)
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
