### PR TITLE
Fix schema for set and frozenset with default value

### DIFF
--- a/changes/4155-aminalaee.md
+++ b/changes/4155-aminalaee.md
@@ -1,0 +1,1 @@
+Fix JSON schema for `set` and `frozenset` when they include default values.

--- a/docs/build/schema_mapping.py
+++ b/docs/build/schema_mapping.py
@@ -75,6 +75,13 @@ table = [
         ''
     ],
     [
+        'frozenset',
+        'array',
+        {'items': {}, 'uniqueItems': True},
+        'JSON Schema Validation',
+        ''
+    ],
+    [
         'List[str]',
         'array',
         {'items': {'type': 'string'}},

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -77,7 +77,7 @@ from .typing import (
     is_none_type,
     is_union,
 )
-from .utils import ROOT_KEY, get_model, lenient_issubclass, sequence_like
+from .utils import ROOT_KEY, get_model, lenient_issubclass
 
 if TYPE_CHECKING:
     from .dataclasses import Dataclass
@@ -984,7 +984,7 @@ def encode_default(dft: Any) -> Any:
         return dft.value
     elif isinstance(dft, (int, float, str)):
         return dft
-    elif sequence_like(dft):
+    elif isinstance(dft, (list, tuple)):
         t = dft.__class__
         seq_args = (encode_default(v) for v in dft)
         return t(*seq_args) if is_namedtuple(t) else t(seq_args)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -530,6 +530,7 @@ def test_set():
     class Model(BaseModel):
         a: Set[int]
         b: set
+        c: set = {1}
 
     assert Model.schema() == {
         'title': 'Model',
@@ -537,6 +538,7 @@ def test_set():
         'properties': {
             'a': {'title': 'A', 'type': 'array', 'uniqueItems': True, 'items': {'type': 'integer'}},
             'b': {'title': 'B', 'type': 'array', 'items': {}, 'uniqueItems': True},
+            'c': {'title': 'C', 'type': 'array', 'items': {}, 'default': [1], 'uniqueItems': True},
         },
         'required': ['a', 'b'],
     }
@@ -2187,13 +2189,13 @@ def test_frozen_set():
         'properties': {
             'a': {
                 'title': 'A',
-                'default': frozenset({1, 2, 3}),
+                'default': [1, 2, 3],
                 'type': 'array',
                 'items': {'type': 'integer'},
                 'uniqueItems': True,
             },
-            'b': {'title': 'B', 'default': frozenset({1, 2, 3}), 'type': 'array', 'items': {}, 'uniqueItems': True},
-            'c': {'title': 'C', 'default': frozenset({1, 2, 3}), 'type': 'array', 'items': {}, 'uniqueItems': True},
+            'b': {'title': 'B', 'default': [1, 2, 3], 'type': 'array', 'items': {}, 'uniqueItems': True},
+            'c': {'title': 'C', 'default': [1, 2, 3], 'type': 'array', 'items': {}, 'uniqueItems': True},
             'd': {'title': 'D', 'type': 'array', 'items': {}, 'uniqueItems': True},
         },
         'required': ['d'],


### PR DESCRIPTION
## Change Summary

Fixes JSON schema for `set` and `frozenset` when they have default values, the output json is not valid and cannot be serialized.

For example:

```python
import json
from pydantic import BaseModel

class Test(BaseModel):
    x = {1}

print(Test.schema())
```

It will produce:

```json
{
  "title": "Test",
  "type": "object",
  "properties": {
    "x": {
      "title": "X",
      "type": "array",
      "default": {1},
      "items": {
        "type": "integer"
      },
      "uniqueItems": true
    }
  },
  "required": [
    "x"
  ]
}
```

But instead should be:

```json
{
  "title": "Test",
  "type": "object",
  "properties": {
    "x": {
      "title": "X",
      "default": [
        1,
      ],
      "type": "array",
      "items": {},
      "uniqueItems": true
    }
  }
}
```

## Related issue number

Fixes https://github.com/samuelcolvin/pydantic/issues/4136

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
