### PR TITLE
Handle mypy versions when installed from git.

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -68,7 +68,11 @@ BASEMODEL_FULLNAME = 'pydantic.main.BaseModel'
 BASESETTINGS_FULLNAME = 'pydantic.env_settings.BaseSettings'
 FIELD_FULLNAME = 'pydantic.fields.Field'
 DATACLASS_FULLNAME = 'pydantic.dataclasses.dataclass'
-BUILTINS_NAME = 'builtins' if float(mypy_version) >= 0.930 else '__builtins__'
+
+if '+dev.' in mypy_version or float(mypy_version) >= 0.930:
+    BUILTINS_NAME = 'builtins'
+else:
+    BUILTINS_NAME = '__builtins__'
 
 
 def plugin(version: str) -> 'TypingType[Plugin]':


### PR DESCRIPTION
When Mypy is installed from git, the Mypy version is not a float. It looks like
'0.970+dev.383...'.

Prevents errors like this:
![afbeelding](https://user-images.githubusercontent.com/216638/173793116-6c6ee81d-a984-4f39-b6b0-e5f5248ae5b0.png)

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
