### PR TITLE
Catch Exceptions in smart_deepcopy

### DIFF
--- a/changes/4184-coneybeare.md
+++ b/changes/4184-coneybeare.md
@@ -1,0 +1,1 @@
+Catch certain raised errors in `smart_deepcopy` and revert to `deepcopy` if so.

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -113,13 +113,6 @@ BUILTIN_COLLECTIONS: Set[Type[Any]] = {
     deque,
 }
 
-# There are error classes caught in smart_deepcopy
-CAUGHT_SMART_DEEPCOPY_ERRORS: Set[Type[Exception]] = {
-    TypeError,
-    ValueError,
-    RuntimeError,
-}
-
 
 def import_string(dotted_path: str) -> Any:
     """
@@ -662,7 +655,7 @@ def smart_deepcopy(obj: Obj) -> Obj:
         if not obj and obj_type in BUILTIN_COLLECTIONS:
             # faster way for empty collections, no need to copy its members
             return obj if obj_type is tuple else obj.copy()  # type: ignore  # tuple doesn't have copy method
-    except tuple(CAUGHT_SMART_DEEPCOPY_ERRORS):
+    except (TypeError, ValueError, RuntimeError):
         # do we really dare to catch ALL errors? Seems a bit risky
         pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,6 @@ from pydantic.typing import (
 )
 from pydantic.utils import (
     BUILTIN_COLLECTIONS,
-    CAUGHT_SMART_DEEPCOPY_ERRORS,
     ClassAttribute,
     LimitedDict,
     ValueItems,
@@ -462,16 +461,15 @@ def test_smart_deepcopy_collection(collection, mocker):
     assert smart_deepcopy(collection) is expected_value
 
 
-@pytest.mark.parametrize('error', CAUGHT_SMART_DEEPCOPY_ERRORS)
+@pytest.mark.parametrize('error', [TypeError, ValueError, RuntimeError])
 def test_smart_deepcopy_error(error, mocker):
     class RaiseOnBooleanOperation(str):
         def __bool__(self):
             raise error('raised error')
 
     obj = RaiseOnBooleanOperation()
-    expected_value = object()
-    mocker.patch('pydantic.utils.deepcopy', return_value=expected_value)
-    assert smart_deepcopy(obj) is expected_value
+    expected_value = deepcopy(obj)
+    assert smart_deepcopy(obj) == expected_value
 
 
 T = TypeVar('T')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ from pydantic.typing import (
 )
 from pydantic.utils import (
     BUILTIN_COLLECTIONS,
+    CAUGHT_SMART_DEEPCOPY_ERRORS,
     ClassAttribute,
     LimitedDict,
     ValueItems,
@@ -459,6 +460,18 @@ def test_smart_deepcopy_collection(collection, mocker):
     expected_value = object()
     mocker.patch('pydantic.utils.deepcopy', return_value=expected_value)
     assert smart_deepcopy(collection) is expected_value
+
+
+@pytest.mark.parametrize('error', CAUGHT_SMART_DEEPCOPY_ERRORS)
+def test_smart_deepcopy_error(error, mocker):
+    class RaiseOnBooleanOperation(str):
+        def __bool__(self):
+            raise error('raised error')
+
+    obj = RaiseOnBooleanOperation()
+    expected_value = object()
+    mocker.patch('pydantic.utils.deepcopy', return_value=expected_value)
+    assert smart_deepcopy(obj) is expected_value
 
 
 T = TypeVar('T')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This PR comes from an issue where a `sqlalchemy` column definition was raising when `not obj` was called in `smart_deepcopy`. Whether or not the raise is warranted is a question for `sqlalchemy`, but catching the error here and falling back to `deepcopy` on seems to be a decent approach as a raise of this nature prevents application import and load.

## Related issue number

Closes #4184 

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100% (coverage is 99.08, but only because of unrelated files missed coverage)
* [X] Documentation reflects the changes where applicable
* [X] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
