### PR TITLE
Fix for bug in root_validator value propogation with pre=True

### DIFF
--- a/changes/4194-jacquelinegarrahan.md
+++ b/changes/4194-jacquelinegarrahan.md
@@ -1,0 +1,1 @@
+Propogate assigned values from root_validators with pre=True to field by field validation.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -363,6 +363,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             for validator in self.__pre_root_validators__:
                 try:
                     new_values = validator(self.__class__, new_values)
+                    value = new_values[name]
                 except (ValueError, TypeError, AssertionError) as exc:
                     raise ValidationError([ErrorWrapper(exc, loc=ROOT_KEY)], self.__class__)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -363,7 +363,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
             for validator in self.__pre_root_validators__:
                 try:
                     new_values = validator(self.__class__, new_values)
-                    value = new_values[name]
                 except (ValueError, TypeError, AssertionError) as exc:
                     raise ValidationError([ErrorWrapper(exc, loc=ROOT_KEY)], self.__class__)
 
@@ -376,7 +375,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 if not known_field.field_info.allow_mutation:
                     raise TypeError(f'"{known_field.name}" has allow_mutation set to False and cannot be assigned')
                 dict_without_original_value = {k: v for k, v in self.__dict__.items() if k != name}
-                value, error_ = known_field.validate(value, dict_without_original_value, loc=name, cls=self.__class__)
+                value, error_ = known_field.validate(new_values[name], dict_without_original_value, loc=name, cls=self.__class__)
                 if error_:
                     raise ValidationError([error_], self.__class__)
                 else:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -375,7 +375,12 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                 if not known_field.field_info.allow_mutation:
                     raise TypeError(f'"{known_field.name}" has allow_mutation set to False and cannot be assigned')
                 dict_without_original_value = {k: v for k, v in self.__dict__.items() if k != name}
-                value, error_ = known_field.validate(new_values[name], dict_without_original_value, loc=name, cls=self.__class__)
+                value, error_ = known_field.validate(
+                    new_values[name],
+                    dict_without_original_value,
+                    loc=name,
+                    cls=self.__class__
+                )
                 if error_:
                     raise ValidationError([error_], self.__class__)
                 else:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -376,10 +376,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
                     raise TypeError(f'"{known_field.name}" has allow_mutation set to False and cannot be assigned')
                 dict_without_original_value = {k: v for k, v in self.__dict__.items() if k != name}
                 value, error_ = known_field.validate(
-                    new_values[name],
-                    dict_without_original_value,
-                    loc=name,
-                    cls=self.__class__
+                    new_values[name], dict_without_original_value, loc=name, cls=self.__class__
                 )
                 if error_:
                     raise ValidationError([error_], self.__class__)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -879,7 +879,7 @@ def test_root_validator_pre():
     assert root_val_values == [{'a': '123', 'b': 'bar'}, {'b': 'snap dragon'}]
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'foobar', 'type': 'value_error'}]
 
-    model = Model({'a': 1, 'b': 'bar'})
+    model = Model(a=1, b='bar')
     model.a = 41
     assert model.a == 42  # assignment as 42 implies root_validator value propogated
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -860,6 +860,9 @@ def test_root_validator_pre():
         a: int = 1
         b: str
 
+        class Config:
+            validate_assignment = True
+
         @validator('b')
         def repeat_b(cls, v):
             return v * 2

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -879,9 +879,10 @@ def test_root_validator_pre():
     assert root_val_values == [{'a': '123', 'b': 'bar'}, {'b': 'snap dragon'}]
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'foobar', 'type': 'value_error'}]
 
-    model = Model({"a": 1, "b": "bar"})
-    model.a = 41 
-    assert model.a == 42 # assignment as 42 implies root_validator value propogated
+    model = Model({'a': 1, 'b': 'bar'})
+    model.a = 41
+    assert model.a == 42  # assignment as 42 implies root_validator value propogated
+
 
 def test_root_validator_repeat():
     with pytest.raises(errors.ConfigError, match='duplicate validator function'):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -879,6 +879,9 @@ def test_root_validator_pre():
     assert root_val_values == [{'a': '123', 'b': 'bar'}, {'b': 'snap dragon'}]
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'foobar', 'type': 'value_error'}]
 
+    model = Model({"a": 1, "b": "bar"})
+    model.a = 41 
+    assert model.a == 42 # assignment as 42 implies root_validator value propogated
 
 def test_root_validator_repeat():
     with pytest.raises(errors.ConfigError, match='duplicate validator function'):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
<!-- Please give a short summary of the changes. -->

During validation on assignment at present, the value returned from a root_validator with pre=True is not propagated and assigned. The reason for this is that the known_field validators operate on the original value.

```python
from pydantic import BaseModel, root_validator

class M(BaseModel):

    x: int = 1

    class Config:
        validate_assignment = True

    @root_validator(pre=True)
    def validate_all(cls, values):
        print('root validator', values)
        values["x"] = 99  # Always hijack x
        print('done', values)
        return values    


m = M(x=3)
m.x = None  # ValidationError: 1 validation error for M
```

This PR adds a single line updating the value with the output of the pre root_validator.


## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
