### PR TITLE
Implement proper support for nested complex env values

### DIFF
--- a/changes/4216-raistleitner.md
+++ b/changes/4216-raistleitner.md
@@ -1,1 +1,1 @@
-Pydantic didn't support setting fields containing "complex values" like dicts or lists from environment variables using nesting. This PR contains an implementation addressing this issue by checking which field the nested environment variable targets to, checking if the field is a complex value and if so, trying to parse the environment value as a JSON.
+Add support for setting nested fields containing complex values like dict or list from environment variables

--- a/changes/4216-raistleitner.md
+++ b/changes/4216-raistleitner.md
@@ -1,3 +1,1 @@
 Pydantic didn't support setting fields containing "complex values" like dicts or lists from environment variables using nesting. This PR contains an implementation addressing this issue by checking which field the nested environment variable targets to, checking if the field is a complex value and if so, trying to parse the environment value as a JSON.
-
-This already worked if explicitly using `env=...` keyword arg for a field but not for nested environment variables.

--- a/changes/4216-raistleitner.md
+++ b/changes/4216-raistleitner.md
@@ -1,0 +1,3 @@
+Pydantic didn't support setting fields containing "complex values" like dicts or lists from environment variables using nesting. This PR contains an implementation addressing this issue by checking which field the nested environment variable targets to, checking if the field is a complex value and if so, trying to parse the environment value as a JSON.
+
+This already worked if explicitly using `env=...` keyword arg for a field but not for nested environment variables.

--- a/docs/examples/settings_nested_env.py
+++ b/docs/examples/settings_nested_env.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, BaseSettings
 
 class DeepSubModel(BaseModel):
     v4: str
-    complex: List[str]
+    complex: List[str] = []
 
 
 class SubModel(BaseModel):

--- a/docs/examples/settings_nested_env.py
+++ b/docs/examples/settings_nested_env.py
@@ -1,8 +1,10 @@
+from typing import List
 from pydantic import BaseModel, BaseSettings
 
 
 class DeepSubModel(BaseModel):
     v4: str
+    complex: List[str]
 
 
 class SubModel(BaseModel):

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -87,6 +87,7 @@ export SUB_MODEL='{"v1": "json-1", "v2": "json-2"}'
 export SUB_MODEL__V2=nested-2
 export SUB_MODEL__V3=3
 export SUB_MODEL__DEEP__V4=v4
+export SUB_MODEL__DEEP__COMPLEX='["one", "two", "tree"]'
 ```
 
 You could load a settings module thus:

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -219,10 +219,7 @@ class EnvSettingsSource:
 
     @staticmethod
     def next_field(field: Optional[ModelField], key: str) -> Optional[ModelField]:
-        if not field:
-            return None
-
-        if field.sub_fields:
+        if not field or field.sub_fields:
             # no support for Unions of complex BaseSettings fields
             return None
         elif field.type_ and field.type_.__fields__.get(key):

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -223,9 +223,8 @@ class EnvSettingsSource:
             return None
 
         if field.sub_fields:
-            for sub_field in field.sub_fields:
-                if sub_field.alias == key:
-                    return sub_field
+            # no support for Unions of complex BaseSettings fields
+            return None
         elif field.type_ and field.type_.__fields__.get(key):
             return cast(ModelField, field.type_.__fields__[key])
 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -218,7 +218,7 @@ class EnvSettingsSource:
         return True, allow_json_failure
 
     @staticmethod
-    def next_field(field: Union[ModelField, None], key: str) -> Union[ModelField, None]:
+    def next_field(field: Optional[ModelField], key: str) -> Optional[ModelField]:
         if not field:
             return None
 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -242,7 +242,7 @@ class EnvSettingsSource:
                 continue
             _, *keys, last_key = env_name.split(self.env_nested_delimiter)
             env_var = result
-            target_field: Union[ModelField, None] = field
+            target_field: Optional[ModelField] = field
 
             for key in keys:
                 target_field = self.next_field(target_field, key)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -181,7 +181,44 @@ def test_nested_env_complex_values(env):
 
     env.set('cfg_sub_model__vals', '["one", "two"]')
     env.set('cfg_sub_model__sub_sub_model__dvals', '{"three": 4}')
+
     assert Cfg().dict() == {'sub_model': {'vals': ['one', 'two'], 'sub_sub_model': {'dvals': {'three': 4}}}}
+
+    env.set('cfg_sub_model__vals', 'invalid')
+    with pytest.raises(SettingsError, match='error parsing JSON for "cfg_sub_model__vals'):
+        Cfg()
+
+
+def test_nested_env_nonexisting_field(env):
+    class SubModel(BaseSettings):
+        vals: List[str]
+
+    class Cfg(BaseSettings):
+        sub_model: SubModel
+
+        class Config:
+            env_prefix = 'cfg_'
+            env_nested_delimiter = '__'
+
+    env.set('cfg_sub_model__foo_vals', '[]')
+    with pytest.raises(ValidationError):
+        Cfg()
+
+
+def test_nested_env_nonexisting_field_deep(env):
+    class SubModel(BaseSettings):
+        vals: List[str]
+
+    class Cfg(BaseSettings):
+        sub_model: SubModel
+
+        class Config:
+            env_prefix = 'cfg_'
+            env_nested_delimiter = '__'
+
+    env.set('cfg_sub_model__vals__foo__bar__vals', '[]')
+    with pytest.raises(ValidationError):
+        Cfg()
 
 
 def test_nested_env_union_complex_values(env):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

Pydantic didn't support setting fields containing "complex values" like dicts or lists from environment variables using nesting. This PR contains an implementation addressing this issue by checking which field the nested environment variable targets to, checking if the field is a complex value and if so, trying to parse the environment value as a JSON.

This already worked if explicitly using `env=...` keyword arg for a field but not for nested environment variables.

## Related issue number

There is no issue created yet.

fix #2304 fix #4389

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
