### PR TITLE
feat: pass config to NamedTuple fields

### DIFF
--- a/changes/4219-synek.md
+++ b/changes/4219-synek.md
@@ -1,0 +1,1 @@
+Use parent model's `Config` when validating nested `NamedTuple` fields.

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -555,11 +555,14 @@ def pattern_validator(v: Any) -> Pattern[str]:
 NamedTupleT = TypeVar('NamedTupleT', bound=NamedTuple)
 
 
-def make_namedtuple_validator(namedtuple_cls: Type[NamedTupleT]) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
+def make_namedtuple_validator(
+    namedtuple_cls: Type[NamedTupleT], config: Type['BaseConfig']
+) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
     from .annotated_types import create_model_from_namedtuple
 
     NamedTupleModel = create_model_from_namedtuple(
         namedtuple_cls,
+        __config__=config,
         __module__=namedtuple_cls.__module__,
     )
     namedtuple_cls.__pydantic_model__ = NamedTupleModel  # type: ignore[attr-defined]
@@ -690,7 +693,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
         return
     if is_namedtuple(type_):
         yield tuple_validator
-        yield make_namedtuple_validator(type_)
+        yield make_namedtuple_validator(type_, config)
         return
     if is_typeddict(type_):
         yield make_typeddict_validator(type_, config)

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -146,6 +146,29 @@ def test_namedtuple_postponed_annotation():
         Model.parse_obj({'t': [-1]})
 
 
+def test_namedtuple_arbitrary_type():
+    class CustomClass:
+        pass
+
+    class Tup(NamedTuple):
+        c: CustomClass
+
+    class Model(BaseModel):
+        x: Tup
+
+        class Config:
+            arbitrary_types_allowed = True
+
+    data = {'x': Tup(c=CustomClass())}
+    model = Model.parse_obj(data)
+    assert isinstance(model.x.c, CustomClass)
+
+    with pytest.raises(RuntimeError):
+
+        class ModelNoArbitraryTypes(BaseModel):
+            x: Tup
+
+
 def test_typeddict():
     class TD(TypedDict):
         a: int


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

This PR changes the way pydantic validates `NamedTuple` fields. Currently, a new vanilla `BaseModel` is created dynamically for the field, and used for validation. This PR simply passes the parent model's `Config` to that newly created model, allowing settings like `allow_arbitrary_types` to be propagated to the attributes of `NamedTuple` fields.

## Related issue number

fix #4219
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
