### PR TITLE
Fix sub-model link in usage/models docs

### DIFF
--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -207,7 +207,7 @@ Each error object contains:
 
 `loc`
 : the error's location as a list. The first item in the list will be the field where the error occurred,
-  and if the field is a [sub-model](models.md#recursive_models), subsequent items will be present to indicate
+  and if the field is a [sub-model](models.md#recursive-models), subsequent items will be present to indicate
   the nested location of the error.
 
 `type`


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
There is a broken link in [Error Handling section of models doc](https://pydantic-docs.helpmanual.io/usage/models/#error-handling).
![pic](https://user-images.githubusercontent.com/3122442/178803538-6b9715f8-91a6-4c99-8f88-ee9fecd341df.png)

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
