### PR TITLE
Fix nested fields not json parsed when they are complex #3971

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 env/
 venv/
 env3*/
+.envrc
+.direnv/
 Pipfile
 *.lock
 *.py[cod]

--- a/changes/3971-rastaclaus.md
+++ b/changes/3971-rastaclaus.md
@@ -1,0 +1,1 @@
+add json parsing for nested models fields

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -152,15 +152,14 @@ class EnvSettingsSource:
         self.env_nested_delimiter: Optional[str] = env_nested_delimiter
 
     @staticmethod
-    def _json_parse(val: Optional[str], name: str, json_loads: Callable[[str], Any], allow_json_failure: bool) -> Any:
-        if val is not None:
-            if val.startswith('-') and val.endswith('-'):
-                val = f'"{val}"'
-            try:
-                return json_loads(val)
-            except ValueError as e:
-                if not allow_json_failure:
-                    raise SettingsError(f'error parsing JSON for "{name}"') from e
+    def _json_parse(val: str, name: str, json_loads: Callable[[str], Any], allow_json_failure: bool) -> Any:
+        if val.startswith('-') and val.endswith('-'):
+            val = f'"{val}"'
+        try:
+            return json_loads(val)
+        except ValueError as e:
+            if not allow_json_failure:
+                raise SettingsError(f'error parsing JSON for "{name}"') from e
         return val
 
     def __call__(self, settings: BaseSettings) -> Dict[str, Any]:  # noqa C901

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -151,6 +151,18 @@ class EnvSettingsSource:
         self.env_file_encoding: Optional[str] = env_file_encoding
         self.env_nested_delimiter: Optional[str] = env_nested_delimiter
 
+    @staticmethod
+    def _json_parse(val: Optional[str], name: str, json_loads: Callable[[str], Any], allow_json_failure: bool) -> Any:
+        if val is not None:
+            if val.startswith('-') and val.endswith('-'):
+                val = f'"{val}"'
+            try:
+                return json_loads(val)
+            except ValueError as e:
+                if not allow_json_failure:
+                    raise SettingsError(f'error parsing JSON for "{name}"') from e
+        return val
+
     def __call__(self, settings: BaseSettings) -> Dict[str, Any]:  # noqa C901
         """
         Build environment variables suitable for passing to the Model.
@@ -184,15 +196,15 @@ class EnvSettingsSource:
                 if env_val is None:
                     # field is complex but no value found so far, try explode_env_vars
                     env_val_built = self.explode_env_vars(field, env_vars)
+                    env_val_built = {
+                        key: self._json_parse(value, key, settings.__config__.json_loads, allow_json_failure)
+                        for key, value in env_val_built.items()
+                    }
                     if env_val_built:
                         d[field.alias] = env_val_built
                 else:
                     # field is complex and there's a value, decode that as JSON, then add explode_env_vars
-                    try:
-                        env_val = settings.__config__.json_loads(env_val)
-                    except ValueError as e:
-                        if not allow_json_failure:
-                            raise SettingsError(f'error parsing JSON for "{env_name}"') from e
+                    env_val = self._json_parse(env_val, env_name, settings.__config__.json_loads, allow_json_failure)
 
                     if isinstance(env_val, dict):
                         d[field.alias] = deep_update(env_val, self.explode_env_vars(field, env_vars))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -198,6 +198,25 @@ def test_invalid_json(env):
         ComplexSettings()
 
 
+def test_env_nested_with_complex_field(env):
+    class Child(BaseModel):
+        nested_field: List[str] = []
+
+    class Parent(BaseSettings):
+        parent_field: List[str]
+        child: Child
+
+        class Config:
+            env_nested_delimiter = '__'
+
+    env.set('PARENT_FIELD', '["c", "d", "e"]')
+    env.set('CHILD__NESTED_FIELD', '["a", "b", "c"]')
+
+    p = Parent()
+
+    assert p.child.nested_field == ['a', 'b', 'c']
+
+
 def test_required_sub_model(env):
     class Settings(BaseSettings):
         foobar: DateModel


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary
composite fields of nested objects are now json-parsed
<!-- Please give a short summary of the changes. -->

## Related issue number 
fix #3971

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
