### PR TITLE
Resolve ForwardRef on Field.outer_type_

### DIFF
--- a/changes/4249-JacobHayes.md
+++ b/changes/4249-JacobHayes.md
@@ -1,0 +1,1 @@
+Update `ForwardRef`s in `Field.outer_type_`

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -465,8 +465,14 @@ def update_field_forward_refs(field: 'ModelField', globalns: Any, localns: Any) 
     """
     Try to update ForwardRefs on fields based on this ModelField, globalns and localns.
     """
+    prepare = False
     if field.type_.__class__ == ForwardRef:
+        prepare = True
         field.type_ = evaluate_forwardref(field.type_, globalns, localns or None)
+    if field.outer_type_.__class__ == ForwardRef:
+        prepare = True
+        field.outer_type_ = evaluate_forwardref(field.outer_type_, globalns, localns or None)
+    if prepare:
         field.prepare()
 
     if field.sub_fields:

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pytest
 
@@ -131,15 +131,12 @@ def test_self_forward_ref_collection(create_module):
         from typing import Dict, List
 
         from pydantic import BaseModel
-        from pydantic.typing import ForwardRef
-
-        Foo = ForwardRef('Foo')
 
         class Foo(BaseModel):
             a: int = 123
-            b: Foo = None
-            c: List[Foo] = []
-            d: Dict[str, Foo] = {}
+            b: "Foo" = None
+            c: "List[Foo]" = []
+            d: "Dict[str, Foo]" = {}
 
         Foo.update_forward_refs()
 
@@ -156,6 +153,14 @@ def test_self_forward_ref_collection(create_module):
     assert exc_info.value.errors() == [
         {'loc': ('c', 0, 'b'), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}
     ]
+
+    assert module.Foo.__fields__['a'].type_ is int
+    assert module.Foo.__fields__['b'].type_ is module.Foo
+    assert module.Foo.__fields__['b'].outer_type_ is module.Foo
+    assert module.Foo.__fields__['c'].type_ is module.Foo
+    assert module.Foo.__fields__['c'].outer_type_ == List[module.Foo]
+    assert module.Foo.__fields__['d'].type_ is module.Foo
+    assert module.Foo.__fields__['d'].outer_type_ == Dict[str, module.Foo]
 
 
 def test_self_forward_ref_local(create_module):

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -134,9 +134,9 @@ def test_self_forward_ref_collection(create_module):
 
         class Foo(BaseModel):
             a: int = 123
-            b: "Foo" = None
-            c: "List[Foo]" = []
-            d: "Dict[str, Foo]" = {}
+            b: 'Foo' = None
+            c: 'List[Foo]' = []
+            d: 'Dict[str, Foo]' = {}
 
         Foo.update_forward_refs()
 


### PR DESCRIPTION
## Change Summary

When resolving `ForwardRef`s, the `Field.outer_type_` is not resolved, only `Field.type_`. This PR updates `update_field_forward_refs` to resolve both attributes, while still only calling `Field.prepare` once.

`Field.outer_type_` can be a nested object (eg: `List[str]`, etc), but I only check if the _entire_ annotation is a `ForwardRef` for simplicity. This should cover most cases, namely:
- all `from __future__ import annoations` annotations
- manually stringized annotations as long as the _whole_ annotation is stringized (eg: `"List[RecursiveType]"` will be resolved, `List["RecursiveType"]` will not)

I think I've seen [other instances](https://github.com/samuelcolvin/pydantic/discussions/4185) where `ForwardRefs` inside nested types aren't full resolved, so 🤞 this is fine for now.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
