### PR TITLE
Discriminated union schemas use oneOf instead of anyOf

### DIFF
--- a/changes/4335-MaxwellPayne.md
+++ b/changes/4335-MaxwellPayne.md
@@ -1,0 +1,1 @@
+Discriminated union models now use `oneOf` instead of `anyOf` when generating OpenAPI schema definitions.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -705,7 +705,8 @@ def field_singleton_sub_fields_schema(
     else:
         s: Dict[str, Any] = {}
         # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminator-object
-        if field.discriminator_key is not None:
+        field_has_discriminator: bool = field.discriminator_key is not None
+        if field_has_discriminator:
             assert field.sub_fields_mapping is not None
 
             discriminator_models_refs: Dict[str, Union[str, Dict[str, Any]]] = {}
@@ -748,16 +749,16 @@ def field_singleton_sub_fields_schema(
             definitions.update(sub_definitions)
             if schema_overrides and 'allOf' in sub_schema:
                 # if the sub_field is a referenced schema we only need the referenced
-                # object. Otherwise we will end up with several allOf inside anyOf.
+                # object. Otherwise we will end up with several allOf inside anyOf/oneOf.
                 # See https://github.com/pydantic/pydantic/issues/1209
                 sub_schema = sub_schema['allOf'][0]
 
-            if sub_schema.keys() == {'discriminator', 'anyOf'}:
-                # we don't want discriminator information inside anyOf choices, this is dealt with elsewhere
+            if sub_schema.keys() == {'discriminator', 'oneOf'}:
+                # we don't want discriminator information inside oneOf choices, this is dealt with elsewhere
                 sub_schema.pop('discriminator')
             sub_field_schemas.append(sub_schema)
             nested_models.update(sub_nested_models)
-        s['anyOf'] = sub_field_schemas
+        s['oneOf' if field_has_discriminator else 'anyOf'] = sub_field_schemas
         return s, definitions, nested_models
 
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1190,7 +1190,7 @@ def test_issue_3162():
     }
 
 
-def test_discrimated_union_basemodel_instance_value():
+def test_discriminated_union_basemodel_instance_value():
     @pydantic.dataclasses.dataclass
     class A:
         l: Literal['a']
@@ -1212,7 +1212,7 @@ def test_discrimated_union_basemodel_instance_value():
             'sub': {
                 'title': 'Sub',
                 'discriminator': {'propertyName': 'l', 'mapping': {'a': '#/definitions/A', 'b': '#/definitions/B'}},
-                'anyOf': [{'$ref': '#/definitions/A'}, {'$ref': '#/definitions/B'}],
+                'oneOf': [{'$ref': '#/definitions/A'}, {'$ref': '#/definitions/B'}],
             }
         },
         'required': ['sub'],

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -588,7 +588,7 @@ def test_discriminated_union_forward_ref(create_module):
     assert module.Pet.schema() == {
         'title': 'Pet',
         'discriminator': {'propertyName': 'type', 'mapping': {'cat': '#/definitions/Cat', 'dog': '#/definitions/Dog'}},
-        'anyOf': [{'$ref': '#/definitions/Cat'}, {'$ref': '#/definitions/Dog'}],
+        'oneOf': [{'$ref': '#/definitions/Cat'}, {'$ref': '#/definitions/Dog'}],
         'definitions': {
             'Cat': {
                 'title': 'Cat',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2675,7 +2675,7 @@ def test_discriminated_union():
                         'lizard': '#/definitions/Lizard',
                     },
                 },
-                'anyOf': [
+                'oneOf': [
                     {'$ref': '#/definitions/Cat'},
                     {'$ref': '#/definitions/Dog'},
                     {'$ref': '#/definitions/Lizard'},
@@ -2708,7 +2708,7 @@ def test_discriminated_union():
                     'propertyName': 'color',
                     'mapping': {'black': '#/definitions/BlackCat', 'white': '#/definitions/WhiteCat'},
                 },
-                'anyOf': [{'$ref': '#/definitions/BlackCat'}, {'$ref': '#/definitions/WhiteCat'}],
+                'oneOf': [{'$ref': '#/definitions/BlackCat'}, {'$ref': '#/definitions/WhiteCat'}],
             },
             'Dog': {
                 'title': 'Dog',
@@ -2775,11 +2775,11 @@ def test_discriminated_annotated_union():
                         'dog': '#/definitions/Dog',
                     },
                 },
-                'anyOf': [
+                'oneOf': [
                     {
-                        'anyOf': [
+                        'oneOf': [
                             {
-                                'anyOf': [
+                                'oneOf': [
                                     {'$ref': '#/definitions/BlackCatWithHeight'},
                                     {'$ref': '#/definitions/BlackCatWithWeight'},
                                 ]
@@ -2858,7 +2858,7 @@ def test_alias_same():
         'properties': {
             'number': {'title': 'Number', 'type': 'integer'},
             'pet': {
-                'anyOf': [{'$ref': '#/definitions/Cat'}, {'$ref': '#/definitions/Dog'}],
+                'oneOf': [{'$ref': '#/definitions/Cat'}, {'$ref': '#/definitions/Dog'}],
                 'discriminator': {
                     'mapping': {'cat': '#/definitions/Cat', 'dog': '#/definitions/Dog'},
                     'propertyName': 'typeOfPet',
@@ -2960,9 +2960,9 @@ def test_discriminated_union_in_list():
                         'dog': '#/definitions/Dog',
                     },
                 },
-                'anyOf': [
+                'oneOf': [
                     {
-                        'anyOf': [
+                        'oneOf': [
                             {'$ref': '#/definitions/BlackCat'},
                             {'$ref': '#/definitions/WhiteCat'},
                         ],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Discriminated union models now use `oneOf` instead of `anyOf` when generating OpenAPI schema definitions. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
Fixes #4125

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
