### PR TITLE
Change path in validation_decorator_types example to a relative path

### DIFF
--- a/docs/examples/validation_decorator_types.py
+++ b/docs/examples/validation_decorator_types.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Pattern, Optional
 
@@ -13,5 +14,5 @@ def find_file(path: DirectoryPath, regex: Pattern, max=None) -> Optional[Path]:
             return f
 
 
-print(find_file('/etc/', '^sys.*'))
-print(find_file('/etc/', '^foobar.*', max=3))
+print(find_file(os.path.dirname(__file__), '^validation.*'))
+print(find_file(os.path.dirname(__file__), '^foobar.*', max=3))

--- a/docs/examples/validation_decorator_types.py
+++ b/docs/examples/validation_decorator_types.py
@@ -14,5 +14,8 @@ def find_file(path: DirectoryPath, regex: Pattern, max=None) -> Optional[Path]:
             return f
 
 
-print(find_file(os.path.dirname(__file__), '^validation.*'))
-print(find_file(os.path.dirname(__file__), '^foobar.*', max=3))
+# note: this_dir is a string here
+this_dir = os.path.dirname(__file__)
+
+print(find_file(this_dir, '^validation.*'))
+print(find_file(this_dir, '^foobar.*', max=3))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary
Change the script path to the `docs/examples/`
<!-- Please give a short summary of the changes. -->

## Related issue number
fix #4245
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
