### PR TITLE
fix "extra fields not permitted" error when dataclass with `Extra.forbid` is validated multiple times

### DIFF
--- a/changes/4343-detachhead.md
+++ b/changes/4343-detachhead.md
@@ -1,0 +1,1 @@
+fix "extra fields not permitted" error when dataclass with `Extra.forbid` is validated multiple times

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -385,6 +385,10 @@ def create_pydantic_model_from_dataclass(
 
 
 def _dataclass_validate_values(self: 'Dataclass') -> None:
+    # validation errors can occur if this function is called twice on an already initialised dataclass.
+    # for example if Extra.forbid is enabled, it would consider __pydantic_initialised__ an invalid extra property
+    if getattr(self, '__pydantic_initialised__'):
+        return
     if getattr(self, '__pydantic_has_field_info_default__', False):
         # We need to remove `FieldInfo` values since they are not valid as input
         # It's ok to do that because they are obviously the default values!

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1360,3 +1360,27 @@ def test_kw_only():
         A(1, '')
 
     assert A(b='hi').b == 'hi'
+
+
+def test_extra_forbid_list_no_error():
+    @pydantic.dataclasses.dataclass(config=dict(extra=Extra.forbid))
+    class Bar:
+        ...
+
+    @pydantic.dataclasses.dataclass
+    class Foo:
+        a: List[Bar]
+
+    assert isinstance(Foo(a=[Bar()]).a[0], Bar)
+
+
+def test_extra_forbid_list_error():
+    @pydantic.dataclasses.dataclass(config=dict(extra=Extra.forbid))
+    class Bar:
+        ...
+
+    with pytest.raises(TypeError, match=re.escape("__init__() got an unexpected keyword argument 'a'")):
+
+        @pydantic.dataclasses.dataclass
+        class Foo:
+            a: List[Bar(a=1)]


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->
if a `dataclass` gets validated multiple times by `_dataclass_validate_values` and has `Extra.forbid` in its config, it will fail validation as `__pydantic_initialised__` is considered to be an invalid extra property.

i figured the safest fix for this (and any potential other similar issues) was to check whether the class has already been validated before validating it again.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fixes #4343
## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
