### PR TITLE
fix dataclass containing `Any`

### DIFF
--- a/changes/4356-DetachHead.md
+++ b/changes/4356-DetachHead.md
@@ -1,0 +1,1 @@
+remove `Any` types from the `dataclass` decorator so it can be used with the `disallow_any_expr` mypy option

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, ForwardRef, Optional, Tup
 
 from typing_extensions import Literal, Protocol
 
-from .typing import AnyCallable
+from .typing import AnyArgTCallable, AnyCallable
 from .utils import GetterDict
 from .version import compiled
 
@@ -62,10 +62,10 @@ if not compiled:
         getter_dict: Type[GetterDict]
         alias_generator: Optional[Callable[[str], str]]
         keep_untouched: Tuple[type, ...]
-        schema_extra: Union[Dict[str, Any], 'SchemaExtraCallable']
-        json_loads: Callable[[str], Any]
-        json_dumps: Callable[..., str]
-        json_encoders: Dict[Type[Any], AnyCallable]
+        schema_extra: Union[Dict[str, object], 'SchemaExtraCallable']
+        json_loads: Callable[[str], object]
+        json_dumps: AnyArgTCallable[str]
+        json_encoders: Dict[Type[object], AnyCallable]
         underscore_attrs_are_private: bool
 
         # whether or not inherited models as fields should be reconstructed as base model
@@ -146,7 +146,7 @@ class BaseConfig:
         pass
 
 
-def get_config(config: Union[ConfigDict, Type[BaseConfig], None]) -> Type[BaseConfig]:
+def get_config(config: Union[ConfigDict, Type[object], None]) -> Type[BaseConfig]:
     if config is None:
         return BaseConfig
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
         __pydantic_validate_values__: ClassVar[Callable[['Dataclass'], None]]
         __pydantic_has_field_info_default__: ClassVar[bool]  # whether a `pydantic.Field` is used as default value
 
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
+        def __init__(self, *args: object, **kwargs: object) -> None:
             pass
 
         @classmethod
@@ -88,6 +88,8 @@ __all__ = [
     'make_dataclass_validator',
 ]
 
+_T = TypeVar('_T')
+
 if sys.version_info >= (3, 10):
 
     @dataclass_transform(kw_only_default=True, field_descriptors=(Field, FieldInfo))
@@ -100,16 +102,16 @@ if sys.version_info >= (3, 10):
         order: bool = False,
         unsafe_hash: bool = False,
         frozen: bool = False,
-        config: Union[ConfigDict, Type[Any], None] = None,
+        config: Union[ConfigDict, Type[object], None] = None,
         validate_on_init: Optional[bool] = None,
         kw_only: bool = ...,
-    ) -> Callable[[Type[Any]], 'DataclassClassOrWrapper']:
+    ) -> Callable[[Type[_T]], 'DataclassClassOrWrapper']:
         ...
 
     @dataclass_transform(kw_only_default=True, field_descriptors=(Field, FieldInfo))
     @overload
     def dataclass(
-        _cls: Type[Any],
+        _cls: Type[_T],
         *,
         init: bool = True,
         repr: bool = True,
@@ -117,7 +119,7 @@ if sys.version_info >= (3, 10):
         order: bool = False,
         unsafe_hash: bool = False,
         frozen: bool = False,
-        config: Union[ConfigDict, Type[Any], None] = None,
+        config: Union[ConfigDict, Type[object], None] = None,
         validate_on_init: Optional[bool] = None,
         kw_only: bool = ...,
     ) -> 'DataclassClassOrWrapper':
@@ -135,15 +137,15 @@ else:
         order: bool = False,
         unsafe_hash: bool = False,
         frozen: bool = False,
-        config: Union[ConfigDict, Type[Any], None] = None,
+        config: Union[ConfigDict, Type[object], None] = None,
         validate_on_init: Optional[bool] = None,
-    ) -> Callable[[Type[Any]], 'DataclassClassOrWrapper']:
+    ) -> Callable[[Type[_T]], 'DataclassClassOrWrapper']:
         ...
 
     @dataclass_transform(kw_only_default=True, field_descriptors=(Field, FieldInfo))
     @overload
     def dataclass(
-        _cls: Type[Any],
+        _cls: Type[_T],
         *,
         init: bool = True,
         repr: bool = True,
@@ -151,7 +153,7 @@ else:
         order: bool = False,
         unsafe_hash: bool = False,
         frozen: bool = False,
-        config: Union[ConfigDict, Type[Any], None] = None,
+        config: Union[ConfigDict, Type[object], None] = None,
         validate_on_init: Optional[bool] = None,
     ) -> 'DataclassClassOrWrapper':
         ...
@@ -159,7 +161,7 @@ else:
 
 @dataclass_transform(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 def dataclass(
-    _cls: Optional[Type[Any]] = None,
+    _cls: Optional[Type[_T]] = None,
     *,
     init: bool = True,
     repr: bool = True,
@@ -167,10 +169,10 @@ def dataclass(
     order: bool = False,
     unsafe_hash: bool = False,
     frozen: bool = False,
-    config: Union[ConfigDict, Type[Any], None] = None,
+    config: Union[ConfigDict, Type[object], None] = None,
     validate_on_init: Optional[bool] = None,
     kw_only: bool = False,
-) -> Union[Callable[[Type[Any]], 'DataclassClassOrWrapper'], 'DataclassClassOrWrapper']:
+) -> Union[Callable[[Type[_T]], 'DataclassClassOrWrapper'], 'DataclassClassOrWrapper']:
     """
     Like the python standard lib dataclasses but with type validation.
     The result is either a pydantic dataclass that will validate input data

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -19,6 +19,7 @@ from typing import (  # type: ignore
     Set,
     Tuple,
     Type,
+    TypeVar,
     Union,
     _eval_type,
     cast,
@@ -76,8 +77,13 @@ else:
         return get_type_hints(obj, globalns, localns, include_extras=True)
 
 
+_T = TypeVar('_T')
+
 AnyCallable = TypingCallable[..., Any]
 NoArgAnyCallable = TypingCallable[[], Any]
+
+# workaround for https://github.com/python/mypy/issues/9496
+AnyArgTCallable = TypingCallable[..., _T]
 
 
 # Annotated[...] is implemented by returning an instance of one of these classes, depending on

--- a/tests/mypy/configs/mypy-plugin-strict-no-any.ini
+++ b/tests/mypy/configs/mypy-plugin-strict-no-any.ini
@@ -1,0 +1,23 @@
+[mypy]
+plugins = pydantic.mypy
+
+follow_imports = silent
+strict_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+disallow_any_generics = True
+check_untyped_defs = True
+no_implicit_reexport = True
+disallow_untyped_defs = True
+disallow_any_decorated = True
+disallow_any_expr = True
+disallow_any_explicit = True
+disallow_any_unimported = True
+disallow_subclassing_any = True
+warn_return_any = True
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
+warn_untyped_fields = True

--- a/tests/mypy/modules/no_any.py
+++ b/tests/mypy/modules/no_any.py
@@ -1,0 +1,11 @@
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class Foo:
+    foo: int
+
+
+@dataclass(config={})
+class Bar:
+    bar: str

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -37,6 +37,7 @@ cases = [
     ('mypy-default.ini', 'fail3.py', 'fail3.txt'),
     ('mypy-default.ini', 'fail4.py', 'fail4.txt'),
     ('mypy-default.ini', 'plugin_success.py', 'plugin_success.txt'),
+    ('mypy-plugin-strict-no-any.ini', 'no_any.py', None),
     ('pyproject-default.toml', 'success.py', None),
     ('pyproject-default.toml', 'fail1.py', 'fail1.txt'),
     ('pyproject-default.toml', 'fail2.py', 'fail2.txt'),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary
remove `Any` types that contributed to usages of the `dataclass` decorator causing mypy errors when using the `disallow-any-expr` rule
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fixes #4355
## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
