### PR TITLE
Fix imports indirectly from pydantic typing

### DIFF
--- a/changes/4358-aminalaee.md
+++ b/changes/4358-aminalaee.md
@@ -1,0 +1,1 @@
+Fix implpicitly importing `ForwardRef` and `Callable` from `pydantic.typing` instead of `typing` and also expose `MappingIntStrAny`.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -4,7 +4,6 @@ from collections.abc import Hashable as CollectionsHashable, Iterable as Collect
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Counter,
     DefaultDict,
     Deque,
@@ -34,6 +33,7 @@ from .error_wrappers import ErrorWrapper
 from .errors import ConfigError, InvalidDiscriminator, MissingDiscriminator, NoneIsNotAllowedError
 from .types import Json, JsonWrapper
 from .typing import (
+    Callable,
     NoArgAnyCallable,
     convert_generics,
     display_as_type,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -4,10 +4,12 @@ from collections.abc import Hashable as CollectionsHashable, Iterable as Collect
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Counter,
     DefaultDict,
     Deque,
     Dict,
+    ForwardRef,
     FrozenSet,
     Generator,
     Iterable,
@@ -32,8 +34,6 @@ from .error_wrappers import ErrorWrapper
 from .errors import ConfigError, InvalidDiscriminator, MissingDiscriminator, NoneIsNotAllowedError
 from .types import Json, JsonWrapper
 from .typing import (
-    Callable,
-    ForwardRef,
     NoArgAnyCallable,
     convert_generics,
     display_as_type,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,6 +1,6 @@
 import copy
 from collections import Counter as CollectionCounter, defaultdict, deque
-from collections.abc import Hashable as CollectionsHashable, Iterable as CollectionsIterable
+from collections.abc import Callable, Hashable as CollectionsHashable, Iterable as CollectionsIterable
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -33,7 +33,6 @@ from .error_wrappers import ErrorWrapper
 from .errors import ConfigError, InvalidDiscriminator, MissingDiscriminator, NoneIsNotAllowedError
 from .types import Json, JsonWrapper
 from .typing import (
-    Callable,
     NoArgAnyCallable,
     convert_generics,
     display_as_type,

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    ForwardRef,
     FrozenSet,
     Generic,
     Iterable,
@@ -66,7 +67,6 @@ from .types import (
     constr,
 )
 from .typing import (
-    ForwardRef,
     all_literal_values,
     get_args,
     get_origin,

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -268,7 +268,6 @@ if TYPE_CHECKING:
     AnyClassMethod = classmethod[Any]
 
 __all__ = (
-    'ForwardRef',
     'Callable',
     'AnyCallable',
     'NoArgAnyCallable',

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -268,7 +268,6 @@ if TYPE_CHECKING:
     AnyClassMethod = classmethod[Any]
 
 __all__ = (
-    'Callable',
     'AnyCallable',
     'NoArgAnyCallable',
     'NoneType',

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -308,6 +308,7 @@ __all__ = (
     'get_all_type_hints',
     'is_union',
     'StrPath',
+    'MappingIntStrAny',
 )
 
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -12,6 +12,7 @@ from typing import (
     Callable,
     Deque,
     Dict,
+    ForwardRef,
     FrozenSet,
     Generator,
     Hashable,
@@ -30,7 +31,6 @@ from . import errors
 from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
 from .typing import (
     AnyCallable,
-    ForwardRef,
     all_literal_values,
     display_as_type,
     get_class,

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -7,7 +7,7 @@ import json
 import os
 from datetime import date, datetime, timedelta
 from pathlib import Path, PurePath
-from typing import Any, Dict, Generic, List, Optional, TypeVar
+from typing import Any, Dict, ForwardRef, Generic, List, Optional, TypeVar
 from uuid import UUID
 
 from typing_extensions import TypedDict
@@ -47,7 +47,6 @@ from pydantic import (
 )
 from pydantic.fields import Field, PrivateAttr
 from pydantic.generics import GenericModel
-from pydantic.typing import ForwardRef
 
 
 class Flags(BaseModel):

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, ForwardRef, List, Optional, Tuple
 
 import pytest
 
@@ -65,8 +65,6 @@ class Bar(BaseModel):
     b: 'Foo'
 """
     )
-
-    from pydantic.typing import ForwardRef
 
     assert module.Foo.__fields__['a'].type_ == ForwardRef('Bar')
     assert module.Bar.__fields__['b'].type_ is module.Foo

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -79,8 +79,6 @@ def test_forward_ref_one_of_fields_not_defined(create_module):
             foo: 'Foo'
             bar: 'Bar'  # noqa: F821
 
-    from pydantic.typing import ForwardRef
-
     assert module.Foo.__fields__['bar'].type_ == ForwardRef('Bar')
     assert module.Foo.__fields__['foo'].type_ is module.Foo
 
@@ -88,10 +86,9 @@ def test_forward_ref_one_of_fields_not_defined(create_module):
 def test_basic_forward_ref(create_module):
     @create_module
     def module():
-        from typing import Optional
+        from typing import ForwardRef, Optional
 
         from pydantic import BaseModel
-        from pydantic.typing import ForwardRef
 
         class Foo(BaseModel):
             a: int
@@ -108,8 +105,9 @@ def test_basic_forward_ref(create_module):
 def test_self_forward_ref_module(create_module):
     @create_module
     def module():
+        from typing import ForwardRef
+
         from pydantic import BaseModel
-        from pydantic.typing import ForwardRef
 
         Foo = ForwardRef('Foo')
 
@@ -164,8 +162,9 @@ def test_self_forward_ref_collection(create_module):
 def test_self_forward_ref_local(create_module):
     @create_module
     def module():
+        from typing import ForwardRef
+
         from pydantic import BaseModel
-        from pydantic.typing import ForwardRef
 
         def main():
             Foo = ForwardRef('Foo')
@@ -185,8 +184,9 @@ def test_self_forward_ref_local(create_module):
 def test_missing_update_forward_refs(create_module):
     @create_module
     def module():
+        from typing import ForwardRef
+
         from pydantic import BaseModel
-        from pydantic.typing import ForwardRef
 
         Foo = ForwardRef('Foo')
 
@@ -233,10 +233,9 @@ class Dataclass:
 def test_forward_ref_sub_types(create_module):
     @create_module
     def module():
-        from typing import Union
+        from typing import ForwardRef, Union
 
         from pydantic import BaseModel
-        from pydantic.typing import ForwardRef
 
         class Leaf(BaseModel):
             a: str
@@ -262,10 +261,9 @@ def test_forward_ref_sub_types(create_module):
 def test_forward_ref_nested_sub_types(create_module):
     @create_module
     def module():
-        from typing import Tuple, Union
+        from typing import ForwardRef, Tuple, Union
 
         from pydantic import BaseModel
-        from pydantic.typing import ForwardRef
 
         class Leaf(BaseModel):
             a: str
@@ -463,12 +461,11 @@ Owner.update_forward_refs()
 def test_forward_ref_with_field(create_module):
     @create_module
     def module():
-        from typing import List
+        from typing import ForwardRef, List
 
         import pytest
 
         from pydantic import BaseModel, Field
-        from pydantic.typing import ForwardRef
 
         Foo = ForwardRef('Foo')
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,6 +1,6 @@
 import sys
 from collections import namedtuple
-from typing import Any, Callable as TypingCallable, ForwardRef, NamedTuple, NewType  # noqa: F401
+from typing import Any, Callable as TypingCallable, Dict, ForwardRef, List, NamedTuple, NewType, Union  # noqa: F401
 
 import pytest
 from typing_extensions import Annotated  # noqa: F401

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,6 +1,6 @@
 import sys
 from collections import namedtuple
-from typing import Any, Callable as TypingCallable, Dict, ForwardRef, List, NamedTuple, NewType, Union  # noqa: F401
+from typing import Any, Callable as TypingCallable, ForwardRef, NamedTuple, NewType  # noqa: F401
 
 import pytest
 from typing_extensions import Annotated  # noqa: F401

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import re
 import string
 import sys
 from copy import copy, deepcopy
-from typing import Callable, Dict, List, NewType, Tuple, TypeVar, Union
+from typing import Callable, Dict, ForwardRef, List, NewType, Tuple, TypeVar, Union
 
 import pytest
 from pkg_resources import safe_version
@@ -16,7 +16,6 @@ from pydantic.color import Color
 from pydantic.dataclasses import dataclass
 from pydantic.fields import Undefined
 from pydantic.typing import (
-    ForwardRef,
     all_literal_values,
     display_as_type,
     get_args,


### PR DESCRIPTION
## Change Summary

Some imports indirectly get `ForwardRef` and other types from `.typing` instead of `typing` module. I came across this when I was working on something else.

Closes #4182 

## Related issue number

None

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
