### PR TITLE
Fix __post_init_post_parse__ is incorrectly passed keyword arguments when no __post_init__ is defined

### DIFF
--- a/changes/4361-hramezani.md
+++ b/changes/4361-hramezani.md
@@ -1,0 +1,1 @@
+Fix `__post_init_post_parse__` is incorrectly passed keyword arguments when no `__post_init__` is defined

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -310,8 +310,7 @@ def _add_pydantic_validation_attributes(  # noqa: C901 (ignore complexity)
                             # set arg value by default
                             initvars_and_values[f.name] = args[i]
                         except IndexError:
-                            initvars_and_values[f.name] = f.default
-                initvars_and_values.update(kwargs)
+                            initvars_and_values[f.name] = kwargs.get(f.name, f.default)
 
                 self.__post_init_post_parse__(**initvars_and_values)
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -600,6 +600,17 @@ def test_initvars_post_init_post_parse():
     assert PathDataPostInitPostParse('world', base_path='/hello').path == Path('/hello/world')
 
 
+def test_post_init_post_parse_without_initvars():
+    @pydantic.dataclasses.dataclass
+    class Foo:
+        a: int
+
+        def __post_init_post_parse__(self):
+            ...
+
+    Foo(a=1)
+
+
 def test_classvar():
     @pydantic.dataclasses.dataclass
     class TestClassVar:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #4342
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
