### PR TITLE
Build binaries for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     needs: [lint, test-linux-compiled, test-not-compiled, test-old-mypy, test-fastapi]
-#    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
+    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,12 +308,12 @@ jobs:
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     needs: [lint, test-linux-compiled, test-not-compiled, test-old-mypy, test-fastapi]
-    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
+#    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')"
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu , macos , windows]
-        python-version: ['7', '8', '9', '10']
+        python-version: ['7', '8', '9', '10', '11']
         include:
         - os: ubuntu
           platform: linux

--- a/changes/4374-samuelcolvin.md
+++ b/changes/4374-samuelcolvin.md
@@ -1,0 +1,1 @@
+Support Python 3.11, including binaries for 3.11 in PyPI.

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@ Installation is as simple as:
 pip install pydantic
 ```
 
-*pydantic* has no required dependencies except Python 3.7, 3.8, 3.9 or 3.10 and
+*pydantic* has no required dependencies except Python 3.7, 3.8, 3.9, 3.10 or 3.11 and
 [`typing-extensions`](https://pypi.org/project/typing-extensions/).
 If you've got Python 3.7+ and `pip` installed, you're good to go.
 

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
See https://github.com/pypa/cibuildwheel/pull/1226, cibuildwheel now support building python 3.11 binaries using `rc1`.

Although it's pretty early to release a package with python 3.11 binaries, the chance of a major change to 3.11 between now and it's release is very small. Also I want pydantic V1.10 to support python 3.11 but I don't want to wait for [October 3rd](https://www.python.org/downloads/release/python-3110rc1/) to release it.

See #4267 for the actual changes that were required to pydantic to support Python 3.11.