### PR TITLE
Fix `StrictStr` does not raise `ValidationError` when `max_length` is present in `Field`

### DIFF
--- a/changes/4388-hramezani.md
+++ b/changes/4388-hramezani.md
@@ -1,0 +1,1 @@
+Fix `StrictStr` does not raise `ValidationError` when `max_length` is present in `Field`

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -54,10 +54,10 @@ from .types import (
     ConstrainedInt,
     ConstrainedList,
     ConstrainedSet,
-    ConstrainedStr,
     SecretBytes,
     SecretStr,
     StrictBytes,
+    StrictStr,
     conbytes,
     condecimal,
     confloat,
@@ -1083,9 +1083,15 @@ def get_annotation_with_constraints(annotation: Any, field_info: FieldInfo) -> T
                 def constraint_func(**kw: Any) -> Type[Any]:
                     return type(type_.__name__, (type_,), kw)
 
-            elif issubclass(type_, str) and not issubclass(type_, (EmailStr, AnyUrl, ConstrainedStr)):
+            elif issubclass(type_, str) and not issubclass(type_, (EmailStr, AnyUrl)):
                 attrs = ('max_length', 'min_length', 'regex')
-                constraint_func = constr
+                if issubclass(type_, StrictStr):
+
+                    def constraint_func(**kw: Any) -> Type[Any]:
+                        return type(type_.__name__, (type_,), kw)
+
+                else:
+                    constraint_func = constr
             elif issubclass(type_, bytes):
                 attrs = ('max_length', 'min_length', 'regex')
                 if issubclass(type_, StrictBytes):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1690,6 +1690,19 @@ def test_strict_str_subclass():
     assert m.v == 'foobar'
 
 
+def test_strict_str_max_length():
+    class Model(BaseModel):
+        u: StrictStr = Field(..., max_length=5)
+
+    assert Model(u='foo').u == 'foo'
+
+    with pytest.raises(ValidationError, match='str type expected'):
+        Model(u=123)
+
+    with pytest.raises(ValidationError, match='ensure this value has at most 5 characters'):
+        Model(u='1234567')
+
+
 def test_strict_bool():
     class Model(BaseModel):
         v: StrictBool


### PR DESCRIPTION
ref #4383.

## Change Summary

same as the fix for `StrictBytes`. 

Without this patch, the following code fails:

```python
from pydantic import BaseModel, Field, StrictStr

class Model(BaseModel):
    a: StrictStr = Field(...)
    b: StrictStr = Field(..., max_length=5)

print(Model(a="123", b="123"))
```
```
Traceback (most recent call last):
  File "/tmp/test.py", line 3, in <module>
    class Model(BaseModel):
  File "/home/hasan/work/pydantic/pydantic/main.py", line 198, in __new__
    fields[ann_name] = ModelField.infer(
  File "/home/hasan/work/pydantic/pydantic/fields.py", line 497, in infer
    annotation = get_annotation_from_field_info(annotation, field_info, name, config.validate_assignment)
  File "/home/hasan/work/pydantic/pydantic/schema.py", line 1011, in get_annotation_from_field_info
    raise ValueError(
ValueError: On field "b" the following field constraints are set but not enforced: max_length. 
For more details see https://pydantic-docs.helpmanual.io/usage/schema/#unenforced-field-constraints

```
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
