### PR TITLE
feat: Make SecretStr hashable

### DIFF
--- a/changes/4387-chbndrhnns.md
+++ b/changes/4387-chbndrhnns.md
@@ -1,0 +1,1 @@
+Make `SecretStr` hashable

--- a/changes/4387-chbndrhnns.md
+++ b/changes/4387-chbndrhnns.md
@@ -1,1 +1,1 @@
-Make `SecretStr` hashable
+Make `SecretStr` and `SecretBytes` hashable

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -834,6 +834,9 @@ class SecretField(abc.ABC):
     def __str__(self) -> str:
         return '**********' if self.get_secret_value() else ''
 
+    def __hash__(self) -> int:
+        return hash(self.get_secret_value())
+
     @abc.abstractmethod
     def get_secret_value(self) -> Any:  # pragma: no cover
         ...
@@ -874,9 +877,6 @@ class SecretStr(SecretField):
 
     def __len__(self) -> int:
         return len(self._secret_value)
-
-    def __hash__(self) -> int:
-        return hash(self.get_secret_value())
 
     def display(self) -> str:
         warnings.warn('`secret_str.display()` is deprecated, use `str(secret_str)` instead', DeprecationWarning)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -875,6 +875,9 @@ class SecretStr(SecretField):
     def __len__(self) -> int:
         return len(self._secret_value)
 
+    def __hash__(self) -> int:
+        return hash(self.get_secret_value())
+
     def display(self) -> str:
         warnings.warn('`secret_str.display()` is deprecated, use `str(secret_str)` instead', DeprecationWarning)
         return str(self)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2651,7 +2651,7 @@ def test_secretstr_idempotent():
 
 
 def test_secretstr_is_hashable():
-    assert hash(SecretStr('secret'))
+    assert type(hash(SecretStr('secret'))) is int
 
 
 def test_secretstr_error():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2746,6 +2746,10 @@ def test_secretbytes_idempotent():
     _ = Foobar(password=SecretBytes(b'1234'))
 
 
+def test_secretbytes_is_hashable():
+    assert type(hash(SecretBytes(b'secret'))) is int
+
+
 def test_secretbytes_error():
     class Foobar(BaseModel):
         password: SecretBytes

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2650,6 +2650,10 @@ def test_secretstr_idempotent():
     assert m.password.get_secret_value() == '1234'
 
 
+def test_secretstr_is_hashable():
+    assert hash(SecretStr('secret'))
+
+
 def test_secretstr_error():
     class Foobar(BaseModel):
         password: SecretStr


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Makes `SecretStr` hashable, cf. https://github.com/pydantic/pydantic/issues/4387

## Related issue number

fix #4387 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
