### PR TITLE
Fix PEP487 `__set_name__` protocol in BaseModel

### DIFF
--- a/changes/4407-tlambert03.md
+++ b/changes/4407-tlambert03.md
@@ -1,0 +1,1 @@
+Fix PEP487 protocol in `BaseModel`: call `__set_name__` on namespace values that implement the method.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -286,6 +286,11 @@ class ModelMetaclass(ABCMeta):
         if resolve_forward_refs:
             cls.__try_update_forward_refs__()
 
+        for name, obj in namespace.items():
+            set_name = getattr(obj, '__set_name__', None)
+            if callable(set_name):
+                set_name(cls, name)
+
         return cls
 
     def __instancecheck__(self, instance: Any) -> bool:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -286,6 +286,7 @@ class ModelMetaclass(ABCMeta):
         if resolve_forward_refs:
             cls.__try_update_forward_refs__()
 
+        # preserve `__set_name__` protocol defined in https://peps.python.org/pep-0487
         for name, obj in namespace.items():
             set_name = getattr(obj, '__set_name__', None)
             if callable(set_name):

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -2,30 +2,38 @@ from typing import Generic, TypeVar
 
 import pytest
 
-from pydantic import BaseModel, Extra, Field, ValidationError, create_model, errors, validator
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    ValidationError,
+    create_model,
+    errors,
+    validator,
+)
 from pydantic.generics import GenericModel
 
 
 def test_create_model():
-    model = create_model('FooModel', foo=(str, ...), bar=123)
+    model = create_model("FooModel", foo=(str, ...), bar=123)
     assert issubclass(model, BaseModel)
     assert issubclass(model.__config__, BaseModel.Config)
-    assert model.__name__ == 'FooModel'
-    assert model.__fields__.keys() == {'foo', 'bar'}
+    assert model.__name__ == "FooModel"
+    assert model.__fields__.keys() == {"foo", "bar"}
     assert model.__validators__ == {}
-    assert model.__config__.__name__ == 'Config'
-    assert model.__module__ == 'pydantic.main'
+    assert model.__config__.__name__ == "Config"
+    assert model.__module__ == "pydantic.main"
 
 
 def test_create_model_usage():
-    model = create_model('FooModel', foo=(str, ...), bar=123)
-    m = model(foo='hello')
-    assert m.foo == 'hello'
+    model = create_model("FooModel", foo=(str, ...), bar=123)
+    m = model(foo="hello")
+    assert m.foo == "hello"
     assert m.bar == 123
     with pytest.raises(ValidationError):
         model()
     with pytest.raises(ValidationError):
-        model(foo='hello', bar='xxx')
+        model(foo="hello", bar="xxx")
 
 
 def test_create_model_pickle(create_module):
@@ -40,12 +48,14 @@ def test_create_model_pickle(create_module):
 
         from pydantic import create_model
 
-        FooModel = create_model('FooModel', foo=(str, ...), bar=123, __module__=__name__)
+        FooModel = create_model(
+            "FooModel", foo=(str, ...), bar=123, __module__=__name__
+        )
 
-        m = FooModel(foo='hello')
+        m = FooModel(foo="hello")
         d = pickle.dumps(m)
         m2 = pickle.loads(d)
-        assert m2.foo == m.foo == 'hello'
+        assert m2.foo == m.foo == "hello"
         assert m2.bar == m.bar == 123
         assert m2 == m
         assert m2 is not m
@@ -53,18 +63,18 @@ def test_create_model_pickle(create_module):
 
 def test_invalid_name():
     with pytest.warns(RuntimeWarning):
-        model = create_model('FooModel', _foo=(str, ...))
+        model = create_model("FooModel", _foo=(str, ...))
     assert len(model.__fields__) == 0
 
 
 def test_field_wrong_tuple():
     with pytest.raises(errors.ConfigError):
-        create_model('FooModel', foo=(1, 2, 3))
+        create_model("FooModel", foo=(1, 2, 3))
 
 
 def test_config_and_base():
     with pytest.raises(errors.ConfigError):
-        create_model('FooModel', __config__=BaseModel.Config, __base__=BaseModel)
+        create_model("FooModel", __config__=BaseModel.Config, __base__=BaseModel)
 
 
 def test_inheritance():
@@ -72,18 +82,18 @@ def test_inheritance():
         x = 1
         y = 2
 
-    model = create_model('FooModel', foo=(str, ...), bar=(int, 123), __base__=BarModel)
-    assert model.__fields__.keys() == {'foo', 'bar', 'x', 'y'}
-    m = model(foo='a', x=4)
-    assert m.dict() == {'bar': 123, 'foo': 'a', 'x': 4, 'y': 2}
+    model = create_model("FooModel", foo=(str, ...), bar=(int, 123), __base__=BarModel)
+    assert model.__fields__.keys() == {"foo", "bar", "x", "y"}
+    m = model(foo="a", x=4)
+    assert m.dict() == {"bar": 123, "foo": "a", "x": 4, "y": 2}
 
 
 def test_custom_config():
     class Config:
-        fields = {'foo': 'api-foo-field'}
+        fields = {"foo": "api-foo-field"}
 
-    model = create_model('FooModel', foo=(int, ...), __config__=Config)
-    assert model(**{'api-foo-field': '987'}).foo == 987
+    model = create_model("FooModel", foo=(int, ...), __config__=Config)
+    assert model(**{"api-foo-field": "987"}).foo == 987
     assert issubclass(model.__config__, BaseModel.Config)
     with pytest.raises(ValidationError):
         model(foo=654)
@@ -91,10 +101,10 @@ def test_custom_config():
 
 def test_custom_config_inherits():
     class Config(BaseModel.Config):
-        fields = {'foo': 'api-foo-field'}
+        fields = {"foo": "api-foo-field"}
 
-    model = create_model('FooModel', foo=(int, ...), __config__=Config)
-    assert model(**{'api-foo-field': '987'}).foo == 987
+    model = create_model("FooModel", foo=(int, ...), __config__=Config)
+    assert model(**{"api-foo-field": "987"}).foo == 987
     assert issubclass(model.__config__, BaseModel.Config)
     with pytest.raises(ValidationError):
         model(foo=654)
@@ -104,7 +114,7 @@ def test_custom_config_extras():
     class Config(BaseModel.Config):
         extra = Extra.forbid
 
-    model = create_model('FooModel', foo=(int, ...), __config__=Config)
+    model = create_model("FooModel", foo=(int, ...), __config__=Config)
     assert model(foo=654)
     with pytest.raises(ValidationError):
         model(bar=654)
@@ -112,53 +122,57 @@ def test_custom_config_extras():
 
 def test_inheritance_validators():
     class BarModel(BaseModel):
-        @validator('a', check_fields=False)
+        @validator("a", check_fields=False)
         def check_a(cls, v):
-            if 'foobar' not in v:
+            if "foobar" not in v:
                 raise ValueError('"foobar" not found in a')
             return v
 
-    model = create_model('FooModel', a='cake', __base__=BarModel)
-    assert model().a == 'cake'
-    assert model(a='this is foobar good').a == 'this is foobar good'
+    model = create_model("FooModel", a="cake", __base__=BarModel)
+    assert model().a == "cake"
+    assert model(a="this is foobar good").a == "this is foobar good"
     with pytest.raises(ValidationError):
-        model(a='something else')
+        model(a="something else")
 
 
 def test_inheritance_validators_always():
     class BarModel(BaseModel):
-        @validator('a', check_fields=False, always=True)
+        @validator("a", check_fields=False, always=True)
         def check_a(cls, v):
-            if 'foobar' not in v:
+            if "foobar" not in v:
                 raise ValueError('"foobar" not found in a')
             return v
 
-    model = create_model('FooModel', a='cake', __base__=BarModel)
+    model = create_model("FooModel", a="cake", __base__=BarModel)
     with pytest.raises(ValidationError):
         model()
-    assert model(a='this is foobar good').a == 'this is foobar good'
+    assert model(a="this is foobar good").a == "this is foobar good"
     with pytest.raises(ValidationError):
-        model(a='something else')
+        model(a="something else")
 
 
 def test_inheritance_validators_all():
     class BarModel(BaseModel):
-        @validator('*')
+        @validator("*")
         def check_all(cls, v):
             return v * 2
 
-    model = create_model('FooModel', a=(int, ...), b=(int, ...), __base__=BarModel)
-    assert model(a=2, b=6).dict() == {'a': 4, 'b': 12}
+    model = create_model("FooModel", a=(int, ...), b=(int, ...), __base__=BarModel)
+    assert model(a=2, b=6).dict() == {"a": 4, "b": 12}
 
 
 def test_funky_name():
-    model = create_model('FooModel', **{'this-is-funky': (int, ...)})
-    m = model(**{'this-is-funky': '123'})
-    assert m.dict() == {'this-is-funky': 123}
+    model = create_model("FooModel", **{"this-is-funky": (int, ...)})
+    m = model(**{"this-is-funky": "123"})
+    assert m.dict() == {"this-is-funky": 123}
     with pytest.raises(ValidationError) as exc_info:
         model()
     assert exc_info.value.errors() == [
-        {'loc': ('this-is-funky',), 'msg': 'field required', 'type': 'value_error.missing'}
+        {
+            "loc": ("this-is-funky",),
+            "msg": "field required",
+            "type": "value_error.missing",
+        }
     ]
 
 
@@ -166,25 +180,25 @@ def test_repeat_base_usage():
     class Model(BaseModel):
         a: str
 
-    assert Model.__fields__.keys() == {'a'}
+    assert Model.__fields__.keys() == {"a"}
 
-    model = create_model('FooModel', b=1, __base__=Model)
+    model = create_model("FooModel", b=1, __base__=Model)
 
-    assert Model.__fields__.keys() == {'a'}
-    assert model.__fields__.keys() == {'a', 'b'}
+    assert Model.__fields__.keys() == {"a"}
+    assert model.__fields__.keys() == {"a", "b"}
 
-    model2 = create_model('Foo2Model', c=1, __base__=Model)
+    model2 = create_model("Foo2Model", c=1, __base__=Model)
 
-    assert Model.__fields__.keys() == {'a'}
-    assert model.__fields__.keys() == {'a', 'b'}
-    assert model2.__fields__.keys() == {'a', 'c'}
+    assert Model.__fields__.keys() == {"a"}
+    assert model.__fields__.keys() == {"a", "b"}
+    assert model2.__fields__.keys() == {"a", "c"}
 
-    model3 = create_model('Foo2Model', d=1, __base__=model)
+    model3 = create_model("Foo2Model", d=1, __base__=model)
 
-    assert Model.__fields__.keys() == {'a'}
-    assert model.__fields__.keys() == {'a', 'b'}
-    assert model2.__fields__.keys() == {'a', 'c'}
-    assert model3.__fields__.keys() == {'a', 'b', 'd'}
+    assert Model.__fields__.keys() == {"a"}
+    assert model.__fields__.keys() == {"a", "b"}
+    assert model2.__fields__.keys() == {"a", "c"}
+    assert model3.__fields__.keys() == {"a", "b", "d"}
 
 
 def test_dynamic_and_static():
@@ -193,32 +207,64 @@ def test_dynamic_and_static():
         y: float
         z: str
 
-    DynamicA = create_model('A', x=(int, ...), y=(float, ...), z=(str, ...))
+    DynamicA = create_model("A", x=(int, ...), y=(float, ...), z=(str, ...))
 
-    for field_name in ('x', 'y', 'z'):
-        assert A.__fields__[field_name].default == DynamicA.__fields__[field_name].default
+    for field_name in ("x", "y", "z"):
+        assert (
+            A.__fields__[field_name].default == DynamicA.__fields__[field_name].default
+        )
 
 
 def test_config_field_info_create_model():
     class Config:
-        fields = {'a': {'description': 'descr'}}
+        fields = {"a": {"description": "descr"}}
 
-    m1 = create_model('M1', __config__=Config, a=(str, ...))
-    assert m1.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
+    m1 = create_model("M1", __config__=Config, a=(str, ...))
+    assert m1.schema()["properties"] == {
+        "a": {"title": "A", "description": "descr", "type": "string"}
+    }
 
-    m2 = create_model('M2', __config__=Config, a=(str, Field(...)))
-    assert m2.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
+    m2 = create_model("M2", __config__=Config, a=(str, Field(...)))
+    assert m2.schema()["properties"] == {
+        "a": {"title": "A", "description": "descr", "type": "string"}
+    }
 
 
 def test_generics_model():
-    T = TypeVar('T')
+    T = TypeVar("T")
 
     class TestGenericModel(GenericModel):
         pass
 
     AAModel = create_model(
-        'AAModel', __base__=(TestGenericModel, Generic[T]), __cls_kwargs__={'orm_mode': True}, aa=(int, Field(0))
+        "AAModel",
+        __base__=(TestGenericModel, Generic[T]),
+        __cls_kwargs__={"orm_mode": True},
+        aa=(int, Field(0)),
     )
     result = AAModel[int](aa=1)
     assert result.aa == 1
     assert result.__config__.orm_mode is True
+
+
+def test_set_name():
+
+    from unittest.mock import Mock
+    from pydantic.fields import ModelPrivateAttr
+
+    mock = Mock()
+
+    class class_deco(ModelPrivateAttr):
+        def __init__(self, fn):
+            super().__init__()
+            self.fn = fn
+
+        def __set_name__(self, owner, name):
+            mock(owner, name)
+
+    class A(BaseModel):
+        @class_deco
+        def _some_func(self):
+            return self
+
+    mock.assert_called_once_with(A, "_some_func")

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -244,4 +244,4 @@ def test_set_name():
         def _some_func(self):
             return self
 
-    mock.assert_called_once_with(A, "_some_func")
+    mock.assert_called_once_with(A, '_some_func')

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -227,6 +227,7 @@ def test_generics_model():
 def test_set_name():
 
     from unittest.mock import Mock
+
     from pydantic.fields import ModelPrivateAttr
 
     mock = Mock()

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -3,6 +3,7 @@ from typing import Generic, TypeVar
 import pytest
 
 from pydantic import BaseModel, Extra, Field, ValidationError, create_model, errors, validator
+from pydantic.fields import ModelPrivateAttr
 from pydantic.generics import GenericModel
 
 
@@ -225,12 +226,7 @@ def test_generics_model():
 
 
 def test_set_name():
-
-    from unittest.mock import Mock
-
-    from pydantic.fields import ModelPrivateAttr
-
-    mock = Mock()
+    calls = []
 
     class class_deco(ModelPrivateAttr):
         def __init__(self, fn):
@@ -238,11 +234,11 @@ def test_set_name():
             self.fn = fn
 
         def __set_name__(self, owner, name):
-            mock(owner, name)
+            calls.append((owner, name))
 
     class A(BaseModel):
         @class_deco
         def _some_func(self):
             return self
 
-    mock.assert_called_once_with(A, '_some_func')
+    assert calls == [(A, '_some_func')]

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -2,38 +2,30 @@ from typing import Generic, TypeVar
 
 import pytest
 
-from pydantic import (
-    BaseModel,
-    Extra,
-    Field,
-    ValidationError,
-    create_model,
-    errors,
-    validator,
-)
+from pydantic import BaseModel, Extra, Field, ValidationError, create_model, errors, validator
 from pydantic.generics import GenericModel
 
 
 def test_create_model():
-    model = create_model("FooModel", foo=(str, ...), bar=123)
+    model = create_model('FooModel', foo=(str, ...), bar=123)
     assert issubclass(model, BaseModel)
     assert issubclass(model.__config__, BaseModel.Config)
-    assert model.__name__ == "FooModel"
-    assert model.__fields__.keys() == {"foo", "bar"}
+    assert model.__name__ == 'FooModel'
+    assert model.__fields__.keys() == {'foo', 'bar'}
     assert model.__validators__ == {}
-    assert model.__config__.__name__ == "Config"
-    assert model.__module__ == "pydantic.main"
+    assert model.__config__.__name__ == 'Config'
+    assert model.__module__ == 'pydantic.main'
 
 
 def test_create_model_usage():
-    model = create_model("FooModel", foo=(str, ...), bar=123)
-    m = model(foo="hello")
-    assert m.foo == "hello"
+    model = create_model('FooModel', foo=(str, ...), bar=123)
+    m = model(foo='hello')
+    assert m.foo == 'hello'
     assert m.bar == 123
     with pytest.raises(ValidationError):
         model()
     with pytest.raises(ValidationError):
-        model(foo="hello", bar="xxx")
+        model(foo='hello', bar='xxx')
 
 
 def test_create_model_pickle(create_module):
@@ -48,14 +40,12 @@ def test_create_model_pickle(create_module):
 
         from pydantic import create_model
 
-        FooModel = create_model(
-            "FooModel", foo=(str, ...), bar=123, __module__=__name__
-        )
+        FooModel = create_model('FooModel', foo=(str, ...), bar=123, __module__=__name__)
 
-        m = FooModel(foo="hello")
+        m = FooModel(foo='hello')
         d = pickle.dumps(m)
         m2 = pickle.loads(d)
-        assert m2.foo == m.foo == "hello"
+        assert m2.foo == m.foo == 'hello'
         assert m2.bar == m.bar == 123
         assert m2 == m
         assert m2 is not m
@@ -63,18 +53,18 @@ def test_create_model_pickle(create_module):
 
 def test_invalid_name():
     with pytest.warns(RuntimeWarning):
-        model = create_model("FooModel", _foo=(str, ...))
+        model = create_model('FooModel', _foo=(str, ...))
     assert len(model.__fields__) == 0
 
 
 def test_field_wrong_tuple():
     with pytest.raises(errors.ConfigError):
-        create_model("FooModel", foo=(1, 2, 3))
+        create_model('FooModel', foo=(1, 2, 3))
 
 
 def test_config_and_base():
     with pytest.raises(errors.ConfigError):
-        create_model("FooModel", __config__=BaseModel.Config, __base__=BaseModel)
+        create_model('FooModel', __config__=BaseModel.Config, __base__=BaseModel)
 
 
 def test_inheritance():
@@ -82,18 +72,18 @@ def test_inheritance():
         x = 1
         y = 2
 
-    model = create_model("FooModel", foo=(str, ...), bar=(int, 123), __base__=BarModel)
-    assert model.__fields__.keys() == {"foo", "bar", "x", "y"}
-    m = model(foo="a", x=4)
-    assert m.dict() == {"bar": 123, "foo": "a", "x": 4, "y": 2}
+    model = create_model('FooModel', foo=(str, ...), bar=(int, 123), __base__=BarModel)
+    assert model.__fields__.keys() == {'foo', 'bar', 'x', 'y'}
+    m = model(foo='a', x=4)
+    assert m.dict() == {'bar': 123, 'foo': 'a', 'x': 4, 'y': 2}
 
 
 def test_custom_config():
     class Config:
-        fields = {"foo": "api-foo-field"}
+        fields = {'foo': 'api-foo-field'}
 
-    model = create_model("FooModel", foo=(int, ...), __config__=Config)
-    assert model(**{"api-foo-field": "987"}).foo == 987
+    model = create_model('FooModel', foo=(int, ...), __config__=Config)
+    assert model(**{'api-foo-field': '987'}).foo == 987
     assert issubclass(model.__config__, BaseModel.Config)
     with pytest.raises(ValidationError):
         model(foo=654)
@@ -101,10 +91,10 @@ def test_custom_config():
 
 def test_custom_config_inherits():
     class Config(BaseModel.Config):
-        fields = {"foo": "api-foo-field"}
+        fields = {'foo': 'api-foo-field'}
 
-    model = create_model("FooModel", foo=(int, ...), __config__=Config)
-    assert model(**{"api-foo-field": "987"}).foo == 987
+    model = create_model('FooModel', foo=(int, ...), __config__=Config)
+    assert model(**{'api-foo-field': '987'}).foo == 987
     assert issubclass(model.__config__, BaseModel.Config)
     with pytest.raises(ValidationError):
         model(foo=654)
@@ -114,7 +104,7 @@ def test_custom_config_extras():
     class Config(BaseModel.Config):
         extra = Extra.forbid
 
-    model = create_model("FooModel", foo=(int, ...), __config__=Config)
+    model = create_model('FooModel', foo=(int, ...), __config__=Config)
     assert model(foo=654)
     with pytest.raises(ValidationError):
         model(bar=654)
@@ -122,57 +112,53 @@ def test_custom_config_extras():
 
 def test_inheritance_validators():
     class BarModel(BaseModel):
-        @validator("a", check_fields=False)
+        @validator('a', check_fields=False)
         def check_a(cls, v):
-            if "foobar" not in v:
+            if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
             return v
 
-    model = create_model("FooModel", a="cake", __base__=BarModel)
-    assert model().a == "cake"
-    assert model(a="this is foobar good").a == "this is foobar good"
+    model = create_model('FooModel', a='cake', __base__=BarModel)
+    assert model().a == 'cake'
+    assert model(a='this is foobar good').a == 'this is foobar good'
     with pytest.raises(ValidationError):
-        model(a="something else")
+        model(a='something else')
 
 
 def test_inheritance_validators_always():
     class BarModel(BaseModel):
-        @validator("a", check_fields=False, always=True)
+        @validator('a', check_fields=False, always=True)
         def check_a(cls, v):
-            if "foobar" not in v:
+            if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
             return v
 
-    model = create_model("FooModel", a="cake", __base__=BarModel)
+    model = create_model('FooModel', a='cake', __base__=BarModel)
     with pytest.raises(ValidationError):
         model()
-    assert model(a="this is foobar good").a == "this is foobar good"
+    assert model(a='this is foobar good').a == 'this is foobar good'
     with pytest.raises(ValidationError):
-        model(a="something else")
+        model(a='something else')
 
 
 def test_inheritance_validators_all():
     class BarModel(BaseModel):
-        @validator("*")
+        @validator('*')
         def check_all(cls, v):
             return v * 2
 
-    model = create_model("FooModel", a=(int, ...), b=(int, ...), __base__=BarModel)
-    assert model(a=2, b=6).dict() == {"a": 4, "b": 12}
+    model = create_model('FooModel', a=(int, ...), b=(int, ...), __base__=BarModel)
+    assert model(a=2, b=6).dict() == {'a': 4, 'b': 12}
 
 
 def test_funky_name():
-    model = create_model("FooModel", **{"this-is-funky": (int, ...)})
-    m = model(**{"this-is-funky": "123"})
-    assert m.dict() == {"this-is-funky": 123}
+    model = create_model('FooModel', **{'this-is-funky': (int, ...)})
+    m = model(**{'this-is-funky': '123'})
+    assert m.dict() == {'this-is-funky': 123}
     with pytest.raises(ValidationError) as exc_info:
         model()
     assert exc_info.value.errors() == [
-        {
-            "loc": ("this-is-funky",),
-            "msg": "field required",
-            "type": "value_error.missing",
-        }
+        {'loc': ('this-is-funky',), 'msg': 'field required', 'type': 'value_error.missing'}
     ]
 
 
@@ -180,25 +166,25 @@ def test_repeat_base_usage():
     class Model(BaseModel):
         a: str
 
-    assert Model.__fields__.keys() == {"a"}
+    assert Model.__fields__.keys() == {'a'}
 
-    model = create_model("FooModel", b=1, __base__=Model)
+    model = create_model('FooModel', b=1, __base__=Model)
 
-    assert Model.__fields__.keys() == {"a"}
-    assert model.__fields__.keys() == {"a", "b"}
+    assert Model.__fields__.keys() == {'a'}
+    assert model.__fields__.keys() == {'a', 'b'}
 
-    model2 = create_model("Foo2Model", c=1, __base__=Model)
+    model2 = create_model('Foo2Model', c=1, __base__=Model)
 
-    assert Model.__fields__.keys() == {"a"}
-    assert model.__fields__.keys() == {"a", "b"}
-    assert model2.__fields__.keys() == {"a", "c"}
+    assert Model.__fields__.keys() == {'a'}
+    assert model.__fields__.keys() == {'a', 'b'}
+    assert model2.__fields__.keys() == {'a', 'c'}
 
-    model3 = create_model("Foo2Model", d=1, __base__=model)
+    model3 = create_model('Foo2Model', d=1, __base__=model)
 
-    assert Model.__fields__.keys() == {"a"}
-    assert model.__fields__.keys() == {"a", "b"}
-    assert model2.__fields__.keys() == {"a", "c"}
-    assert model3.__fields__.keys() == {"a", "b", "d"}
+    assert Model.__fields__.keys() == {'a'}
+    assert model.__fields__.keys() == {'a', 'b'}
+    assert model2.__fields__.keys() == {'a', 'c'}
+    assert model3.__fields__.keys() == {'a', 'b', 'd'}
 
 
 def test_dynamic_and_static():
@@ -207,40 +193,31 @@ def test_dynamic_and_static():
         y: float
         z: str
 
-    DynamicA = create_model("A", x=(int, ...), y=(float, ...), z=(str, ...))
+    DynamicA = create_model('A', x=(int, ...), y=(float, ...), z=(str, ...))
 
-    for field_name in ("x", "y", "z"):
-        assert (
-            A.__fields__[field_name].default == DynamicA.__fields__[field_name].default
-        )
+    for field_name in ('x', 'y', 'z'):
+        assert A.__fields__[field_name].default == DynamicA.__fields__[field_name].default
 
 
 def test_config_field_info_create_model():
     class Config:
-        fields = {"a": {"description": "descr"}}
+        fields = {'a': {'description': 'descr'}}
 
-    m1 = create_model("M1", __config__=Config, a=(str, ...))
-    assert m1.schema()["properties"] == {
-        "a": {"title": "A", "description": "descr", "type": "string"}
-    }
+    m1 = create_model('M1', __config__=Config, a=(str, ...))
+    assert m1.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
 
-    m2 = create_model("M2", __config__=Config, a=(str, Field(...)))
-    assert m2.schema()["properties"] == {
-        "a": {"title": "A", "description": "descr", "type": "string"}
-    }
+    m2 = create_model('M2', __config__=Config, a=(str, Field(...)))
+    assert m2.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
 
 
 def test_generics_model():
-    T = TypeVar("T")
+    T = TypeVar('T')
 
     class TestGenericModel(GenericModel):
         pass
 
     AAModel = create_model(
-        "AAModel",
-        __base__=(TestGenericModel, Generic[T]),
-        __cls_kwargs__={"orm_mode": True},
-        aa=(int, Field(0)),
+        'AAModel', __base__=(TestGenericModel, Generic[T]), __cls_kwargs__={'orm_mode': True}, aa=(int, Field(0))
     )
     result = AAModel[int](aa=1)
     assert result.aa == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

This is a small change that brings BaseModel back into compliance with the the `__set_name__` protocol defined in [[PEP 487](https://peps.python.org/pep-0487/](https://peps.python.org/pep-0487/#proposal)), and described in the [creating the class object](https://docs.python.org/3/reference/datamodel.html#creating-the-class-object) portion of the python documentation, which states:

> the following additional customization steps are invoked after creating the class object:
>
> - The `type.__new__` method collects all of the attributes in the class namespace that define a [`__set_name__()`](https://docs.python.org/3/reference/datamodel.html#object.__set_name__) method;
> - Those `__set_name__` methods are called with the class being defined and the assigned name of that particular attribute

In the case of `BaseModel`, some names in the original namespace (such as instances of `ModelPrivateAttr`) are stripped before calling `type.__new__` with the `new_namespace`.  As such, objects implementing this `__set_name__` protocol are skipped.

Rather than calling `type.__new__` with the original namespace, this PR implements the protocol directly by calling `__set_name__` on any objects in the namespace that provide the method.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/main/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


## Context

For context, I've been using [sqlmodel](https://github.com/tiangolo/sqlmodel) recently and would like to to implement this pattern

```python
from sqlmodel import SQLModel

class SomeObject(SQLModel, table=True):
    name: str
    slug: str | None

    @on_before_save
    def _do_stuff(self):
        self.slug = slugify(self.name)
```

to bind object-specific listeners to various SqlAlchemy [ORM events](https://docs.sqlalchemy.org/orm/events.html)... however, this requires that the decorator know the class in which it is being called (which, among other things, seems to have been a primary motivator of `__set_name__`)