### PR TITLE
Fix duplicate calls to `__set_name__` for non-private attributes in `BaseModel.__new__`

### DIFF
--- a/changes/4407-tlambert03.md
+++ b/changes/4407-tlambert03.md
@@ -1,1 +1,1 @@
-Fix PEP487 protocol in `BaseModel`: call `__set_name__` on namespace values that implement the method.
+Fix PEP487 `__set_name__` protocol in `BaseModel` for PrivateAttrs.

--- a/changes/4410-tlambert03.md
+++ b/changes/4410-tlambert03.md
@@ -1,0 +1,1 @@
+Fix duplicate calls to `__set_name__` for non-private attributes in `BaseModel.__new__`.  Add more tests.

--- a/changes/4410-tlambert03.md
+++ b/changes/4410-tlambert03.md
@@ -1,1 +1,0 @@
-Fix duplicate calls to `__set_name__` for non-private attributes in `BaseModel.__new__`.  Add more tests.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -287,10 +287,12 @@ class ModelMetaclass(ABCMeta):
             cls.__try_update_forward_refs__()
 
         # preserve `__set_name__` protocol defined in https://peps.python.org/pep-0487
+        # for attributes not in `new_namespace` (e.g. private attributes)
         for name, obj in namespace.items():
-            set_name = getattr(obj, '__set_name__', None)
-            if callable(set_name):
-                set_name(cls, name)
+            if name not in new_namespace:
+                set_name = getattr(obj, '__set_name__', None)
+                if callable(set_name):
+                    set_name(cls, name)
 
         return cls
 


### PR DESCRIPTION
## Change Summary

My apologies @samuelcolvin, as I was working on adding the test you requested in https://github.com/pydantic/pydantic/pull/4407#discussion_r950847546, I found a bug in my implementation, which is that `__set_name__` was now getting called twice for public attributes (i.e. anything in `new_namespace`), and only once for private attributes.  I didn't notice the auto-merge in time :)

This PR fixes that, adds a test that `__set_name__` is called only once both for regular `object` subclasses as well as `ModelPrivateAttrs`, and adds the test requested above to make sure the bound method works (for regular objects... privateAttrs likely won't work for this pattern, as commented in the test)

skip change file check

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/main/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
