### PR TITLE
Revert "Fix PEP487 `__set_name__` protocol in BaseModel"

### DIFF
--- a/changes/4407-tlambert03.md
+++ b/changes/4407-tlambert03.md
@@ -1,1 +1,0 @@
-Fix PEP487 protocol in `BaseModel`: call `__set_name__` on namespace values that implement the method.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -286,12 +286,6 @@ class ModelMetaclass(ABCMeta):
         if resolve_forward_refs:
             cls.__try_update_forward_refs__()
 
-        # preserve `__set_name__` protocol defined in https://peps.python.org/pep-0487
-        for name, obj in namespace.items():
-            set_name = getattr(obj, '__set_name__', None)
-            if callable(set_name):
-                set_name(cls, name)
-
         return cls
 
     def __instancecheck__(self, instance: Any) -> bool:

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -3,7 +3,6 @@ from typing import Generic, TypeVar
 import pytest
 
 from pydantic import BaseModel, Extra, Field, ValidationError, create_model, errors, validator
-from pydantic.fields import ModelPrivateAttr
 from pydantic.generics import GenericModel
 
 
@@ -223,22 +222,3 @@ def test_generics_model():
     result = AAModel[int](aa=1)
     assert result.aa == 1
     assert result.__config__.orm_mode is True
-
-
-def test_set_name():
-    calls = []
-
-    class class_deco(ModelPrivateAttr):
-        def __init__(self, fn):
-            super().__init__()
-            self.fn = fn
-
-        def __set_name__(self, owner, name):
-            calls.append((owner, name))
-
-    class A(BaseModel):
-        @class_deco
-        def _some_func(self):
-            return self
-
-    assert calls == [(A, '_some_func')]


### PR DESCRIPTION
Reverts #4407

See #4410 for explanation.

skip change file check