### PR TITLE
avoid docs update on pre-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
       - name: set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: get dist artifacts
         uses: actions/download-artifact@v3
@@ -393,9 +393,7 @@ jobs:
           path: site
 
       - name: install
-        run: |
-          make install-docs
-          pip install -U twine
+        run: pip install -U twine packaging
 
       - name: twine check
         run: |
@@ -403,6 +401,7 @@ jobs:
           ls -lh dist
 
       - name: check tag
+        id: check-tag
         run: ./tests/check_tag.py
 
       - name: upload to pypi
@@ -412,6 +411,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.pypi_token }}
 
       - name: publish docs
+        if: '!fromJSON(steps.check-tag.outputs.IS_PRERELEASE)'
         run: make publish-docs
         env:
           NETLIFY: ${{ secrets.netlify_token }}

--- a/tests/check_tag.py
+++ b/tests/check_tag.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
+import json
 import os
 import re
 import sys
+from importlib.machinery import SourceFileLoader
 
-from pydantic.version import VERSION
+from packaging.version import parse
 
 
 def main(env_var='GITHUB_REF') -> int:
     git_ref = os.getenv(env_var, 'none')
     tag = re.sub('^refs/tags/v*', '', git_ref.lower())
-    version = VERSION.lower()
+    version = SourceFileLoader('version', 'pydantic/version.py').load_module().VERSION.lower()
     if tag == version:
-        print(f'✓ {env_var} env var {git_ref!r} matches package version: {tag!r} == {version!r}')
+        is_prerelease = parse(version).is_prerelease
+        print(
+            f'✓ {env_var} env var {git_ref!r} matches package version: {tag!r} == {version!r}, '
+            f'is pre-release: {is_prerelease}'
+        )
+        print(f'::set-output name=IS_PRERELEASE::{json.dumps(is_prerelease)}')
         return 0
     else:
         print(f'✖ {env_var} env var {git_ref!r} does not match package version: {tag!r} != {version!r}')


### PR DESCRIPTION
## Change Summary

Avoid updating the docs when deploying a pre-release. I've tested this in a sandbox and seems to work.

skip change file check
