### PR TITLE
Handle `extra` behavior in `BaseModel.copy` 

### DIFF
--- a/changes/4449-jskrzypek.md
+++ b/changes/4449-jskrzypek.md
@@ -1,0 +1,1 @@
+Add support for `Extra.ignore`- and `Extra.forbid`-like behavior in `BaseModel.copy`.

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -79,6 +79,11 @@ class ValidationError(Representation, ValueError):
         return [('model', self.model.__name__), ('errors', self.errors())]
 
 
+class CopyError(ValidationError):
+    def __str__(self) -> str:
+        return super().__str__().replace("validation error", "copy error")
+
+
 def display_errors(errors: List['ErrorDict']) -> str:
     return '\n'.join(f'{_display_error_loc(e)}\n  {e["msg"]} ({_display_error_type_and_ctx(e)})' for e in errors)
 

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional
 
 import pytest
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Extra, Field, PrivateAttr
 from pydantic.fields import Undefined
 
 
@@ -220,6 +220,25 @@ def test_copy_update_unset():
         bar: Optional[str]
 
     assert Foo(foo='hello').copy(update={'bar': 'world'}).json(exclude_unset=True) == '{"foo": "hello", "bar": "world"}'
+
+
+def test_copy_update_extra_ignore():
+    class Model(BaseModel):
+        a: float
+        b: float
+
+        class Config:
+            extra = Extra.ignore
+
+    model = Model(a=0.2, b=0.3)
+
+    copied_model = model.copy(update={'b': 3.5, 'c': 2.5})
+    assert model.a == model.a == 0.2
+    assert copied_model.b == 3.5
+    assert not hasattr(copied_model, 'c')
+
+    with pytest.raises(ValueError, match='"Model" object has no field "c"'):
+        copied_model.c = 1
 
 
 def test_copy_set_fields():


### PR DESCRIPTION
- feat: Accept `extra` kwarg in `BaseModel.copy`
- Add change into history
- Add tests for `BaseModel.copy(..., extra=...)`

## Change Summary

Add behavior to `BaseModel.copy` to handle extra keys like the contructor does. A new keyword argument (`extra`) drives
logic similar to the `BaseConfig.extra` attribute.

## Related issue number

fix #3732

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/main/changes/README.md) for details.
  You can [skip this check](https://github.com/pydantic/hooky#change-file-checks) if the change does not need a change file.)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
