### PR TITLE
fix type hints in `BaseSettings.Config`

### DIFF
--- a/changes/4450-samuelcolvin.md
+++ b/changes/4450-samuelcolvin.md
@@ -1,0 +1,1 @@
+Add type hints to `BaseSettings.Config` to avoid mypy errors, also correct mypy version compatibility notice in docs.

--- a/docs/mypy_plugin.md
+++ b/docs/mypy_plugin.md
@@ -90,7 +90,7 @@ To get started, all you need to do is create a `mypy.ini` file with following co
 plugins = pydantic.mypy
 ```
 
-The plugin is compatible with mypy versions 0.910, 0.920, 0.921 and 0.930.
+The plugin is compatible with mypy versions `>=0.910`.
 
 See the [mypy usage](usage/mypy.md) and [plugin configuration](#configuring-the-plugin) docs for more details.
 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -79,15 +79,15 @@ class BaseSettings(BaseModel):
             return {}
 
     class Config(BaseConfig):
-        env_prefix = ''
-        env_file = None
-        env_file_encoding = None
-        env_nested_delimiter = None
-        secrets_dir = None
-        validate_all = True
-        extra = Extra.forbid
-        arbitrary_types_allowed = True
-        case_sensitive = False
+        env_prefix: str = ''
+        env_file: Optional[DotenvType] = None
+        env_file_encoding: Optional[str] = None
+        env_nested_delimiter: Optional[str] = None
+        secrets_dir: Optional[StrPath] = None
+        validate_all: bool = True
+        extra: Extra = Extra.forbid
+        arbitrary_types_allowed: bool = True
+        case_sensitive: bool = False
 
         @classmethod
         def prepare_field(cls, field: ModelField) -> None:

--- a/tests/mypy/modules/settings_config.py
+++ b/tests/mypy/modules/settings_config.py
@@ -1,0 +1,7 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    class Config(BaseSettings.Config):
+        env_file = '.env'
+        env_file_encoding = 'utf-8'

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -48,6 +48,7 @@ cases = [
     ('pyproject-plugin-strict.toml', 'plugin_success.py', 'plugin-success-strict.txt'),
     ('pyproject-plugin-strict.toml', 'plugin_fail.py', 'plugin-fail-strict.txt'),
     ('pyproject-plugin-strict.toml', 'fail_defaults.py', 'fail_defaults.txt'),
+    ('mypy-plugin-strict.ini', 'settings_config.py', None),
 ]
 executable_modules = list({fname[:-3] for _, fname, out_fname in cases if out_fname is None})
 


### PR DESCRIPTION
## Change Summary

Add type hints to `BaseSettings.Config` to avoid mypy errors, also correct mypy version compatibility comment in the docs.

## Related issue number

See https://github.com/pydantic/pydantic/issues/4223#issuecomment-1230894434

