### PR TITLE
Fix existing percent encoding

### DIFF
--- a/changes/4458-samuelcolvin.md
+++ b/changes/4458-samuelcolvin.md
@@ -1,0 +1,1 @@
+Fix percent encoding of URLs with which are already percent encoded.

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1,5 +1,4 @@
 import re
-from functools import partial
 from ipaddress import (
     IPv4Address,
     IPv4Interface,
@@ -397,19 +396,17 @@ class AnyUrl(str):
 
     @classmethod
     def quote(cls, string: str) -> str:
-        if cls.quote_plus:
-            quote_func = partial(quote_plus, safe='+/')
-        else:
-            quote_func = partial(quote, safe='/')
+        quote_func = quote_plus if cls.quote_plus else quote
+        safe = '+/'
 
         last_end = 0
         quoted = ''
         for match in re.finditer(r'(.*?)(%[\dA-F]{2})', string, flags=re.S | re.I):
             raw, percent = match.groups()
-            quoted += quote_func(raw) + percent.upper()
+            quoted += quote_func(raw, safe) + percent.upper()
             last_end = match.end()
 
-        return quoted + quote_func(string[last_end:])
+        return quoted + quote_func(string[last_end:], safe)
 
     def __repr__(self) -> str:
         extra = ', '.join(f'{n}={getattr(self, n)!r}' for n in self.__slots__ if getattr(self, n) is not None)


### PR DESCRIPTION
## Change Summary

As described in the issue, #4458 was double encoding URLs, this splits the URL on encoding groups with the regex `(.*?)(%[\dA-F]{2})` to (hopefully) fix the issue.

Changes:
* existing "percentage encodings" are not re-encoded - they're just cast to upper case to match RFC 3986 and httpe - e.g. `foo%2Bbar` is left unchanged while `foo%2bbar` is converted to `foo%2Bbar`
* forward slash `/` is no longer encoded in query paramters, e.g. `http://example.com?a=b/c` is left unchanged

## Related issue number

fix #4458

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
