### PR TITLE
Use tomllib on Python 3.11

### DIFF
--- a/changes/4476-hauntsaninja.md
+++ b/changes/4476-hauntsaninja.md
@@ -1,0 +1,1 @@
+Use `tomllib` on Python 3.11 when parsing `mypy` configuration.

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -1,3 +1,4 @@
+import sys
 from configparser import ConfigParser
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type as TypingType, Union
 
@@ -820,18 +821,21 @@ def parse_toml(config_file: str) -> Optional[Dict[str, Any]]:
         return None
 
     read_mode = 'rb'
-    try:
-        import tomli as toml_
-    except ImportError:
-        # older versions of mypy have toml as a dependency, not tomli
-        read_mode = 'r'
+    if sys.version_info >= (3, 11):
+        import tomllib as toml_
+    else:
         try:
-            import toml as toml_  # type: ignore[no-redef]
-        except ImportError:  # pragma: no cover
-            import warnings
+            import tomli as toml_
+        except ImportError:
+            # older versions of mypy have toml as a dependency, not tomli
+            read_mode = 'r'
+            try:
+                import toml as toml_  # type: ignore[no-redef]
+            except ImportError:  # pragma: no cover
+                import warnings
 
-            warnings.warn('No TOML parser installed, cannot read configuration from `pyproject.toml`.')
-            return None
+                warnings.warn('No TOML parser installed, cannot read configuration from `pyproject.toml`.')
+                return None
 
     with open(config_file, read_mode) as rf:
         return toml_.load(rf)  # type: ignore[arg-type]


### PR DESCRIPTION
## Change Summary

Python 3.11 includes tomllib in the standard library. When installed on Python 3.11, mypy will use tomllib and does not have tomli or toml as a dependency.