### PR TITLE
prevent long strings as int inputs

### DIFF
--- a/changes/1477-samuelcolvin.md
+++ b/changes/1477-samuelcolvin.md
@@ -1,0 +1,3 @@
+Prevent long (length > `10_000`) strings/bytes as input to int fields, see 
+[python/cpython#95778](https://github.com/python/cpython/issues/95778) and 
+[CVE-2020-10735](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735)

--- a/changes/1477-samuelcolvin.md
+++ b/changes/1477-samuelcolvin.md
@@ -1,3 +1,3 @@
-Prevent long (length > `10_000`) strings/bytes as input to int fields, see 
+Prevent long (length > `4_300`) strings/bytes as input to int fields, see 
 [python/cpython#95778](https://github.com/python/cpython/issues/95778) and 
 [CVE-2020-10735](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735)

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -131,9 +131,9 @@ def int_validator(v: Any) -> int:
     # see https://github.com/pydantic/pydantic/issues/1477 and in turn, https://github.com/python/cpython/issues/95778
     # this check should be unnecessary once patch releases are out for 3.7, 3.8, 3.9 and 3.10
     # but better to check here until then.
-    # NOTICE: this does not full protect user from the DOS risk since the standard library JSON implementation
-    # (and other std lib modules like xml) use `int()` and are called before this, the best workaround is to
-    # 1. update to the latest patch release of python, 2. use a different JSON library like ujson
+    # NOTICE: this does not fully protect user from the DOS risk since the standard library JSON implementation
+    # (and other std lib modules like xml) use `int()` and are likely called before this, the best workaround is to
+    # 1. update to the latest patch release of python once released, 2. use a different JSON library like ujson
     if isinstance(v, (str, bytes, bytearray)) and len(v) > max_str_int:
         raise errors.IntegerError()
 

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -120,9 +120,22 @@ def bool_validator(v: Any) -> bool:
     raise errors.BoolError()
 
 
+# matches the default limit cpython, see https://github.com/python/cpython/pull/96500
+max_str_int = 4_300
+
+
 def int_validator(v: Any) -> int:
     if isinstance(v, int) and not (v is True or v is False):
         return v
+
+    # see https://github.com/pydantic/pydantic/issues/1477 and in turn, https://github.com/python/cpython/issues/95778
+    # this check should be unnecessary once patch releases are out for 3.7, 3.8, 3.9 and 3.10
+    # but better to check here until then.
+    # NOTICE: this does not full protect user from the DOS risk since the standard library JSON implementation
+    # (and other std lib modules like xml) use `int()` and are called before this, the best workaround is to
+    # 1. update to the latest patch release of python, 2. use a different JSON library like ujson
+    if isinstance(v, (str, bytes, bytearray)) and len(v) > max_str_int:
+        raise errors.IntegerError()
 
     try:
         return int(v)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2048,11 +2048,11 @@ def test_long_int():
     class Model(BaseModel):
         x: int
 
-    assert Model(x='1' * 10_000).x == int('1' * 10_000)
-    assert Model(x=b'1' * 10_000).x == int('1' * 10_000)
-    assert Model(x=bytearray(b'1' * 10_000)).x == int('1' * 10_000)
+    assert Model(x='1' * 4_300).x == int('1' * 4_300)
+    assert Model(x=b'1' * 4_300).x == int('1' * 4_300)
+    assert Model(x=bytearray(b'1' * 4_300)).x == int('1' * 4_300)
 
-    too_long = '1' * 10_001
+    too_long = '1' * 4_301
     with pytest.raises(ValidationError) as exc_info:
         Model(x=too_long)
 


### PR DESCRIPTION
see #1477 and in turn, python/cpython#95778 this check should be unnecessary once patch releases are out for 3.7, 3.8, 3.9 and 3.10 but better to check here until then.

See [this twitter thread](https://twitter.com/samuel_colvin/status/1565999997396680704) the python patch releases should be out in the next few days, but I know how slow people are to upgrade these things, so I think better to fix here.

### NOTICE:

This does not full protect user from the DOS risk since the standard library JSON implementation
(and other std lib modules like xml) use `int()` and are called before this, the best workaround is to

1. update to the latest patch release of python when it's released
2. (until then) use a different JSON library like ujson

## Related issue number

fix #1477

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
