### PR TITLE
Basic fix of GenericModel cache to detect order of arguments in Union models

### DIFF
--- a/changes/4474-sveinugu.md
+++ b/changes/4474-sveinugu.md
@@ -1,0 +1,1 @@
+Basic fix of GenericModel cache to detect order of arguments in Union models

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -62,7 +62,11 @@ class GenericModel(BaseModel):
             returned as is.
 
         """
-        cached = _generic_types_cache.get((cls, params))
+
+        def _cache_key(_params: Any) -> Tuple[Type[GenericModelT], Any, Tuple[Any, ...]]:
+            return cls, _params, get_args(_params)
+
+        cached = _generic_types_cache.get(_cache_key(params))
         if cached is not None:
             return cached
         if cls.__concrete__ and Generic not in cls.__bases__:
@@ -128,9 +132,9 @@ class GenericModel(BaseModel):
 
         # Save created model in cache so we don't end up creating duplicate
         # models that should be identical.
-        _generic_types_cache[(cls, params)] = created_model
+        _generic_types_cache[_cache_key(params)] = created_model
         if len(params) == 1:
-            _generic_types_cache[(cls, params[0])] = created_model
+            _generic_types_cache[_cache_key(params[0])] = created_model
 
         # Recursively walk class type hints and replace generic typevars
         # with concrete types that were passed.

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -688,6 +688,52 @@ def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
         assert globals()['MyGeneric[Model]__'] is third_concrete
 
 
+def test_generic_model_caching_detect_order_of_union_args_basic(create_module):
+    # Basic variant of https://github.com/pydantic/pydantic/issues/4474
+    @create_module
+    def module():
+        from typing import Generic, TypeVar, Union
+
+        from pydantic.generics import GenericModel
+
+        t = TypeVar('t')
+
+        class Model(GenericModel, Generic[t]):
+            data: t
+
+        int_or_float_model = Model[Union[int, float]]
+        float_or_int_model = Model[Union[float, int]]
+
+        assert type(int_or_float_model(data='1').data) is int
+        assert type(float_or_int_model(data='1').data) is float
+
+
+@pytest.mark.skip(
+    reason="""
+Depends on similar issue in CPython itself: https://github.com/python/cpython/issues/86483
+Documented and skipped for possible fix later.
+"""
+)
+def test_generic_model_caching_detect_order_of_union_args_nested(create_module):
+    # Nested variant of https://github.com/pydantic/pydantic/issues/4474
+    @create_module
+    def module():
+        from typing import Generic, List, TypeVar, Union
+
+        from pydantic.generics import GenericModel
+
+        t = TypeVar('t')
+
+        class Model(GenericModel, Generic[t]):
+            data: t
+
+        int_or_float_model = Model[List[Union[int, float]]]
+        float_or_int_model = Model[List[Union[float, int]]]
+
+        assert type(int_or_float_model(data=['1']).data[0]) is int
+        assert type(float_or_int_model(data=['1']).data[0]) is float
+
+
 def test_get_caller_frame_info(create_module):
     @create_module
     def module():


### PR DESCRIPTION
## Change Summary

Basic fix of GenericModel cache to include the order of arguments in Union models into the cache key. 
This fixes the basic problem described in issue #4474, so that e.g. Model[Union[float, int]] is not used as a
blueprint for Model[Union[float, int]].  Added tests for basic and nested versions of the problem. Fixing the
nested problem depends on the fixing of the almost identical issue described in
 https://github.com/python/cpython/issues/86483 in CPython. The test was thus skipped, but kept for 
documentation.


## Related issue number

fix #4474

## Checklist

* [ x ] Unit tests for the changes exist
* [ x ] Tests pass on CI and coverage remains at 100%
* [ x ] Documentation reflects the changes where applicable
* [ x ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/main/changes/README.md) for details.
  You can [skip this check](https://github.com/pydantic/hooky#change-file-checks) if the change does not need a change file.)
* [ x ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
