### PR TITLE
fix: dataclass wrapper was not always called

### DIFF
--- a/changes/4477-PrettyWood.md
+++ b/changes/4477-PrettyWood.md
@@ -1,0 +1,1 @@
+fix: dataclass wrapper was not always called

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -34,7 +34,20 @@ validation without altering default `M` behaviour.
 import sys
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator, Optional, Type, TypeVar, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Generator,
+    Optional,
+    Set,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from typing_extensions import dataclass_transform
 
@@ -184,7 +197,7 @@ def dataclass(
     def wrap(cls: Type[Any]) -> 'DataclassClassOrWrapper':
         import dataclasses
 
-        if is_builtin_dataclass(cls):
+        if is_builtin_dataclass(cls) and _extra_dc_args(_cls) == _extra_dc_args(_cls.__bases__[0]):  # type: ignore
             dc_cls_doc = ''
             dc_cls = DataclassProxy(cls)
             default_validate_on_init = False
@@ -416,6 +429,14 @@ def _dataclass_validate_assignment_setattr(self: 'Dataclass', name: str, value: 
                 raise ValidationError([error_], self.__class__)
 
     object.__setattr__(self, name, value)
+
+
+def _extra_dc_args(cls: Type[Any]) -> Set[str]:
+    return {
+        x
+        for x in dir(cls)
+        if x not in getattr(cls, '__dataclass_fields__', {}) and not (x.startswith('__') and x.endswith('__'))
+    }
 
 
 def is_builtin_dataclass(_cls: Type[Any]) -> bool:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1395,3 +1395,80 @@ def test_extra_forbid_list_error():
         @pydantic.dataclasses.dataclass
         class Foo:
             a: List[Bar(a=1)]
+
+
+def test_parent_post_init():
+    @dataclasses.dataclass
+    class A:
+        a: float = 1
+
+        def __post_init__(self):
+            self.a *= 2
+
+    @pydantic.dataclasses.dataclass
+    class B(A):
+        @validator('a')
+        def validate_a(cls, value):
+            value += 3
+            return value
+
+    assert B().a == 5  # 1 * 2 + 3
+
+
+def test_subclass_post_init_post_parse():
+    @dataclasses.dataclass
+    class A:
+        a: float = 1
+
+    @pydantic.dataclasses.dataclass
+    class B(A):
+        def __post_init_post_parse__(self):
+            self.a *= 2
+
+        @validator('a')
+        def validate_a(cls, value):
+            value += 3
+            return value
+
+    assert B().a == 8  # (1 + 3) * 2
+
+
+def test_subclass_post_init():
+    @dataclasses.dataclass
+    class A:
+        a: int = 1
+
+    @pydantic.dataclasses.dataclass
+    class B(A):
+        def __post_init__(self):
+            self.a *= 2
+
+        @validator('a')
+        def validate_a(cls, value):
+            value += 3
+            return value
+
+    assert B().a == 5  # 1 * 2 + 3
+
+
+def test_subclass_post_init_inheritance():
+    @dataclasses.dataclass
+    class A:
+        a: int = 1
+
+    @pydantic.dataclasses.dataclass
+    class B(A):
+        def __post_init__(self):
+            self.a *= 2
+
+        @validator('a')
+        def validate_a(cls, value):
+            value += 3
+            return value
+
+    @pydantic.dataclasses.dataclass
+    class C(B):
+        def __post_init__(self):
+            self.a *= 3
+
+    assert C().a == 6  # 1 * 3 + 3


### PR DESCRIPTION
## Change Summary
In a stdlib dataclass without `__post_init__`, `__post_init__` call is not added in the generated `__init__`.
So when we inherit from a stdlib dataclass and we add  a `__post_init__`, it won't be called. So all its related code + validation will be ignored.
Now it should be okish (not ok because it's a mess).

In v2, we should rely on stdlib dataclasses and go with a more functional approach

## Related issue number
fix #4477

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/main/changes/README.md) for details.
  You can [skip this check](https://github.com/pydantic/hooky#change-file-checks) if the change does not need a change file.)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
