### PR TITLE
Fix field constraints with Collection and Sequence

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
+    Collection,
     Deque,
     Dict,
     FrozenSet,
@@ -1569,6 +1570,8 @@ def test_unenforced_constraints_schema(kwargs, type_):
     [
         ({'max_length': 5}, str, 'foo'),
         ({'min_length': 2}, str, 'foo'),
+        ({'min_items': 1}, Collection[int], [0]),
+        ({'max_items': 1}, Collection[int], [0]),
         ({'max_length': 5}, bytes, b'foo'),
         ({'regex': '^foo$'}, str, 'foo'),
         ({'gt': 2}, int, 3),


### PR DESCRIPTION
With pydantic 1.10.2, this model
```python
class Model(BaseModel):
    name: Collection[str] = Field(..., min_items=1)
```
gives an error
```bash
E   ValueError: On field "name" the following field constraints are set but not enforced: min_items. 
E   For more details see https://pydantic-docs.helpmanual.io/usage/schema/#unenforced-field-constraints
```

This PR extents the allowed constraints of `List` (*{min,max,unique}_items*) to `Collection` and `Sequence`.