### PR TITLE
Fix missing default value of field for enum schema generation.

### DIFF
--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -666,6 +666,11 @@ def enum_process_schema(enum: Type[Enum], *, field: Optional[ModelField] = None)
         'enum': [item.value for item in cast(Iterable[Enum], enum)],
     }
 
+    if field is not None:
+        if not field.required and field.default is not None and not is_callable_type(field.outer_type_):
+            # Add default value to the schema.
+            schema_['default'] = encode_default(field.default)
+
     add_field_type_to_schema(enum, schema_)
 
     modify_schema = getattr(enum, '__modify_schema__', None)


### PR DESCRIPTION
Fixed missing `default` value in the schema generation of enums with fields.

When using the first example from https://pydantic-docs.helpmanual.io/usage/schema/ and changing 
```
gender: Gender = Field(None, alias='Gender')
```
to
```
gender: Gender = Field(Gender.female, alias='Gender')
```
the schema is missing the default field for Gender:
```
{
  "title": "Main",
  "description": "This is the description of the main model",
  "type": "object",
  "properties": {
    "foo_bar": {
      "$ref": "#/definitions/FooBar"
    },
    "Gender": {
      "default": "female",
      "allOf": [
        {
          "$ref": "#/definitions/Gender"
        }
      ]
    },
    "snap": {
      "title": "The Snap",
      "description": "this is the value of snap",
      "default": 42,
      "exclusiveMinimum": 30,
      "exclusiveMaximum": 50,
      "type": "integer"
    }
  },
  "required": [
    "foo_bar"
  ],
  "definitions": {
    "FooBar": {
      "title": "FooBar",
      "type": "object",
      "properties": {
        "count": {
          "title": "Count",
          "type": "integer"
        },
        "size": {
          "title": "Size",
          "type": "number"
        }
      },
      "required": [
        "count"
      ]
    },
    "Gender": {
      "title": "Gender",
      "description": "An enumeration.",
      "enum": [
        "male",
        "female",
        "other",
        "not_given"
      ],
      "type": "string"
    }
  }
}
```

With this patch the default field is properly added:
```
{
  "title": "Main",
  "description": "This is the description of the main model",
  "type": "object",
  "properties": {
    "foo_bar": {
      "$ref": "#/definitions/FooBar"
    },
    "Gender": {
      "default": "female",
      "allOf": [
        {
          "$ref": "#/definitions/Gender"
        }
      ]
    },
    "snap": {
      "title": "The Snap",
      "description": "this is the value of snap",
      "default": 42,
      "exclusiveMinimum": 30,
      "exclusiveMaximum": 50,
      "type": "integer"
    }
  },
  "required": [
    "foo_bar"
  ],
  "definitions": {
    "FooBar": {
      "title": "FooBar",
      "type": "object",
      "properties": {
        "count": {
          "title": "Count",
          "type": "integer"
        },
        "size": {
          "title": "Size",
          "type": "number"
        }
      },
      "required": [
        "count"
      ]
    },
    "Gender": {
      "title": "Gender",
      "description": "An enumeration.",
      "enum": [
        "male",
        "female",
        "other",
        "not_given"
      ],
      "default": "female",
      "type": "string"
    }
  }
}
```

Code:
```
from enum import Enum
from pydantic import BaseModel, Field


class FooBar(BaseModel):
    count: int
    size: float = None


class Gender(str, Enum):
    male = 'male'
    female = 'female'
    other = 'other'
    not_given = 'not_given'


class MainModel(BaseModel):
    """
    This is the description of the main model
    """

    foo_bar: FooBar = Field(...)
    gender: Gender = Field(Gender.femail, alias='Gender')
    snap: int = Field(
        42,
        title='The Snap',
        description='this is the value of snap',
        gt=30,
        lt=50,
    )

    class Config:
        title = 'Main'


# this is equivalent to json.dumps(MainModel.schema(), indent=2):
print(MainModel.schema_json(indent=2))
```
