### PR TITLE
Enumerate the index of duplicated items

### DIFF
--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -332,7 +332,10 @@ class ListMaxLengthError(PydanticValueError):
 
 class ListUniqueItemsError(PydanticValueError):
     code = 'list.unique_items'
-    msg_template = 'the list has duplicated items'
+    msg_template = 'the list has a duplicated item at index {index}'
+
+    def __init__(self, *, index: int) -> None:
+        super().__init__(index=index)
 
 
 class SetMinLengthError(PydanticValueError):

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -598,7 +598,7 @@ class ConstrainedList(list):  # type: ignore
     def unique_items_validator(cls, v: 'List[T]') -> 'List[T]':
         for i, value in enumerate(v, start=1):
             if value in v[i:]:
-                raise errors.ListUniqueItemsError(index=i)
+                raise errors.ListUniqueItemsError(index=i - 1)
 
         return v
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -598,7 +598,7 @@ class ConstrainedList(list):  # type: ignore
     def unique_items_validator(cls, v: 'List[T]') -> 'List[T]':
         for i, value in enumerate(v, start=1):
             if value in v[i:]:
-                raise errors.ListUniqueItemsError()
+                raise errors.ListUniqueItemsError(index=i)
 
         return v
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -243,9 +243,9 @@ def test_constrained_list_not_unique_hashable_items():
     assert exc_info.value.errors() == [
         {
             'loc': ('v',),
-            'msg': 'the list has a duplicated item at index 1',
+            'msg': 'the list has a duplicated item at index 0',
             'type': 'value_error.list.unique_items',
-            'ctx': {'index': 1},
+            'ctx': {'index': 0},
         }
     ]
 
@@ -262,9 +262,9 @@ def test_constrained_list_not_unique_unhashable_items():
     assert exc_info.value.errors() == [
         {
             'loc': ('v',),
-            'msg': 'the list has a duplicated item at index 1',
+            'msg': 'the list has a duplicated item at index 0',
             'type': 'value_error.list.unique_items',
-            'ctx': {'index': 1},
+            'ctx': {'index': 0},
         }
     ]
 
@@ -360,7 +360,7 @@ def test_conlist():
     with pytest.raises(ValidationError, match='ensure this value has at most 4 items'):
         Model(foo=list(range(5)))
 
-    with pytest.raises(ValidationError, match='the list has a duplicated item at index 1'):
+    with pytest.raises(ValidationError, match='the list has a duplicated item at index 0'):
         Model(foo=[1, 1, 2, 2])
 
     assert Model.schema() == {

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -243,8 +243,9 @@ def test_constrained_list_not_unique_hashable_items():
     assert exc_info.value.errors() == [
         {
             'loc': ('v',),
-            'msg': 'the list has duplicated items',
+            'msg': 'the list has a duplicated item at index 1',
             'type': 'value_error.list.unique_items',
+            'ctx': {'index': 1},
         }
     ]
 
@@ -261,8 +262,9 @@ def test_constrained_list_not_unique_unhashable_items():
     assert exc_info.value.errors() == [
         {
             'loc': ('v',),
-            'msg': 'the list has duplicated items',
+            'msg': 'the list has a duplicated item at index 1',
             'type': 'value_error.list.unique_items',
+            'ctx': {'index': 1},
         }
     ]
 
@@ -358,7 +360,7 @@ def test_conlist():
     with pytest.raises(ValidationError, match='ensure this value has at most 4 items'):
         Model(foo=list(range(5)))
 
-    with pytest.raises(ValidationError, match='the list has duplicated items'):
+    with pytest.raises(ValidationError, match='the list has a duplicated item at index 1'):
         Model(foo=[1, 1, 2, 2])
 
     assert Model.schema() == {


### PR DESCRIPTION
When debugging uniqueness validation errors, it would be useful to know the index of duplicates (especially when the list being validated is very long). This change modifies the error message to include the index of the first duplicate encountered.