### PR TITLE
Minor typo in `docs/usage/validation_decorator.md`

### DIFF
--- a/docs/usage/validation_decorator.md
+++ b/docs/usage/validation_decorator.md
@@ -55,7 +55,7 @@ as the default value of the field:
 
 {!.tmp_examples/validation_decorator_field.md!}
 
-The [alias](model_config#alias-precedence) can be used with the decorator as normal.
+The [alias](model_config.md#alias-precedence) can be used with the decorator as normal.
 
 {!.tmp_examples/validation_decorator_field_alias.md!}
 


### PR DESCRIPTION
Hello.

This is a very small change that fixes a typo, missing file extension in the link to `model_config.md` in `validation_decorator.md`.

```diff
-The [alias](model_config#alias-precedence) can be used with the decorator as normal.
+The [alias](model_config.md#alias-precedence) can be used with the decorator as normal.
```
I didn't find any more typos with `model_config.md`, I think this is a single issue of such kind.

Thanks for your project!