### PR TITLE
mypy plugin: Use annotation to determine if field is optional

### DIFF
--- a/changes/4523-hackedd.md
+++ b/changes/4523-hackedd.md
@@ -1,0 +1,1 @@
+Use annotation in mypy plugin to determine if field is optional

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -522,24 +522,24 @@ class PydanticModelTransformer:
         Returns a boolean indicating whether the field defined in `stmt` is a required field.
         """
         expr = stmt.rvalue
+        # Annotated as Optional, or otherwise having NoneType in the union
+        value_type = get_proper_type(cls.info[lhs.name].type)
+        optional = isinstance(value_type, UnionType) and any(isinstance(item, NoneType) for item in value_type.items)
         if isinstance(expr, TempNode):
             # TempNode means annotation-only, so only non-required if Optional
-            value_type = get_proper_type(cls.info[lhs.name].type)
-            if isinstance(value_type, UnionType) and any(isinstance(item, NoneType) for item in value_type.items):
-                # Annotated as Optional, or otherwise having NoneType in the union
-                return False
-            return True
+            return not optional
         if isinstance(expr, CallExpr) and isinstance(expr.callee, RefExpr) and expr.callee.fullname == FIELD_FULLNAME:
             # The "default value" is a call to `Field`; at this point, the field is
-            # only required if default is Ellipsis (i.e., `field_name: Annotation = Field(...)`) or if default_factory
-            # is specified.
+            # required if default is Ellipsis (i.e., `field_name: Annotation = Field(...)`) and default_factory
+            # is not specified.
             for arg, name in zip(expr.args, expr.arg_names):
-                # If name is None, then this arg is the default because it is the only positonal argument.
+                # If name is None, then this arg is the default because it is the only positional argument.
                 if name is None or name == 'default':
                     return arg.__class__ is EllipsisExpr
                 if name == 'default_factory':
                     return False
-            return True
+            # If no default value is specified in the `Field`, use the annotation.
+            return not optional
         # Only required if the "default value" is Ellipsis (i.e., `field_name: Annotation = ...`)
         return isinstance(expr, EllipsisExpr)
 

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -224,3 +224,10 @@ class FieldDefaultTestingModel(BaseModel):
     g: List[int] = Field(default_factory=_default_factory_list)
     h: str = Field(default_factory=_default_factory_str)
     i: str = Field(default_factory=lambda: 'test')
+
+
+class FieldOptionalNoDefaultModel(BaseModel):
+    x: Optional[str] = Field()
+
+
+FieldOptionalNoDefaultModel()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1067,6 +1067,15 @@ def test_optional_required():
     assert Model(bar=None).dict() == {'bar': None}
 
 
+def test_optional_required_field_call():
+    class Model(BaseModel):
+        bar: Optional[int] = Field()
+
+    assert Model(bar=123).dict() == {'bar': 123}
+    assert Model().dict() == {'bar': None}
+    assert Model(bar=None).dict() == {'bar': None}
+
+
 def test_invalid_validator():
     class InvalidValidator:
         @classmethod


### PR DESCRIPTION
## Change Summary

The mypy plugin would previously incorrectly mark fields as required when the `Field()` function was used but does not specify a default, resulting in _Missing named argument_ errors.

For example:

```python
class Model(BaseModel):
    bar: Optional[int] = Field()

m = Model()
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/main/changes/README.md) for details.
  You can [skip this check](https://github.com/pydantic/hooky#change-file-checks) if the change does not need a change file.)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
