### PR TITLE
v2 docs broken link fix

### DIFF
--- a/docs/blog/pydantic-v2.md
+++ b/docs/blog/pydantic-v2.md
@@ -123,7 +123,7 @@ The motivation for building pydantic-core in Rust is as follows:
 pydantic-core is usable now, albeit with an unintuitive API, if you're interested, please give it a try.
 
 pydantic-core provides validators for common data types,
-[see a list here](https://github.com/pydantic/pydantic-core/blob/main/pydantic_core/_types.py#L291).
+[see a list here](https://github.com/pydantic/pydantic-core/blob/main/pydantic_core/schema_types.py#L291).
 Other, less commonly used data types will be supported via validator functions implemented in pydantic, in Python.
 
 See [pydantic-core#153](https://github.com/pydantic/pydantic-core/issues/153)

--- a/docs/blog/pydantic-v2.md
+++ b/docs/blog/pydantic-v2.md
@@ -123,7 +123,7 @@ The motivation for building pydantic-core in Rust is as follows:
 pydantic-core is usable now, albeit with an unintuitive API, if you're interested, please give it a try.
 
 pydantic-core provides validators for common data types,
-[see a list here](https://github.com/pydantic/pydantic-core/blob/main/pydantic_core/schema_types.py#L291).
+[see a list here](https://github.com/pydantic/pydantic-core/blob/main/pydantic_core/schema_types.py#L314).
 Other, less commonly used data types will be supported via validator functions implemented in pydantic, in Python.
 
 See [pydantic-core#153](https://github.com/pydantic/pydantic-core/issues/153)


### PR DESCRIPTION
Broken link to _types.py fix to schema_types.py

# WARNING!!!

We're currently in the process of rewriting pydantic in preparation for V2, see
https://pydantic-docs.helpmanual.io/blog/pydantic-v2/.

As a result, much of the codebase will change significantly over the coming months.

To avoid wasting your time, please only create Pull Requests if you've got explicit approval by a maintainer.

Otherwise, your pull requests may be closed without review.

Thank you for your interest in pydantic, and your patience. :pray:

**Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch.
