### PR TITLE
[1.10.X] Fix field regex with StrictStr type annotation

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1759,6 +1759,45 @@ def test_strict_str_max_length():
         Model(u='1234567')
 
 
+def test_strict_str_regex():
+    class Model(BaseModel):
+        u: StrictStr = Field(..., regex=r'^[0-9]+$')
+
+    assert Model(u='123').u == '123'
+
+    with pytest.raises(ValidationError, match='str type expected'):
+        Model(u=123)
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(u='abc')
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('u',),
+            'msg': 'string does not match regex "^[0-9]+$"',
+            'type': 'value_error.str.regex',
+            'ctx': {'pattern': '^[0-9]+$'},
+        }
+    ]
+
+
+def test_string_regex():
+    class Model(BaseModel):
+        u: str = Field(..., regex=r'^[0-9]+$')
+
+    assert Model(u='123').u == '123'
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(u='abc')
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('u',),
+            'msg': 'string does not match regex "^[0-9]+$"',
+            'type': 'value_error.str.regex',
+            'ctx': {'pattern': '^[0-9]+$'},
+        }
+    ]
+
+
 def test_strict_bool():
     class Model(BaseModel):
         v: StrictBool


### PR DESCRIPTION
There's an inconsistency between `constr(...)` and `ConstrainedStr`, which is the base class of `StrictStr`, with regard to the expected type of the `regex` argument/attribute which causes a field of type `StrictStr` with a `regex` constraint specified via the `Field(...)` class to raise an error:

```text
File "pydantic/main.py", line 340, in pydantic.main.BaseModel.__init__
File "pydantic/main.py", line 1076, in pydantic.main.validate_model
File "pydantic/fields.py", line 884, in pydantic.fields.ModelField.validate
File "pydantic/fields.py", line 1101, in pydantic.fields.ModelField._validate_singleton
File "pydantic/fields.py", line 1148, in pydantic.fields.ModelField._apply_validators
File "pydantic/class_validators.py", line 318, in pydantic.class_validators._generic_validator_basic.lambda13
File "pydantic/types.py", line 433, in pydantic.types.ConstrainedStr.validate
AttributeError: 'str' object has no attribute 'match'
```

I've fixed this inconsistency in a backwards compatible way by extending the type of `regex` in `ConstrainedStr` to also support a `str` value in addition to `Pattern[str]`.

I hope this fix will be considered despite the ongoing efforts towards Pydantic v2. :slightly_smiling_face: