### PR TITLE
Remove superfluous (???) files from sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,17 +2,18 @@
 requires = ['hatchling', 'hatch-fancy-pypi-readme>=22.5.0']
 build-backend = 'hatchling.build'
 
-[tool.hatch]
-version = { path = 'pydantic/version.py' }
-build = { exclude = [
+[tool.hatch.version]
+path = 'pydantic/version.py'
+
+[tool.hatch.build]
+exclude = [
     '/.github/**',
     '/changes/**',
     '/docs/**',
     '/mkdocs.yml',
     '/.pre-commit-config.yaml',
-    '/.gitignore',
     '/setup.py',
-] }
+]
 
 [project]
 name = 'pydantic'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,16 @@ build-backend = 'hatchling.build'
 [tool.hatch.version]
 path = 'pydantic/version.py'
 
-[tool.hatch.build]
-exclude = [
-    '/.github',
-    '/changes',
-    '/docs',
-    '/mkdocs.yml',
-    '/.pre-commit-config.yaml',
-    '/setup.py',
+[tool.hatch.build.targets.sdist]
+# limit which files are included in the sdist (.tar.gz) asset,
+# see https://github.com/pydantic/pydantic/pull/4542
+include = [
+    '/README.md',
+    '/HISTORY.md',
+    '/Makefile',
+    '/pydantic',
+    '/tests',
+    '/requirements',
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ path = 'pydantic/version.py'
 
 [tool.hatch.build]
 exclude = [
-    '/.github/**',
-    '/changes/**',
-    '/docs/**',
+    '/.github',
+    '/changes',
+    '/docs',
     '/mkdocs.yml',
     '/.pre-commit-config.yaml',
     '/setup.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,17 @@
 requires = ['hatchling', 'hatch-fancy-pypi-readme>=22.5.0']
 build-backend = 'hatchling.build'
 
-[tool.hatch.version]
-path = 'pydantic/version.py'
+[tool.hatch]
+version = { path = 'pydantic/version.py' }
+build = { exclude = [
+    '/.github/**',
+    '/changes/**',
+    '/docs/**',
+    '/mkdocs.yml',
+    '/.pre-commit-config.yaml',
+    '/.gitignore',
+    '/setup.py',
+] }
 
 [project]
 name = 'pydantic'


### PR DESCRIPTION
Will this, a bunch of files are removed from the sdist (`.tar.gz`) file which will be uploaded to PyPI.

## Question

* Is this correct?
* should tests still be included?
* I'm excluding `/docs/`, I think this is better, is there a strong argument against this?

With this changes, the following files are included in `pydantic-2.0.0.dev0.tar.gz`:
```
pydantic-2.0.0.dev0
├── .gitignore
├── HISTORY.md
├── LICENSE
├── Makefile
├── PKG-INFO
├── pydantic
│  ├── __init__.py
│  ├── _internal
│  │  ├── __init__.py
│  │  ├── ... 3 more files
│  ├── ... 23 more files
├── pyproject.toml
├── README.md
├── requirements
│  ├── 10 files
└── tests
   ├── mypy
   │  ├── 34 files
   ├── pyright
   │  ├── ... 2 files
   ├── ... 34 files
```