### PR TITLE
Allows Optional lists with unique_items check

### DIFF
--- a/changes/4568-mfulgo.md
+++ b/changes/4568-mfulgo.md
@@ -1,0 +1,1 @@
+Fixes error passing None for optional lists with `unique_items`

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -599,7 +599,10 @@ class ConstrainedList(list):  # type: ignore
         return v
 
     @classmethod
-    def unique_items_validator(cls, v: 'List[T]') -> 'List[T]':
+    def unique_items_validator(cls, v: 'Optional[List[T]]') -> 'Optional[List[T]]':
+        if v is None:
+            return None
+
         for i, value in enumerate(v, start=1):
             if value in v[i:]:
                 raise errors.ListUniqueItemsError()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import pytest
 from typing_extensions import Literal
 
-from pydantic import BaseModel, ConfigError, Extra, Field, ValidationError, errors, validator
+from pydantic import BaseModel, ConfigError, Extra, Field, ValidationError, conlist, errors, validator
 from pydantic.class_validators import make_generic_validator, root_validator
 
 
@@ -1329,3 +1329,19 @@ def test_overridden_root_validators(mocker):
 
     B(x='pika')
     assert validate_stub.call_args_list == [mocker.call('B', 'pre'), mocker.call('B', 'post')]
+
+
+def test_list_unique_items_with_optional():
+    class Model(BaseModel):
+        foo: Optional[List[str]] = Field(None, unique_items=True)
+        bar: conlist(str, unique_items=True) = Field(None)
+
+    assert Model().dict() == {'foo': None, 'bar': None}
+    assert Model(foo=None, bar=None).dict() == {'foo': None, 'bar': None}
+    assert Model(foo=['k1'], bar=['k1']).dict() == {'foo': ['k1'], 'bar': ['k1']}
+    with pytest.raises(ValidationError) as exc_info:
+        Model(foo=['k1', 'k1'], bar=['k1', 'k1'])
+    assert exc_info.value.errors() == [
+        {'loc': ('foo',), 'msg': 'the list has duplicated items', 'type': 'value_error.list.unique_items'},
+        {'loc': ('bar',), 'msg': 'the list has duplicated items', 'type': 'value_error.list.unique_items'},
+    ]


### PR DESCRIPTION
When using `unique_items` with an `Optional[List[T]]` field, the field validator would raise the following error if the field was not provided:
> `'NoneType' object is not iterable (type=type_error)`

Updating the validator to return `None` in these cases avoids the issue.

Fixes #3957, fix #4050, fix #4119
