### PR TITLE
Use isinstance enum validator for 0-members enums

### DIFF
--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -724,7 +724,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if is_builtin_dataclass(type_):
         yield from make_dataclass_validator(type_, config)
         return
-    if type_ is Enum:
+    if issubclass(type_, Enum) and len(list(type_)) == 0:
         yield enum_validator
         return
     if type_ is IntEnum:


### PR DESCRIPTION
Bugfix for 1.10.2.

Tiny change to solve a left-over problem in from #1735 where "middle" enum subclasses used to override or provide methods instead of setting members could not be validated