### PR TITLE
Fix coercion of dict items with `Mapping` type

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1042,7 +1042,7 @@ class ModelField(Representation):
         """
         original_cls = original.__class__
 
-        if original_cls == dict or original_cls == Dict:
+        if original_cls in {dict, Dict, list, List, tuple, Tuple}:
             return converted
         elif original_cls in {defaultdict, DefaultDict}:
             return defaultdict(self.type_, converted)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2107,6 +2107,16 @@ def test_typing_coercion_dict():
     assert repr(m) == "Model(x={'one': 1, 'two': 2})"
 
 
+def test_typing_coercion_dict_mapping_items():
+    class Model(BaseModel):
+        x: Dict[Any, Any]
+        y: Mapping[Any, Any]
+
+    v = [['one', 1], ['two', 2]]
+    m = Model(x=v, y=v)
+    assert repr(m) == "Model(x={'one': 1, 'two': 2}, y={'one': 1, 'two': 2})"
+
+
 def test_typing_non_coercion_of_dict_subclasses():
     KT = TypeVar('KT')
     VT = TypeVar('VT')


### PR DESCRIPTION
I've fixed a bug related to coercing dict items (a list of pairs) when using the `Mapping` type. It works fine with the `Dict` type but fails with the `Mapping` time which is incorrect and inconsistent.

Fixes #4588.

I hope this fix will be considered despite the ongoing efforts towards Pydantic v2. :slightly_smiling_face: