### PR TITLE
Allow dicts to have both patternProperties and additionalProperties

### DIFF
--- a/changes/4642-jparise.md
+++ b/changes/4642-jparise.md
@@ -1,0 +1,1 @@
+Allow dict schemas to have both `patternProperties` and `additionalProperties`

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -490,7 +490,7 @@ def field_type_schema(
             # Dict keys have a regex pattern
             # items_schema might be a schema or empty dict, add it either way
             f_schema['patternProperties'] = {regex.pattern: items_schema}
-        elif items_schema:
+        if items_schema:
             # The dict values are not simply Any, so they need a schema
             f_schema['additionalProperties'] = items_schema
     elif field.shape == SHAPE_TUPLE or (field.shape == SHAPE_GENERIC and not issubclass(field.type_, BaseModel)):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1654,7 +1654,13 @@ def test_schema_dict_constr():
         'title': 'Foo',
         'type': 'object',
         'properties': {
-            'a': {'type': 'object', 'title': 'A', 'default': {}, 'patternProperties': {regex_str: {'type': 'string'}}}
+            'a': {
+                'type': 'object',
+                'title': 'A',
+                'default': {},
+                'additionalProperties': {'type': 'string'},
+                'patternProperties': {regex_str: {'type': 'string'}},
+            }
         },
     }
 


### PR DESCRIPTION
Support for `patternProperties` was introduced in #332, but that logic unfortunately made `patternProperties` and `additionalProperties` mutually exclusive. JSON Schema supports their combination:

https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties

This prevented well-typed code generation for dictionaries that use regex-constrained string keys.