### PR TITLE
chore: Update outdated LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 - 2022 Samuel Colvin and other contributors
+Copyright (c) 2017 - present Samuel Colvin and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the outdated copyright year to the present. 
So there will not be a need for any further license year updates.