### PR TITLE
Fix TypeError for GenericModel with Callable param

### DIFF
--- a/changes/4551-mfulgo.md
+++ b/changes/4551-mfulgo.md
@@ -1,1 +1,1 @@
-Fix GenericModel with Callable param raising a TypeError
+Fix `GenericModel` with `Callable` param raising a `TypeError`

--- a/changes/4551-mfulgo.md
+++ b/changes/4551-mfulgo.md
@@ -1,0 +1,1 @@
+Fix GenericModel with Callable param raising a TypeError

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -64,7 +64,11 @@ class GenericModel(BaseModel):
         """
 
         def _cache_key(_params: Any) -> Tuple[Type[GenericModelT], Any, Tuple[Any, ...]]:
-            return cls, _params, get_args(_params)
+            args = get_args(_params)
+            # python returns a list for Callables, which is not hashable
+            if len(args) == 2 and isinstance(args[0], list):
+                args = (tuple(args[0]), args[1])
+            return cls, _params, args
 
         cached = _generic_types_cache.get(_cache_key(params))
         if cached is not None:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -7,6 +7,7 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
+    Iterable,
     List,
     Mapping,
     Optional,
@@ -232,6 +233,32 @@ def test_cover_cache():
     assert len(_generic_types_cache) == cache_size + 2
     Model[int]  # uses the cache
     assert len(_generic_types_cache) == cache_size + 2
+
+
+def test_cache_keys_are_hashable():
+    cache_size = len(_generic_types_cache)
+    T = TypeVar('T')
+    C = Callable[[str, Dict[str, Any]], Iterable[str]]
+
+    class MyGenericModel(GenericModel, Generic[T]):
+        t: T
+
+    # Callable's first params get converted to a list, which is not hashable.
+    # Make sure we can handle that special case
+    Simple = MyGenericModel[Callable[[int], str]]
+    assert len(_generic_types_cache) == cache_size + 2
+    # Nested Callables
+    MyGenericModel[Callable[[C], Iterable[str]]]
+    assert len(_generic_types_cache) == cache_size + 4
+    MyGenericModel[Callable[[Simple], Iterable[int]]]
+    assert len(_generic_types_cache) == cache_size + 6
+    MyGenericModel[Callable[[MyGenericModel[C]], Iterable[int]]]
+    assert len(_generic_types_cache) == cache_size + 10
+
+    class Model(BaseModel):
+        x: MyGenericModel[Callable[[C], Iterable[str]]] = Field(...)
+
+    assert len(_generic_types_cache) == cache_size + 10
 
 
 def test_generic_config():


### PR DESCRIPTION
Introduced in 1.10.2, a TypeError would be raised upon creation of a GenericModel class that used a Callable type parameter. This would happen when `typing.get_args` returned a list for the first type agruments in a Callable and pydantic would try to use the value as a dictionary key. To avoid the issue, we convert the list to a tuple before using it as a key.

The possible approach of modifying pydantic's `get_args` function to return a tuple instead of a list didn't work out because the return values are used in more places, some of which expect the list and not a tuple.

Fixes #4551
