### PR TITLE
Support extracting attributes from the parent namespace

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -28,13 +28,7 @@ if typing.TYPE_CHECKING:
     from ..config import BaseConfig
     from ..main import BaseModel
 
-__all__ = (
-    'object_setattr',
-    'init_private_attributes',
-    'inspect_namespace',
-    'complete_model_class',
-    'parent_frame_namespace',
-)
+__all__ = 'object_setattr', 'init_private_attributes', 'inspect_namespace', 'complete_model_class'
 
 
 IGNORED_TYPES: tuple[Any, ...] = (FunctionType, property, type, classmethod, staticmethod)
@@ -168,27 +162,6 @@ def complete_model_class(
     # set __signature__ attr only for model class, but not for its instances
     cls.__signature__ = ClassAttribute('__signature__', generate_model_signature(cls.__init__, fields, cls.__config__))
     return True
-
-
-def parent_frame_namespace(parent_index: int = 2) -> dict[str, Any] | None:
-    """
-    WARNING: it matters exactly where this is called. By default this function will build a namespace from the parent
-    of where it's called.
-
-    We allow use of items in parent namespace to get around this issue with `get_type_hints` only looking in the
-    global module namespace. See https://github.com/pydantic/pydantic/issues/2678#issuecomment-1008139014 -> Scope
-    and suggestion at the end of the next comment.
-
-    WARNING: this only looks in the parent namespace, not other parents since (AFAIK) there's no easy and reliable
-    way to collect a dict of exactly what's in scope. Using `f_back` would work sometimes but would be very
-    wrong and confusing in many other cases.
-    """
-    frame = sys._getframe(parent_index)
-    # if f_back is None, it's the global module namespace and we don't need to include it here
-    if frame.f_back is None:
-        return None
-    else:
-        return frame.f_locals
 
 
 def build_inner_schema(  # noqa: C901

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -27,6 +27,7 @@ __all__ = (
     'origin_is_union',
     'NotRequired',
     'Required',
+    'parent_frame_namespace',
     'get_type_hints',
 )
 
@@ -189,6 +190,27 @@ def _check_finalvar(v: type[Any] | None) -> bool:
 
 def is_finalvar(ann_type: type[Any]) -> bool:
     return _check_finalvar(ann_type) or _check_finalvar(get_origin(ann_type))
+
+
+def parent_frame_namespace(*, parent_depth: int = 2) -> dict[str, Any] | None:
+    """
+    We allow use of items in parent namespace to get around the issue with `get_type_hints` only looking in the
+    global module namespace. See https://github.com/pydantic/pydantic/issues/2678#issuecomment-1008139014 -> Scope
+    and suggestion at the end of the next comment by @gvanrossum.
+
+    WARNING 1: it matters exactly where this is called. By default, this function will build a namespace from the
+    parent of where it is called.
+
+    WARNING 2: this only looks in the parent namespace, not other parents since (AFAIK) there's no way to collect a
+    dict of exactly what's in scope. Using `f_back` would work sometimes but would be very wrong and confusing in many
+    other cases. See https://discuss.python.org/t/is-there-a-way-to-access-parent-nested-namespaces/20659.
+    """
+    frame = sys._getframe(parent_depth)
+    # if f_back is None, it's the global module namespace and we don't need to include it here
+    if frame.f_back is None:
+        return None
+    else:
+        return frame.f_locals
 
 
 if sys.version_info >= (3, 10):  # noqa C901

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -98,7 +98,7 @@ class ModelMetaclass(ABCMeta):
                 cls_name,
                 validator_functions,
                 bases,
-                types_namespace=_model_construction.parent_frame_namespace(),
+                types_namespace=_typing_extra.parent_frame_namespace(),
                 raise_errors=False,
             )
             return cls
@@ -460,7 +460,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         if not force and cls.__pydantic_model_complete__:
             return None
         else:
-            parents_namespace = _model_construction.parent_frame_namespace()
+            parents_namespace = _typing_extra.parent_frame_namespace()
             if types_namespace and parents_namespace:
                 types_namespace = {**parents_namespace, **types_namespace}
             elif parents_namespace:

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -775,25 +775,21 @@ def nested():
 
 
 def test_nested_more_annotation(create_module):
-    module = create_module(
-        # language=Python
-        """
-from __future__ import annotations
-from pydantic import BaseModel
+    @create_module
+    def module():
+        from pydantic import BaseModel
 
-def nested():
-    class Foo(BaseModel):
-        a: int
+        def nested():
+            class Foo(BaseModel):
+                a: int
 
-    def more_nested():
-        class Bar(BaseModel):
-            b: Foo
+            def more_nested():
+                class Bar(BaseModel):
+                    b: 'Foo'
 
-        return Bar
+                return Bar
 
-    return more_nested()
-"""
-    )
+            return more_nested()
 
     bar_model = module.nested()
     # this does not work because Foo is in a parent scope

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -807,7 +807,7 @@ def test_nested_annotation_priority(create_module):
         Foobar = Annotated[int, Gt(0)]  # noqa: F841
 
         def nested():
-            Foobar = Annotated[int, Gt(10)]
+            Foobar = Annotated[int, Gt(10)]  # noqa: F841
 
             class Bar(BaseModel):
                 b: 'Foobar'


### PR DESCRIPTION
Working on workaround for problems with python type hints namespaces, see #2678.

I'm not yet sure if this is a good idea, it's still confusing since intermediate parent namespaces are ignored.

Still this is an interesting idea.

Will need to be rebased to main once #4516 is merged.