### PR TITLE
Add postgresql+psycopg as allowed scheme for PostgreDsn

### DIFF
--- a/changes/4689-morian.md
+++ b/changes/4689-morian.md
@@ -1,0 +1,1 @@
+Add `postgresql+psycopg` as allowed scheme for `PostgreDsn` to make it usable with SQLAlchemy 2

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -598,6 +598,7 @@ For URI/URL validation the following types are available:
   - `postgresql`
   - `postgresql+asyncpg`
   - `postgresql+pg8000`
+  - `postgresql+psycopg`
   - `postgresql+psycopg2`
   - `postgresql+psycopg2cffi`
   - `postgresql+py-postgresql`

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -490,6 +490,7 @@ class PostgresDsn(MultiHostDsn):
         'postgresql',
         'postgresql+asyncpg',
         'postgresql+pg8000',
+        'postgresql+psycopg',
         'postgresql+psycopg2',
         'postgresql+psycopg2cffi',
         'postgresql+py-postgresql',

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -37,6 +37,7 @@ except ImportError:
         'postgres://just-user@localhost:5432/app',
         'postgresql+asyncpg://user:pass@localhost:5432/app',
         'postgresql+pg8000://user:pass@localhost:5432/app',
+        'postgresql+psycopg://postgres:postgres@localhost:5432/hatch',
         'postgresql+psycopg2://postgres:postgres@localhost:5432/hatch',
         'postgresql+psycopg2cffi://user:pass@localhost:5432/app',
         'postgresql+py-postgresql://user:pass@localhost:5432/app',


### PR DESCRIPTION
Merge request for #4689.

Support is limited to `PostgreDsn` for now.
CockroachDsn was introduced in `pydantic` by #3830 based on what was supported by [sqlalchemy-cockroachdb](https://github.com/cockroachdb/sqlalchemy-cockroachdb).
This project does not show any sign of support for psycopg3 so far, so this was not included in this patch.
