### PR TITLE
Fix improper parsing of Enum document

### DIFF
--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 import warnings
 from collections import defaultdict

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -618,7 +618,7 @@ def enum_process_schema(enum: Type[Enum], *, field: Optional[ModelField] = None)
         'title': enum.__name__,
         # Python assigns all enums a default docstring value of 'An enumeration', so
         # all enums will have a description field even if not explicitly provided.
-        'description': enum.__doc__ or 'An enumeration.',
+        'description': inspect.cleandoc(enum.__doc__) or 'An enumeration.',
         # Add enum values and the enum field type to the schema.
         'enum': [item.value for item in cast(Iterable[Enum], enum)],
     }

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -1,4 +1,3 @@
-import inspect
 import re
 import warnings
 from collections import defaultdict
@@ -615,11 +614,13 @@ def enum_process_schema(enum: Type[Enum], *, field: Optional[ModelField] = None)
 
     This is similar to the `model_process_schema` function, but applies to ``Enum`` objects.
     """
+    import inspect
+
     schema_: Dict[str, Any] = {
         'title': enum.__name__,
         # Python assigns all enums a default docstring value of 'An enumeration', so
         # all enums will have a description field even if not explicitly provided.
-        'description': inspect.cleandoc(enum.__doc__) or 'An enumeration.',
+        'description': inspect.cleandoc(enum.__doc__ or 'An enumeration.'),
         # Add enum values and the enum field type to the schema.
         'enum': [item.value for item in cast(Iterable[Enum], enum)],
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -449,6 +449,34 @@ def test_list_enum_schema_extras():
     }
 
 
+def test_enum_schema_cleandoc():
+    class FooBar(str, Enum):
+        """
+        This is docstring which needs to be cleaned up
+        """
+
+        foo = 'foo'
+        bar = 'bar'
+
+    class Model(BaseModel):
+        enum: FooBar
+
+    assert Model.schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'enum': {'$ref': '#/definitions/FooBar'}},
+        'required': ['enum'],
+        'definitions': {
+            'FooBar': {
+                'title': 'FooBar',
+                'description': 'This is docstring which needs to be cleaned up',
+                'enum': ['foo', 'bar'],
+                'type': 'string',
+            }
+        },
+    }
+
+
 def test_json_schema():
     class Model(BaseModel):
         a = b'foobar'


### PR DESCRIPTION
To properly display document of an Enum, it requires to `inspect.cleandoc` before put into schema.
It had worked perfectly in 1.9.x, but it seems #4267 broke its behavior.

Expected behavior:
![](https://user-images.githubusercontent.com/32300164/200483279-dd9c2004-b3d5-4823-bc22-b2cf4c251e4a.png)

Actual behavior:
![](https://user-images.githubusercontent.com/32300164/200483355-cac9c0ea-7d7b-43e2-a7b3-d24e06f62ff3.png)

Enum code:
```python
class CommentType(IntEnum):
    """
    评论来源类型

    | **数值** | **含义** |
    |---|---|
    | 1 | 视频 |
    | 12 | 文章 |
    | 11 | 含图片的动态 |
    | 17 | 不含图片的动态 |
    | 14 | 音乐 |
    | 19 | 歌单 |
    """

    VIDEO = 1
    ARTICLE = 12
    DYNAMIC_PICTURE = 11
    DYNAMIC_TEXT = 17
    AUDIO = 14
    AUDIO_LIST = 19

```