### PR TITLE
skip mypy tests on py3.11, switch `pytest-sugar` -> `pytest-pretty`

### DIFF
--- a/requirements/testing.in
+++ b/requirements/testing.in
@@ -2,4 +2,4 @@ coverage[toml]
 dirty-equals
 pytest
 pytest-mock
-pytest-sugar
+pytest-pretty

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -6,40 +6,49 @@
 #
 attrs==22.1.0
     # via pytest
+commonmark==0.9.1
+    # via rich
 coverage[toml]==6.4.4
     # via -r requirements/testing.in
 dirty-equals==0.5.0
     # via -r requirements/testing.in
+importlib-metadata==5.0.0
+    # via
+    #   pluggy
+    #   pytest
 iniconfig==1.1.1
     # via pytest
 packaging==21.3
-    # via
-    #   pytest
-    #   pytest-sugar
+    # via pytest
 pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
+pygments==2.13.0
+    # via rich
 pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via
     #   -r requirements/testing.in
     #   pytest-mock
-    #   pytest-sugar
+    #   pytest-pretty
 pytest-mock==3.8.2
     # via -r requirements/testing.in
-pytest-sugar==0.9.5
+pytest-pretty==0.0.1
     # via -r requirements/testing.in
 pytz==2022.4
     # via dirty-equals
-termcolor==1.1.0
-    # via pytest-sugar
+rich==12.6.0
+    # via pytest-pretty
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
 typing-extensions==4.3.0
-    # via dirty-equals
+    # via
+    #   dirty-equals
+    #   importlib-metadata
+    #   rich
 zipp==3.8.1
     # via importlib-metadata

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -19,14 +19,15 @@ except ImportError:
 
 def should_skip():
     if sys.version_info >= (3, 11):
-        # mypy doesn't full support 3.11 and tests are taking minutes
-        # TODO remove ones 3.11 is fully supported
+        # mypy doesn't fully support 3.11 and tests are taking minutes, see #4738
+        # mypy v0.990 is even worse, see #4735
+        # TODO remove once 3.11 is fully supported by mypy
         return True
     else:
         return sys.platform != 'linux' and 'CI' in os.environ
 
 
-pytestmark = pytest.mark.skipif(should_skip(), reason='skipp on 3.11, only run on linux when on CI')
+pytestmark = pytest.mark.skipif(should_skip(), reason='Skip on 3.11, only run on linux when on CI')
 
 # This ensures mypy can find the test files, no matter where tests are run from:
 os.chdir(Path(__file__).parent.parent.parent)

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -17,7 +17,16 @@ except ImportError:
     parse_mypy_version = lambda _: (0,)  # noqa: E731
 
 
-pytestmark = pytest.mark.skipif(sys.platform != 'linux' and 'CI' in os.environ, reason='only run on linux when on CI')
+def should_skip():
+    if sys.version_info >= (3, 11):
+        # mypy doesn't full support 3.11 and tests are taking minutes
+        # TODO remove ones 3.11 is fully supported
+        return True
+    else:
+        return sys.platform != 'linux' and 'CI' in os.environ
+
+
+pytestmark = pytest.mark.skipif(should_skip(), reason='skipp on 3.11, only run on linux when on CI')
 
 # This ensures mypy can find the test files, no matter where tests are run from:
 os.chdir(Path(__file__).parent.parent.parent)


### PR DESCRIPTION
mypy tests are taking minutse on 3.11, see [this build](https://github.com/pydantic/pydantic/actions/runs/3412825586/jobs/5678818272).