### PR TITLE
minor: fix broken cross-references

### DIFF
--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -435,7 +435,7 @@ as the value:
 
 {!.tmp_examples/models_required_fields.md!}
 
-Where `Field` refers to the [field function](schema.md#field-customisation).
+Where `Field` refers to the [field function](schema.md#field-customization).
 
 Here `a`, `b` and `c` are all required. However, use of the ellipses in `b` will not work well
 with [mypy](mypy.md), and as of **v1.0** should be avoided in most cases.
@@ -471,7 +471,7 @@ Example of usage:
 
 {!.tmp_examples/models_default_factory.md!}
 
-Where `Field` refers to the [field function](schema.md#field-customisation).
+Where `Field` refers to the [field function](schema.md#field-customization).
 
 !!! warning
     The `default_factory` expects the field type to be set.

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -782,7 +782,7 @@ The value of numerous common types can be restricted using `con*` type functions
 
 {!.tmp_examples/types_constrained.md!}
 
-Where `Field` refers to the [field function](schema.md#field-customisation).
+Where `Field` refers to the [field function](schema.md#field-customization).
 
 ### Arguments to `conlist`
 The following arguments are available when using the `conlist` type function

--- a/docs/usage/validation_decorator.md
+++ b/docs/usage/validation_decorator.md
@@ -48,7 +48,7 @@ To demonstrate all the above parameter types:
 
 ## Using Field to describe function arguments
 
-[Field](schema.md#field-customisation) can also be used with `validate_arguments` to provide extra information about
+[Field](schema.md#field-customization) can also be used with `validate_arguments` to provide extra information about
 the field and validations. In general it should be used in a type hint with
 [Annotated](schema.md#typingannotated-fields), unless `default_factory` is specified, in which case it should be used
 as the default value of the field:


### PR DESCRIPTION
This PR just fixes some broken cross-references due to an inconsistency between usage American and British spelling.
(saw the note about changes and branches but wasn't sure how it applies to documentation. feel free to move or modify)