### PR TITLE
Renaming BaseModel

### DIFF
--- a/docs/examples/models_orm_mode_reserved_name.py
+++ b/docs/examples/models_orm_mode_reserved_name.py
@@ -12,10 +12,10 @@ class MyModel(BaseModel):
         orm_mode = True
 
 
-BaseModel = declarative_base()
+Base = declarative_base()
 
 
-class SQLModel(BaseModel):
+class SQLModel(Base):
     __tablename__ = 'my_table'
     id = sa.Column('id', sa.Integer, primary_key=True)
     # 'metadata' is reserved by SQLAlchemy, hence the '_'


### PR DESCRIPTION
Hello

BaseModel is an import from pydantic.
Using that same name for the Base from sqlachemy can be misleading, and not aligned to the other examples.

I therefore suggest to use the same naming that the other example.

Pierre

# NOTICE

We're currently in the process of rewriting pydantic in preparation for V2, see
https://pydantic-docs.helpmanual.io/blog/pydantic-v2/.

Please see https://github.com/orgs/pydantic/projects/1 for the major tasks required for this migration.

To avoid wasting your time, it would be best if you only created significant PRs related to that project.

Thank you for your interest in pydantic, and your patience. :pray:

**Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch.
