### PR TITLE
Handle dataclass initialization with alias

### DIFF
--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1472,3 +1472,26 @@ def test_subclass_post_init_inheritance():
             self.a *= 3
 
     assert C().a == 6  # 1 * 3 + 3
+
+
+def test_alias():
+    @pydantic.dataclasses.dataclass
+    class Foo:
+        field1: Optional[str] = pydantic.Field(None, alias='f1')
+        field2: Optional[str] = pydantic.Field(None)
+
+    foo = Foo(f1='a', field2='b')
+    assert foo.field1 == 'a'
+
+    foo = Foo(field1='a', field2='b')
+    assert foo.field1 is None
+
+
+def test_alias_population_by_field_name():
+    @pydantic.dataclasses.dataclass(config=dict(allow_population_by_field_name=True))
+    class Foo:
+        field1: Optional[str] = pydantic.Field(None, alias='f1')
+        field2: Optional[str] = pydantic.Field(None)
+
+    foo = Foo(field1='a', field2='b')
+    assert foo.field1 == 'a'


### PR DESCRIPTION
Hello! I initially came across this problem through a FastAPI issue (tiangolo/fastapi#5093) where `pydantic.dataclasses` did not work as expected when a field has an alias.
Basically when the field has an alias, users are unable to set the field using the field's name nor the alias.

I tried to create a fix for this but I am fairly new to pydantic - please let me know if this is not a bug but an intended behavior. Thank you!