### PR TITLE
[1.10.x] Properly encode model and dataclass default for schema

### DIFF
--- a/changes/4781-Bobronium.md
+++ b/changes/4781-Bobronium.md
@@ -1,0 +1,1 @@
+Fix `schema` and `schema_json` on models where a model instance is a one of default values.

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -1,6 +1,7 @@
 import re
 import warnings
 from collections import defaultdict
+from dataclasses import is_dataclass
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
@@ -971,7 +972,11 @@ def multitypes_literal_field_for_schema(values: Tuple[Any, ...], field: ModelFie
 
 
 def encode_default(dft: Any) -> Any:
-    if isinstance(dft, Enum):
+    from .main import BaseModel
+
+    if isinstance(dft, BaseModel) or is_dataclass(dft):
+        dft = cast(dict[str, Any], pydantic_encoder(dft))
+    elif isinstance(dft, Enum):
         return dft.value
     elif isinstance(dft, (int, float, str)):
         return dft
@@ -979,7 +984,8 @@ def encode_default(dft: Any) -> Any:
         t = dft.__class__
         seq_args = (encode_default(v) for v in dft)
         return t(*seq_args) if is_namedtuple(t) else t(seq_args)
-    elif isinstance(dft, dict):
+
+    if isinstance(dft, dict):
         return {encode_default(k): encode_default(v) for k, v in dft.items()}
     elif dft is None:
         return None

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -975,7 +975,7 @@ def encode_default(dft: Any) -> Any:
     from .main import BaseModel
 
     if isinstance(dft, BaseModel) or is_dataclass(dft):
-        dft = cast(dict[str, Any], pydantic_encoder(dft))
+        dft = cast('dict[str, Any]', pydantic_encoder(dft))
     elif isinstance(dft, Enum):
         return dft.value
     elif isinstance(dft, (int, float, str)):

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -976,6 +976,9 @@ def encode_default(dft: Any) -> Any:
 
     if isinstance(dft, BaseModel) or is_dataclass(dft):
         dft = cast('dict[str, Any]', pydantic_encoder(dft))
+
+    if isinstance(dft, dict):
+        return {encode_default(k): encode_default(v) for k, v in dft.items()}
     elif isinstance(dft, Enum):
         return dft.value
     elif isinstance(dft, (int, float, str)):
@@ -984,9 +987,6 @@ def encode_default(dft: Any) -> Any:
         t = dft.__class__
         seq_args = (encode_default(v) for v in dft)
         return t(*seq_args) if is_namedtuple(t) else t(seq_args)
-
-    if isinstance(dft, dict):
-        return {encode_default(k): encode_default(v) for k, v in dft.items()}
     elif dft is None:
         return None
     else:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1528,7 +1528,7 @@ def test_model_default():
     from pydantic import BaseModel
 
     class Inner(BaseModel):
-        a: dict[Path, str] = {Path(): ''}
+        a: Dict[Path, str] = {Path(): ''}
 
     class Outer(BaseModel):
         inner: Inner = Inner()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1525,8 +1525,6 @@ def test_dict_default():
 
 def test_model_default():
     """Make sure inner model types are encoded properly"""
-    from pydantic import BaseModel
-
     class Inner(BaseModel):
         a: Dict[Path, str] = {Path(): ''}
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1523,6 +1523,39 @@ def test_dict_default():
     }
 
 
+def test_model_default():
+    """Make sure inner model types are encoded properly"""
+    from pydantic import BaseModel
+
+    class Inner(BaseModel):
+        a: dict[Path, str] = {Path(): ''}
+
+    class Outer(BaseModel):
+        inner: Inner = Inner()
+
+    assert Outer.schema() == {
+        'definitions': {
+            'Inner': {
+                'properties': {
+                    'a': {
+                        'additionalProperties': {'type': 'string'},
+                        'default': {'.': ''},
+                        'title': 'A',
+                        'type': 'object',
+                    }
+                },
+                'title': 'Inner',
+                'type': 'object',
+            }
+        },
+        'properties': {
+            'inner': {'allOf': [{'$ref': '#/definitions/Inner'}], 'default': {'a': {'.': ''}}, 'title': 'Inner'}
+        },
+        'title': 'Outer',
+        'type': 'object',
+    }
+
+
 @pytest.mark.parametrize(
     'kwargs,type_,expected_extra',
     [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1525,6 +1525,7 @@ def test_dict_default():
 
 def test_model_default():
     """Make sure inner model types are encoded properly"""
+
     class Inner(BaseModel):
         a: Dict[Path, str] = {Path(): ''}
 


### PR DESCRIPTION
Closes #4774

Fix was pretty straightforward, I guess we can have this in 1.10.x.