### PR TITLE
Install setuptools before installing requirements in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
             ${{ env.pythonLocation }}
             ${{ hashFiles('requirements/linting.txt') }}
 
+      - name: install setuptools
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install setuptools
+
       - name: install
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r requirements/linting.txt
@@ -109,6 +113,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: install setuptools
+      run: pip install setuptools
 
     - name: install min deps
       run: pip install -r requirements/pyproject-min.txt -r requirements/testing.txt


### PR DESCRIPTION
Fixes the CI problem in https://github.com/pydantic/pydantic/pull/4781
Seems we need to install `setuptools` first.
I found the solution from https://github.com/pypa/packaging-problems/issues/573