### PR TITLE
Add newline before `Outputs:` when printing json output in docs

### DIFF
--- a/docs/build/exec_examples.py
+++ b/docs/build/exec_examples.py
@@ -40,11 +40,12 @@ PYTHON_CODE_MD_TMPL = """
     ```
 """.strip()
 JSON_OUTPUT_MD_TMPL = """
+
 Outputs:
 ```json
 {output}
 ```
-""".strip()
+"""
 
 
 def to_string(value: Any) -> str:


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/pull/4799#issuecomment-1330788495

Thanks @Kludex for reporting