### PR TITLE
feat(minor): Allow passing config to parse_obj_as

### DIFF
--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -2,6 +2,7 @@ from functools import lru_cache
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 from ._internal import _repr
+from .config import BaseConfig
 
 __all__ = 'parse_obj_as', 'schema_of', 'schema_json_of'
 
@@ -13,21 +14,25 @@ def _generate_parsing_type_name(type_: Any) -> str:
 
 
 @lru_cache(maxsize=2048)
-def _get_parsing_type(type_: Any, *, type_name: Optional[NameFactory] = None) -> Any:
+def _get_parsing_type(
+    type_: Any, *, type_name: Optional[NameFactory] = None, config: Optional[Type[BaseConfig]] = None
+) -> Any:
     from pydantic.main import create_model
 
     if type_name is None:
         type_name = _generate_parsing_type_name
     if not isinstance(type_name, str):
         type_name = type_name(type_)
-    return create_model(type_name, __root__=(type_, ...))
+    return create_model(type_name, __root__=(type_, ...), __config__=config)
 
 
 T = TypeVar('T')
 
 
-def parse_obj_as(type_: Type[T], obj: Any, *, type_name: Optional[NameFactory] = None) -> T:
-    model_type = _get_parsing_type(type_, type_name=type_name)  # type: ignore[arg-type]
+def parse_obj_as(
+    type_: Type[T], obj: Any, *, type_name: Optional[NameFactory] = None, config: Optional[Type[BaseConfig]] = None
+) -> T:
+    model_type = _get_parsing_type(type_, type_name=type_name, config=config)  # type: ignore[arg-type]
     return model_type(__root__=obj).__root__
 
 


### PR DESCRIPTION
The `parse_obj_as` API doesn't allow arbitrary objects which can be extended by passing Config. My use case is similar to [this question](https://stackoverflow.com/a/60989198/10309266) @samuelcolvin has answered on SO.

```python
# before - ohno runtime error I can probably do nothing about ༼ಢ_ಢ༽ 
In [1]: parse_obj_as(list[File], 'true')
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
File <ipython-input-7-4e10774d8e55>:1, in <cell line: 1>()
----> 1 parse_obj_as(list[File], 'true')
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/tools.py:30, in pydantic.tools._get_parsing_type()
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/main.py:1026, in pydantic.main.create_model()
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/main.py:198, in pydantic.main.ModelMetaclass.__new__()
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/fields.py:506, in pydantic.fields.ModelField.infer()
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/fields.py:436, in pydantic.fields.ModelField.__init__()
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/fields.py:557, in pydantic.fields.ModelField.prepare()
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/fields.py:831, in pydantic.fields.ModelField.populate_validators()
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/validators.py:765, in find_validators()
RuntimeError: no validator found for <class 'frappe.core.doctype.file.file.File'>, see `arbitrary_types_allowed` in Config

# after - works as expected ヽ(^ᴗ^ヽ)
In [2]: parse_obj_as(list[File], 'true', config=FrappePydanticConfig)
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
File <ipython-input-12-268e8a88311f>:1, in <cell line: 1>()
----> 1 parse_obj_as(list[File], 'true', config=FrappePydanticConfig)

File ~/Desktop/projects-bench/apps/frappe/frappe/utils/typing_validations.py:76, in parse_obj_as(type_, obj, type_name, config)
     67 def parse_obj_as(
     68 	type_: type[T],
     69 	obj: Any,
   (...)
     73 ) -> T:
     74 	# Note: This is a copy of pydantic.tools.parse_obj_as with the addition of allowing a config argument
     75 	model_type = _get_parsing_type(type_, type_name=type_name, config=config)  # type: ignore[arg-type]
---> 76 	return model_type(__root__=obj).__root__

File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pydantic/main.py:342, in pydantic.main.BaseModel.__init__()

ValidationError: 1 validation error for ParsingModel[list[frappe.core.doctype.file.file.File]]
__root__
  value is not a valid list (type=type_error.list)
```