### PR TITLE
Implement AwareDatetime and NaiveDatetime

### DIFF
--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -445,6 +445,12 @@ With proper ordering in an annotated `Union`, you can use this to parse types of
 `FutureDate`
 : like `date`, but the date should be in the future
 
+`AwareDatetime`
+: like `datetime`, but requires the value to have timezone info
+
+`NaiveDatetime`
+: like `datetime`, but requires the value to lack timezone info
+
 `EmailStr`
 : requires [email-validator](https://github.com/JoshData/python-email-validator) to be installed;
   the input string must be a valid email address, and the output is a simple string

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -105,6 +105,8 @@ __all__ = [
     'ByteSize',
     'PastDate',
     'FutureDate',
+    'AwareDatetime',
+    'NaiveDatetime',
     # version
     'VERSION',
 ]

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import abc
 import dataclasses as _dataclasses
 import re
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
@@ -70,6 +70,8 @@ __all__ = [
     'PastDate',
     'FutureDate',
     'condate',
+    'AwareDatetime',
+    'NaiveDatetime',
 ]
 
 from ._internal._utils import update_not_none
@@ -769,3 +771,43 @@ def condate(*, strict: bool = None, gt: date = None, ge: date = None, lt: date =
         Strict(strict) if strict is not None else None,
         annotated_types.Interval(gt=gt, ge=ge, lt=lt, le=le),
     ]
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ DATETIME TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+if TYPE_CHECKING:
+    AwareDatetime = Annotated[datetime, ...]
+    NaiveDatetime = Annotated[datetime, ...]
+else:
+
+    class AwareDatetime:
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, schema: core_schema.CoreSchema | None = None, **_kwargs: Any
+        ) -> core_schema.CoreSchema:
+            if schema is None:
+                # used directly as a type
+                return core_schema.datetime_schema(tz_constraint='aware')
+            else:
+                assert schema['type'] == 'datetime'
+                schema['tz_constraint'] = 'aware'
+                return schema
+
+        def __repr__(self) -> str:
+            return 'AwareDatetime'
+
+    class NaiveDatetime:
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, schema: core_schema.CoreSchema | None = None, **_kwargs: Any
+        ) -> core_schema.CoreSchema:
+            if schema is None:
+                # used directly as a type
+                return core_schema.datetime_schema(tz_constraint='naive')
+            else:
+                assert schema['type'] == 'datetime'
+                schema['tz_constraint'] = 'naive'
+                return schema
+
+        def __repr__(self) -> str:
+            return 'NaiveDatetime'

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -4,7 +4,7 @@ Test pydantic's compliance with mypy.
 Do a little skipping about with types to demonstrate its usage.
 """
 import os
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path, PurePath
 from typing import Any, Dict, ForwardRef, Generic, List, Optional, Type, TypeVar
 from uuid import UUID
@@ -14,6 +14,7 @@ from typing_extensions import Annotated, TypedDict
 
 from pydantic import (
     UUID1,
+    AwareDatetime,
     BaseModel,
     ConfigDict,
     DirectoryPath,
@@ -22,6 +23,7 @@ from pydantic import (
     FutureDate,
     ImportString,
     Json,
+    NaiveDatetime,
     NegativeFloat,
     NegativeInt,
     NonNegativeFloat,
@@ -222,6 +224,9 @@ class PydanticTypes(BaseModel):
     # Date
     my_past_date: PastDate = date.today() - timedelta(1)
     my_future_date: FutureDate = date.today() + timedelta(1)
+    # Datetime
+    my_aware_datetime: AwareDatetime = datetime.now(tz=timezone.utc)
+    my_naive_datetime: NaiveDatetime = datetime.now()
 
     class Config:
         validate_all = True


### PR DESCRIPTION
As discussed [here](https://github.com/pydantic/pydantic/discussions/3477#discussioncomment-3771452), and in continuation of [this PR on pydantic-core](https://github.com/pydantic/pydantic-core/pull/343).

We add two new types, implementing constraining datetime values to either enforce or disallow timezone info. The implementation is simple and utilizes the 'aware' and 'naive' constraints from the underlying pydantic-core.

Admittedly, I added the `insert_assert` comment just by looking at surrounding code, without looking deeper into how that works. Hopefully it just makes sense here too. (I'm guessing this is some sort of macro that is pre-processed? I'm intrigued!).

Oh, and of course this PR depends on a new release of pydantic-core 🙂
