### PR TITLE
Support Pattern types with arguments

### DIFF
--- a/changes/4815-danielkza.md
+++ b/changes/4815-danielkza.md
@@ -1,0 +1,1 @@
+Support Pattern types with arguments

--- a/docs/build/schema_mapping.py
+++ b/docs/build/schema_mapping.py
@@ -176,6 +176,20 @@ table: list[tuple[str, str, str | dict[str, Any], str, str]] = [
         '',
     ),
     (
+        'Pattern[str]',
+        'string',
+        {'format': 'regex'},
+        'JSON Schema Validation',
+        '',
+    ),
+    (
+        'Pattern[bytes]',
+        'string',
+        {'format': 'regex'},
+        'JSON Schema Validation',
+        '',
+    ),
+    (
         'bytes',
         'string',
         {'format': 'binary'},

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -128,8 +128,11 @@ with custom properties and validation.
 `typing.Callable`
 : see [Callable](#callable) below for more detail on parsing and validation
 
-`typing.Pattern`
+`typing.Pattern or typing.Pattern[str]`
 : will cause the input value to be passed to `re.compile(v)` to create a regex pattern
+
+`typing.Pattern[bytes]`
+: will cause the input value to be passed to `re.compile(v)` as bytes, to create a regex pattern to match bytes
 
 `ipaddress.IPv4Address`
 : simply uses the type itself for validation by passing the value to `IPv4Address(v)`;
@@ -620,7 +623,7 @@ For URI/URL validation the following types are available:
 
 !!! warning
     In V1.10.0 and v1.10.1 `stricturl` also took an optional `quote_plus` argument and URL components were percent
-    encoded in some cases. This feature was removed in v1.10.2, see 
+    encoded in some cases. This feature was removed in v1.10.2, see
     [#4470](https://github.com/pydantic/pydantic/pull/4470) for explanation and more details.
 
 The above types (which all inherit from `AnyUrl`) will attempt to give descriptive errors when invalid URLs are

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,5 +1,4 @@
 import copy
-import re
 from collections import Counter as CollectionCounter, defaultdict, deque
 from collections.abc import Callable, Hashable as CollectionsHashable, Iterable as CollectionsIterable
 from typing import (
@@ -17,7 +16,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Pattern,
     Sequence,
     Set,
     Tuple,
@@ -43,6 +41,7 @@ from .typing import (
     is_literal_type,
     is_new_type,
     is_none_type,
+    is_pattern_type,
     is_typeddict,
     is_typeddict_special,
     is_union,
@@ -603,8 +602,7 @@ class ModelField(Representation):
                 self.required = False
             self.allow_none = True
             return
-        elif self.type_ is Pattern or self.type_ is re.Pattern:
-            # python 3.7 only, Pattern is a typing object but without sub fields
+        elif is_pattern_type(self.type_):
             return
         elif is_literal_type(self.type_):
             return

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -6,7 +6,7 @@ from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6
 from pathlib import Path
 from re import Pattern
 from types import GeneratorType
-from typing import Any, Callable, Dict, Type, Union
+from typing import Any, AnyStr, Callable, Dict, Type, Union
 from uuid import UUID
 
 from .color import Color
@@ -41,6 +41,14 @@ def decimal_encoder(dec_value: Decimal) -> Union[int, float]:
         return float(dec_value)
 
 
+def pattern_encoder(pattern: Pattern[AnyStr]) -> str:
+    pattern_s = pattern.pattern
+    if isinstance(pattern_s, bytes):
+        return pattern_s.decode('utf-8', errors='backslashreplace')
+    else:
+        return pattern_s
+
+
 ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     bytes: lambda o: o.decode(),
     Color: str,
@@ -61,7 +69,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     IPv6Network: str,
     NameEmail: str,
     Path: str,
-    Pattern: lambda o: o.pattern,
+    Pattern: pattern_encoder,
     SecretBytes: str,
     SecretStr: str,
     set: list,

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -1,12 +1,12 @@
 import datetime
+import re
 from collections import deque
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
-from re import Pattern
 from types import GeneratorType
-from typing import Any, AnyStr, Callable, Dict, Type, Union
+from typing import Any, AnyStr, Callable, Dict, Pattern, Type, Union
 from uuid import UUID
 
 from .color import Color
@@ -69,7 +69,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
     IPv6Network: str,
     NameEmail: str,
     Path: str,
-    Pattern: pattern_encoder,
+    re.Pattern: pattern_encoder,
     SecretBytes: str,
     SecretStr: str,
     set: list,

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from collections.abc import Callable
 from os import PathLike
@@ -15,6 +16,7 @@ from typing import (  # type: ignore
     Mapping,
     NewType,
     Optional,
+    Pattern,
     Sequence,
     Set,
     Tuple,
@@ -410,6 +412,10 @@ def is_callable_type(type_: Type[Any]) -> bool:
 
 def is_literal_type(type_: Type[Any]) -> bool:
     return Literal is not None and get_origin(type_) is Literal
+
+
+def is_pattern_type(type_: Type[Any]) -> bool:
+    return type_ is Pattern or type_ is re.Pattern or get_origin(type_) is Pattern or get_origin(type_) is re.Pattern
 
 
 def literal_values(type_: Type[Any]) -> Tuple[Any, ...]:

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -25,7 +25,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    get_args,
 )
 from uuid import UUID
 
@@ -35,6 +34,7 @@ from .typing import (
     AnyCallable,
     all_literal_values,
     display_as_type,
+    get_args,
     get_class,
     is_callable_type,
     is_literal_type,

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -473,6 +473,6 @@ def test_legacy_typeddict_no_required_not_required():
         t: TD
 
 
-def test_pattern_with_constraints():
+def test_pattern_annotated():
     class Foobar(BaseModel):
         pattern: Annotated[Pattern[str], Field(description='My Regex')]

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -6,7 +6,7 @@ Tests for annotated types that _pydantic_ can validate like
 import json
 import sys
 from collections import namedtuple
-from typing import List, NamedTuple, Optional, Tuple
+from typing import List, NamedTuple, Optional, Pattern, Tuple
 
 import pytest
 from typing_extensions import Annotated, NotRequired, Required, TypedDict
@@ -471,3 +471,8 @@ def test_legacy_typeddict_no_required_not_required():
 
     class Model(BaseModel):
         t: TD
+
+
+def test_pattern_with_constraints():
+    class Foobar(BaseModel):
+        pattern: Annotated[Pattern[str], Field(description='My Regex')]

--- a/tests/test_annotated_types.py
+++ b/tests/test_annotated_types.py
@@ -474,5 +474,8 @@ def test_legacy_typeddict_no_required_not_required():
 
 
 def test_pattern_annotated():
-    class Foobar(BaseModel):
-        pattern: Annotated[Pattern[str], Field(description='My Regex')]
+    # No constraints are used in Pattern types
+    with pytest.raises(ValueError, match='On field "pattern" the following field constraints are set but not enforced'):
+
+        class Foobar(BaseModel):
+            pattern: Annotated[Pattern[str], Field(allow_mutation=False)]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -66,17 +66,17 @@ PATTERN_TEST_CASES = [
     # str patterns
     (re.Pattern, re.compile('^hello, world$'), '^hello, world$'),
     (Pattern, re.compile('^hello, world$'), '^hello, world$'),
+    (Pattern[str], re.compile('^hello, world$'), '^hello, world$'),
+    (Pattern[bytes], re.compile(b'^\x00hello, world$'), '^\\u0000hello, world$'),
 ]
 
 if sys.version_info >= (3, 9, 0):
-    # Pattern type with type args is only available from python 3.9
+    # re.Pattern type with type args is only available from python 3.9
     PATTERN_TEST_CASES += [
         # str patterns
         (re.Pattern[str], re.compile('^hello, world$'), '^hello, world$'),
-        (Pattern[str], re.compile('^hello, world$'), '^hello, world$'),
         # bytes patterns
         (re.Pattern[bytes], re.compile(b'^\x00hello, world$'), '^\\u0000hello, world$'),
-        (Pattern[bytes], re.compile(b'^\x00hello, world$'), '^\\u0000hello, world$'),
     ]
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -62,19 +62,25 @@ def test_encoding(input, output):
     assert output == json.dumps(input, default=pydantic_encoder)
 
 
-@pytest.mark.parametrize(
-    'field_type,pattern,output',
-    [
+PATTERN_TEST_CASES = [
+    # str patterns
+    (re.Pattern, re.compile('^hello, world$'), '^hello, world$'),
+    (Pattern, re.compile('^hello, world$'), '^hello, world$'),
+]
+
+if sys.version_info >= (3, 9, 0):
+    # Pattern type with type args is only available from python 3.9
+    PATTERN_TEST_CASES += [
         # str patterns
-        (re.Pattern, re.compile('^hello, world$'), '^hello, world$'),
         (re.Pattern[str], re.compile('^hello, world$'), '^hello, world$'),
-        (Pattern, re.compile('^hello, world$'), '^hello, world$'),
         (Pattern[str], re.compile('^hello, world$'), '^hello, world$'),
         # bytes patterns
         (re.Pattern[bytes], re.compile(b'^\x00hello, world$'), '^\\u0000hello, world$'),
         (Pattern[bytes], re.compile(b'^\x00hello, world$'), '^\\u0000hello, world$'),
-    ],
-)
+    ]
+
+
+@pytest.mark.parametrize('field_type,pattern,output', PATTERN_TEST_CASES)
 def test_pattern_round_trip_coding(field_type, pattern, output):
     """
     Ensure all types of regex patterns work, str and bytes, and that the

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 import json
 import math
 import os
+import re
 import sys
 import tempfile
 from datetime import date, datetime, time, timedelta
@@ -20,6 +21,7 @@ from typing import (
     NamedTuple,
     NewType,
     Optional,
+    Pattern,
     Set,
     Tuple,
     Type,
@@ -1741,6 +1743,20 @@ def test_bytes_constrained_types(field_type, expected_schema):
 
     base_schema = {'title': 'Model', 'type': 'object', 'properties': {'a': {}}, 'required': ['a']}
     base_schema['properties']['a'] = expected_schema
+
+    assert Model.schema() == base_schema
+
+
+@pytest.mark.parametrize(
+    'field_type', [re.Pattern, Pattern, re.Pattern[str], Pattern[str], re.Pattern[bytes], Pattern[bytes]]
+)
+def test_pattern(field_type):
+    class Model(BaseModel):
+        pattern: field_type
+
+    expected_schema = {'title': 'Pattern', 'type': 'string', 'format': 'regex'}
+    base_schema = {'title': 'Model', 'type': 'object', 'properties': {'pattern': {}}, 'required': ['pattern']}
+    base_schema['properties']['pattern'] = expected_schema
 
     assert Model.schema() == base_schema
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1747,9 +1747,12 @@ def test_bytes_constrained_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
-@pytest.mark.parametrize(
-    'field_type', [re.Pattern, Pattern, re.Pattern[str], Pattern[str], re.Pattern[bytes], Pattern[bytes]]
-)
+PATTERN_TEST_CASES = [re.Pattern, Pattern]
+if sys.version_info >= (3, 9, 0):
+    PATTERN_TEST_CASES += [re.Pattern[str], Pattern[str], re.Pattern[bytes], Pattern[bytes]]
+
+
+@pytest.mark.parametrize('field_type', PATTERN_TEST_CASES)
 def test_pattern(field_type):
     class Model(BaseModel):
         pattern: field_type

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1747,9 +1747,10 @@ def test_bytes_constrained_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
-PATTERN_TEST_CASES = [re.Pattern, Pattern]
+PATTERN_TEST_CASES = [re.Pattern, Pattern, Pattern[str], Pattern[bytes]]
 if sys.version_info >= (3, 9, 0):
-    PATTERN_TEST_CASES += [re.Pattern[str], Pattern[str], re.Pattern[bytes], Pattern[bytes]]
+    # re.Pattern type with type args is only available from python 3.9
+    PATTERN_TEST_CASES += [re.Pattern[str], re.Pattern[bytes]]
 
 
 @pytest.mark.parametrize('field_type', PATTERN_TEST_CASES)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2660,7 +2660,15 @@ def test_json_no_default():
     assert JsonRequired().dict() == {'json_obj': None}
 
 
-@pytest.mark.parametrize('pattern_type', [re.Pattern, Pattern, re.Pattern[str], Pattern[str]])
+PATTERN_STR_TYPES = [re.Pattern, Pattern]
+PATTERN_BYTES_TYPES = []
+
+if sys.version_info >= (3, 9, 0):
+    PATTERN_STR_TYPES += [re.Pattern[str], Pattern[str]]
+    PATTERN_BYTES_TYPES += [re.Pattern[bytes], Pattern[bytes]]
+
+
+@pytest.mark.parametrize('pattern_type', PATTERN_STR_TYPES)
 def test_pattern(pattern_type):
     class Foobar(BaseModel):
         pattern: pattern_type
@@ -2684,7 +2692,7 @@ def test_pattern(pattern_type):
     }
 
 
-@pytest.mark.parametrize('pattern_type', [Pattern[bytes], re.Pattern[bytes]])
+@pytest.mark.parametrize('pattern_type', PATTERN_BYTES_TYPES)
 def test_pattern_bytes(pattern_type):
     class Foobar(BaseModel):
         pattern: pattern_type
@@ -2708,7 +2716,7 @@ def test_pattern_bytes(pattern_type):
     }
 
 
-@pytest.mark.parametrize('pattern_type', [re.Pattern, Pattern, re.Pattern[str], Pattern[str]])
+@pytest.mark.parametrize('pattern_type', PATTERN_STR_TYPES)
 def test_pattern_error(pattern_type):
     class Foobar(BaseModel):
         pattern: pattern_type
@@ -2720,7 +2728,7 @@ def test_pattern_error(pattern_type):
     ]
 
 
-@pytest.mark.parametrize('pattern_type', [re.Pattern[bytes], Pattern[bytes]])
+@pytest.mark.parametrize('pattern_type', PATTERN_BYTES_TYPES)
 def test_pattern_bytes_error(pattern_type):
     class Foobar(BaseModel):
         pattern: pattern_type

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2660,12 +2660,13 @@ def test_json_no_default():
     assert JsonRequired().dict() == {'json_obj': None}
 
 
-PATTERN_STR_TYPES = [re.Pattern, Pattern]
-PATTERN_BYTES_TYPES = []
+PATTERN_STR_TYPES = [re.Pattern, Pattern, Pattern[str]]
+PATTERN_BYTES_TYPES = [Pattern[bytes]]
 
 if sys.version_info >= (3, 9, 0):
-    PATTERN_STR_TYPES += [re.Pattern[str], Pattern[str]]
-    PATTERN_BYTES_TYPES += [re.Pattern[bytes], Pattern[bytes]]
+    # re.Pattern type with type args is only available from python 3.9
+    PATTERN_STR_TYPES += [re.Pattern[str]]
+    PATTERN_BYTES_TYPES += [re.Pattern[bytes]]
 
 
 @pytest.mark.parametrize('pattern_type', PATTERN_STR_TYPES)


### PR DESCRIPTION
## Change Summary

To preserve previous behaviour, `Pattern` and `re.Pattern` without
arguments are treated as `str` patterns.

Explicit usages of `Pattern[bytes]` or `re.Pattern[bytes]` will create
`bytes` patterns and make sure any invalid characters get escaped.

Explicit usages of `Pattern[str]` now also work, satisfying type
checkers that complained otherwise, but with no change in behaviour.

Tests to better cover the existing behaviour were added, as were some
for new behaviours.

## Related issue number

Fixes #2636

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/pydantic/pydantic/blob/main/changes/README.md) for details.
  You can [skip this check](https://github.com/pydantic/hooky#change-file-checks) if the change does not need a change file.)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**