### PR TITLE
Moving docs to `docs.pydantic.dev`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,8 +268,9 @@ jobs:
   deploy:
     name: Deploy
     needs:
-      - check
-    if: "success() && startsWith(github.ref, 'refs/tags/')"
+      - docs-build
+#      - check
+#    if: "success() && startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
 
     steps:
@@ -279,6 +280,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - run: npm install wrangler npx
 
       - name: get docs
         uses: actions/download-artifact@v3
@@ -299,14 +307,15 @@ jobs:
       - run: ls -lh dist
       - run: twine check dist/*
 
-      - name: upload to pypi
-        run: twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pypi_token }}
+#      - name: upload to pypi
+#        run: twine upload dist/*
+#        env:
+#          TWINE_USERNAME: __token__
+#          TWINE_PASSWORD: ${{ secrets.pypi_token }}
 
       - name: publish docs
-        if: '!fromJSON(steps.check-tag.outputs.IS_PRERELEASE)'
+#        if: '!fromJSON(steps.check-tag.outputs.IS_PRERELEASE)'
         run: make publish-docs
         env:
-          NETLIFY: ${{ secrets.netlify_token }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.cloudflare_account_id }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,9 +290,9 @@ jobs:
       - name: install
         run: pip install -U twine build packaging
 
-      - name: check tag
-        id: check-tag
-        run: ./tests/check_tag.py
+#      - name: check tag
+#        id: check-tag
+#        run: ./tests/check_tag.py
 
       - name: build
         run: python -m build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,9 @@ jobs:
 
       - name: publish docs
 #        if: '!fromJSON(steps.check-tag.outputs.IS_PRERELEASE)'
-        run: make publish-docs
+        uses: cloudflare/wrangler-action@2.0.0
+        with:
+          apiToken: ${{ secrets.cloudflare_api_token }}
+          command: pages publish --project-name=pydantic-docs site
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.cloudflare_account_id }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,13 +281,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          cache: 'npm'
-
-      - run: npm install wrangler npx
-
       - name: get docs
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,6 @@ jobs:
         uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.cloudflare_api_token }}
-          command: pages publish --project-name=pydantic-docs site
+          command: pages publish --project-name=pydantic-docs --branch=main site
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.cloudflare_account_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,8 @@ jobs:
   deploy:
     name: Deploy
     needs:
-      - docs-build
-#      - check
-#    if: "success() && startsWith(github.ref, 'refs/tags/')"
+      - check
+    if: "success() && startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
 
     steps:
@@ -290,9 +289,9 @@ jobs:
       - name: install
         run: pip install -U twine build packaging
 
-#      - name: check tag
-#        id: check-tag
-#        run: ./tests/check_tag.py
+      - name: check tag
+        id: check-tag
+        run: ./tests/check_tag.py
 
       - name: build
         run: python -m build
@@ -300,14 +299,14 @@ jobs:
       - run: ls -lh dist
       - run: twine check dist/*
 
-#      - name: upload to pypi
-#        run: twine upload dist/*
-#        env:
-#          TWINE_USERNAME: __token__
-#          TWINE_PASSWORD: ${{ secrets.pypi_token }}
+      - name: upload to pypi
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_token }}
 
       - name: publish docs
-#        if: '!fromJSON(steps.check-tag.outputs.IS_PRERELEASE)'
+        if: '!fromJSON(steps.check-tag.outputs.IS_PRERELEASE)'
         uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.cloudflare_api_token }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -159,10 +159,10 @@ for their kind support.
 ### Highlights
 
 * add Python 3.10 support, #2885 by @PrettyWood
-* [Discriminated unions](https://pydantic-docs.helpmanual.io/usage/types/#discriminated-unions-aka-tagged-unions), #619 by @PrettyWood
-* [`Config.smart_union` for better union logic](https://pydantic-docs.helpmanual.io/usage/model_config/#smart-union), #2092 by @PrettyWood
+* [Discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions), #619 by @PrettyWood
+* [`Config.smart_union` for better union logic](https://docs.pydantic.dev/usage/model_config/#smart-union), #2092 by @PrettyWood
 * Binaries for Macos M1 CPUs, #3498 by @samuelcolvin
-* Complex types can be set via [nested environment variables](https://pydantic-docs.helpmanual.io/usage/settings/#parsing-environment-variable-values), e.g. `foo___bar`, #3159 by @Air-Mark
+* Complex types can be set via [nested environment variables](https://docs.pydantic.dev/usage/settings/#parsing-environment-variable-values), e.g. `foo___bar`, #3159 by @Air-Mark
 * add a dark mode to _pydantic_ documentation, #2913 by @gbdlin
 * Add support for autocomplete in VS Code via `__dataclass_transform__`, #2721 by @tiangolo
 * Add "exclude" as a field parameter so that it can be configured using model config, #660 by @daviskirk
@@ -193,7 +193,7 @@ for their kind support.
   `pydantic.fields.ModelField`) to `__modify_schema__()` if present, #3434 by @jasujm
 * Fix issue when pydantic fail to parse `typing.ClassVar` string type annotation, #3401 by @uriyyo
 * Mention Python >= 3.9.2 as an alternative to `typing_extensions.TypedDict`, #3374 by @BvB93
-* Changed the validator method name in the [Custom Errors example](https://pydantic-docs.helpmanual.io/usage/models/#custom-errors)
+* Changed the validator method name in the [Custom Errors example](https://docs.pydantic.dev/usage/models/#custom-errors)
   to more accurately describe what the validator is doing; changed from `name_must_contain_space` to ` value_must_equal_bar`, #3327 by @michaelrios28
 * Add `AmqpDsn` class, #3254 by @kludex
 * Always use `Enum` value as default in generated JSON schema, #3190 by @joaommartins
@@ -215,7 +215,7 @@ for their kind support.
   just as when sourced from environment variables, #2917 by @davidmreed
 * add a dark mode to _pydantic_ documentation, #2913 by @gbdlin
 * Make `pydantic-mypy` plugin compatible with `pyproject.toml` configuration, consistent with `mypy` changes.
-  See the [doc](https://pydantic-docs.helpmanual.io/mypy_plugin/#configuring-the-plugin) for more information, #2908 by @jrwalk
+  See the [doc](https://docs.pydantic.dev/mypy_plugin/#configuring-the-plugin) for more information, #2908 by @jrwalk
 * add Python 3.10 support, #2885 by @PrettyWood
 * Correctly parse generic models with `Json[T]`, #2860 by @geekingfrog
 * Update contrib docs re: Python version to use for building docs, #2856 by @paxcodes
@@ -260,7 +260,7 @@ for their kind support.
 * Support generating schema for `Generic` fields with subtypes, #2375 by @maximberg
 * fix(encoder): serialize `NameEmail` to str, #2341 by @alecgerona
 * add `Config.smart_union` to prevent coercion in `Union` if possible, see
- [the doc](https://pydantic-docs.helpmanual.io/usage/model_config/#smart-union) for more information, #2092 by @PrettyWood
+ [the doc](https://docs.pydantic.dev/usage/model_config/#smart-union) for more information, #2092 by @PrettyWood
 * Add ability to use `typing.Counter` as a model field type, #2060 by @uriyyo
 * Add parameterised subclasses to `__bases__` when constructing new parameterised classes, so that `A <: B => A[int] <: B[int]`, #2007 by @diabolo-dan
 * Create `FileUrl` type that allows URLs that conform to [RFC 8089](https://tools.ietf.org/html/rfc8089#section-2).
@@ -310,10 +310,10 @@ for their kind support.
 
 ### Highlights
 
-* [Hypothesis plugin](https://pydantic-docs.helpmanual.io/hypothesis_plugin/) for testing, #2097 by @Zac-HD
-* support for [`NamedTuple` and `TypedDict`](https://pydantic-docs.helpmanual.io/usage/types/#annotated-types), #2216 by @PrettyWood
-* Support [`Annotated` hints on model fields](https://pydantic-docs.helpmanual.io/usage/schema/#typingannotated-fields), #2147 by @JacobHayes
-* [`frozen` parameter on `Config`](https://pydantic-docs.helpmanual.io/usage/model_config/) to allow models to be hashed, #1880 by @rhuille
+* [Hypothesis plugin](https://docs.pydantic.dev/hypothesis_plugin/) for testing, #2097 by @Zac-HD
+* support for [`NamedTuple` and `TypedDict`](https://docs.pydantic.dev/usage/types/#annotated-types), #2216 by @PrettyWood
+* Support [`Annotated` hints on model fields](https://docs.pydantic.dev/usage/schema/#typingannotated-fields), #2147 by @JacobHayes
+* [`frozen` parameter on `Config`](https://docs.pydantic.dev/usage/model_config/) to allow models to be hashed, #1880 by @rhuille
 
 ### Changes
 
@@ -370,7 +370,7 @@ for their kind support.
   to validate parameters without actually calling the function, #2127 by @PrettyWood
 * Add the ability to customize settings sources (add / disable / change priority order), #2107 by @kozlek
 * Fix mypy complaints about most custom _pydantic_ types, #2098 by @PrettyWood
-* Add a [Hypothesis](https://hypothesis.readthedocs.io/) plugin for easier [property-based testing](https://increment.com/testing/in-praise-of-property-based-testing/) with Pydantic's custom types - [usage details here](https://pydantic-docs.helpmanual.io/hypothesis_plugin/), #2097 by @Zac-HD
+* Add a [Hypothesis](https://hypothesis.readthedocs.io/) plugin for easier [property-based testing](https://increment.com/testing/in-praise-of-property-based-testing/) with Pydantic's custom types - [usage details here](https://docs.pydantic.dev/hypothesis_plugin/), #2097 by @Zac-HD
 * add validator for `None`, `NoneType` or `Literal[None]`, #2095 by @PrettyWood
 * Handle properly fields of type `Callable` with a default value, #2094 by @PrettyWood
 * Updated `create_model` return type annotation to return type which inherits from `__base__` argument, #2071 by @uriyyo
@@ -440,9 +440,9 @@ for their kind support.
 ### Highlights
 
 * Python 3.9 support, thanks @PrettyWood
-* [Private model attributes](https://pydantic-docs.helpmanual.io/usage/models/#private-model-attributes), thanks @Bobronium
-* ["secrets files" support in `BaseSettings`](https://pydantic-docs.helpmanual.io/usage/settings/#secret-support), thanks @mdgilene
-* [convert stdlib dataclasses to pydantic dataclasses and use stdlib dataclasses in models](https://pydantic-docs.helpmanual.io/usage/dataclasses/#stdlib-dataclasses-and-pydantic-dataclasses), thanks @PrettyWood
+* [Private model attributes](https://docs.pydantic.dev/usage/models/#private-model-attributes), thanks @Bobronium
+* ["secrets files" support in `BaseSettings`](https://docs.pydantic.dev/usage/settings/#secret-support), thanks @mdgilene
+* [convert stdlib dataclasses to pydantic dataclasses and use stdlib dataclasses in models](https://docs.pydantic.dev/usage/dataclasses/#stdlib-dataclasses-and-pydantic-dataclasses), thanks @PrettyWood
 
 ### Changes
 
@@ -585,7 +585,7 @@ Thank you to pydantic's sponsors: @matin, @tiangolo, @chdsbd, @jorgecarleitao, a
 
 * **Breaking Change:** alias precedence logic changed so aliases on a field always take priority over
   an alias from `alias_generator` to avoid buggy/unexpected behaviour,
-  see [here](https://pydantic-docs.helpmanual.io/usage/model_config/#alias-precedence) for details, #1178 by @samuelcolvin
+  see [here](https://docs.pydantic.dev/usage/model_config/#alias-precedence) for details, #1178 by @samuelcolvin
 * Add support for unicode and punycode in TLDs, #1182 by @jamescurtin
 * Fix `cls` argument in validators during assignment, #1172 by @samuelcolvin
 * completing Luhn algorithm for `PaymentCardNumber`, #1166 by @cuencandres
@@ -627,7 +627,7 @@ Thank you to pydantic's sponsors: @matin, @tiangolo, @chdsbd, @jorgecarleitao, a
 
 * **Possible Breaking Change:** Add support for required `Optional` with `name: Optional[AnyType] = Field(...)`
   and refactor `ModelField` creation to preserve `required` parameter value, #1031 by @tiangolo;
-  see [here](https://pydantic-docs.helpmanual.io/usage/models/#required-optional-fields) for details
+  see [here](https://docs.pydantic.dev/usage/models/#required-optional-fields) for details
 * Add benchmarks for `cattrs`, #513 by @sebastianmika
 * Add `exclude_none` option to `dict()` and friends, #587 by @niknetniko
 * Add benchmarks for `valideer`, #670 by @gsakkis

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,3 @@ docs:
 docs-serve:
 	python docs/build/main.py
 	mkdocs serve
-
-.PHONY: publish-docs
-publish-docs:
-	npx wrangler pages publish --project-name pydantic-docs site

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,4 @@ docs-serve:
 
 .PHONY: publish-docs
 publish-docs:
-	zip -r site.zip site
-	@curl -H "Content-Type: application/zip" -H "Authorization: Bearer ${NETLIFY}" \
-	      --data-binary "@site.zip" https://api.netlify.com/api/v1/sites/pydantic-docs.netlify.com/deploys
+	npx wrangler pages publish --project-name pydantic-docs site

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Data validation using Python type hints.
 **This branch relates to development of pydantic V2 which is not yet ready for release.**
 
 If you're a user of pydantic, you probably want either
-[pydantic V1.10 Documentation](https://pydantic-docs.helpmanual.io/) or,
+[pydantic V1.10 Documentation](https://docs.pydantic.dev/) or,
 [`1.10.X-fixes` git branch](https://github.com/pydantic/pydantic/tree/1.10.X-fixes).
 
 ---
@@ -27,13 +27,13 @@ Define how data should be in pure, canonical Python 3.7+; validate it with *pyda
 
 ## Help
 
-See [documentation](https://pydantic-docs.helpmanual.io/) for more details.
+See [documentation](https://docs.pydantic.dev/) for more details.
 
 ## Installation
 
 Install using `pip install -U pydantic` or `conda install pydantic -c conda-forge`.
 For more installation options to make *pydantic* even faster,
-see the [Install](https://pydantic-docs.helpmanual.io/install/) section in the documentation.
+see the [Install](https://docs.pydantic.dev/install/) section in the documentation.
 
 ## A Simple Example
 
@@ -60,7 +60,7 @@ print(user.id)
 
 For guidance on setting up a development environment and how to make a
 contribution to *pydantic*, see
-[Contributing to Pydantic](https://pydantic-docs.helpmanual.io/contributing/).
+[Contributing to Pydantic](https://docs.pydantic.dev/contributing/).
 
 ## Reporting a Security Vulnerability
 

--- a/docs/blog/pydantic-v2.md
+++ b/docs/blog/pydantic-v2.md
@@ -639,7 +639,7 @@ The word "parse" will no longer be used except when talking about JSON parsing, 
 
 Since the core structure of validators has changed from "a list of validators to call one after another" to
 "a tree of validators which call each other", the
-[`__get_validators__`](https://pydantic-docs.helpmanual.io/usage/types/#classes-with-__get_validators__)
+[`__get_validators__`](https://docs.pydantic.dev/usage/types/#classes-with-__get_validators__)
 way of defining custom field types no longer makes sense.
 
 Instead, we'll look for the attribute `__pydantic_validation_schema__` which must be a
@@ -745,7 +745,7 @@ The emoji here is just for variation, I'm not frowning about any of this, these 
    specific need to keep the type, you can use wrap validators or custom type validation as described above
 6. integers are represented in rust code as `i64`, meaning if you want to use ints where `abs(v) > 2^63 − 1`
    (9,223,372,036,854,775,807), you'll need to use a [wrap validator](#validator-function-improvements) and your own logic
-7. [Settings Management](https://pydantic-docs.helpmanual.io/usage/settings/) ??? - I definitely don't want to
+7. [Settings Management](https://docs.pydantic.dev/usage/settings/) ??? - I definitely don't want to
    remove the functionality, but it's something of a historical curiosity that it lives within pydantic,
    perhaps it should move to a separate package, perhaps installable alongside pydantic with
    `pip install pydantic[settings]`?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: pydantic
 site_description: Data validation using Python type hints
 strict: true
-site_url: https://pydantic-docs.helpmanual.io/
+site_url: https://docs.pydantic.dev/
 
 theme:
   name: 'material'

--- a/pydantic/_hypothesis_plugin.py
+++ b/pydantic/_hypothesis_plugin.py
@@ -12,7 +12,7 @@ Pydantic is installed.  See also:
 https://hypothesis.readthedocs.io/en/latest/strategies.html#registering-strategies-via-setuptools-entry-points
 https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.register_type_strategy
 https://hypothesis.readthedocs.io/en/latest/strategies.html#interaction-with-pytest-cov
-https://pydantic-docs.helpmanual.io/usage/types/#pydantic-types
+https://docs.pydantic.dev/usage/types/#pydantic-types
 
 Note that because our motivation is to *improve user experience*, the strategies
 are always sound (never generate invalid data) but sacrifice completeness for

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -979,7 +979,7 @@ def get_annotation_from_field_info(
         raise ValueError(
             f'On field "{field_name}" the following field constraints are set but not enforced: '
             f'{", ".join(unused_constraints)}. '
-            f'\nFor more details see https://pydantic-docs.helpmanual.io/usage/schema/#unenforced-field-constraints'
+            f'\nFor more details see https://docs.pydantic.dev/usage/schema/#unenforced-field-constraints'
         )
 
     return annotation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,10 @@ entry-points.hypothesis = {_ = 'pydantic._hypothesis_plugin'}
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic'
-Documentation = 'https://pydantic-docs.helpmanual.io'
+Documentation = 'https://docs.pydantic.dev'
 Funding = 'https://github.com/sponsors/samuelcolvin'
 Source = 'https://github.com/pydantic/pydantic'
-Changelog = 'https://pydantic-docs.helpmanual.io/changelog'
+Changelog = 'https://docs.pydantic.dev/changelog'
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = 'text/markdown'
@@ -73,7 +73,7 @@ fragments = [
     {path = "README.md"},
     {text = "\n## Changelog\n\n"},
     {path = "HISTORY.md", pattern = "(.+?)<!-- package description limit -->"},
-    {text = "\n... see [here](https://pydantic-docs.helpmanual.io/changelog/#v0322-2019-08-17) for earlier changes.\n"},
+    {text = "\n... see [here](https://docs.pydantic.dev/changelog/#v0322-2019-08-17) for earlier changes.\n"},
 ]
 # convert GitHUB issue/PR numbers and handles to links
 substitutions = [

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -227,9 +227,9 @@ def test_at_in_path():
 
 
 def test_fragment_without_query():
-    url = validate_url('https://pydantic-docs.helpmanual.io/usage/types/#constrained-types')
+    url = validate_url('https://docs.pydantic.dev/usage/types/#constrained-types')
     assert url.scheme == 'https'
-    assert url.host == 'pydantic-docs.helpmanual.io'
+    assert url.host == 'docs.pydantic.dev'
     assert url.path == '/usage/types/'
     assert url.query is None
     assert url.fragment == 'constrained-types'


### PR DESCRIPTION
Docs being on a subdomain of `helpmanual.io` is an historical curiosity, let's move them somewhere sensible like [docs.pydantic.dev](https://docs.pydantic.dev).

I'm also moving from netlify to cloudflare pages at the same time.

Steps once this is merged:
* cherry-pick the commit onto `jina-ai` since #4767 was the last update to the live docs
* manually deploy to https://docs.pydantic.dev/
* setup a redirect in CloudFlare from `https://pydantic-docs.helpmanual.io/*` to `https://docs.pydantic.dev/$1`
* update google search console and google analytics to use the new URL