### PR TITLE
move xfail from module to individual failing tests

### DIFF
--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -7,9 +7,8 @@ import pytest
 from pydantic import BaseConfig, BaseModel, Extra, ValidationError
 from pydantic.fields import Field
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_generator():
     def to_camel(string: str):
         return ''.join(x.capitalize() for x in string.split('_'))
@@ -28,6 +27,7 @@ def test_alias_generator():
     assert v.dict(by_alias=True) == data
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_generator_with_field_schema():
     def to_upper_case(string: str):
         return string.upper()
@@ -47,6 +47,7 @@ def test_alias_generator_with_field_schema():
     assert m.dict(by_alias=True) == data
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_generator_wrong_type_error():
     def return_bytes(string):
         return b'not a string'
@@ -62,6 +63,7 @@ def test_alias_generator_wrong_type_error():
     assert str(e.value) == "Config.alias_generator must return str, not <class 'bytes'>"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_infer_alias():
     class Model(BaseModel):
         a = 'foobar'
@@ -75,6 +77,7 @@ def test_infer_alias():
     )
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_error():
     class Model(BaseModel):
         a = 123
@@ -91,6 +94,7 @@ def test_alias_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_annotation_config():
     class Model(BaseModel):
         b: float
@@ -105,6 +109,7 @@ def test_annotation_config():
     assert Model(foobar='123').b == 123.0
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_camel_case():
     class Model(BaseModel):
         one_thing: int
@@ -124,6 +129,7 @@ def test_alias_camel_case():
     assert v == {'one_thing': 123, 'another_thing': 321}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_get_field_info_inherit():
     class ModelOne(BaseModel):
         class Config(BaseConfig):
@@ -146,6 +152,7 @@ def test_get_field_info_inherit():
     assert v == {'one_thing': 123, 'another_thing': 321, 'third_thing': 1}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_pop_by_field_name():
     class Model(BaseModel):
         last_updated_by: Optional[str] = None
@@ -164,6 +171,7 @@ def test_pop_by_field_name():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_child_precedence():
     class Parent(BaseModel):
         x: int
@@ -181,6 +189,7 @@ def test_alias_child_precedence():
     assert Child.__fields__['x'].alias == 'x2'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_generator_parent():
     class Parent(BaseModel):
         x: int
@@ -204,6 +213,7 @@ def test_alias_generator_parent():
     assert Child.__fields__['x'].alias == 'x2'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_generator_on_parent():
     class Parent(BaseModel):
         x: bool = Field(..., alias='a_b_c')
@@ -225,6 +235,7 @@ def test_alias_generator_on_parent():
     assert Child.__fields__['z'].alias == 'Z'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_generator_on_child():
     class Parent(BaseModel):
         x: bool = Field(..., alias='abc')
@@ -243,6 +254,7 @@ def test_alias_generator_on_child():
     assert [f.alias for f in Child.__fields__.values()] == ['abc', 'Y', 'Z']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_low_priority_alias():
     class Parent(BaseModel):
         x: bool = Field(..., alias='abc', alias_priority=1)
@@ -261,6 +273,7 @@ def test_low_priority_alias():
     assert [f.alias for f in Child.__fields__.values()] == ['X', 'Y', 'Z']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_low_priority_alias_config():
     class Parent(BaseModel):
         x: bool
@@ -282,6 +295,7 @@ def test_low_priority_alias_config():
     assert [f.alias for f in Child.__fields__.values()] == ['X', 'Y', 'Z']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_field_vs_config():
     class Model(BaseModel):
         x: str = Field(..., alias='x_on_field')
@@ -294,6 +308,7 @@ def test_field_vs_config():
     assert [f.alias for f in Model.__fields__.values()] == ['x_on_field', 'y_on_config', 'z']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_priority():
     class Parent(BaseModel):
         a: str = Field(..., alias='a_field_parent')
@@ -340,6 +355,7 @@ def test_alias_priority():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_empty_string_alias():
     class Model(BaseModel):
         empty_string_key: int = Field(alias='')

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -6,8 +6,6 @@ import pytest
 from pydantic import BaseModel, Field, PrivateAttr
 from pydantic.fields import Undefined
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
-
 
 class Model(BaseModel):
     a: float
@@ -95,6 +93,7 @@ def model_two_fixture():
     return ModelTwo
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_deep_copy(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='12'))
     m.__foo__ = {'new value'}
@@ -110,6 +109,7 @@ def test_deep_copy(ModelTwo):
     assert m.__foo__ is not m2.__foo__
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_exclude(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy(exclude={'b'})
@@ -126,6 +126,7 @@ def test_copy_exclude(ModelTwo):
     assert m != m2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_include(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy(include={'a'})
@@ -137,6 +138,7 @@ def test_copy_include(ModelTwo):
     assert m != m2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_include_exclude(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy(include={'a', 'b', 'c'}, exclude={'c'})
@@ -145,6 +147,7 @@ def test_copy_include_exclude(ModelTwo):
     assert set(m2.dict().keys()) == {'a', 'b'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_advanced_exclude():
     class SubSubModel(BaseModel):
         a: str
@@ -168,6 +171,7 @@ def test_copy_advanced_exclude():
     assert m2.dict() == {'f': {'c': 'foo'}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_advanced_include():
     class SubSubModel(BaseModel):
         a: str
@@ -191,6 +195,7 @@ def test_copy_advanced_include():
     assert m2.dict() == {'e': 'e', 'f': {'d': [{'a': 'c', 'b': 'e'}]}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_advanced_include_exclude():
     class SubSubModel(BaseModel):
         a: str
@@ -209,6 +214,7 @@ def test_copy_advanced_include_exclude():
     assert m2.dict() == {'f': {'d': [{'a': 'c', 'b': 'e'}]}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_update(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy(update={'a': 'different'})
@@ -220,6 +226,7 @@ def test_copy_update(ModelTwo):
     assert m != m2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_update_unset():
     class Foo(BaseModel):
         foo: Optional[str]
@@ -228,6 +235,7 @@ def test_copy_update_unset():
     assert Foo(foo='hello').copy(update={'bar': 'world'}).json(exclude_unset=True) == '{"foo": "hello", "bar": "world"}'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_set_fields(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = m.copy()
@@ -249,6 +257,7 @@ def test_simple_pickle():
     assert m.__fields__ == m2.__fields__
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_recursive_pickle(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='123.45'))
     m2 = pickle.loads(pickle.dumps(m))
@@ -260,6 +269,7 @@ def test_recursive_pickle(ModelTwo):
     assert m.__foo__ == m2.__foo__
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_pickle_undefined(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='123.45'))
     m2 = pickle.loads(pickle.dumps(m))
@@ -270,6 +280,7 @@ def test_pickle_undefined(ModelTwo):
     assert not hasattr(m3, '__foo__')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_undefined(ModelTwo):
     m = ModelTwo(a=24, d=Model(a='123.45'))
     m2 = m.copy()
@@ -280,6 +291,7 @@ def test_copy_undefined(ModelTwo):
     assert not hasattr(m3, '__foo__')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_immutable_copy_with_allow_mutation():
     class Model(BaseModel):
         a: int
@@ -321,6 +333,7 @@ def test_pickle_fields_set():
     assert m2.dict(exclude_unset=True) == {'a': 24}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_copy_update_exclude():
     class SubModel(BaseModel):
         a: str
@@ -357,6 +370,7 @@ def test_shallow_copy_modify():
     assert y.deep['deep_thing'] == [1, 2, 3]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_construct_default_factory():
     class Model(BaseModel):
         foo: List[int] = Field(default_factory=list)

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -6,9 +6,8 @@ from pydantic import BaseModel, Extra, Field, ValidationError, create_model, err
 from pydantic.fields import ModelPrivateAttr
 from pydantic.generics import GenericModel
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_create_model():
     model = create_model('FooModel', foo=(str, ...), bar=123)
     assert issubclass(model, BaseModel)
@@ -20,6 +19,7 @@ def test_create_model():
     assert model.__module__ == 'pydantic.main'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_create_model_usage():
     model = create_model('FooModel', foo=(str, ...), bar=123)
     m = model(foo='hello')
@@ -70,6 +70,7 @@ def test_config_and_base():
         create_model('FooModel', __config__=BaseModel.Config, __base__=BaseModel)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance():
     class BarModel(BaseModel):
         x = 1
@@ -81,6 +82,7 @@ def test_inheritance():
     assert m.dict() == {'bar': 123, 'foo': 'a', 'x': 4, 'y': 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_config():
     class Config:
         fields = {'foo': 'api-foo-field'}
@@ -92,6 +94,7 @@ def test_custom_config():
         model(foo=654)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_config_inherits():
     class Config(BaseModel.Config):
         fields = {'foo': 'api-foo-field'}
@@ -113,6 +116,7 @@ def test_custom_config_extras():
         model(bar=654)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_validators():
     class BarModel(BaseModel):
         @validator('a', check_fields=False)
@@ -128,6 +132,7 @@ def test_inheritance_validators():
         model(a='something else')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_validators_always():
     class BarModel(BaseModel):
         @validator('a', check_fields=False, always=True)
@@ -144,6 +149,7 @@ def test_inheritance_validators_always():
         model(a='something else')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_validators_all():
     class BarModel(BaseModel):
         @validator('*')
@@ -154,6 +160,7 @@ def test_inheritance_validators_all():
     assert model(a=2, b=6).dict() == {'a': 4, 'b': 12}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_funky_name():
     model = create_model('FooModel', **{'this-is-funky': (int, ...)})
     m = model(**{'this-is-funky': '123'})
@@ -165,6 +172,7 @@ def test_funky_name():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_repeat_base_usage():
     class Model(BaseModel):
         a: str
@@ -202,6 +210,7 @@ def test_dynamic_and_static():
         assert A.__fields__[field_name].default == DynamicA.__fields__[field_name].default
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_create_model():
     class Config:
         fields = {'a': {'description': 'descr'}}
@@ -213,6 +222,7 @@ def test_config_field_info_create_model():
     assert m2.schema()['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_generics_model():
     T = TypeVar('T')
 
@@ -227,6 +237,7 @@ def test_generics_model():
     assert result.__config__.orm_mode is True
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('base', [ModelPrivateAttr, object])
 def test_set_name(base):
     calls = []
@@ -259,7 +270,7 @@ def test_set_name(base):
     if base is object:
         assert a._some_func == 2
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_create_model_with_slots():
     field_definitions = {'__slots__': (Optional[Tuple[str, ...]], None), 'foobar': (Optional[int], None)}
     with pytest.warns(RuntimeWarning, match='__slots__ should not be passed to create_model'):

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -271,7 +271,6 @@ def test_set_name(base):
         assert a._some_func == 2
 
 
-@pytest.mark.xfail(reason='working on V2', strict=False)
 def test_create_model_with_slots():
     field_definitions = {'__slots__': (Optional[Tuple[str, ...]], None), 'foobar': (Optional[int], None)}
     with pytest.warns(RuntimeWarning, match='__slots__ should not be passed to create_model'):

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -270,7 +270,8 @@ def test_set_name(base):
     if base is object:
         assert a._some_func == 2
 
-@pytest.mark.xfail(reason='working on V2')
+
+@pytest.mark.xfail(reason='working on V2', strict=False)
 def test_create_model_with_slots():
     field_definitions = {'__slots__': (Optional[Tuple[str, ...]], None), 'foobar': (Optional[int], None)}
     with pytest.warns(RuntimeWarning, match='__slots__ should not be passed to create_model'):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -13,9 +13,8 @@ from typing_extensions import Literal
 import pydantic
 from pydantic import BaseModel, Extra, ValidationError, validator
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_simple():
     @pydantic.dataclasses.dataclass
     class MyDataclass:
@@ -30,6 +29,7 @@ def test_simple():
     assert d.b == 10
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_name():
     @pydantic.dataclasses.dataclass
     class MyDataClass:
@@ -41,6 +41,7 @@ def test_model_name():
     assert d.model_name == 'foo'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_value_error():
     @pydantic.dataclasses.dataclass
     class MyDataclass:
@@ -55,6 +56,7 @@ def test_value_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_frozen():
     @pydantic.dataclasses.dataclass(frozen=True)
     class MyDataclass:
@@ -67,6 +69,7 @@ def test_frozen():
         d.a = 7
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_assignment():
     class Config:
         validate_assignment = True
@@ -82,6 +85,7 @@ def test_validate_assignment():
     assert d.a == 7
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_assignment_error():
     @pydantic.dataclasses.dataclass(config=dict(validate_assignment=True))
     class MyDataclass:
@@ -96,6 +100,7 @@ def test_validate_assignment_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_not_validate_assignment():
     @pydantic.dataclasses.dataclass
     class MyDataclass:
@@ -108,6 +113,7 @@ def test_not_validate_assignment():
     assert d.a == '7'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_assignment_value_change():
     class Config:
         validate_assignment = True
@@ -127,6 +133,7 @@ def test_validate_assignment_value_change():
     assert d.a == 6
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_assignment_extra():
     class Config:
         validate_assignment = True
@@ -144,6 +151,7 @@ def test_validate_assignment_extra():
     assert d.extra_field == 'bye'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init():
     post_init_called = False
 
@@ -160,6 +168,7 @@ def test_post_init():
     assert post_init_called
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_validation():
     @dataclasses.dataclass
     class DC:
@@ -176,6 +185,7 @@ def test_post_init_validation():
     assert PydanticDC(a='2').a == 23
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_inheritance_chain():
     parent_post_init_called = False
     post_init_called = False
@@ -204,6 +214,7 @@ def test_post_init_inheritance_chain():
     assert post_init_called
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_post_parse():
     post_init_post_parse_called = False
 
@@ -220,6 +231,7 @@ def test_post_init_post_parse():
     assert post_init_post_parse_called
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_post_parse_types():
     @pydantic.dataclasses.dataclass
     class CustomType:
@@ -239,6 +251,7 @@ def test_post_init_post_parse_types():
     assert d.a.b == 1
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_assignment():
     from dataclasses import field
 
@@ -258,6 +271,7 @@ def test_post_init_assignment():
     assert c.c == 0.30000000000000004
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance():
     @pydantic.dataclasses.dataclass
     class A:
@@ -275,6 +289,7 @@ def test_inheritance():
         B(a='a', b='b')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_long_string_error():
     class Config:
         max_anystr_length = 3
@@ -296,6 +311,7 @@ def test_validate_long_string_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_assigment_long_string_error():
     class Config:
         max_anystr_length = 3
@@ -320,6 +336,7 @@ def test_validate_assigment_long_string_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_no_validate_assigment_long_string_error():
     class Config:
         max_anystr_length = 3
@@ -335,6 +352,7 @@ def test_no_validate_assigment_long_string_error():
     assert d.a == 'xxxx'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_dataclass():
     @pydantic.dataclasses.dataclass
     class Nested:
@@ -374,6 +392,7 @@ def test_nested_dataclass():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_arbitrary_types_allowed():
     class Button:
         def __init__(self, href: str):
@@ -402,6 +421,7 @@ def test_arbitrary_types_allowed():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_dataclass_model():
     @pydantic.dataclasses.dataclass
     class Nested:
@@ -414,6 +434,7 @@ def test_nested_dataclass_model():
     assert navbar.n.number == 1
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_fields():
     @pydantic.dataclasses.dataclass
     class User:
@@ -434,6 +455,7 @@ def test_fields():
     assert fields['signup_ts'].default is None
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_default_factory_field():
     @pydantic.dataclasses.dataclass
     class User:
@@ -450,6 +472,7 @@ def test_default_factory_field():
     assert fields['aliases'].default_factory() == {'John': 'Joey'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_default_factory_singleton_field():
     class MySingleton:
         pass
@@ -467,6 +490,7 @@ def test_default_factory_singleton_field():
     assert Foo().singleton is Foo().singleton
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema():
     @pydantic.dataclasses.dataclass
     class User:
@@ -508,6 +532,7 @@ def test_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_schema():
     @pydantic.dataclasses.dataclass
     class Nested:
@@ -533,6 +558,7 @@ def test_nested_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_initvar():
     InitVar = dataclasses.InitVar
 
@@ -547,6 +573,7 @@ def test_initvar():
         tiv.y
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_derived_field_from_initvar():
     InitVar = dataclasses.InitVar
 
@@ -564,6 +591,7 @@ def test_derived_field_from_initvar():
         DerivedWithInitVar('Not A Number')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_initvars_post_init():
     @pydantic.dataclasses.dataclass
     class PathDataPostInit:
@@ -584,6 +612,7 @@ def test_initvars_post_init():
     assert str(exc_info.value) == "unsupported operand type(s) for /: 'str' and 'str'"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_initvars_post_init_post_parse():
     @pydantic.dataclasses.dataclass
     class PathDataPostInitPostParse:
@@ -602,6 +631,7 @@ def test_initvars_post_init_post_parse():
     assert PathDataPostInitPostParse('world', base_path='/hello').path == Path('/hello/world')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_post_parse_without_initvars():
     @pydantic.dataclasses.dataclass
     class Foo:
@@ -613,6 +643,7 @@ def test_post_init_post_parse_without_initvars():
     Foo(a=1)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_classvar():
     @pydantic.dataclasses.dataclass
     class TestClassVar:
@@ -623,6 +654,7 @@ def test_classvar():
     assert tcv.klassvar == "I'm a Class variable"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_frozenset_field():
     @pydantic.dataclasses.dataclass
     class TestFrozenSet:
@@ -634,6 +666,7 @@ def test_frozenset_field():
     assert object_under_test.set == test_set
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_post_init():
     post_init_called = False
 
@@ -653,6 +686,7 @@ def test_inheritance_post_init():
     assert post_init_called
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_hashable_required():
     @pydantic.dataclasses.dataclass
     class MyDataclass:
@@ -669,6 +703,7 @@ def test_hashable_required():
     assert "__init__() missing 1 required positional argument: 'v'" in str(exc_info.value)
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('default', [1, None, ...])
 def test_hashable_optional(default):
     @pydantic.dataclasses.dataclass
@@ -679,6 +714,7 @@ def test_hashable_optional(default):
     MyDataclass(v=None)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_override_builtin_dataclass():
     @dataclasses.dataclass
     class File:
@@ -706,6 +742,7 @@ def test_override_builtin_dataclass():
     assert e.value.errors() == [{'loc': ('hash',), 'msg': 'str type expected', 'type': 'type_error.str'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_override_builtin_dataclass_2():
     @dataclasses.dataclass
     class Meta:
@@ -727,6 +764,7 @@ def test_override_builtin_dataclass_2():
     assert f.seen_count == 7
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_override_builtin_dataclass_nested():
     @dataclasses.dataclass
     class Meta:
@@ -766,6 +804,7 @@ def test_override_builtin_dataclass_nested():
     assert foo.file.meta.seen_count == 7
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_override_builtin_dataclass_nested_schema():
     @dataclasses.dataclass
     class Meta:
@@ -800,6 +839,7 @@ def test_override_builtin_dataclass_nested_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inherit_builtin_dataclass():
     @dataclasses.dataclass
     class Z:
@@ -819,6 +859,7 @@ def test_inherit_builtin_dataclass():
     assert pika.z == 3
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_dataclass_arbitrary():
     class ArbitraryType:
         def __init__(self):
@@ -839,6 +880,7 @@ def test_dataclass_arbitrary():
     TestModel(a=ArbitraryType(), b=(ArbitraryType(), [ArbitraryType()]))
 
 
+@pytest.mark.xfail(reason='working on V2', strict=False)
 def test_forward_stdlib_dataclass_params():
     @dataclasses.dataclass(frozen=True)
     class Item:
@@ -857,6 +899,7 @@ def test_forward_stdlib_dataclass_params():
         e.item.name = 'pika2'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_pydantic_callable_field():
     """pydantic callable fields behaviour should be the same as stdlib dataclass"""
 
@@ -911,6 +954,7 @@ def test_pydantic_callable_field():
     )
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_pickle_overriden_builtin_dataclass(create_module):
     module = create_module(
         # language=Python
@@ -945,6 +989,7 @@ class ModelForPickle(pydantic.BaseModel):
         restored_obj.dataclass.value = 'value of a wrong type'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_create_model():
     # works
     class A1(BaseModel):
@@ -964,6 +1009,7 @@ def test_config_field_info_create_model():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def gen_2162_dataclasses():
     # TODO fix and remove this return
     return
@@ -1014,6 +1060,7 @@ def test_issue_2162(foo, bar):
     assert foo == bar.c
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_2383():
     @dataclasses.dataclass
     class A:
@@ -1032,6 +1079,7 @@ def test_issue_2383():
     assert hash(b.a) == 123
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_2398():
     @dataclasses.dataclass(order=True)
     class DC:
@@ -1049,6 +1097,7 @@ def test_issue_2398():
     assert real_dc <= model.dc
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_2424():
     @dataclasses.dataclass
     class Base:
@@ -1068,6 +1117,7 @@ def test_issue_2424():
     assert ValidatedThing(x='hi').y == ''
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_2541():
     @dataclasses.dataclass(frozen=True)
     class Infos:
@@ -1088,6 +1138,7 @@ def test_issue_2541():
         e.item.infos.id = 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_2555():
     @dataclasses.dataclass
     class Span:
@@ -1114,6 +1165,7 @@ def test_issue_2555():
     assert M.schema()
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_2594():
     @dataclasses.dataclass
     class Empty:
@@ -1126,6 +1178,7 @@ def test_issue_2594():
     assert isinstance(M(e={}).e, Empty)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_description_unset():
     @pydantic.dataclasses.dataclass
     class A:
@@ -1141,6 +1194,7 @@ def test_schema_description_unset():
     assert 'description' not in B.__pydantic_model__.schema()
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_description_set():
     @pydantic.dataclasses.dataclass
     class A:
@@ -1160,6 +1214,7 @@ def test_schema_description_set():
     assert A.__pydantic_model__.schema()['description'] == 'my description'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_3011():
     @dataclasses.dataclass
     class A:
@@ -1180,6 +1235,7 @@ def test_issue_3011():
     assert c.thing.thing_a == 'Thing A'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_issue_3162():
     @dataclasses.dataclass
     class User:
@@ -1206,6 +1262,7 @@ def test_issue_3162():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_basemodel_instance_value():
     @pydantic.dataclasses.dataclass
     class A:
@@ -1249,6 +1306,7 @@ def test_discriminated_union_basemodel_instance_value():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_after_validation():
     @dataclasses.dataclass
     class SetWrapper:
@@ -1267,6 +1325,7 @@ def test_post_init_after_validation():
     assert Model.parse_raw(json_text) == model
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_keeps_custom_properties():
     class StandardClass:
         """Class which modifies instance creation."""
@@ -1292,6 +1351,7 @@ def test_keeps_custom_properties():
         assert instance.a == test_string
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ignore_extra():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.ignore))
     class Foo:
@@ -1301,6 +1361,7 @@ def test_ignore_extra():
     assert foo.__dict__ == {'x': 1, '__pydantic_initialised__': True}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ignore_extra_subclass():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.ignore))
     class Foo:
@@ -1314,6 +1375,7 @@ def test_ignore_extra_subclass():
     assert bar.__dict__ == {'x': 1, 'y': 2, '__pydantic_initialised__': True}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_allow_extra():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.allow))
     class Foo:
@@ -1323,6 +1385,7 @@ def test_allow_extra():
     assert foo.__dict__ == {'x': 1, 'y': '2', '__pydantic_initialised__': True}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_allow_extra_subclass():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.allow))
     class Foo:
@@ -1336,6 +1399,7 @@ def test_allow_extra_subclass():
     assert bar.__dict__ == {'x': 1, 'y': 2, 'z': '3', '__pydantic_initialised__': True}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_forbid_extra():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.forbid))
     class Foo:
@@ -1345,6 +1409,7 @@ def test_forbid_extra():
         Foo(**{'x': '1', 'y': '2'})
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_post_init_allow_extra():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.allow))
     class Foobar:
@@ -1357,6 +1422,7 @@ def test_post_init_allow_extra():
     assert Foobar(a=1, b='a', c=4).__dict__ == {'a': 2, 'b': 'a', 'c': 4, '__pydantic_initialised__': True}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_self_reference_dataclass():
     @pydantic.dataclasses.dataclass
     class MyDataclass:
@@ -1365,6 +1431,7 @@ def test_self_reference_dataclass():
     assert MyDataclass.__pydantic_model__.__fields__['self_reference'].type_ is MyDataclass
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='kw_only is not available in python < 3.10')
 def test_kw_only():
     @pydantic.dataclasses.dataclass(kw_only=True)
@@ -1378,6 +1445,7 @@ def test_kw_only():
     assert A(b='hi').b == 'hi'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_extra_forbid_list_no_error():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.forbid))
     class Bar:
@@ -1390,6 +1458,7 @@ def test_extra_forbid_list_no_error():
     assert isinstance(Foo(a=[Bar()]).a[0], Bar)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_extra_forbid_list_error():
     @pydantic.dataclasses.dataclass(config=dict(extra=Extra.forbid))
     class Bar:
@@ -1402,6 +1471,7 @@ def test_extra_forbid_list_error():
             a: List[Bar(a=1)]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parent_post_init():
     @dataclasses.dataclass
     class A:
@@ -1420,6 +1490,7 @@ def test_parent_post_init():
     assert B().a == 5  # 1 * 2 + 3
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_subclass_post_init_post_parse():
     @dataclasses.dataclass
     class A:
@@ -1438,6 +1509,7 @@ def test_subclass_post_init_post_parse():
     assert B().a == 8  # (1 + 3) * 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_subclass_post_init():
     @dataclasses.dataclass
     class A:
@@ -1456,6 +1528,7 @@ def test_subclass_post_init():
     assert B().a == 5  # 1 * 2 + 3
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_subclass_post_init_inheritance():
     @dataclasses.dataclass
     class A:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -12,10 +12,10 @@ from pydantic import BaseModel, Extra, Field, ValidationError, validate_argument
 from pydantic.decorator import ValidatedFunction
 from pydantic.errors import PydanticUserError
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 skip_pre_38 = pytest.mark.skipif(sys.version_info < (3, 8), reason='testing >= 3.8 behaviour only')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_args():
     @validate_arguments
     def foo(a: int, b: int):
@@ -70,6 +70,7 @@ def test_args():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_wrap():
     @validate_arguments
     def foo_bar(a: int, b: int):
@@ -91,6 +92,7 @@ def test_wrap():
     assert repr(inspect.signature(foo_bar)) == '<Signature (a: int, b: int)>'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_kwargs():
     @validate_arguments
     def foo(*, a: int, b: int):
@@ -116,6 +118,7 @@ def test_kwargs():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2', strict=False)
 def test_untyped():
     @validate_arguments
     def foo(a, b, c='x', *, d='y'):
@@ -125,6 +128,7 @@ def test_untyped():
     assert foo(1, {'x': 2}, c='3', d='4') == "1, {'x': 2}, 3, 4"
 
 
+@pytest.mark.xfail(reason='working on V2', strict=False)
 @pytest.mark.parametrize('validated', (True, False))
 def test_var_args_kwargs(validated):
     def foo(a, b, *args, d=3, **kwargs):
@@ -143,6 +147,7 @@ def test_var_args_kwargs(validated):
     assert foo(1, 2, kwargs=4, e=5) == "a=1, b=2, args=(), d=3, kwargs={'kwargs': 4, 'e': 5}"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_field_can_provide_factory() -> None:
     @validate_arguments
     def foo(a: int, b: int = Field(default_factory=lambda: 99), *args: int) -> int:
@@ -153,6 +158,7 @@ def test_field_can_provide_factory() -> None:
     assert foo(1, 2, 3) == 6
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_annotated_field_can_provide_factory() -> None:
     @validate_arguments
     def foo2(a: int, b: Annotated[int, Field(default_factory=lambda: 99)], *args: int) -> int:
@@ -162,6 +168,7 @@ def test_annotated_field_can_provide_factory() -> None:
     assert foo2(1) == 100
 
 
+@pytest.mark.xfail(reason='working on V2')
 @skip_pre_38
 def test_positional_only(create_module):
     module = create_module(
@@ -197,6 +204,7 @@ def foo(a, b, /, c=None):
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_args_name():
     @validate_arguments
     def foo(args: int, kwargs: int):
@@ -262,6 +270,7 @@ def test_v_args():
             pass
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_async():
     @validate_arguments
     async def foo(a, b):
@@ -278,6 +287,7 @@ def test_async():
     assert exc_info.value.errors() == [{'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_string_annotation():
     @validate_arguments
     def foo(a: 'List[int]', b: 'Path'):
@@ -293,6 +303,7 @@ def test_string_annotation():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_item_method():
     class X:
         def __init__(self, v):
@@ -316,6 +327,7 @@ def test_item_method():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_class_method():
     class X:
         @classmethod
@@ -337,6 +349,7 @@ def test_class_method():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_config_title():
     @validate_arguments(config=dict(title='Testing'))
     def foo(a: int, b: int):
@@ -347,6 +360,7 @@ def test_config_title():
     assert foo.model.schema()['title'] == 'Testing'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_config_title_cls():
     class Config:
         title = 'Testing'
@@ -370,6 +384,7 @@ def test_config_fields():
             return f'{a}, {b}'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_config_arbitrary_types_allowed():
     class EggBox:
         def __str__(self) -> str:
@@ -407,6 +422,7 @@ def test_validate(mocker):
     stub.assert_not_called()
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_annotated_use_of_alias():
     @validate_arguments
     def foo(a: Annotated[int, Field(alias='b')], c: Annotated[int, Field()], d: Annotated[int, Field(alias='')]):
@@ -433,6 +449,7 @@ def test_use_of_alias():
     assert foo(b=10) == 30
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_allow_population_by_field_name():
     @validate_arguments(config=dict(allow_population_by_field_name=True))
     def foo(a: Annotated[int, Field(alias='b')], c: Annotated[int, Field(alias='d')]):
@@ -443,6 +460,7 @@ def test_allow_population_by_field_name():
     assert foo(a=10, c=1) == 11
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_all():
     @validate_arguments(config=dict(validate_all=True))
     def foo(dt: datetime = Field(default_factory=lambda: 946684800)):
@@ -452,6 +470,7 @@ def test_validate_all():
     assert foo(0) == datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
+@pytest.mark.xfail(reason='working on V2')
 @skip_pre_38
 def test_validate_all_positional(create_module):
     module = create_module(
@@ -470,6 +489,7 @@ def foo(dt: datetime = Field(default_factory=lambda: 946684800), /):
     assert module.foo(0) == datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_extra():
     class TypedTest(TypedDict):
         y: str

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -9,9 +9,8 @@ from pydantic import BaseModel, Field, ValidationError
 from pydantic.errors import PydanticUserError
 from pydantic.generics import GenericModel
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_only_union():
     with pytest.raises(
         TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
@@ -21,6 +20,7 @@ def test_discriminated_union_only_union():
             x: str = Field(..., discriminator='qwe')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_single_variant():
     with pytest.raises(
         TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
@@ -30,6 +30,7 @@ def test_discriminated_union_single_variant():
             x: Union[str] = Field(..., discriminator='qwe')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_invalid_type():
     with pytest.raises(TypeError, match="Type 'str' is not a valid `BaseModel` or `dataclass`"):
 
@@ -37,6 +38,7 @@ def test_discriminated_union_invalid_type():
             x: Union[str, int] = Field(..., discriminator='qwe')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_defined_discriminator():
     class Cat(BaseModel):
         c: str
@@ -52,6 +54,7 @@ def test_discriminated_union_defined_discriminator():
             number: int
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_literal_discriminator():
     class Cat(BaseModel):
         pet_type: int
@@ -68,6 +71,7 @@ def test_discriminated_union_literal_discriminator():
             number: int
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_root_same_discriminator():
     class BlackCat(BaseModel):
         pet_type: Literal['blackcat']
@@ -87,6 +91,7 @@ def test_discriminated_union_root_same_discriminator():
             __root__: Union[Cat, Dog] = Field(..., discriminator='pet_type')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_validation():
     class BlackCat(BaseModel):
         pet_type: Literal['cat']
@@ -177,6 +182,7 @@ def test_discriminated_union_validation():
     assert isinstance(m.pet.__root__, WhiteCat)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_annotated_union():
     class BlackCat(BaseModel):
         pet_type: Literal['cat']
@@ -287,6 +293,7 @@ def test_discriminated_union_basemodel_instance_value_with_alias():
     assert Top(sub=B(literal='b')).sub.literal == 'b'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_int():
     class A(BaseModel):
         m: Literal[1]
@@ -310,6 +317,7 @@ def test_discriminated_union_int():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_enum():
     class EnumValue(Enum):
         a = 1
@@ -341,6 +349,7 @@ def test_discriminated_union_enum():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_different():
     class Cat(BaseModel):
         pet_type: Literal['cat'] = Field(alias='U')
@@ -395,6 +404,7 @@ def test_nested():
     assert isinstance(Model(**{'pet': {'pet_type': 'dog', 'name': 'Milou'}, 'n': 5}).pet, Dog)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_generic():
     T = TypeVar('T')
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -946,6 +946,7 @@ def test_valid_string_types(value, expected):
 
     assert Model(v=value).v == expected
 
+
 @pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'value,errors',
@@ -1656,6 +1657,7 @@ def test_optional_validator():
     assert Model(something='hello').dict() == {'something': 'hello'}
     assert val_calls == [None, 'hello']
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_required_optional():
     class Model(BaseModel):
@@ -1682,6 +1684,7 @@ def test_required_optional():
         {'loc': ('nullable1',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
         {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
     ]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_required_any():
@@ -1721,6 +1724,7 @@ def test_required_any():
         'nullable1': 1,
         'nullable2': 'two',
     }
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_validators():
@@ -1780,6 +1784,7 @@ def test_custom_generic_validators():
     assert m.gen2.t1 == 1
     assert m.gen2.t2 == 2
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_arbitrary_allowed():
     T1 = TypeVar('T1')
@@ -1819,6 +1824,7 @@ def test_custom_generic_arbitrary_allowed():
     assert m.gen.t1 == 'bar'
     assert m.gen.t2 is True
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_disallowed():
     T1 = TypeVar('T1')
@@ -1835,6 +1841,7 @@ def test_custom_generic_disallowed():
         class Model(BaseModel):
             a: str
             gen: MyGen[str, bool]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_hashable_required():
@@ -1895,6 +1902,7 @@ def test_default_factory_called_once():
         {'loc': ('id',), 'msg': 'value is not a valid list', 'type': 'type_error.list'},
     ]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_default_factory_validator_child():
     class Parent(BaseModel):
@@ -1910,6 +1918,7 @@ def test_default_factory_validator_child():
         pass
 
     assert Child(foo=['a', 'b']).foo == ['a-1', 'b-1']
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_resolve_annotations_module_missing(tmp_path):
@@ -1938,6 +1947,7 @@ def test_iter_coverage():
 
     assert list(MyModel()._iter(by_alias=True)) == [('x', 1), ('y', 'a')]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_config_field_info():
     class Foo(BaseModel):
@@ -1948,6 +1958,7 @@ def test_config_field_info():
 
     assert Foo.schema(by_alias=True)['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_alias():
     class Foo(BaseModel):
@@ -1957,6 +1968,7 @@ def test_config_field_info_alias():
             fields = {'a': {'alias': 'b'}}
 
     assert Foo.schema(by_alias=True)['properties'] == {'b': {'title': 'B', 'type': 'string'}}
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_merge():
@@ -1969,6 +1981,7 @@ def test_config_field_info_merge():
     assert Foo.schema(by_alias=True)['properties'] == {
         'a': {'bar': 'Bar', 'foo': 'Foo', 'title': 'A', 'type': 'string'}
     }
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_allow_mutation():
@@ -2027,6 +2040,7 @@ def test_bytes_subclass():
     m = MyModel(my_bytes=BytesSubclass(b'foobar'))
     assert m.my_bytes.__class__ == BytesSubclass
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_int_subclass():
     class MyModel(BaseModel):
@@ -2053,6 +2067,7 @@ def test_model_issubclass():
         __fields__ = True
 
     assert not issubclass(Custom, BaseModel)
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_long_int():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -10,9 +10,8 @@ import pytest
 from pydantic import BaseModel, Extra, ValidationError, constr, errors, validator
 from pydantic.fields import Field
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_str_bytes():
     class Model(BaseModel):
         v: Union[str, bytes] = ...
@@ -31,6 +30,7 @@ def test_str_bytes():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_str_bytes_none():
     class Model(BaseModel):
         v: Union[None, str, bytes] = ...
@@ -45,6 +45,7 @@ def test_str_bytes_none():
     assert m.v is None
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_union_int_str():
     class Model(BaseModel):
         v: Union[int, str] = ...
@@ -69,6 +70,7 @@ def test_union_int_str():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_union_int_any():
     class Model(BaseModel):
         v: Union[int, Any]
@@ -86,6 +88,7 @@ def test_union_int_any():
     assert m.v is None
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_union_priority():
     class ModelOne(BaseModel):
         v: Union[int, str] = ...
@@ -97,6 +100,7 @@ def test_union_priority():
     assert ModelTwo(v='123').v == '123'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_typed_list():
     class Model(BaseModel):
         v: List[int] = ...
@@ -116,6 +120,7 @@ def test_typed_list():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid list', 'type': 'type_error.list'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_typed_set():
     class Model(BaseModel):
         v: Set[int] = ...
@@ -137,6 +142,7 @@ def test_dict_dict():
     assert Model(v={'foo': 1}).dict() == {'v': {'foo': 1}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_none_list():
     class Model(BaseModel):
         v = [None]
@@ -148,6 +154,7 @@ def test_none_list():
     }
 
 
+@pytest.mark.xfail(reason='working on V2', strict=False)
 @pytest.mark.parametrize(
     'value,result',
     [
@@ -163,6 +170,7 @@ def test_typed_dict(value, result):
     assert Model(v=value).v == result
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'value,errors',
     [
@@ -180,6 +188,7 @@ def test_typed_dict_error(value, errors):
     assert exc_info.value.errors() == errors
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_dict_key_error():
     class Model(BaseModel):
         v: Dict[int, int] = ...
@@ -193,6 +202,7 @@ def test_dict_key_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_tuple():
     class Model(BaseModel):
         v: Tuple[int, float, bool]
@@ -201,6 +211,7 @@ def test_tuple():
     assert m.v == (1, 2.2, True)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_tuple_more():
     class Model(BaseModel):
         empty_tuple: Tuple[()]
@@ -222,6 +233,7 @@ def test_tuple_more():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'dict_cls,frozenset_cls,list_cls,set_cls,tuple_cls,type_cls',
     [
@@ -311,6 +323,7 @@ def test_pep585_generic_types(dict_cls, frozenset_cls, list_cls, set_cls, tuple_
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_tuple_length_error():
     class Model(BaseModel):
         v: Tuple[int, float, bool]
@@ -334,6 +347,7 @@ def test_tuple_length_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_tuple_invalid():
     class Model(BaseModel):
         v: Tuple[int, float, bool]
@@ -343,6 +357,7 @@ def test_tuple_invalid():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'value is not a valid tuple', 'type': 'type_error.tuple'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_tuple_value_error():
     class Model(BaseModel):
         v: Tuple[int, float, Decimal]
@@ -356,6 +371,7 @@ def test_tuple_value_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_recursive_list():
     class SubModel(BaseModel):
         name: str = ...
@@ -378,6 +394,7 @@ def test_recursive_list():
     assert exc_info.value.errors() == [{'loc': ('v', 0), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_recursive_list_error():
     class SubModel(BaseModel):
         name: str = ...
@@ -393,6 +410,7 @@ def test_recursive_list_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_list_unions():
     class Model(BaseModel):
         v: List[Union[int, str]] = ...
@@ -407,6 +425,7 @@ def test_list_unions():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_recursive_lists():
     class Model(BaseModel):
         v: List[List[Union[int, float]]] = ...
@@ -444,6 +463,7 @@ def test_any_dict():
     assert Model(v={2: [1, 2, 3]}).dict() == {'v': {2: [1, 2, 3]}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_success_values_include():
     class Model(BaseModel):
         a: int = 1
@@ -457,6 +477,7 @@ def test_success_values_include():
     assert m.dict(include={'a', 'b'}, exclude={'a'}) == {'b': 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_include_exclude_unset():
     class Model(BaseModel):
         a: int
@@ -481,6 +502,7 @@ def test_include_exclude_unset():
     assert m.dict(include={'a', 'b', 'c'}, exclude={'a', 'c'}, exclude_unset=True) == {'b': 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_include_exclude_defaults():
     class Model(BaseModel):
         a: int
@@ -531,6 +553,7 @@ def test_skip_defaults_deprecated():
         assert m.json(skip_defaults=False) == m.json(exclude_unset=False)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_advanced_exclude():
     class SubSubModel(BaseModel):
         a: str
@@ -553,6 +576,7 @@ def test_advanced_exclude():
     assert m.dict(exclude={'e': ..., 'f': {'d'}}) == {'f': {'c': 'foo'}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_advanced_exclude_by_alias():
     class SubSubModel(BaseModel):
         a: str
@@ -581,6 +605,7 @@ def test_advanced_exclude_by_alias():
     assert m.dict(exclude=excludes, by_alias=True) == {'f_alias': {'c_alias': 'foo'}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_advanced_value_include():
     class SubSubModel(BaseModel):
         a: str
@@ -601,6 +626,7 @@ def test_advanced_value_include():
     assert m.dict(include={'f': {'d': {0: ..., -1: {'b'}}}}) == {'f': {'d': [{'a': 'a', 'b': 'b'}, {'b': 'e'}]}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_advanced_value_exclude_include():
     class SubSubModel(BaseModel):
         a: str
@@ -861,6 +887,7 @@ def test_inheritance():
     assert Bar().dict() == {'x': 12.3, 'a': 123.0}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_subclass_default():
     class MyStr(str):
         pass
@@ -882,6 +909,7 @@ def test_inheritance_subclass_default():
     assert Sub.__fields__['y'].type_ == MyStr
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_invalid_type():
     with pytest.raises(RuntimeError) as exc_info:
 
@@ -896,6 +924,7 @@ class CustomStr(str):
         return 7
 
 
+@pytest.mark.xfail(reason='working on V2', strict=False)
 @pytest.mark.parametrize(
     'value,expected',
     [
@@ -917,7 +946,7 @@ def test_valid_string_types(value, expected):
 
     assert Model(v=value).v == expected
 
-
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'value,errors',
     [
@@ -934,6 +963,7 @@ def test_invalid_string_types(value, errors):
     assert exc_info.value.errors() == errors
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_config():
     class Parent(BaseModel):
         a: int
@@ -948,6 +978,7 @@ def test_inheritance_config():
     assert repr(m) == "Child(a=1, b='s')"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_partial_inheritance_config():
     class Parent(BaseModel):
         a: int
@@ -965,6 +996,7 @@ def test_partial_inheritance_config():
     assert repr(m) == "Child(a=1, b='s')"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_annotation_inheritance():
     class A(BaseModel):
         integer: int = 1
@@ -995,6 +1027,7 @@ def test_annotation_inheritance():
     )
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_string_none():
     class Model(BaseModel):
         a: constr(min_length=20, max_length=1000) = ...
@@ -1041,6 +1074,7 @@ def test_string_none():
 #     assert e.errors() == [{'loc': ('foo',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_optional_required():
     class Model(BaseModel):
         bar: Optional[int]
@@ -1050,6 +1084,7 @@ def test_optional_required():
     assert Model(bar=None).dict() == {'bar': None}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_invalid_validator():
     class InvalidValidator:
         @classmethod
@@ -1068,6 +1103,7 @@ def test_invalid_validator():
     assert exc_info.value.args[0].startswith('Invalid signature for validator')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_unable_to_infer():
     with pytest.raises(errors.PydanticUserError) as exc_info:
 
@@ -1077,6 +1113,7 @@ def test_unable_to_infer():
     assert exc_info.value.args[0] == 'unable to infer type for attribute "x"'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_multiple_errors():
     class Model(BaseModel):
         a: Union[None, int, float, Decimal]
@@ -1093,6 +1130,7 @@ def test_multiple_errors():
     assert Model(a=None).a is None
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_all():
     class Model(BaseModel):
         a: int
@@ -1129,6 +1167,7 @@ def test_illegal_extra_value():
                 extra = 'foo'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_multiple_inheritance_config():
     class Parent(BaseModel):
         class Config:
@@ -1183,6 +1222,7 @@ def test_submodel_different_type():
         Spam(c=Bar(b='123'))
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_self():
     class Model(BaseModel):
         self: str
@@ -1209,6 +1249,7 @@ def test_self_recursive():
     assert m.dict() == {'sm': {'self': 123}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_init():
     class NestedModel(BaseModel):
         self: str
@@ -1240,6 +1281,7 @@ def test_init_inspection():
     Foobar(x=1)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_type_on_annotation():
     class FooBar:
         pass
@@ -1258,6 +1300,7 @@ def test_type_on_annotation():
     assert Model.__fields__.keys() == {'b', 'c', 'e', 'f', 'g', 'h', 'i'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_assign_type():
     class Parent:
         def echo(self):
@@ -1289,6 +1332,7 @@ def test_assign_type():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_optional_subfields():
     class Model(BaseModel):
         a: Optional[int]
@@ -1307,6 +1351,7 @@ def test_optional_subfields():
     assert Model(a=12).a == 12
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_not_optional_subfields():
     class Model(BaseModel):
         a: Optional[int]
@@ -1330,6 +1375,7 @@ def test_not_optional_subfields():
     assert Model(a=12).a == 12
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_optional_field_constraints():
     class MyModel(BaseModel):
         my_int: Optional[int] = Field(..., ge=3)
@@ -1346,6 +1392,7 @@ def test_optional_field_constraints():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_field_str_shape():
     class Model(BaseModel):
         a: List[int]
@@ -1371,6 +1418,7 @@ class DisplayGen(Generic[T1, T2]):
         yield validator
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'type_,expected',
     [
@@ -1405,6 +1453,7 @@ def test_any_none():
     assert dict(m) == {'foo': None}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_type_var_any():
     Foobar = TypeVar('Foobar')
 
@@ -1417,6 +1466,7 @@ def test_type_var_any():
     assert MyModel(foo=123).foo == 123
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_type_var_constraint():
     Foobar = TypeVar('Foobar', int, str)
 
@@ -1437,6 +1487,7 @@ def test_type_var_constraint():
     assert MyModel(foo=123).foo == 123
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_type_var_bound():
     Foobar = TypeVar('Foobar', bound=int)
 
@@ -1480,6 +1531,7 @@ def test_dict_any():
     assert m.foo == {'x': 'a', 'y': None}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_modify_fields():
     class Foo(BaseModel):
         foo: List[List[int]]
@@ -1551,6 +1603,7 @@ def test_exclude_none_with_extra():
     assert m.dict() == {'a': 'a', 'b': 'b', 'c': None}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_str_method_inheritance():
     import pydantic
 
@@ -1568,6 +1621,7 @@ def test_str_method_inheritance():
     assert str(Bar()) == '7'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_repr_method_inheritance():
     import pydantic
 
@@ -1585,6 +1639,7 @@ def test_repr_method_inheritance():
     assert repr(Bar()) == '7'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_optional_validator():
     val_calls = []
 
@@ -1601,7 +1656,7 @@ def test_optional_validator():
     assert Model(something='hello').dict() == {'something': 'hello'}
     assert val_calls == [None, 'hello']
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_required_optional():
     class Model(BaseModel):
         nullable1: Optional[int] = ...
@@ -1628,7 +1683,7 @@ def test_required_optional():
         {'loc': ('nullable2',), 'msg': 'field required', 'type': 'value_error.missing'},
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_required_any():
     class Model(BaseModel):
         optional1: Any
@@ -1667,7 +1722,7 @@ def test_required_any():
         'nullable2': 'two',
     }
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_validators():
     T1 = TypeVar('T1')
     T2 = TypeVar('T2')
@@ -1725,7 +1780,7 @@ def test_custom_generic_validators():
     assert m.gen2.t1 == 1
     assert m.gen2.t2 == 2
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_arbitrary_allowed():
     T1 = TypeVar('T1')
     T2 = TypeVar('T2')
@@ -1764,7 +1819,7 @@ def test_custom_generic_arbitrary_allowed():
     assert m.gen.t1 == 'bar'
     assert m.gen.t2 is True
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_disallowed():
     T1 = TypeVar('T1')
     T2 = TypeVar('T2')
@@ -1781,7 +1836,7 @@ def test_custom_generic_disallowed():
             a: str
             gen: MyGen[str, bool]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_hashable_required():
     class Model(BaseModel):
         v: Hashable
@@ -1797,6 +1852,7 @@ def test_hashable_required():
     assert exc_info.value.errors() == [{'loc': ('v',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('default', [1, None])
 def test_hashable_optional(default):
     class Model(BaseModel):
@@ -1806,6 +1862,7 @@ def test_hashable_optional(default):
     Model()
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_default_factory_called_once():
     """It should never call `default_factory` more than once even when `validate_all` is set"""
 
@@ -1838,7 +1895,7 @@ def test_default_factory_called_once():
         {'loc': ('id',), 'msg': 'value is not a valid list', 'type': 'type_error.list'},
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_default_factory_validator_child():
     class Parent(BaseModel):
         foo: List[str] = Field(default_factory=list)
@@ -1854,7 +1911,7 @@ def test_default_factory_validator_child():
 
     assert Child(foo=['a', 'b']).foo == ['a-1', 'b-1']
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_resolve_annotations_module_missing(tmp_path):
     # see https://github.com/pydantic/pydantic/issues/2363
     file_path = tmp_path / 'module_to_load.py'
@@ -1881,7 +1938,7 @@ def test_iter_coverage():
 
     assert list(MyModel()._iter(by_alias=True)) == [('x', 1), ('y', 'a')]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_config_field_info():
     class Foo(BaseModel):
         a: str = Field(...)
@@ -1891,7 +1948,7 @@ def test_config_field_info():
 
     assert Foo.schema(by_alias=True)['properties'] == {'a': {'title': 'A', 'description': 'descr', 'type': 'string'}}
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_alias():
     class Foo(BaseModel):
         a: str = Field(...)
@@ -1901,7 +1958,7 @@ def test_config_field_info_alias():
 
     assert Foo.schema(by_alias=True)['properties'] == {'b': {'title': 'B', 'type': 'string'}}
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_merge():
     class Foo(BaseModel):
         a: str = Field(..., foo='Foo')
@@ -1913,7 +1970,7 @@ def test_config_field_info_merge():
         'a': {'bar': 'Bar', 'foo': 'Foo', 'title': 'A', 'type': 'string'}
     }
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_config_field_info_allow_mutation():
     class Foo(BaseModel):
         a: str = Field(...)
@@ -1970,7 +2027,7 @@ def test_bytes_subclass():
     m = MyModel(my_bytes=BytesSubclass(b'foobar'))
     assert m.my_bytes.__class__ == BytesSubclass
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_int_subclass():
     class MyModel(BaseModel):
         my_int: int
@@ -1997,7 +2054,7 @@ def test_model_issubclass():
 
     assert not issubclass(Custom, BaseModel)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_long_int():
     """
     see https://github.com/pydantic/pydantic/issues/1477 and in turn, https://github.com/python/cpython/issues/95778

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -23,6 +23,7 @@ from typing_extensions import Annotated, Literal
 from pydantic import BaseModel, Field, Json, ValidationError, root_validator, validator
 from pydantic.generics import GenericModel, _generic_types_cache, iter_contained_typevars, replace_types
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_name():
     data_type = TypeVar('data_type')
@@ -35,6 +36,7 @@ def test_generic_name():
     assert Result[List[int]].__name__ == 'Result[List[int]]'
     assert Result[int].__name__ == 'Result[int]'
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_double_parameterize_error():
     data_type = TypeVar('data_type')
@@ -46,6 +48,7 @@ def test_double_parameterize_error():
         Result[int][int]
 
     assert str(exc_info.value) == 'Cannot parameterize a concrete instantiation of a generic model'
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_value_validation():
@@ -81,6 +84,7 @@ def test_value_validation():
         Response[Dict[int, int]](data={1: 3, 2: 6})
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'sum too large', 'type': 'value_error'}]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_methods_are_inherited():
     class CustomGenericModel(GenericModel):
@@ -95,6 +99,7 @@ def test_methods_are_inherited():
     instance = Model[int](data=1)
 
     assert instance.method() == 1
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_config_is_inherited():
@@ -114,6 +119,7 @@ def test_config_is_inherited():
 
     assert str(exc_info.value) == '"Model[int]" is immutable and does not support item assignment'
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_default_argument():
     T = TypeVar('T')
@@ -124,6 +130,7 @@ def test_default_argument():
 
     result = Result[int](data=1)
     assert result.other is True
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_default_argument_for_typevar():
@@ -141,6 +148,7 @@ def test_default_argument_for_typevar():
     result = Result[int](data=1)
     assert result.data == 1
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_classvar():
     T = TypeVar('T')
@@ -153,6 +161,7 @@ def test_classvar():
     assert Result[int].other == 1
     assert Result[int](data=1).other == 1
     assert 'other' not in Result.__fields__
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_non_annotated_field():
@@ -203,6 +212,7 @@ def test_subclass_can_be_genericized():
 
     Result[T]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_parameter_count():
     T = TypeVar('T')
@@ -220,6 +230,7 @@ def test_parameter_count():
         Model[int]
     assert str(exc_info.value) == 'Too few parameters for Model; actual 1, expected 2'
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_cover_cache():
     cache_size = len(_generic_types_cache)
@@ -232,6 +243,7 @@ def test_cover_cache():
     assert len(_generic_types_cache) == cache_size + 2
     Model[int]  # uses the cache
     assert len(_generic_types_cache) == cache_size + 2
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_config():
@@ -248,6 +260,7 @@ def test_generic_config():
     with pytest.raises(TypeError):
         result.data = 2
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_enum_generic():
     T = TypeVar('T')
@@ -261,6 +274,7 @@ def test_enum_generic():
 
     Model[MyEnum](enum=MyEnum.x)
     Model[MyEnum](enum=2)
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic():
@@ -316,6 +330,7 @@ def test_generic():
         {'loc': ('error',), 'msg': 'Must not provide both data and error', 'type': 'value_error'}
     ]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_alongside_concrete_generics():
     from pydantic.generics import GenericModel
@@ -330,6 +345,7 @@ def test_alongside_concrete_generics():
     assert model.item == 1
     assert model.metadata == {}
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_complex_nesting():
     from pydantic.generics import GenericModel
@@ -343,6 +359,7 @@ def test_complex_nesting():
     model = MyModel[str](item=item)
     assert model.item == item
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_required_value():
     T = TypeVar('T')
@@ -354,6 +371,7 @@ def test_required_value():
         MyModel[int]()
     assert exc_info.value.errors() == [{'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_optional_value():
     T = TypeVar('T')
@@ -364,6 +382,7 @@ def test_optional_value():
     model = MyModel[int]()
     assert model.dict() == {'a': 1}
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_custom_schema():
     T = TypeVar('T')
@@ -373,6 +392,7 @@ def test_custom_schema():
 
     schema = MyModel[int].schema()
     assert schema['properties']['a'].get('description') == 'Custom'
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_child_schema():
@@ -392,6 +412,7 @@ def test_child_schema():
         'required': ['a'],
     }
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_naming():
     T = TypeVar('T')
@@ -407,6 +428,7 @@ def test_custom_generic_naming():
 
     assert repr(MyModel[int](value=1)) == 'OptionalIntWrapper(value=1)'
     assert repr(MyModel[str](value=None)) == 'OptionalStrWrapper(value=None)'
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_nested():
@@ -439,6 +461,7 @@ def test_nested():
         {'loc': ('i', 'a'), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_partial_specification():
     AT = TypeVar('AT')
@@ -457,6 +480,7 @@ def test_partial_specification():
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
         {'loc': ('b',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_with_inner_typevar():
@@ -477,6 +501,7 @@ def test_partial_specification_with_inner_typevar():
     assert nested_resolved.a == ['123']
     assert nested_resolved.b == [456]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_name():
     AT = TypeVar('AT')
@@ -490,6 +515,7 @@ def test_partial_specification_name():
     assert partial_model.__name__ == 'Model[int, BT]'
     concrete_model = partial_model[str]
     assert concrete_model.__name__ == 'Model[int, BT][str]'
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_instantiation():
@@ -510,6 +536,7 @@ def test_partial_specification_instantiation():
     assert exc_info.value.errors() == [
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_instantiation_bounded():
@@ -535,6 +562,7 @@ def test_partial_specification_instantiation_bounded():
         {'loc': ('b',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_typevar_parametrization():
     AT = TypeVar('AT')
@@ -553,6 +581,7 @@ def test_typevar_parametrization():
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
         {'loc': ('b',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
     ]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_multiple_specification():
@@ -574,6 +603,7 @@ def test_multiple_specification():
         {'loc': ('b',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass_of_concrete_generic():
     T = TypeVar('T')
@@ -594,6 +624,7 @@ def test_generic_subclass_of_concrete_generic():
         ConcreteSub(data='wrong', extra=2)
 
     ConcreteSub(data=2, extra=3)
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_model_pickle(create_module):
@@ -623,6 +654,7 @@ def test_generic_model_pickle(create_module):
         assert loaded.value.b == original.value.b == 10
         assert loaded == original
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_model_from_function_pickle_fail(create_module):
     @create_module
@@ -650,6 +682,7 @@ def test_generic_model_from_function_pickle_fail(create_module):
         original = get_generic(Model)(value=Model(a='24'))
         with pytest.raises(pickle.PicklingError):
             pickle.dumps(original)
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
@@ -686,6 +719,7 @@ def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
         assert globals()['MyGeneric[Model]'] is concrete
         assert globals()['MyGeneric[Model]_'] is second_concrete
         assert globals()['MyGeneric[Model]__'] is third_concrete
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_model_caching_detect_order_of_union_args_basic(create_module):
@@ -778,6 +812,7 @@ def test_get_caller_frame_info_when_sys_getframe_undefined():
     finally:  # just to make sure we always setting original attribute back
         sys._getframe = getframe
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_iter_contained_typevars():
     T = TypeVar('T')
@@ -791,6 +826,7 @@ def test_iter_contained_typevars():
     assert list(iter_contained_typevars(Optional[List[Union[str, Model[int]]]])) == []
     assert list(iter_contained_typevars(Optional[List[Union[str, Model[T], Callable[[T2, T], str]]]])) == [T, T2, T]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_nested_identity_parameterization():
     T = TypeVar('T')
@@ -802,6 +838,7 @@ def test_nested_identity_parameterization():
     assert Model[T][T][T] is Model
     assert Model[T] is Model
     assert Model[T2] is not Model
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_replace_types():
@@ -825,6 +862,7 @@ def test_replace_types():
         # resolve correctly (don't get translated to typing versions for
         # example)
         assert replace_types(list[Union[str, list, T]], {T: int}) == list[Union[str, list, int]]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_replace_types_with_user_defined_generic_type_field():
@@ -857,6 +895,7 @@ def test_replace_types_identity_on_unchanged():
     type_ = List[Union[str, Callable[[list], Optional[str]], U]]
     assert replace_types(type_, {T: int}) is type_
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_deep_generic():
     T = TypeVar('T')
@@ -888,6 +927,7 @@ def test_deep_generic():
     assert InnerModel.__concrete__ is False
     assert inner_model.__concrete__ is True
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_inner_typevar():
     T = TypeVar('T')
@@ -904,6 +944,7 @@ def test_deep_generic_with_inner_typevar():
     with pytest.raises(ValidationError):
         InnerModel[int](a=['wrong'])
     assert InnerModel[int](a=['1']).a == [1]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_referenced_generic():
@@ -925,6 +966,7 @@ def test_deep_generic_with_referenced_generic():
     with pytest.raises(ValidationError):
         InnerModel[int](a={'a': 'wrong'})
     assert InnerModel[int](a={'a': 1}).a.a == 1
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_referenced_inner_generic():
@@ -949,6 +991,7 @@ def test_deep_generic_with_referenced_inner_generic():
     assert InnerModel[int].__fields__['a'].outer_type_ == List[Union[ReferencedModel[int], str]]
     assert (InnerModel[int].__fields__['a'].sub_fields[0].sub_fields[0].outer_type_.__fields__['a'].outer_type_) == int
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_multiple_typevars():
     T = TypeVar('T')
@@ -965,6 +1008,7 @@ def test_deep_generic_with_multiple_typevars():
     assert ConcreteInnerModel.__fields__['extra'].outer_type_ == int
 
     assert ConcreteInnerModel(data=['1'], extra='2').dict() == {'data': [1.0], 'extra': 2}
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_multiple_inheritance():
@@ -993,6 +1037,7 @@ def test_deep_generic_with_multiple_inheritance():
         'extra': 5,
     }
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_with_referenced_generic_type_1():
     T = TypeVar('T')
@@ -1006,6 +1051,7 @@ def test_generic_with_referenced_generic_type_1():
         abstract_base_with_type: ModelWithType[T]
 
     ReferenceModel[int]
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_with_referenced_nested_typevar():
@@ -1022,6 +1068,7 @@ def test_generic_with_referenced_nested_typevar():
 
     ReferenceModel[int]
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_with_callable():
     T = TypeVar('T')
@@ -1032,6 +1079,7 @@ def test_generic_with_callable():
 
     Model[str].__concrete__ is True
     Model.__concrete__ is False
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_with_partial_callable():
@@ -1047,6 +1095,7 @@ def test_generic_with_partial_callable():
     Model[str, U].__concrete__ is False
     Model[str, U].__parameters__ == [U]
     Model[str, int].__concrete__ is False
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_recursive_models(create_module):
@@ -1071,6 +1120,7 @@ def test_generic_recursive_models(create_module):
     result = Model1[str].parse_obj(dict(ref=dict(ref=dict(ref=dict(ref=123)))))
     assert result == Model1(ref=Model2(ref=Model1(ref=Model2(ref='123'))))
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_enum():
     T = TypeVar('T')
@@ -1088,6 +1138,7 @@ def test_generic_enum():
     m = MyModel.parse_obj({'my_gen': {'some_field': 'A'}})
     assert m.my_gen.some_field is SomeStringEnum.A
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_literal():
     FieldType = TypeVar('FieldType')
@@ -1099,6 +1150,7 @@ def test_generic_literal():
     Fields = Literal['foo', 'bar']
     m = GModel[Fields, str](field={'foo': 'x'})
     assert m.dict() == {'field': {'foo': 'x'}}
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_enums():
@@ -1119,6 +1171,7 @@ def test_generic_enums():
 
     assert set(Model.schema()['definitions']) == {'EnumA', 'EnumB', 'GModel_EnumA_', 'GModel_EnumB_'}
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_with_user_defined_generic_field():
     T = TypeVar('T')
@@ -1136,6 +1189,7 @@ def test_generic_with_user_defined_generic_field():
     with pytest.raises(ValidationError):
         model = Model[int](field=['a'])
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_annotated():
     T = TypeVar('T')
@@ -1144,6 +1198,7 @@ def test_generic_annotated():
         some_field: Annotated[T, Field(alias='the_alias')]
 
     SomeGenericModel[str](the_alias='qwe')
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass():
@@ -1159,6 +1214,7 @@ def test_generic_subclass():
     assert issubclass(B[int], B)
     assert issubclass(B[int], A[int])
     assert not issubclass(B[int], A[str])
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass_with_partial_application():
@@ -1176,6 +1232,7 @@ def test_generic_subclass_with_partial_application():
     assert not issubclass(PartiallyAppliedB[int], A[str])
     assert not issubclass(PartiallyAppliedB[str], A[int])
 
+
 @pytest.mark.xfail(reason='working on V2')
 def test_multilevel_generic_binding():
     T = TypeVar('T')
@@ -1190,6 +1247,7 @@ def test_multilevel_generic_binding():
     assert B[int].__name__ == 'B[int]'
     assert issubclass(B[int], A[str, int])
     assert not issubclass(B[str], A[str, int])
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass_with_extra_type():
@@ -1206,6 +1264,7 @@ def test_generic_subclass_with_extra_type():
     assert issubclass(B[str, int], B)
     assert issubclass(B[str, int], A[int])
     assert not issubclass(B[int, str], A[int])
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_multi_inheritance_generic_binding():
@@ -1225,6 +1284,7 @@ def test_multi_inheritance_generic_binding():
     assert not issubclass(C[float], B[int])
     assert issubclass(C[float], A[int])
     assert not issubclass(C[float], A[str])
+
 
 @pytest.mark.xfail(reason='working on V2')
 def test_parse_generic_json():

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -23,9 +23,7 @@ from typing_extensions import Annotated, Literal
 from pydantic import BaseModel, Field, Json, ValidationError, root_validator, validator
 from pydantic.generics import GenericModel, _generic_types_cache, iter_contained_typevars, replace_types
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
-
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_name():
     data_type = TypeVar('data_type')
 
@@ -37,7 +35,7 @@ def test_generic_name():
     assert Result[List[int]].__name__ == 'Result[List[int]]'
     assert Result[int].__name__ == 'Result[int]'
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_double_parameterize_error():
     data_type = TypeVar('data_type')
 
@@ -49,7 +47,7 @@ def test_double_parameterize_error():
 
     assert str(exc_info.value) == 'Cannot parameterize a concrete instantiation of a generic model'
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_value_validation():
     T = TypeVar('T')
 
@@ -83,7 +81,7 @@ def test_value_validation():
         Response[Dict[int, int]](data={1: 3, 2: 6})
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'sum too large', 'type': 'value_error'}]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_methods_are_inherited():
     class CustomGenericModel(GenericModel):
         def method(self):
@@ -98,7 +96,7 @@ def test_methods_are_inherited():
 
     assert instance.method() == 1
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_config_is_inherited():
     class CustomGenericModel(GenericModel):
         class Config:
@@ -116,7 +114,7 @@ def test_config_is_inherited():
 
     assert str(exc_info.value) == '"Model[int]" is immutable and does not support item assignment'
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_default_argument():
     T = TypeVar('T')
 
@@ -127,7 +125,7 @@ def test_default_argument():
     result = Result[int](data=1)
     assert result.other is True
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_default_argument_for_typevar():
     T = TypeVar('T')
 
@@ -143,7 +141,7 @@ def test_default_argument_for_typevar():
     result = Result[int](data=1)
     assert result.data == 1
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_classvar():
     T = TypeVar('T')
 
@@ -156,7 +154,7 @@ def test_classvar():
     assert Result[int](data=1).other == 1
     assert 'other' not in Result.__fields__
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_non_annotated_field():
     T = TypeVar('T')
 
@@ -205,7 +203,7 @@ def test_subclass_can_be_genericized():
 
     Result[T]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_parameter_count():
     T = TypeVar('T')
     S = TypeVar('S')
@@ -222,7 +220,7 @@ def test_parameter_count():
         Model[int]
     assert str(exc_info.value) == 'Too few parameters for Model; actual 1, expected 2'
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_cover_cache():
     cache_size = len(_generic_types_cache)
     T = TypeVar('T')
@@ -235,7 +233,7 @@ def test_cover_cache():
     Model[int]  # uses the cache
     assert len(_generic_types_cache) == cache_size + 2
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_config():
     data_type = TypeVar('data_type')
 
@@ -250,7 +248,7 @@ def test_generic_config():
     with pytest.raises(TypeError):
         result.data = 2
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_generic():
     T = TypeVar('T')
 
@@ -264,7 +262,7 @@ def test_enum_generic():
     Model[MyEnum](enum=MyEnum.x)
     Model[MyEnum](enum=2)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic():
     data_type = TypeVar('data_type')
     error_type = TypeVar('error_type')
@@ -318,7 +316,7 @@ def test_generic():
         {'loc': ('error',), 'msg': 'Must not provide both data and error', 'type': 'value_error'}
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_alongside_concrete_generics():
     from pydantic.generics import GenericModel
 
@@ -332,7 +330,7 @@ def test_alongside_concrete_generics():
     assert model.item == 1
     assert model.metadata == {}
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_complex_nesting():
     from pydantic.generics import GenericModel
 
@@ -345,7 +343,7 @@ def test_complex_nesting():
     model = MyModel[str](item=item)
     assert model.item == item
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_required_value():
     T = TypeVar('T')
 
@@ -356,7 +354,7 @@ def test_required_value():
         MyModel[int]()
     assert exc_info.value.errors() == [{'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_optional_value():
     T = TypeVar('T')
 
@@ -366,7 +364,7 @@ def test_optional_value():
     model = MyModel[int]()
     assert model.dict() == {'a': 1}
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_schema():
     T = TypeVar('T')
 
@@ -376,7 +374,7 @@ def test_custom_schema():
     schema = MyModel[int].schema()
     assert schema['properties']['a'].get('description') == 'Custom'
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_child_schema():
     T = TypeVar('T')
 
@@ -394,7 +392,7 @@ def test_child_schema():
         'required': ['a'],
     }
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_generic_naming():
     T = TypeVar('T')
 
@@ -410,7 +408,7 @@ def test_custom_generic_naming():
     assert repr(MyModel[int](value=1)) == 'OptionalIntWrapper(value=1)'
     assert repr(MyModel[str](value=None)) == 'OptionalStrWrapper(value=None)'
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_nested():
     AT = TypeVar('AT')
 
@@ -441,7 +439,7 @@ def test_nested():
         {'loc': ('i', 'a'), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_partial_specification():
     AT = TypeVar('AT')
     BT = TypeVar('BT')
@@ -460,7 +458,7 @@ def test_partial_specification():
         {'loc': ('b',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_with_inner_typevar():
     AT = TypeVar('AT')
     BT = TypeVar('BT')
@@ -479,7 +477,7 @@ def test_partial_specification_with_inner_typevar():
     assert nested_resolved.a == ['123']
     assert nested_resolved.b == [456]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_name():
     AT = TypeVar('AT')
     BT = TypeVar('BT')
@@ -493,7 +491,7 @@ def test_partial_specification_name():
     concrete_model = partial_model[str]
     assert concrete_model.__name__ == 'Model[int, BT][str]'
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_instantiation():
     AT = TypeVar('AT')
     BT = TypeVar('BT')
@@ -513,7 +511,7 @@ def test_partial_specification_instantiation():
         {'loc': ('a',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_partial_specification_instantiation_bounded():
     AT = TypeVar('AT')
     BT = TypeVar('BT', bound=int)
@@ -537,7 +535,7 @@ def test_partial_specification_instantiation_bounded():
         {'loc': ('b',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_typevar_parametrization():
     AT = TypeVar('AT')
     BT = TypeVar('BT')
@@ -556,7 +554,7 @@ def test_typevar_parametrization():
         {'loc': ('b',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_multiple_specification():
     AT = TypeVar('AT')
     BT = TypeVar('BT')
@@ -576,7 +574,7 @@ def test_multiple_specification():
         {'loc': ('b',), 'msg': 'none is not an allowed value', 'type': 'type_error.none.not_allowed'},
     ]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass_of_concrete_generic():
     T = TypeVar('T')
     U = TypeVar('U')
@@ -597,7 +595,7 @@ def test_generic_subclass_of_concrete_generic():
 
     ConcreteSub(data=2, extra=3)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_model_pickle(create_module):
     # Using create_module because pickle doesn't support
     # objects with <locals> in their __qualname__  (e. g. defined in function)
@@ -625,7 +623,7 @@ def test_generic_model_pickle(create_module):
         assert loaded.value.b == original.value.b == 10
         assert loaded == original
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_model_from_function_pickle_fail(create_module):
     @create_module
     def module():
@@ -653,7 +651,7 @@ def test_generic_model_from_function_pickle_fail(create_module):
         with pytest.raises(pickle.PicklingError):
             pickle.dumps(original)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
 
     # match identity checker otherwise we never get to the redefinition check
@@ -689,7 +687,7 @@ def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
         assert globals()['MyGeneric[Model]_'] is second_concrete
         assert globals()['MyGeneric[Model]__'] is third_concrete
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_model_caching_detect_order_of_union_args_basic(create_module):
     # Basic variant of https://github.com/pydantic/pydantic/issues/4474
     @create_module
@@ -780,7 +778,7 @@ def test_get_caller_frame_info_when_sys_getframe_undefined():
     finally:  # just to make sure we always setting original attribute back
         sys._getframe = getframe
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_iter_contained_typevars():
     T = TypeVar('T')
     T2 = TypeVar('T2')
@@ -793,7 +791,7 @@ def test_iter_contained_typevars():
     assert list(iter_contained_typevars(Optional[List[Union[str, Model[int]]]])) == []
     assert list(iter_contained_typevars(Optional[List[Union[str, Model[T], Callable[[T2, T], str]]]])) == [T, T2, T]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_identity_parameterization():
     T = TypeVar('T')
     T2 = TypeVar('T2')
@@ -805,7 +803,7 @@ def test_nested_identity_parameterization():
     assert Model[T] is Model
     assert Model[T2] is not Model
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_replace_types():
     T = TypeVar('T')
 
@@ -828,7 +826,7 @@ def test_replace_types():
         # example)
         assert replace_types(list[Union[str, list, T]], {T: int}) == list[Union[str, list, int]]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_replace_types_with_user_defined_generic_type_field():
     """Test that using user defined generic types as generic model fields are handled correctly."""
 
@@ -859,7 +857,7 @@ def test_replace_types_identity_on_unchanged():
     type_ = List[Union[str, Callable[[list], Optional[str]], U]]
     assert replace_types(type_, {T: int}) is type_
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_deep_generic():
     T = TypeVar('T')
     S = TypeVar('S')
@@ -890,7 +888,7 @@ def test_deep_generic():
     assert InnerModel.__concrete__ is False
     assert inner_model.__concrete__ is True
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_inner_typevar():
     T = TypeVar('T')
 
@@ -907,7 +905,7 @@ def test_deep_generic_with_inner_typevar():
         InnerModel[int](a=['wrong'])
     assert InnerModel[int](a=['1']).a == [1]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_referenced_generic():
     T = TypeVar('T')
     R = TypeVar('R')
@@ -928,7 +926,7 @@ def test_deep_generic_with_referenced_generic():
         InnerModel[int](a={'a': 'wrong'})
     assert InnerModel[int](a={'a': 1}).a.a == 1
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_referenced_inner_generic():
     T = TypeVar('T')
 
@@ -951,7 +949,7 @@ def test_deep_generic_with_referenced_inner_generic():
     assert InnerModel[int].__fields__['a'].outer_type_ == List[Union[ReferencedModel[int], str]]
     assert (InnerModel[int].__fields__['a'].sub_fields[0].sub_fields[0].outer_type_.__fields__['a'].outer_type_) == int
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_multiple_typevars():
     T = TypeVar('T')
     U = TypeVar('U')
@@ -968,7 +966,7 @@ def test_deep_generic_with_multiple_typevars():
 
     assert ConcreteInnerModel(data=['1'], extra='2').dict() == {'data': [1.0], 'extra': 2}
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_deep_generic_with_multiple_inheritance():
     K = TypeVar('K')
     V = TypeVar('V')
@@ -995,7 +993,7 @@ def test_deep_generic_with_multiple_inheritance():
         'extra': 5,
     }
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_with_referenced_generic_type_1():
     T = TypeVar('T')
 
@@ -1009,7 +1007,7 @@ def test_generic_with_referenced_generic_type_1():
 
     ReferenceModel[int]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_with_referenced_nested_typevar():
     T = TypeVar('T')
 
@@ -1024,7 +1022,7 @@ def test_generic_with_referenced_nested_typevar():
 
     ReferenceModel[int]
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_with_callable():
     T = TypeVar('T')
 
@@ -1035,7 +1033,7 @@ def test_generic_with_callable():
     Model[str].__concrete__ is True
     Model.__concrete__ is False
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_with_partial_callable():
     T = TypeVar('T')
     U = TypeVar('U')
@@ -1050,7 +1048,7 @@ def test_generic_with_partial_callable():
     Model[str, U].__parameters__ == [U]
     Model[str, int].__concrete__ is False
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_recursive_models(create_module):
     @create_module
     def module():
@@ -1073,7 +1071,7 @@ def test_generic_recursive_models(create_module):
     result = Model1[str].parse_obj(dict(ref=dict(ref=dict(ref=dict(ref=123)))))
     assert result == Model1(ref=Model2(ref=Model1(ref=Model2(ref='123'))))
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_enum():
     T = TypeVar('T')
 
@@ -1090,7 +1088,7 @@ def test_generic_enum():
     m = MyModel.parse_obj({'my_gen': {'some_field': 'A'}})
     assert m.my_gen.some_field is SomeStringEnum.A
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_literal():
     FieldType = TypeVar('FieldType')
     ValueType = TypeVar('ValueType')
@@ -1102,7 +1100,7 @@ def test_generic_literal():
     m = GModel[Fields, str](field={'foo': 'x'})
     assert m.dict() == {'field': {'foo': 'x'}}
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_enums():
     T = TypeVar('T')
 
@@ -1121,7 +1119,7 @@ def test_generic_enums():
 
     assert set(Model.schema()['definitions']) == {'EnumA', 'EnumB', 'GModel_EnumA_', 'GModel_EnumB_'}
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_with_user_defined_generic_field():
     T = TypeVar('T')
 
@@ -1138,7 +1136,7 @@ def test_generic_with_user_defined_generic_field():
     with pytest.raises(ValidationError):
         model = Model[int](field=['a'])
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_annotated():
     T = TypeVar('T')
 
@@ -1147,7 +1145,7 @@ def test_generic_annotated():
 
     SomeGenericModel[str](the_alias='qwe')
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass():
     T = TypeVar('T')
 
@@ -1162,7 +1160,7 @@ def test_generic_subclass():
     assert issubclass(B[int], A[int])
     assert not issubclass(B[int], A[str])
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass_with_partial_application():
     T = TypeVar('T')
     S = TypeVar('S')
@@ -1178,7 +1176,7 @@ def test_generic_subclass_with_partial_application():
     assert not issubclass(PartiallyAppliedB[int], A[str])
     assert not issubclass(PartiallyAppliedB[str], A[int])
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_multilevel_generic_binding():
     T = TypeVar('T')
     S = TypeVar('S')
@@ -1193,7 +1191,7 @@ def test_multilevel_generic_binding():
     assert issubclass(B[int], A[str, int])
     assert not issubclass(B[str], A[str, int])
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_generic_subclass_with_extra_type():
     T = TypeVar('T')
     S = TypeVar('S')
@@ -1209,7 +1207,7 @@ def test_generic_subclass_with_extra_type():
     assert issubclass(B[str, int], A[int])
     assert not issubclass(B[int, str], A[int])
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_multi_inheritance_generic_binding():
     T = TypeVar('T')
 
@@ -1228,7 +1226,7 @@ def test_multi_inheritance_generic_binding():
     assert issubclass(C[float], A[int])
     assert not issubclass(C[float], A[str])
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_generic_json():
     T = TypeVar('T')
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -23,6 +23,7 @@ class MyEnum(Enum):
     foo = 'bar'
     snap = 'crackle'
 
+
 @pytest.mark.xfail(reason='working on V2', strict=False)
 @pytest.mark.parametrize(
     'gen_input,output',

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -18,14 +18,12 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.json import pydantic_encoder, timedelta_isoformat
 from pydantic.types import DirectoryPath, FilePath, SecretBytes, SecretStr
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
-
 
 class MyEnum(Enum):
     foo = 'bar'
     snap = 'crackle'
 
-
+@pytest.mark.xfail(reason='working on V2', strict=False)
 @pytest.mark.parametrize(
     'gen_input,output',
     [
@@ -80,6 +78,7 @@ def test_path_encoding(tmpdir):
     assert json.dumps(model, default=pydantic_encoder) == expected
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_encoding():
     class ModelA(BaseModel):
         x: int
@@ -97,6 +96,7 @@ def test_model_encoding():
     assert m.json(exclude={'b'}) == '{"a": 10.2, "c": 10.2, "d": {"x": 123, "y": "123"}}'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_subclass_encoding():
     class SubDate(datetime.datetime):
         pass
@@ -110,6 +110,7 @@ def test_subclass_encoding():
     assert m.json() == '{"a": "2032-01-01T01:01:00", "b": "2020-02-29T12:30:00"}'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_subclass_custom_encoding():
     class SubDate(datetime.datetime):
         pass
@@ -195,6 +196,7 @@ def test_custom_iso_timedelta():
 #     assert Obj.parse_raw('{"id": 1, "price": 0.01}') == Obj(id=1)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_json_encoder_simple_inheritance():
     class Parent(BaseModel):
         dt: datetime.datetime = datetime.datetime.now()
@@ -210,6 +212,7 @@ def test_json_encoder_simple_inheritance():
     assert Child().json() == '{"dt": "parent_encoder", "timedt": "child_encoder"}'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_json_encoder_inheritance_override():
     class Parent(BaseModel):
         dt: datetime.datetime = datetime.datetime.now()
@@ -243,6 +246,7 @@ def test_encode_dataclass():
     assert '{"bar": 123, "spam": "apple pie"}' == json.dumps(f, default=pydantic_encoder)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_encode_pydantic_dataclass():
     @pydantic_dataclass
     class Foo:
@@ -253,6 +257,7 @@ def test_encode_pydantic_dataclass():
     assert '{"bar": 123, "spam": "apple pie"}' == json.dumps(f, default=pydantic_encoder)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_encode_custom_root():
     class Model(BaseModel):
         __root__: List[str]
@@ -260,6 +265,7 @@ def test_encode_custom_root():
     assert Model(__root__=['a', 'b']).json() == '["a", "b"]'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_decode_encode():
     load_calls, dump_calls = 0, 0
 
@@ -286,6 +292,7 @@ def test_custom_decode_encode():
     assert m.json() == '{\n  "a": 1,\n  "b": "foo"\n}'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_json_nested_encode_models():
     class Phone(BaseModel):
         manufacturer: str
@@ -368,6 +375,7 @@ def test_custom_encode_error():
         Foo(x=MyExoticType()).json(encoder=custom_encoder)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_recursive():
     class Model(BaseModel):
         value: Optional[str]

--- a/tests/test_orm_mode.py
+++ b/tests/test_orm_mode.py
@@ -5,9 +5,8 @@ import pytest
 
 from pydantic import BaseModel, PydanticUserError, ValidationError, root_validator
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_getdict():
     class TestCls:
         a = 1
@@ -50,6 +49,7 @@ def test_getdict():
     assert repr(gd) == "GetterDict[TestCls]({'a': 1, 'c': 3, 'd': 4})"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_orm_mode_root():
     class PokemonCls:
         def __init__(self, *, en_name: str, jp_name: str):
@@ -91,6 +91,7 @@ def test_orm_mode_root():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_orm_mode():
     class PetCls:
         def __init__(self, *, name: str, species: str):
@@ -131,6 +132,7 @@ def test_orm_mode():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_not_orm_mode():
     class Pet(BaseModel):
         name: str
@@ -140,6 +142,7 @@ def test_not_orm_mode():
         Pet.from_orm(None)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_object_with_getattr():
     class FooGetAttr:
         def __getattr__(self, key: str):
@@ -171,6 +174,7 @@ def test_object_with_getattr():
         ModelInvalid.from_orm(foo)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_properties():
     class XyProperty:
         x = 4
@@ -191,6 +195,7 @@ def test_properties():
     assert model.y == 5
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_extra_allow():
     class TestCls:
         x = 1
@@ -207,6 +212,7 @@ def test_extra_allow():
     assert model.dict() == {'x': 1}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_extra_forbid():
     class TestCls:
         x = 1
@@ -223,6 +229,7 @@ def test_extra_forbid():
     assert model.dict() == {'x': 1}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator():
     validator_value = None
 
@@ -250,6 +257,7 @@ def test_root_validator():
     assert validator_value == {'x': 1, 'y': 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_custom_getter_dict():
     class TestCls:
         x = 1
@@ -271,6 +279,7 @@ def test_custom_getter_dict():
     assert model.dict() == {'x': 42, 'y': 24}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_recursive_parsing():
     class Getter:  # GetterDict
         # try to read the modified property name
@@ -305,6 +314,7 @@ def test_recursive_parsing():
     assert ModelB.from_orm(obj) == ModelB(b=ModelA(a=1))
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_orm():
     class User(BaseModel):
         first_name: str

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -6,8 +6,6 @@ import pytest
 
 from pydantic import BaseModel, Field, ValidationError, parse_obj_as
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
-
 
 class Model(BaseModel):
     a: float
@@ -19,6 +17,7 @@ def test_obj():
     assert str(m) == 'a=10.2 b=10'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_fails():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_obj([1, 2, 3])
@@ -27,11 +26,13 @@ def test_parse_obj_fails():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_submodel():
     m = Model.parse_obj(Model(a=10.2))
     assert m.dict() == {'a': 10.2, 'b': 10}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_wrong_model():
     class Foo(BaseModel):
         c = 123
@@ -41,6 +42,7 @@ def test_parse_obj_wrong_model():
     assert exc_info.value.errors() == [{'loc': ('a',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_root():
     class MyModel(BaseModel):
         __root__: str
@@ -50,6 +52,7 @@ def test_parse_obj_root():
     assert m.__root__ == 'a'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_root_list():
     class MyModel(BaseModel):
         __root__: List[str]
@@ -59,6 +62,7 @@ def test_parse_root_list():
     assert m.__root__ == ['a']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_nested_root_list():
     class NestedData(BaseModel):
         id: str
@@ -74,6 +78,7 @@ def test_parse_nested_root_list():
     assert isinstance(m.nested.__root__[0], NestedData)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_nested_root_tuple():
     class NestedData(BaseModel):
         id: str
@@ -93,6 +98,7 @@ def test_parse_nested_root_tuple():
     assert isinstance(nested, NestedModel)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_nested_custom_root():
     class NestedModel(BaseModel):
         __root__: List[str]
@@ -108,19 +114,23 @@ def test_parse_nested_custom_root():
     assert isinstance(m.__root__.__root__[0], str)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_json():
     assert Model.parse_raw('{"a": 12, "b": 8}') == Model(a=12, b=8)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_json_ct():
     assert Model.parse_raw('{"a": 12, "b": 8}', content_type='application/json') == Model(a=12, b=8)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_pickle_ct():
     data = pickle.dumps(dict(a=12, b=8))
     assert Model.parse_raw(data, content_type='application/pickle', allow_pickle=True) == Model(a=12, b=8)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_bad_ct():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', content_type='application/missing')
@@ -129,24 +139,28 @@ def test_bad_ct():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_bad_proto():
     with pytest.raises(ValidationError) as exc_info:
         Model.parse_raw('{"a": 12, "b": 8}', proto='foobar')
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'Unknown protocol: foobar', 'type': 'type_error'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_file_json(tmpdir):
     p = tmpdir.join('test.json')
     p.write('{"a": 12, "b": 8}')
     assert Model.parse_file(str(p)) == Model(a=12, b=8)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_file_json_no_ext(tmpdir):
     p = tmpdir.join('test')
     p.write('{"a": 12, "b": 8}')
     assert Model.parse_file(str(p)) == Model(a=12, b=8)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_file_json_loads(tmp_path):
     def custom_json_loads(*args, **kwargs):
         data = json.loads(*args, **kwargs)
@@ -165,18 +179,21 @@ def test_file_json_loads(tmp_path):
     assert Example.parse_file(p) == Example(a=99)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_file_pickle(tmpdir):
     p = tmpdir.join('test.pkl')
     p.write_binary(pickle.dumps(dict(a=12, b=8)))
     assert Model.parse_file(str(p), allow_pickle=True) == Model(a=12, b=8)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_file_pickle_no_ext(tmpdir):
     p = tmpdir.join('test')
     p.write_binary(pickle.dumps(dict(a=12, b=8)))
     assert Model.parse_file(str(p), content_type='application/pickle', allow_pickle=True) == Model(a=12, b=8)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_const_differentiates_union():
     class SubModelA(BaseModel):
         key: str = Field('A', const=True)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -78,11 +78,10 @@ try:
 except ImportError:
     email_validator = None
 
-
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 T = TypeVar('T')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_key():
     class ApplePie(BaseModel):
         """
@@ -105,6 +104,7 @@ def test_key():
     assert ApplePie.schema() == s
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_by_alias():
     class ApplePie(BaseModel):
         a: float
@@ -127,6 +127,7 @@ def test_by_alias():
     assert list(ApplePie.schema(by_alias=False)['properties'].keys()) == ['a', 'b']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ref_template():
     class KeyLimePie(BaseModel):
         x: str = None
@@ -156,6 +157,7 @@ def test_ref_template():
     assert '#/definitions/KeyLimePie' not in json_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_by_alias_generator():
     class ApplePie(BaseModel):
         a: float
@@ -175,6 +177,7 @@ def test_by_alias_generator():
     assert ApplePie.schema(by_alias=False)['properties'].keys() == {'a', 'b'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_sub_model():
     class Foo(BaseModel):
         """hello"""
@@ -202,6 +205,7 @@ def test_sub_model():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_class():
     class Model(BaseModel):
         foo: int = Field(4, title='Foo is Great')
@@ -224,12 +228,14 @@ def test_schema_class():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_repr():
     s = Field(4, title='Foo is Great')
     assert str(s) == "default=4 title='Foo is Great' extra={}"
     assert repr(s) == "FieldInfo(default=4, title='Foo is Great', extra={})"
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_class_by_alias():
     class Model(BaseModel):
         foo: int = Field(4, alias='foofoo')
@@ -238,6 +244,7 @@ def test_schema_class_by_alias():
     assert list(Model.schema(by_alias=False)['properties'].keys()) == ['foo']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_choices():
     FooEnum = Enum('FooEnum', {'foo': 'f', 'bar': 'b'})
     BarEnum = IntEnum('BarEnum', {'foo': 1, 'bar': 2})
@@ -268,6 +275,7 @@ def test_choices():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_modify_schema():
     class SpamEnum(str, Enum):
         foo = 'f'
@@ -296,6 +304,7 @@ def test_enum_modify_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_schema_custom_field():
     class FooBarEnum(str, Enum):
         foo = 'foo'
@@ -335,6 +344,7 @@ def test_enum_schema_custom_field():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_and_model_have_same_behaviour():
     class Names(str, Enum):
         rick = 'Rick'
@@ -393,6 +403,7 @@ def test_enum_and_model_have_same_behaviour():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_includes_extra_without_other_params():
     class Names(str, Enum):
         rick = 'Rick'
@@ -422,6 +433,7 @@ def test_enum_includes_extra_without_other_params():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_list_enum_schema_extras():
     class FoodChoice(str, Enum):
         spam = 'spam'
@@ -449,6 +461,7 @@ def test_list_enum_schema_extras():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_schema_cleandoc():
     class FooBar(str, Enum):
         """
@@ -477,6 +490,7 @@ def test_enum_schema_cleandoc():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_json_schema():
     class Model(BaseModel):
         a = b'foobar'
@@ -492,6 +506,7 @@ def test_json_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_list_sub_model():
     class Foo(BaseModel):
         a: float
@@ -515,6 +530,7 @@ def test_list_sub_model():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_optional():
     class Model(BaseModel):
         a: Optional[str]
@@ -522,6 +538,7 @@ def test_optional():
     assert Model.schema() == {'title': 'Model', 'type': 'object', 'properties': {'a': {'type': 'string', 'title': 'A'}}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_any():
     class Model(BaseModel):
         a: Any
@@ -537,6 +554,7 @@ def test_any():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_set():
     class Model(BaseModel):
         a: Set[int]
@@ -555,6 +573,7 @@ def test_set():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_const_str():
     class Model(BaseModel):
         a: str = Field('some string', const=True)
@@ -566,6 +585,7 @@ def test_const_str():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_const_false():
     class Model(BaseModel):
         a: str = Field('some string', const=False)
@@ -577,6 +597,7 @@ def test_const_false():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,extra_props',
     [
@@ -610,6 +631,7 @@ def test_tuple(field_type, extra_props):
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_deque():
     class Model(BaseModel):
         a: Deque[str]
@@ -622,6 +644,7 @@ def test_deque():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_bool():
     class Model(BaseModel):
         a: bool
@@ -634,6 +657,7 @@ def test_bool():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_strict_bool():
     class Model(BaseModel):
         a: StrictBool
@@ -646,6 +670,7 @@ def test_strict_bool():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_dict():
     class Model(BaseModel):
         a: dict
@@ -658,6 +683,7 @@ def test_dict():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_list():
     class Model(BaseModel):
         a: list
@@ -674,6 +700,7 @@ class Foo(BaseModel):
     a: float
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -732,6 +759,7 @@ def test_list_union_dict(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -753,6 +781,7 @@ def test_date_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -776,6 +805,7 @@ def test_date_constrained_types(field_type, expected_schema):
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -809,6 +839,7 @@ def test_str_basic_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -832,6 +863,7 @@ def test_str_constrained_types(field_type, expected_schema):
     assert model_schema == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -852,6 +884,7 @@ def test_special_str_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 @pytest.mark.parametrize('field_type,expected_schema', [(EmailStr, 'email'), (NameEmail, 'name-email')])
 def test_email_str_types(field_type, expected_schema):
@@ -869,6 +902,7 @@ def test_email_str_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('field_type,inner_type', [(SecretBytes, 'string'), (SecretStr, 'string')])
 def test_secret_types(field_type, inner_type):
     class Model(BaseModel):
@@ -884,6 +918,7 @@ def test_secret_types(field_type, inner_type):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -912,6 +947,7 @@ def test_special_int_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -944,6 +980,7 @@ def test_special_float_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [(UUID, 'uuid'), (UUID1, 'uuid1'), (UUID3, 'uuid3'), (UUID4, 'uuid4'), (UUID5, 'uuid5')],
@@ -963,6 +1000,7 @@ def test_uuid_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema', [(FilePath, 'file-path'), (DirectoryPath, 'directory-path'), (Path, 'path')]
 )
@@ -981,6 +1019,7 @@ def test_path_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_json_type():
     class Model(BaseModel):
         a: Json
@@ -999,6 +1038,7 @@ def test_json_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipv4address_type():
     class Model(BaseModel):
         ip_address: IPv4Address
@@ -1012,6 +1052,7 @@ def test_ipv4address_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipv6address_type():
     class Model(BaseModel):
         ip_address: IPv6Address
@@ -1025,6 +1066,7 @@ def test_ipv6address_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipvanyaddress_type():
     class Model(BaseModel):
         ip_address: IPvAnyAddress
@@ -1038,6 +1080,7 @@ def test_ipvanyaddress_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipv4interface_type():
     class Model(BaseModel):
         ip_interface: IPv4Interface
@@ -1051,6 +1094,7 @@ def test_ipv4interface_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipv6interface_type():
     class Model(BaseModel):
         ip_interface: IPv6Interface
@@ -1064,6 +1108,7 @@ def test_ipv6interface_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipvanyinterface_type():
     class Model(BaseModel):
         ip_interface: IPvAnyInterface
@@ -1077,6 +1122,7 @@ def test_ipvanyinterface_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipv4network_type():
     class Model(BaseModel):
         ip_network: IPv4Network
@@ -1090,6 +1136,7 @@ def test_ipv4network_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipv6network_type():
     class Model(BaseModel):
         ip_network: IPv6Network
@@ -1103,6 +1150,7 @@ def test_ipv6network_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_ipvanynetwork_type():
     class Model(BaseModel):
         ip_network: IPvAnyNetwork
@@ -1116,6 +1164,7 @@ def test_ipvanynetwork_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'type_,default_value',
     (
@@ -1136,6 +1185,7 @@ def test_callable_type(type_, default_value):
     assert 'callback' not in model_schema['properties']
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_error_non_supported_types():
     class Model(BaseModel):
         a: ImportString
@@ -1144,6 +1194,7 @@ def test_error_non_supported_types():
         Model.schema()
 
 
+@pytest.mark.xfail(reason='working on V2')
 def create_testing_submodules():
     base_path = Path(tempfile.mkdtemp())
     mod_root_path = base_path / 'pydantic_schema_test'
@@ -1165,6 +1216,7 @@ def create_testing_submodules():
     sys.path.insert(0, str(base_path))
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_flat_models_unique_models():
     create_testing_submodules()
     from pydantic_schema_test.modulea.modela import Model as ModelA
@@ -1175,6 +1227,7 @@ def test_flat_models_unique_models():
     assert flat_models == {ModelA, ModelB}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_flat_models_with_submodels():
     class Foo(BaseModel):
         a: str
@@ -1189,6 +1242,7 @@ def test_flat_models_with_submodels():
     assert flat_models == {Foo, Bar, Baz}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_flat_models_with_submodels_from_sequence():
     class Foo(BaseModel):
         a: str
@@ -1207,6 +1261,7 @@ def test_flat_models_with_submodels_from_sequence():
     assert flat_models == {Foo, Bar, Ingredient, Pizza}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_name_maps():
     create_testing_submodules()
     from pydantic_schema_test.modulea.modela import Model as ModelA
@@ -1235,6 +1290,7 @@ def test_model_name_maps():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_overrides():
     class Foo(BaseModel):
         a: str
@@ -1271,6 +1327,7 @@ def test_schema_overrides():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_overrides_w_union():
     class Foo(BaseModel):
         pass
@@ -1290,6 +1347,7 @@ def test_schema_overrides_w_union():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_from_models():
     class Foo(BaseModel):
         a: str
@@ -1364,6 +1422,7 @@ def test_schema_from_models():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'ref_prefix,ref_template',
     [
@@ -1409,6 +1468,7 @@ def test_schema_with_refs(ref_prefix, ref_template):
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_with_custom_ref_template():
     class Foo(BaseModel):
         a: str
@@ -1444,6 +1504,7 @@ def test_schema_with_custom_ref_template():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_ref_template_key_error():
     class Foo(BaseModel):
         a: str
@@ -1463,6 +1524,7 @@ def test_schema_no_definitions():
     assert model_schema == {'title': 'Schema without definitions'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_list_default():
     class UserModel(BaseModel):
         friends: List[int] = [1]
@@ -1474,6 +1536,7 @@ def test_list_default():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_str_default():
     class MyEnum(str, Enum):
         FOO = 'foo'
@@ -1484,6 +1547,7 @@ def test_enum_str_default():
     assert UserModel.schema()['properties']['friends']['default'] is MyEnum.FOO.value
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_enum_int_default():
     class MyEnum(IntEnum):
         FOO = 1
@@ -1494,6 +1558,7 @@ def test_enum_int_default():
     assert UserModel.schema()['properties']['friends']['default'] is MyEnum.FOO.value
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_dict_default():
     class UserModel(BaseModel):
         friends: Dict[str, float] = {'a': 1.1, 'b': 2.2}
@@ -1512,6 +1577,7 @@ def test_dict_default():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_default():
     """Make sure inner model types are encoded properly"""
 
@@ -1544,6 +1610,7 @@ def test_model_default():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'kwargs,type_,expected_extra',
     [
@@ -1587,6 +1654,7 @@ def test_constraints_schema(kwargs, type_, expected_extra):
     assert Foo.schema() == expected_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'kwargs,type_',
     [
@@ -1613,6 +1681,7 @@ def test_unenforced_constraints_schema(kwargs, type_):
             a: type_ = Field('foo', title='A title', description='A description', **kwargs)
 
 
+@pytest.mark.xfail(reason='working on V2', strict=False)
 @pytest.mark.parametrize(
     'kwargs,type_,value',
     [
@@ -1652,6 +1721,7 @@ def test_constraints_schema_validation(kwargs, type_, value):
     assert Foo(a=value)
 
 
+@pytest.mark.xfail(reason='working on V2', strict=False)
 @pytest.mark.parametrize(
     'kwargs,type_,value',
     [
@@ -1680,6 +1750,7 @@ def test_constraints_schema_validation_raises(kwargs, type_, value):
         Foo(a=value)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_kwargs():
     class Foo(BaseModel):
         a: str = Field('foo', examples=['bar'])
@@ -1691,6 +1762,7 @@ def test_schema_kwargs():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_dict_constr():
     regex_str = r'^([a-zA-Z_][a-zA-Z0-9_]*)$'
     ConStrType = constr(regex=regex_str)
@@ -1708,6 +1780,7 @@ def test_schema_dict_constr():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -1728,6 +1801,7 @@ def test_bytes_constrained_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_optional_dict():
     class Model(BaseModel):
         something: Optional[Dict[str, Any]]
@@ -1742,6 +1816,7 @@ def test_optional_dict():
     assert Model(something={'foo': 'Bar'}).dict() == {'something': {'foo': 'Bar'}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_optional_validator():
     class Model(BaseModel):
         something: Optional[str]
@@ -1762,6 +1837,7 @@ def test_optional_validator():
     assert Model(something='hello').dict() == {'something': 'hello'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_field_with_validator():
     class Model(BaseModel):
         something: Optional[int] = None
@@ -1777,6 +1853,7 @@ def test_field_with_validator():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_unparameterized_schema_generation():
     class FooList(BaseModel):
         d: List
@@ -1816,6 +1893,7 @@ def test_unparameterized_schema_generation():
     assert foo_dict_schema == bar_dict_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_known_model_optimization():
     class Dep(BaseModel):
         number: int
@@ -1845,6 +1923,7 @@ def test_known_model_optimization():
     assert Model.schema() == expected
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root():
     class Model(BaseModel):
         __root__: str
@@ -1852,6 +1931,7 @@ def test_root():
     assert Model.schema() == {'title': 'Model', 'type': 'string'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_list():
     class Model(BaseModel):
         __root__: List[str]
@@ -1859,6 +1939,7 @@ def test_root_list():
     assert Model.schema() == {'title': 'Model', 'type': 'array', 'items': {'type': 'string'}}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_nested_model():
     class NestedModel(BaseModel):
         a: str
@@ -1881,6 +1962,7 @@ def test_root_nested_model():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_new_type_schema():
     a_type = NewType('a_type', int)
     b_type = NewType('b_type', a_type)
@@ -1903,6 +1985,7 @@ def test_new_type_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_literal_schema():
     class Model(BaseModel):
         a: Literal[1]
@@ -1929,6 +2012,7 @@ def test_literal_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_literal_enum():
     class MyEnum(str, Enum):
         FOO = 'foo'
@@ -1945,6 +2029,7 @@ def test_literal_enum():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_color_type():
     class Model(BaseModel):
         color: Color
@@ -1958,6 +2043,7 @@ def test_color_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_with_schema_extra():
     class Model(BaseModel):
         a: str
@@ -1974,6 +2060,7 @@ def test_model_with_schema_extra():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_with_schema_extra_callable():
     class Model(BaseModel):
         name: str = None
@@ -1988,6 +2075,7 @@ def test_model_with_schema_extra_callable():
     assert Model.schema() == {'title': 'Model', 'type': 'override'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_with_schema_extra_callable_no_model_class():
     class Model(BaseModel):
         name: str = None
@@ -2001,6 +2089,7 @@ def test_model_with_schema_extra_callable_no_model_class():
     assert Model.schema() == {'title': 'Model', 'type': 'override'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_with_schema_extra_callable_classmethod():
     class Model(BaseModel):
         name: str = None
@@ -2017,6 +2106,7 @@ def test_model_with_schema_extra_callable_classmethod():
     assert Model.schema() == {'title': 'Model', 'type': 'foo'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_with_schema_extra_callable_instance_method():
     class Model(BaseModel):
         name: str = None
@@ -2030,6 +2120,7 @@ def test_model_with_schema_extra_callable_instance_method():
     assert Model.schema() == {'title': 'Model', 'type': 'override'}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_with_extra_forbidden():
     class Model(BaseModel):
         a: str
@@ -2046,6 +2137,7 @@ def test_model_with_extra_forbidden():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize(
     'annotation,kwargs,field_schema',
     [
@@ -2110,6 +2202,7 @@ def test_enforced_constraints(annotation, kwargs, field_schema):
     assert schema['properties']['a'] == field_schema
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_real_vs_phony_constraints():
     class Model1(BaseModel):
         foo: int = Field(..., gt=123)
@@ -2140,6 +2233,7 @@ def test_real_vs_phony_constraints():
     )
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_subfield_field_info():
     class MyModel(BaseModel):
         entries: Dict[str, List[int]]
@@ -2158,6 +2252,7 @@ def test_subfield_field_info():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_dataclass():
     @dataclass
     class Model:
@@ -2182,6 +2277,7 @@ def test_dataclass():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_attributes():
     class ExampleEnum(Enum):
         """This is a test description."""
@@ -2221,6 +2317,7 @@ def test_model_process_schema_enum():
     assert model_schema == {'title': 'SpamEnum', 'description': 'An enumeration.', 'type': 'string', 'enum': ['f', 'b']}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_path_modify_schema():
     class MyPath(Path):
         @classmethod
@@ -2244,6 +2341,7 @@ def test_path_modify_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_frozen_set():
     class Model(BaseModel):
         a: FrozenSet[int] = frozenset({1, 2, 3})
@@ -2270,6 +2368,7 @@ def test_frozen_set():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_iterable():
     class Model(BaseModel):
         a: Iterable[int]
@@ -2282,6 +2381,7 @@ def test_iterable():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_new_type():
     new_type = NewType('NewStr', str)
 
@@ -2296,6 +2396,7 @@ def test_new_type():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_multiple_models_with_same_name(create_module):
     module = create_module(
         # language=Python
@@ -2334,6 +2435,7 @@ class NestedModel(BaseModel):
     assert model_names == expected_model_names
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_multiple_enums_with_same_name(create_module):
     module_1 = create_module(
         # language=Python
@@ -2386,6 +2488,7 @@ class MyModel(BaseModel):
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_for_generic_field():
     T = TypeVar('T')
 
@@ -2438,6 +2541,7 @@ def test_schema_for_generic_field():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_namedtuple_default():
     class Coordinates(NamedTuple):
         x: float
@@ -2462,6 +2566,7 @@ def test_namedtuple_default():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_advanced_generic_schema():
     T = TypeVar('T')
     K = TypeVar('K')
@@ -2572,6 +2677,7 @@ def test_advanced_generic_schema():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_generic():
     """
     Test a nested BaseModel that is also a Generic
@@ -2606,6 +2712,7 @@ def test_nested_generic():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_generic_model():
     """
     Test a nested GenericModel
@@ -2634,6 +2741,7 @@ def test_nested_generic_model():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_complex_nested_generic():
     """
     Handle a union of a generic.
@@ -2684,6 +2792,7 @@ def test_complex_nested_generic():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema_with_field_parameter():
     class RestrictedAlphabetStr(str):
         @classmethod
@@ -2705,6 +2814,7 @@ def test_schema_with_field_parameter():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union():
     class BlackCat(BaseModel):
         pet_type: Literal['cat']
@@ -2792,6 +2902,7 @@ def test_discriminated_union():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_annotated_union():
     class BlackCatWithHeight(BaseModel):
         pet_type: Literal['cat']
@@ -2905,6 +3016,7 @@ def test_discriminated_annotated_union():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_alias_same():
     class Cat(BaseModel):
         pet_type: Literal['cat'] = Field(alias='typeOfPet')
@@ -2956,6 +3068,7 @@ def test_alias_same():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_python_dataclasses():
     """
     Test schema generation for nested python dataclasses
@@ -2987,6 +3100,7 @@ def test_nested_python_dataclasses():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_in_list():
     class BlackCat(BaseModel):
         pet_type: Literal['cat']
@@ -3073,6 +3187,7 @@ def test_discriminated_union_in_list():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_extra_inheritance():
     class A(BaseModel):
         root: Optional[str]
@@ -3097,6 +3212,7 @@ def test_extra_inheritance():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_model_with_type_attributes():
     class Foo:
         a: float
@@ -3116,6 +3232,7 @@ def test_model_with_type_attributes():
     }
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('secret_cls', [SecretStr, SecretBytes])
 @pytest.mark.parametrize(
     'field_kw,schema_kw',

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,14 +6,14 @@ from pydantic import BaseModel, ValidationError
 from pydantic.dataclasses import dataclass
 from pydantic.tools import parse_obj_as, schema_json_of, schema_of
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('obj,type_,parsed', [('1', int, 1), (['1'], List[int], [1])])
 def test_parse_obj(obj, type_, parsed):
     assert parse_obj_as(type_, obj) == parsed
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_as_model():
     class Model(BaseModel):
         x: int
@@ -24,6 +24,7 @@ def test_parse_obj_as_model():
     assert parse_obj_as(Model, model_inputs) == Model(**model_inputs)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_preserves_subclasses():
     class ModelA(BaseModel):
         a: Mapping[int, str]
@@ -37,6 +38,7 @@ def test_parse_obj_preserves_subclasses():
     assert parsed == [model_b]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_fails():
     with pytest.raises(ValidationError) as exc_info:
         parse_obj_as(int, 'a')
@@ -46,6 +48,7 @@ def test_parse_obj_fails():
     assert exc_info.value.model.__name__ == 'ParsingModel[int]'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parsing_model_naming():
     with pytest.raises(ValidationError) as exc_info:
         parse_obj_as(int, 'a')
@@ -60,6 +63,7 @@ def test_parsing_model_naming():
     assert str(exc_info.value).split('\n')[0] == '1 validation error for int'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_as_dataclass():
     @dataclass
     class PydanticDataclass:
@@ -69,11 +73,13 @@ def test_parse_as_dataclass():
     assert parse_obj_as(PydanticDataclass, inputs) == PydanticDataclass(1)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_parse_mapping_as():
     inputs = {'1': '2'}
     assert parse_obj_as(Dict[int, int], inputs) == {1: 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_schema():
     assert schema_of(Union[int, str], title='IntOrStr') == {
         'title': 'IntOrStr',

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -10,9 +10,8 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Extra, Field, PydanticUserError, ValidationError, errors, validator
 from pydantic.validator_functions import root_validator
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_simple():
     class Model(BaseModel):
         a: str
@@ -30,6 +29,7 @@ def test_simple():
     assert exc_info.value.errors() == [{'loc': ('a',), 'msg': '"foobar" not found in a', 'type': 'value_error'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_int_validation():
     class Model(BaseModel):
         a: int
@@ -45,6 +45,7 @@ def test_int_validation():
     assert Model(a=4.5).a == 4
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('value', [2.2250738585072011e308, float('nan'), float('inf')])
 def test_int_overflow_validation(value):
     class Model(BaseModel):
@@ -57,6 +58,7 @@ def test_int_overflow_validation(value):
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_frozenset_validation():
     class Model(BaseModel):
         a: frozenset
@@ -72,6 +74,7 @@ def test_frozenset_validation():
     assert Model(a=(6,)).a == frozenset({6})
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_deque_validation():
     class Model(BaseModel):
         a: deque
@@ -85,6 +88,7 @@ def test_deque_validation():
     assert Model(a=(6,)).a == deque([6])
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_whole():
     class Model(BaseModel):
         a: List[int]
@@ -102,6 +106,7 @@ def test_validate_whole():
     assert Model(a=[1, 2]).a == [1, 2, 123, 456]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_kwargs():
     class Model(BaseModel):
         b: int
@@ -114,6 +119,7 @@ def test_validate_kwargs():
     assert Model(a=[1, 2], b=6).a == [7, 8]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_pre_error():
     calls = []
 
@@ -175,11 +181,13 @@ def validate_assignment_model_fixture():
     return ValidateAssignmentModel
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_ok(ValidateAssignmentModel):
     p = ValidateAssignmentModel(b='hello')
     assert p.b == 'hello'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_fail(ValidateAssignmentModel):
     with pytest.raises(ValidationError):
         ValidateAssignmentModel(a=10, b='hello')
@@ -189,6 +197,7 @@ def test_validating_assignment_fail(ValidateAssignmentModel):
         p.b = 'x'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_value_change(ValidateAssignmentModel):
     p = ValidateAssignmentModel(b='hello', c=2)
     assert p.c == 4
@@ -199,6 +208,7 @@ def test_validating_assignment_value_change(ValidateAssignmentModel):
     assert p.c == 6
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_extra(ValidateAssignmentModel):
     p = ValidateAssignmentModel(b='hello', extra_field=1.23)
     assert p.extra_field == 1.23
@@ -210,6 +220,7 @@ def test_validating_assignment_extra(ValidateAssignmentModel):
     assert p.extra_field == 'bye'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_dict(ValidateAssignmentModel):
     with pytest.raises(ValidationError) as exc_info:
         ValidateAssignmentModel(a='x', b='xx')
@@ -218,6 +229,7 @@ def test_validating_assignment_dict(ValidateAssignmentModel):
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_values_dict():
     class ModelOne(BaseModel):
         a: int
@@ -242,6 +254,7 @@ def test_validating_assignment_values_dict():
     assert model.b == 4
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_multiple():
     # also test TypeError
     class Model(BaseModel):
@@ -264,6 +277,7 @@ def test_validate_multiple():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_classmethod():
     class Model(BaseModel):
         a: str
@@ -278,6 +292,7 @@ def test_classmethod():
     m.check_a('x')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_duplicates():
     with pytest.raises(errors.PydanticUserError) as exc_info:
 
@@ -326,6 +341,7 @@ def test_use_no_fields():
     assert 'validator with no fields specified' in str(exc_info.value)
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_always():
     check_calls = 0
 
@@ -344,6 +360,7 @@ def test_validate_always():
     assert check_calls == 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_always_on_inheritance():
     check_calls = 0
 
@@ -363,6 +380,7 @@ def test_validate_always_on_inheritance():
     assert check_calls == 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_not_always():
     check_calls = 0
 
@@ -381,6 +399,7 @@ def test_validate_not_always():
     assert check_calls == 1
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_wildcard_validators():
     calls = []
 
@@ -402,6 +421,7 @@ def test_wildcard_validators():
     assert calls == [('check_a', 'abc', 'a'), ('check_all', 'abc', 'a'), ('check_all', 123, 'b')]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_wildcard_validator_error():
     class Model(BaseModel):
         a: str
@@ -423,6 +443,7 @@ def test_wildcard_validator_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_invalid_field():
     with pytest.raises(errors.PydanticUserError) as exc_info:
 
@@ -439,6 +460,7 @@ def test_invalid_field():
     )
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_child():
     class Parent(BaseModel):
         a: str
@@ -456,6 +478,7 @@ def test_validate_child():
         Child(a='snap')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_child_extra():
     class Parent(BaseModel):
         a: str
@@ -477,6 +500,7 @@ def test_validate_child_extra():
         Child(a='snap')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_child_all():
     class Parent(BaseModel):
         a: str
@@ -494,6 +518,7 @@ def test_validate_child_all():
         Child(a='snap')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_parent():
     class Parent(BaseModel):
         a: str
@@ -515,6 +540,7 @@ def test_validate_parent():
         Child(a='snap')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_parent_all():
     class Parent(BaseModel):
         a: str
@@ -536,6 +562,7 @@ def test_validate_parent_all():
         Child(a='snap')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_keep():
     class Parent(BaseModel):
         a: int
@@ -550,6 +577,7 @@ def test_inheritance_keep():
     assert Child(a=0).a == 1
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_replace():
     class Parent(BaseModel):
         a: int
@@ -566,6 +594,7 @@ def test_inheritance_replace():
     assert Child(a=0).a == 5
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_new():
     class Parent(BaseModel):
         a: int
@@ -582,6 +611,7 @@ def test_inheritance_new():
     assert Child(a=0).a == 6
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validation_each_item():
     class Model(BaseModel):
         foobar: Dict[int, int]
@@ -593,6 +623,7 @@ def test_validation_each_item():
     assert Model(foobar={1: 1}).foobar == {1: 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validation_each_item_one_sublevel():
     class Model(BaseModel):
         foobar: List[Tuple[int, int]]
@@ -606,6 +637,7 @@ def test_validation_each_item_one_sublevel():
     assert Model(foobar=[(1, 1), (2, 2)]).foobar == [(1, 1), (2, 2)]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_key_validation():
     class Model(BaseModel):
         foobar: Dict[int, int]
@@ -617,6 +649,7 @@ def test_key_validation():
     assert Model(foobar={1: 1}).foobar == {2: 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validator_always_optional():
     check_calls = 0
 
@@ -635,6 +668,7 @@ def test_validator_always_optional():
     assert check_calls == 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validator_always_pre():
     check_calls = 0
 
@@ -652,6 +686,7 @@ def test_validator_always_pre():
     assert check_calls == 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validator_always_post():
     class Model(BaseModel):
         a: str = None
@@ -664,6 +699,7 @@ def test_validator_always_post():
     assert Model().a == 'default value'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validator_always_post_optional():
     class Model(BaseModel):
         a: Optional[str] = None
@@ -692,6 +728,7 @@ def test_validator_bad_fields_throws_configerror():
                 return v
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_datetime_validator():
     check_calls = 0
 
@@ -712,6 +749,7 @@ def test_datetime_validator():
     assert check_calls == 3
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_pre_called_once():
     check_calls = 0
 
@@ -728,6 +766,7 @@ def test_pre_called_once():
     assert check_calls == 1
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_assert_raises_validation_error():
     class Model(BaseModel):
         a: str
@@ -747,6 +786,7 @@ def test_assert_raises_validation_error():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_whole():
     with pytest.warns(DeprecationWarning, match='The "whole" keyword argument is deprecated'):
 
@@ -758,6 +798,7 @@ def test_whole():
                 return v
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator():
     root_val_values = []
 
@@ -809,6 +850,7 @@ def test_root_validator():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_pre():
     root_val_values = []
 
@@ -836,6 +878,7 @@ def test_root_validator_pre():
     assert exc_info.value.errors() == [{'loc': ('__root__',), 'msg': 'foobar', 'type': 'value_error'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_repeat():
     with pytest.raises(errors.PydanticUserError, match='duplicate validator function'):
 
@@ -851,6 +894,7 @@ def test_root_validator_repeat():
                 return values
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_repeat2():
     with pytest.raises(errors.PydanticUserError, match='duplicate validator function'):
 
@@ -866,6 +910,7 @@ def test_root_validator_repeat2():
                 return values
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_self():
     with pytest.raises(
         errors.PydanticUserError, match=r'Invalid signature for root validator root_validator: \(self, values\)'
@@ -879,6 +924,7 @@ def test_root_validator_self():
                 return values
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_extra():
     with pytest.raises(errors.PydanticUserError) as exc_info:
 
@@ -894,6 +940,7 @@ def test_root_validator_extra():
     )
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_types():
     root_val_values = None
 
@@ -915,6 +962,7 @@ def test_root_validator_types():
     assert root_val_values == (Model, {'a': 1, 'b': 'bar', 'c': 'wobble'})
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_inheritance():
     calls = []
 
@@ -940,6 +988,7 @@ def test_root_validator_inheritance():
     assert calls == ["parent validator: {'a': 123}", "child validator: {'extra1': 1, 'a': 123}"]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_returns_none_exception():
     class Model(BaseModel):
         a: int = 1
@@ -952,10 +1001,12 @@ def test_root_validator_returns_none_exception():
         Model()
 
 
+@pytest.mark.xfail(reason='working on V2')
 def reusable_validator(num):
     return num * 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_reuse_global_validators():
     class Model(BaseModel):
         x: int
@@ -967,6 +1018,7 @@ def test_reuse_global_validators():
     assert dict(Model(x=1, y=1)) == {'x': 2, 'y': 2}
 
 
+@pytest.mark.xfail(reason='working on V2')
 def declare_with_reused_validators(include_root, allow_1, allow_2, allow_3):
     class Model(BaseModel):
         a: str
@@ -997,6 +1049,7 @@ def reset_tracked_validators():
     _FUNCS.update(original_tracked_validators)
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('include_root,allow_1,allow_2,allow_3', product(*[[True, False]] * 4))
 def test_allow_reuse(include_root, allow_1, allow_2, allow_3, reset_tracked_validators):
     duplication_count = int(not allow_1) + int(not allow_2) + int(include_root and not allow_3)
@@ -1008,6 +1061,7 @@ def test_allow_reuse(include_root, allow_1, allow_2, allow_3, reset_tracked_vali
         declare_with_reused_validators(include_root, allow_1, allow_2, allow_3)
 
 
+@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('validator_classmethod,root_validator_classmethod', product(*[[True, False]] * 2))
 def test_root_validator_classmethod(validator_classmethod, root_validator_classmethod, reset_tracked_validators):
     root_val_values = []
@@ -1048,6 +1102,7 @@ def test_root_validator_classmethod(validator_classmethod, root_validator_classm
     assert root_val_values == [{'a': 123, 'b': 'barbar'}, {'a': 1, 'b': 'snap dragonsnap dragon'}, {'b': 'barbar'}]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_skip_on_failure():
     a_called = False
 
@@ -1077,6 +1132,7 @@ def test_root_validator_skip_on_failure():
     assert not b_called
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_assignment_validator_cls():
     validator_calls = 0
 
@@ -1098,6 +1154,7 @@ def test_assignment_validator_cls():
     assert validator_calls == 2
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_literal_validator():
     class Model(BaseModel):
         a: Literal['foo']
@@ -1116,6 +1173,7 @@ def test_literal_validator():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_literal_validator_str_enum():
     class Bar(str, Enum):
         FIZ = 'fiz'
@@ -1137,6 +1195,7 @@ def test_literal_validator_str_enum():
     assert my_foo.fizfuz is Bar.FUZ
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_nested_literal_validator():
     L1 = Literal['foo']
     L2 = Literal['bar']
@@ -1158,6 +1217,7 @@ def test_nested_literal_validator():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_union_literal_with_constraints():
     class Model(BaseModel, validate_assignment=True):
         x: Union[Literal[42], Literal['pika']] = Field(allow_mutation=False)
@@ -1167,6 +1227,7 @@ def test_union_literal_with_constraints():
         m.x += 1
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_field_that_is_being_validated_is_excluded_from_validator_values(mocker):
     check_values = mocker.MagicMock()
 
@@ -1204,6 +1265,7 @@ def test_field_that_is_being_validated_is_excluded_from_validator_values(mocker)
     assert list(dict(model).items()) == [('foo', 'new_foo_value'), ('bar', 'new_bar_value'), ('baz', 'baz_value')]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_exceptions_in_field_validators_restore_original_field_value():
     class Model(BaseModel):
         foo: str
@@ -1223,6 +1285,7 @@ def test_exceptions_in_field_validators_restore_original_field_value():
     assert model.foo == 'foo'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_overridden_root_validators(mocker):
     validate_stub = mocker.stub(name='validate')
 
@@ -1259,6 +1322,7 @@ def test_overridden_root_validators(mocker):
     assert validate_stub.call_args_list == [mocker.call('B', 'pre'), mocker.call('B', 'post')]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_pre_root_validator_fail():
     class Model(BaseModel):
         current_value: float = Field(..., alias='current')
@@ -1285,6 +1349,7 @@ def test_validating_assignment_pre_root_validator_fail():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validating_assignment_post_root_validator_fail():
     class Model(BaseModel):
         current_value: float = Field(..., alias='current')
@@ -1329,6 +1394,7 @@ def test_validating_assignment_post_root_validator_fail():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator_many_values_change():
     """It should run root_validator on assignment and update ALL concerned fields"""
 

--- a/tests/test_validators_dataclass.py
+++ b/tests/test_validators_dataclass.py
@@ -6,9 +6,8 @@ import pytest
 from pydantic import ValidationError, root_validator, validator
 from pydantic.dataclasses import dataclass
 
-pytestmark = pytest.mark.xfail(reason='working on V2', strict=False)
 
-
+@pytest.mark.xfail(reason='working on V2')
 def test_simple():
     @dataclass
     class MyDataclass:
@@ -21,6 +20,7 @@ def test_simple():
     assert MyDataclass(a='this is foobar good').a == 'this is foobar good changed'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_pre():
     @dataclass
     class MyDataclass:
@@ -39,6 +39,7 @@ def test_validate_pre():
     assert MyDataclass(a=[1, 2]).a == [1, 2, 123, 456]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_multiple():
     # also test TypeError
     @dataclass
@@ -62,6 +63,7 @@ def test_validate_multiple():
     ]
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_classmethod():
     @dataclass
     class MyDataclass:
@@ -77,6 +79,7 @@ def test_classmethod():
     m.check_a('x')
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_validate_parent():
     @dataclass
     class Parent:
@@ -94,6 +97,7 @@ def test_validate_parent():
     assert Child(a='this is foobar good').a == 'this is foobar good changed'
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_replace():
     @dataclass
     class Parent:
@@ -112,6 +116,7 @@ def test_inheritance_replace():
     assert Child(a=0).a == 5
 
 
+@pytest.mark.xfail(reason='working on V2')
 def test_root_validator():
     root_val_values = []
 


### PR DESCRIPTION
As requested by @samuelcolvin here: https://github.com/pydantic/pydantic/pull/4835#issuecomment-1346606879

> If you're interested in testing, one useful task would be to go through some of the test files with many tests passing but the entire module marked as xfail, remove the global xfail and mark just the tests which are actually failing as xfail. Let me know if you need more information.