### PR TITLE
Remove annoying warning when using fields starting with an underscore in a dataclass (#2816)

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -659,8 +659,6 @@ def create_model(
     annotations = {}
 
     for f_name, f_def in field_definitions.items():
-        if f_name.startswith('_'):
-            warnings.warn(f'fields may not start with an underscore, ignoring "{f_name}"', RuntimeWarning)
         if isinstance(f_def, tuple):
             try:
                 f_annotation, f_value = f_def


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/2816
cc @PrettyWood