### PR TITLE
Replace deprecated `get_event_loop` with `asyncio.run` (#4859)

### DIFF
--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -266,10 +266,9 @@ def test_async():
         v = await foo(1, 2)
         assert v == 'a=1 b=2'
 
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    loop.run_until_complete(run())
+    asyncio.run(run())
     with pytest.raises(ValidationError) as exc_info:
-        loop.run_until_complete(foo('x'))
+        asyncio.run(foo('x'))
     assert exc_info.value.errors() == [{'loc': ('b',), 'msg': 'field required', 'type': 'value_error.missing'}]
 
 


### PR DESCRIPTION
# NOTICE

We're currently in the process of rewriting pydantic in preparation for V2, see
https://pydantic-docs.helpmanual.io/blog/pydantic-v2/.

Please see https://github.com/orgs/pydantic/projects/1 for the major tasks required for this migration.

To avoid wasting your time, it would be best if you only created significant PRs related to that project.

Thank you for your interest in pydantic, and your patience. :pray:

**Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch.

skip change file check
