### PR TITLE
Reduce binary sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,35 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
+  inspect-pypi-assets:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: get dist artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: pypi_files
+          path: dist
+
+      - name: list dist files
+        run: |
+         ls -lh dist/
+         echo "`ls dist | wc -l` files"
+
+      - name: extract and list sdist file
+        run: |
+         mkdir sdist-files
+         tar -xvf dist/*.tar.gz -C sdist-files
+         tree -a sdist-files
+
+      - name: extract and list wheel file
+        run: |
+         ls dist/*cp310-manylinux*x86_64.whl | head -n 1
+         python -m zipfile --list `ls dist/*cp310-manylinux*x86_64.whl | head -n 1`
+
   deploy:
     name: Deploy
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,6 @@ jobs:
 
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
-    needs: [lint, test-linux-compiled, test-not-compiled, test-old-mypy, test-fastapi]
     strategy:
       fail-fast: false
       matrix:
@@ -378,6 +377,7 @@ jobs:
       - test-not-compiled
       - test-old-mypy
       - test-fastapi
+      - build
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,6 @@ jobs:
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
     needs: [lint, test-linux-compiled, test-not-compiled, test-old-mypy, test-fastapi]
-    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')"
     strategy:
       fail-fast: false
       matrix:

--- a/changes/2276-samuelcolvin.md
+++ b/changes/2276-samuelcolvin.md
@@ -1,0 +1,1 @@
+Reduce the size of binary wheels.

--- a/setup.py
+++ b/setup.py
@@ -82,9 +82,9 @@ if not any(arg in sys.argv for arg in ['clean', 'check']) and 'SKIP_CYTHON' not 
         compiler_directives = {}
         if 'CYTHON_TRACE' in sys.argv:
             compiler_directives['linetrace'] = True
-        # Set CFLAG to all optimizations (-O3)
+        # Set CFLAG to all optimizations (-O3), add `-g0` to reduce size of binaries, see #2276
         # Any additional CFLAGS will be appended. Only the last optimization flag will have effect
-        os.environ['CFLAGS'] = '-O3 ' + os.environ.get('CFLAGS', '')
+        os.environ['CFLAGS'] = '-O3 -g0 ' + os.environ.get('CFLAGS', '')
         ext_modules = cythonize(
             'pydantic/*.py',
             exclude=['pydantic/generics.py'],


### PR DESCRIPTION
fix #2276

I'm on MacOS, so I used gitpod.io to build binaries on Ubuntu, I get the following change:

```
(env38) gitpod /workspace/pydantic (reduce-binary-size) $ ls -lh dist-1.10.X-fixes/
total 19M
-rw-r--r-- 1 gitpod gitpod  16M Dec 21 13:39 pydantic-1.10.2-cp38-cp38-linux_x86_64.whl
-rw-r--r-- 1 gitpod gitpod 2.8M Dec 21 13:35 pydantic-1.10.2.tar.gz
(env38) gitpod /workspace/pydantic (reduce-binary-size) $ ls -lh dist-reduce-binary-size/
total 5.8M
-rw-r--r-- 1 gitpod gitpod 3.1M Dec 21 13:42 pydantic-1.10.2-cp38-cp38-linux_x86_64.whl
-rw-r--r-- 1 gitpod gitpod 2.8M Dec 21 13:40 pydantic-1.10.2.tar.gz
```