### PR TITLE
[1.10.X] Turn off debug information in C extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ if not any(arg in sys.argv for arg in ['clean', 'check']) and 'SKIP_CYTHON' not 
             compiler_directives['linetrace'] = True
         # Set CFLAG to all optimizations (-O3)
         # Any additional CFLAGS will be appended. Only the last optimization flag will have effect
-        os.environ['CFLAGS'] = '-O3 ' + os.environ.get('CFLAGS', '')
+        os.environ['CFLAGS'] = '-O3 -g0' + os.environ.get('CFLAGS', '')
         ext_modules = cythonize(
             'pydantic/*.py',
             exclude=['pydantic/generics.py'],


### PR DESCRIPTION
Previously, pydantic used the default Python CFLAGS which include `-g` (debug level 2). This is good for debugging at the C level, but it significantly increases the size of the C extension shared library, and is probably not needed by the vast majority of pydantic users. Thus, it seems a better tradeoff to turn debug info off.

This can be overridden when building pydantic from source (not from PyPI wheel) by using `CFLAGS='-O3 -g'`.

This change reduces the pydantic binary on cp310-linux-x86_64 from 31MB (12MB wheel) to 8.9MB (3MB wheel).

Fixes #2276
