### PR TITLE
(#4674) Remove inferred types from create_model

### DIFF
--- a/docs/examples/models_dynamic_creation.py
+++ b/docs/examples/models_dynamic_creation.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, create_model
 
-DynamicFoobarModel = create_model('DynamicFoobarModel', foo=(str, ...), bar=123)
+DynamicFoobarModel = create_model('DynamicFoobarModel', foo=(str, ...), bar=(int, 123))
 
 
 class StaticFoobarModel(BaseModel):

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -9,7 +9,7 @@ from pydantic.generics import GenericModel
 
 @pytest.mark.xfail(reason='working on V2')
 def test_create_model():
-    model = create_model('FooModel', foo=(str, ...), bar=123)
+    model = create_model('FooModel', foo=(str, ...), bar=(int, 123))
     assert issubclass(model, BaseModel)
     assert issubclass(model.__config__, BaseModel.Config)
     assert model.__name__ == 'FooModel'
@@ -19,9 +19,8 @@ def test_create_model():
     assert model.__module__ == 'pydantic.main'
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_create_model_usage():
-    model = create_model('FooModel', foo=(str, ...), bar=123)
+    model = create_model('FooModel', foo=(str, ...), bar=(int, 123))
     m = model(foo='hello')
     assert m.foo == 'hello'
     assert m.bar == 123
@@ -34,7 +33,7 @@ def test_create_model_usage():
 def test_create_model_pickle(create_module):
     """
     Pickle will work for dynamically created model only if it was defined globally with its class name
-    and module where it's defined was specified
+    and module where it's defined was test_create_model_usagespecified
     """
 
     @create_module
@@ -43,7 +42,7 @@ def test_create_model_pickle(create_module):
 
         from pydantic import create_model
 
-        FooModel = create_model('FooModel', foo=(str, ...), bar=123, __module__=__name__)
+        FooModel = create_model('FooModel', foo=(str, ...), bar=(int, 123), __module__=__name__)
 
         m = FooModel(foo='hello')
         d = pickle.dumps(m)
@@ -73,8 +72,8 @@ def test_config_and_base():
 @pytest.mark.xfail(reason='working on V2')
 def test_inheritance():
     class BarModel(BaseModel):
-        x = 1
-        y = 2
+        x: int = 1
+        y: int = 2
 
     model = create_model('FooModel', foo=(str, ...), bar=(int, 123), __base__=BarModel)
     assert model.__fields__.keys() == {'foo', 'bar', 'x', 'y'}


### PR DESCRIPTION
Fixes #4674.

This removes the behavior of inferring default types from `create_model`, as Pydantic 2.0 requires types to be explicitly declared. I have made sure the error message raised should be clear enough for people transitioning from 1.x to 2.x who are relying on this behavior. (Albeit it does not mention an explicit deprecation-- let me know if you'd like this to be changed.)

I've also updated the tests somewhat to only cover explicitly declared types. So all instances of `create_model('FooModel', foo=(str, ...), bar=123)` were replaced with `create_model('FooModel', foo=(str, ...), bar=(int, 123))` (i.e. the `bar=123` was replaced with `bar=(int, 123)`).

That said, a few additional tests are still failing due to changes to the core BaseModel behavior. I've left those marked as xfail. Let me know what you want to do with those.