### PR TITLE
Typing extensions min version

### DIFF
--- a/changes/4885-samuelcolvin.md
+++ b/changes/4885-samuelcolvin.md
@@ -1,0 +1,1 @@
+Change dependency to `typing-extensions>=4.2.0`

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ setup(
     python_requires='>=3.7',
     zip_safe=False,  # https://mypy.readthedocs.io/en/latest/installed_packages.html
     install_requires=[
-        'typing-extensions>=4.1.0'
+        'typing-extensions>=4.2.0'
     ],
     extras_require={
         'email': ['email-validator>=1.0.3'],

--- a/tests/requirements-testing.txt
+++ b/tests/requirements-testing.txt
@@ -7,3 +7,5 @@ pytest==7.1.2
 pytest-cov==3.0.0
 pytest-mock==3.8.2
 pytest-sugar==0.9.5
+# pin typing-extensions to minimum requirement - see #4885
+typing-extensions==4.2.0


### PR DESCRIPTION
fix #4885.

I've checked the [changelog](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md) and tried this locally and everything seems to run fine.