### PR TITLE
Added more detailed documentation plus several code examples for ImportString #537

### DIFF
--- a/.github/workflows/dependencies-check.yml
+++ b/.github/workflows/dependencies-check.yml
@@ -19,6 +19,10 @@ jobs:
 
   test:
     name: test py${{ matrix.python-version }} on ${{ matrix.PYTHON_DEPENDENCY_CASE }}
+
+    needs:
+    - find_dependency_cases
+
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/dependencies-check.yml
+++ b/.github/workflows/dependencies-check.yml
@@ -2,7 +2,7 @@ name: Dependencies Check
 
 on:
   schedule:
-  - cron: '30 19 * * *'
+  - cron: '43 3 * * 6,3'
   workflow_dispatch: {}
 
 jobs:
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: samuelcolvin/list-python-dependencies@main
       id: list-python-dependencies
+      with:
+        mode: first-last
 
   test:
     name: test py${{ matrix.python-version }} on ${{ matrix.PYTHON_DEPENDENCY_CASE }}

--- a/.github/workflows/dependencies-check.yml
+++ b/.github/workflows/dependencies-check.yml
@@ -2,7 +2,8 @@ name: Dependencies Check
 
 on:
   schedule:
-    - cron: '55 18 * * *'
+  - cron: '30 19 * * *'
+  workflow_dispatch: {}
 
 jobs:
   find_dependency_cases:
@@ -12,9 +13,9 @@ jobs:
       PYTHON_DEPENDENCY_CASES: ${{ steps.list-python-dependencies.outputs.PYTHON_DEPENDENCY_CASES }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: samuelcolvin/list-python-dependencies@main
-        id: list-python-dependencies
+    - uses: actions/checkout@v3
+    - uses: samuelcolvin/list-python-dependencies@main
+      id: list-python-dependencies
 
   test:
     name: test py${{ matrix.python-version }} on ${{ matrix.PYTHON_DEPENDENCY_CASE }}

--- a/docs/examples/types_import_string_1.py
+++ b/docs/examples/types_import_string_1.py
@@ -1,0 +1,48 @@
+from pydantic import BaseModel, ImportString, ValidationError
+
+
+class ImportThings(BaseModel):
+    obj: ImportString
+
+
+# A string value will cause an automatic import
+my_cos = ImportThings(obj='math.cos')
+
+# You can use the imported function as you would expect
+cos_of_0 = my_cos.obj(0)
+assert cos_of_0 == 1
+
+
+# However, the imported "object" is not available outside the class
+try:
+    math.cos(0)
+except (NameError, TypeError) as e:
+    print(e)
+
+
+# A string whose value cannot be imported will raise an error
+try:
+    ImportThings(obj='foo.bar')
+except ValidationError as e:
+    print(e)
+
+
+# An object defined in the current namespace can indeed be imported,
+# though you should probably avoid doing this (since the ordering of declaration
+# can have an impact on behavior).
+class Foo:
+    bar = 1
+
+
+# This now works
+my_foo = ImportThings(obj=Foo)
+# So does this
+my_foo_2 = ImportThings(obj='__main__.Foo')
+
+
+# Actual python objects can be assigned as well
+import builtins  # noqa: E402
+my_abs = ImportThings(obj=builtins.abs)
+my_abs_2 = ImportThings(obj=abs)
+my_abs_3 = ImportThings(obj='builtins.abs')
+assert my_abs == my_abs_2 == my_abs_3

--- a/docs/examples/types_import_string_2.py
+++ b/docs/examples/types_import_string_2.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, ImportString
+
+
+class ImportThingsWithDefault(BaseModel):
+    obj: ImportString = 'math.cos'
+
+
+# Using A default value doesn't cause automatic an import
+my_cos = ImportThingsWithDefault()
+print(my_cos.obj, type(my_cos.obj))
+
+try:
+    cos_of_0 = my_cos.obj(0)
+except (NameError, TypeError) as e:
+    print(e)
+
+
+# Typically, you can overcome this with config settings
+# Unfortunately this does not work here.
+class ImportThingsWithDefaultValidated(BaseModel):
+    obj: ImportString = 'math.cos'
+
+    class Config:
+        validate_all = True
+
+
+my_cos_v = ImportThingsWithDefaultValidated()
+print(my_cos_v.obj, type(my_cos_v.obj))
+
+try:
+    cos_of_0 = my_cos_v.obj(0)
+except (NameError, TypeError) as e:
+    print(e)

--- a/docs/examples/types_import_string_3.py
+++ b/docs/examples/types_import_string_3.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel, ImportString
+from types import BuiltinFunctionType
+
+
+# The following class will not successfully serialize to JSON
+# Since "obj" is evaluated to an object, not a pydantic `ImportString`
+class WithCustomEncodersBad(BaseModel):
+    obj: ImportString
+
+    class Config:
+        json_encoders = {
+            ImportString: lambda x: str(x)
+        }
+
+
+# Create an instance
+m = WithCustomEncodersBad(obj='math.cos')
+
+try:
+    m.json()
+except TypeError as e:
+    print(e)
+
+# Let's do some sanity checks to verify that m.obj is not an "ImportString"
+print(isinstance(m.obj, ImportString))
+print(isinstance(m.obj, BuiltinFunctionType))
+
+
+# So now that we know that after an ImportString is evaluated by Pydantic
+# it results in its underlying object, we can configure our json encoder
+# to account for those specific types
+class WithCustomEncodersGood(BaseModel):
+    obj: ImportString
+
+    class Config:
+        json_encoders = {
+            BuiltinFunctionType: lambda x: str(x)
+        }
+
+
+m = WithCustomEncodersGood(obj='math.cos')
+print(m.json())

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -459,9 +459,10 @@ With proper ordering in an annotated `Union`, you can use this to parse types of
   for `fred.bloggs@example.com` it would be `"fred.bloggs"`.
 
 
-`PyObject`
-: expects a string and loads the Python object importable at that dotted path;
-  e.g. if `'math.cos'` was provided, the resulting field value would be the function `cos`
+`ImportString`
+: expects a string and loads the Python object importable at that dotted path; e.g. if `'math.cos'` was provided,
+the resulting field value would be the function `cos`; see [ImportString](#importstring)
+
 
 `Color`
 : for parsing HTML and CSS colors; see [Color Type](#color-type)
@@ -583,6 +584,28 @@ With proper ordering in an annotated `Union`, you can use this to parse types of
 `constr`
 : type method for constraining strs;
   see [Constrained Types](#constrained-types)
+
+### Exotic Types
+Pydantic also supports exotic types, which are described in detail below:
+
+#### ImportString
+On model instantiation, pointers will be evaluated and imported,
+(distantly related behavior to [PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject)).
+There is some nuance to this behavior, demonstrated in the examples below.
+
+**Good behavior:**
+{!.tmp_examples/types_import_string_1.md!}
+(This script is complete, it should run "as is")
+
+**Assigning a default string value doesn't result in evaluation:**
+_(Known issue)_
+{!.tmp_examples/types_import_string_2.md!}
+(This script is complete, it should run "as is")
+
+**Serializing an `ImportString` type to json is possible with a
+[custom encoder](exporting_models.md#json_encoders) which accounts for
+the evaluated object:**
+{!.tmp_examples/types_import_string_3.md!}
 
 ### URLs
 
@@ -910,7 +933,7 @@ to get validators to parse and validate the input data.
 
 !!! tip
     These validators have the same semantics as in [Validators](validators.md), you can
-    declare a parameter `config`, `field`, etc.
+    declare a parameter `config`,types_import_string_1.py `field`, etc.
 
 {!.tmp_examples/types_custom_type.md!}
 


### PR DESCRIPTION
Added enhanced documentation for the specifics of `ImportString`.

### Some important details:
* Created a new subsection in `types` docs for "exotic types"
  * The term "exotic type" is pretty fun, and I have seen it used loosely in various documentation guides. But I don't have a "text book definition" for it. What I mean to say is, perhaps `"exotic types"` is appropriate section title, perhaps not.
* Added some examples of expected "good behavior" for `ImportString`
* Added some examples of expected "bad behavior"  for `ImportString`
* Added an example of _**unexpected "bad behavior"**_ as well 😢
  * Maybe there's a solution we can employ (or a workaround) in the code example. If not, I think it's best to document what doesn't work, save people some headaches.

**Side note:** This is my first PR for pydantic! Woot woot!