### PR TITLE
Allow default variant in discriminated unions

### DIFF
--- a/docs/examples/types_union_discriminated_default.py
+++ b/docs/examples/types_union_discriminated_default.py
@@ -1,0 +1,25 @@
+from typing import Literal, Union, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+
+
+class RequestV1(BaseModel):
+    version: Optional[Literal[1]] = 1
+    items: list[str]
+
+
+class RequestV2(BaseModel):
+    version: Literal[2]
+    items: list[dict[str, str]]
+
+
+class Body(BaseModel):
+    request: Union[RequestV1, RequestV2] = Field(..., discriminator='version')
+
+
+print(Body(request={'items': ['apple', 'orange']}))
+print(Body(request={'version': 2, 'items': [{'name': 'apple'}]}))
+try:
+    Body(request={'items': [{'name': 'apple'}]})
+except ValidationError as e:
+    print(e)

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -285,6 +285,11 @@ Setting a discriminated union has many benefits:
     Python changes `Union[T]` into `T` at interpretation time, so it is not possible for `pydantic` to
     distinguish fields of `Union[T]` from `T`.
 
+You can set discriminated field as `Optional` in one of the variants. This variant becomes the default
+if the value is not set:
+
+{!.tmp_examples/types_union_discriminated_default.md!}
+
 #### Nested Discriminated Unions
 
 Only one discriminator can be set for a field but sometimes you want to combine multiple discriminators.

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -66,6 +66,22 @@ def test_discriminated_union_literal_discriminator():
             number: int
 
 
+def test_discriminated_union_single_default_discriminator():
+    class Cat(BaseModel):
+        pet_type: Optional[Literal['cat']]
+        c: str
+
+    class Dog(BaseModel):
+        pet_type: Optional[Literal['dog']]
+        d: str
+
+    with pytest.raises(ConfigError, match="Discriminator field 'pet_type' is defined `Optional` in 2 variants"):
+
+        class Model(BaseModel):
+            pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+            number: int
+
+
 def test_discriminated_union_root_same_discriminator():
     class BlackCat(BaseModel):
         pet_type: Literal['blackcat']

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Generic, TypeVar, Union
+from typing import Generic, Optional, TypeVar, Union
 
 import pytest
 from typing_extensions import Annotated, Literal
@@ -265,6 +265,20 @@ def test_discriminated_union_basemodel_instance_value():
 
     t = Top(sub=A(l='a'))
     assert isinstance(t, Top)
+
+
+def test_discriminated_union_with_default():
+    class A(BaseModel):
+        l: Optional[Literal['a']] = 'a'
+
+    class B(BaseModel):
+        l: Literal['b']
+
+    class Top(BaseModel):
+        sub: Union[A, B] = Field(..., discriminator='l')
+
+    t = Top(sub={})
+    assert isinstance(t, Top) and isinstance(t.sub, A)
 
 
 def test_discriminated_union_basemodel_instance_value_with_alias():


### PR DESCRIPTION
Hi! I've implemented a feature for discriminated unions that allows users to defined the default enum variant if there is no  discriminator in the input:

```python
from typing import Literal, Union, Optional

from pydantic import BaseModel, Field, ValidationError


class RequestV1(BaseModel):
    version: Optional[Literal[1]] = 1
    items: list[str]


class RequestV2(BaseModel):
    version: Literal[2]
    items: list[dict[str, str]]


class Body(BaseModel):
    request: Union[RequestV1, RequestV2] = Field(..., discriminator='version')


print(Body(request={'items': ['apple', 'orange']}))
#> request=RequestV1(version=1, items=['apple', 'orange'])
print(Body(request={'version': 2, 'items': [{'name': 'apple'}]}))
#> request=RequestV2(version=2, items=[{'name': 'apple'}])
try:
    Body(request={'items': [{'name': 'apple'}]})
except ValidationError as e:
    print(e)
    """
    1 validation error for Body
    request -> RequestV1 -> items -> 0
      str type expected (type=type_error.str)
    """
    ```