### PR TITLE
Update email-validator optional dependency to >= 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     'pydantic-core>=0.7.1',
     'annotated-types>=0.4.0',
 ]
-optional-dependencies = { email = ['email-validator>=1.2.0'] }
+optional-dependencies = { email = ['email-validator>=1.3.0'] }
 dynamic = ['version', 'readme']
 
 entry-points.hypothesis = {_ = 'pydantic._hypothesis_plugin'}


### PR DESCRIPTION
After updating `email-validator` to >- 1.2.0 in https://github.com/pydantic/pydantic/commit/3c1c3505d68e6d234e26d7ebea2308e262184988
Now we have another error in [Dependencies Check Action](https://github.com/pydantic/pydantic/actions/runs/3889484239/jobs/6637779176)