### PR TITLE
uprev mkdocs-material, fix maxcdn errors

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,13 +3,12 @@ ansi2html==1.8.0
 flake8==5.0.4
 flake8-quotes==3.3.1
 hypothesis==6.54.4
-markdown-include==0.7.0
+markdown-include==0.8.0
 mdx-truly-sane-lists==1.3
-mkdocs==1.3.1
+mkdocs==1.4.2
 mkdocs-exclude==1.0.2
-mkdocs-material==8.4.2
+mkdocs-material==9.0.5
 pyupgrade==2.37.3
 sqlalchemy
 orjson
 ujson
-


### PR DESCRIPTION
See https://github.com/squidfunk/mkdocs-material/issues/4843 which is fixed in latest release.

skip change file check