### PR TITLE
Handle X | Y union in GenericModel

### DIFF
--- a/changes/4146-thenx.md
+++ b/changes/4146-thenx.md
@@ -1,0 +1,1 @@
+Fix X | Y union syntax breaks GenericModel (#4146)

--- a/changes/4146-thenx.md
+++ b/changes/4146-thenx.md
@@ -1,1 +1,1 @@
-Fix X | Y union syntax breaks GenericModel (#4146)
+Fix `X | Y` union syntax breaking `GenericModel`

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -1,5 +1,3 @@
-import functools
-import operator
 import sys
 import types
 import typing
@@ -28,6 +26,9 @@ from .main import BaseModel, create_model
 from .types import JsonWrapper
 from .typing import display_as_type, get_all_type_hints, get_args, get_origin, typing_base
 from .utils import LimitedDict, all_identical, lenient_issubclass
+
+if sys.version_info >= (3, 10):
+    from typing import _UnionGenericAlias
 
 GenericModelT = TypeVar('GenericModelT', bound='GenericModel')
 TypeVarType = Any  # since mypy doesn't allow the use of TypeVar as a type
@@ -274,7 +275,7 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
         # PEP-604 syntax (Ex.: list | str) is represented with a types.UnionType object that does not have __getitem__.
         # We also cannot use isinstance() since we have to compare types.
         if sys.version_info >= (3, 10) and origin_type is types.UnionType:  # noqa: E721
-            return functools.reduce(operator.or_, resolved_type_args)
+            return _UnionGenericAlias(origin_type, resolved_type_args)
         return origin_type[resolved_type_args]
 
     # We handle pydantic generic models separately as they don't have the same

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -1,4 +1,7 @@
+import functools
+import operator
 import sys
+import types
 import typing
 from typing import (
     TYPE_CHECKING,
@@ -268,6 +271,10 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
             # See: https://www.python.org/dev/peps/pep-0585
             origin_type = getattr(typing, type_._name)
         assert origin_type is not None
+        # PEP-604 syntax (Ex.: list | str) is represented with a types.UnionType object that does not have __getitem__.
+        # We also cannot use isinstance() since we have to compare types.
+        if sys.version_info >= (3, 10) and origin_type is types.UnionType:  # noqa: E721
+            return functools.reduce(operator.or_, resolved_type_args)
         return origin_type[resolved_type_args]
 
     # We handle pydantic generic models separately as they don't have the same

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -862,6 +862,7 @@ def test_replace_types_with_pep_604_syntax() -> None:
         a: T
 
     assert replace_types(T | None, {T: int}) == int | None
+    assert replace_types(T | int | str, {T: float}) == float | int | str
     assert replace_types(list[T] | None, {T: int}) == list[int] | None
     assert replace_types(List[str | list | T], {T: int}) == List[str | list | int]
     assert replace_types(list[str | list | T], {T: int}) == list[str | list | int]

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -735,6 +735,27 @@ def test_generic_model_caching_detect_order_of_union_args_basic(create_module):
         assert type(float_or_int_model(data='1').data) is float
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='pep-604 syntax (Ex.: list | int) was added in python3.10')
+def test_generic_model_caching_detect_order_of_union_args_basic_with_pep_604_syntax(create_module):
+    # Basic variant of https://github.com/pydantic/pydantic/issues/4474 with pep-604 syntax.
+    @create_module
+    def module():
+        from typing import Generic, TypeVar
+
+        from pydantic.generics import GenericModel
+
+        t = TypeVar('t')
+
+        class Model(GenericModel, Generic[t]):
+            data: t
+
+        int_or_float_model = Model[int | float]
+        float_or_int_model = Model[float | int]
+
+        assert type(int_or_float_model(data='1').data) is int
+        assert type(float_or_int_model(data='1').data) is float
+
+
 @pytest.mark.skip(
     reason="""
 Depends on similar issue in CPython itself: https://github.com/python/cpython/issues/86483

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -853,6 +853,17 @@ def test_replace_types():
         # example)
         assert replace_types(list[Union[str, list, T]], {T: int}) == list[Union[str, list, int]]
 
+    if sys.version_info >= (3, 10):
+        assert replace_types(list[T] | None, {T: int}) == list[int] | None
+        assert replace_types(List[str | list | T], {T: int}) == List[str | list | int]
+        assert replace_types(list[str | list | T], {T: int}) == list[str | list | int]
+        assert replace_types(list[str | list | list[T]], {T: int}) == list[str | list | list[int]]
+        assert replace_types(list[Model[T] | None] | None, {T: T}) == list[Model[T] | None] | None
+        assert (
+            replace_types(T | list[T | list[T | list[T | None] | None] | None] | None, {T: int})
+            == int | list[int | list[int | list[int | None] | None] | None] | None
+        )
+
 
 def test_replace_types_with_user_defined_generic_type_field():
     """Test that using user defined generic types as generic model fields are handled correctly."""


### PR DESCRIPTION
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

The root cause of the issue is that  X | Y has type types.UnionType which does not have \_\_getitem\_\_. This makes `pydantic.generics.replace_types` to fail with `TypeError: 'type' object is not subscriptable`.

In this PR we handle types.UnionType separately.

## Related issue number
fix #4146 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Peculiarities
- Had to mute `Do not compare types, use 'isinstance()' (E721)`
- For some reason there was no TypeError when running for the second time the code from the issue. Didn't investigate.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**