### PR TITLE
BaseSettings: Support `Field(env=...)` in nested sub models

### DIFF
--- a/changes/4991-RafaelWO.md
+++ b/changes/4991-RafaelWO.md
@@ -1,0 +1,1 @@
+BaseSettings: Support the definition of environment variable via `Field(env=...)` in nested sub models 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -91,6 +91,15 @@ class BaseSettings(BaseModel):
 
         @classmethod
         def prepare_field(cls, field: ModelField) -> None:
+            # Set 'env_names' for nested sub models of type 'BaseModel'
+            if (
+                isinstance(field.type_, type)
+                and issubclass(field.type_, BaseModel)
+                and not issubclass(field.type_, BaseSettings)
+            ):
+                for name, subfield in field.type_.__fields__.items():
+                    cls.prepare_field(subfield)
+
             env_names: Union[List[str], AbstractSet[str]]
             field_info_from_config = cls.get_field_info(field.name)
 

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -91,12 +91,8 @@ class BaseSettings(BaseModel):
 
         @classmethod
         def prepare_field(cls, field: ModelField) -> None:
-            # Set 'env_names' for nested sub models of type 'BaseModel'
-            if (
-                isinstance(field.type_, type)
-                and issubclass(field.type_, BaseModel)
-                and not issubclass(field.type_, BaseSettings)
-            ):
+            # Set 'env_names' for nested sub models of type 'BaseModel' (except 'BaseSettings')
+            if type(field.type_) == type(BaseModel) and not issubclass(field.type_, BaseSettings):
                 for name, subfield in field.type_.__fields__.items():
                     cls.prepare_field(subfield)
 
@@ -226,7 +222,7 @@ class EnvSettingsSource:
             if env_val is not None:
                 return env_val, env_name
 
-        if issubclass(field.type_, BaseModel):
+        if type(field.type_) == type(BaseModel):
             # If the field type is a BaseModel, recurse into the fields of the BaseModel
             d = {}
             for name, subfield in field.type_.__fields__.items():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -278,6 +278,37 @@ def test_env_list_field(env):
     assert s.foobar == 'env value'
 
 
+def test_env_list_field_nested(env):
+    class SubSub(BaseSettings):
+        baz: str = Field(..., env='baz')
+
+    class Sub(BaseSettings):
+        bar: str = Field(..., env='bar')
+        sub_sub: SubSub
+
+    class Settings(BaseSettings):
+        foo: str = Field(..., env='foo')
+        sub: Sub
+
+    env.set('FOO', 'foo!')
+    env.set('BAR', 'bar!')
+    env.set('BAZ', 'baz!')
+    s = Settings()
+    assert s.foo == 'foo!'
+    assert s.sub.bar == 'bar!'
+    assert s.sub.sub_sub.baz == 'baz!'
+
+    env.clear()
+    env.set('FOO', 'foo!')
+    env.set('SUB', '{"bar": "secret_bar", "sub_sub": {"baz": "secret_baz"}}')  # takes precedence
+    env.set('BAR', 'bar!')
+    env.set('BAZ', 'baz!')
+    s = Settings()
+    assert s.foo == 'foo!'
+    assert s.sub.bar == 'secret_bar'
+    assert s.sub.sub_sub.baz == 'secret_baz'
+
+
 def test_env_list_last(env):
     class Settings(BaseSettings):
         foobar: str

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -279,10 +279,10 @@ def test_env_list_field(env):
 
 
 def test_env_list_field_nested(env):
-    class SubSub(BaseSettings):
+    class SubSub(BaseModel):
         baz: str = Field(..., env='baz')
 
-    class Sub(BaseSettings):
+    class Sub(BaseModel):
         bar: str = Field(..., env='bar')
         sub_sub: SubSub
 


### PR DESCRIPTION
Fixes #4982 

This MR fixes the issue of environment variable names defined in nested sub-models of a `BaseSettings` class via `Field(env=...)` not being recognised.

I implemented some recursion mechanism to get those environment variables specified in nested models. This may not be the best way but it works. Of course, I'm happy for any feedback and suggestions to make this fix cleaner.

#### Additional Details / Questions
I noticed that if the nested models are subclasses of `BaseSettings` (instead of `BaseModel`), the recursive call of `BaseSettings.Config.prepare_field()` would not be needed. I also saw people using nested `BaseSettings`, however, the docs only show this with `BaseModel`. Are both ways supposed to work? Or should we use `BaseSettings` only for the "root" class? 