### PR TITLE
Invalidate mypy cache if config changes

### DIFF
--- a/changes/5007-cdce8p.md
+++ b/changes/5007-cdce8p.md
@@ -1,0 +1,1 @@
+Invalidate mypy cache if plugin config changes

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -42,6 +42,7 @@ from mypy.plugin import (
     FunctionContext,
     MethodContext,
     Plugin,
+    ReportConfigContext,
     SemanticAnalyzerPluginInterface,
 )
 from mypy.plugins import dataclasses
@@ -98,6 +99,7 @@ def plugin(version: str) -> 'TypingType[Plugin]':
 class PydanticPlugin(Plugin):
     def __init__(self, options: Options) -> None:
         self.plugin_config = PydanticPluginConfig(options)
+        self._plugin_data = self.plugin_config.to_data()
         super().__init__(options)
 
     def get_base_class_hook(self, fullname: str) -> 'Optional[Callable[[ClassDefContext], None]]':
@@ -123,6 +125,9 @@ class PydanticPlugin(Plugin):
         if fullname == DATACLASS_FULLNAME:
             return dataclasses.dataclass_class_maker_callback  # type: ignore[return-value]
         return None
+
+    def report_config_data(self, ctx: ReportConfigContext) -> Dict[str, Any]:
+        return self._plugin_data
 
     def _pydantic_model_class_maker_callback(self, ctx: ClassDefContext) -> None:
         transformer = PydanticModelTransformer(ctx, self.plugin_config)
@@ -203,6 +208,9 @@ class PydanticPluginConfig:
             for key in self.__slots__:
                 setting = plugin_config.getboolean(CONFIGFILE_KEY, key, fallback=False)
                 setattr(self, key, setting)
+
+    def to_data(self) -> Dict[str, Any]:
+        return {key: getattr(self, key) for key in self.__slots__}
 
 
 def from_orm_callback(ctx: MethodContext) -> Type:

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -127,6 +127,10 @@ class PydanticPlugin(Plugin):
         return None
 
     def report_config_data(self, ctx: ReportConfigContext) -> Dict[str, Any]:
+        """Return all plugin config data.
+
+        Used by mypy to determine if cache needs to be discarded.
+        """
         return self._plugin_data
 
     def _pydantic_model_class_maker_callback(self, ctx: ClassDefContext) -> None:


### PR DESCRIPTION
Implement `Plugin.report_config_data` to return all plugin config data. For every run, mypy will compare if the data matches the cached one if not the cache is discarded.

`report_config_data` is called multiple times for every file. I would have liked to use `cached_property` but that requires `3.8`, unfortunately.

https://github.com/python/mypy/blob/v0.991/mypy/plugin.py#L539

_This is my first PR here, so I wasn't quite sure which branch to target as this is an issue in both `1.10.x` and `main`. Please let me know if I should change anything and I'll do so._