### PR TITLE
follow pep593 by preserving unknown metadata in annotation

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -589,10 +589,10 @@ def apply_metadata(  # noqa: C901
             # e.g. `Annotated[int, Strict]` as well as `Annotated[int, Strict()]`
             metadata_dict = {k: v for k, v in vars(metadata).items() if not k.startswith('_')}
         else:
-            raise PydanticSchemaGenerationError(
-                'Metadata must be instances of annotated_types.BaseMetadata or PydanticMetadata '
-                'or a subclass of PydanticMetadata'
-            )
+            # PEP 593: "If a library (or tool) encounters a typehint Annotated[T, x] and has no
+            # special logic for metadata x, it should ignore it and simply treat the type as T."
+            # Allow, but ignore, any unknown metadata.
+            continue
 
         # TODO we need a way to remove metadata which this line currently prevents
         metadata_dict = {k: v for k, v in metadata_dict.items() if v is not None}

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -6,7 +6,6 @@ from annotated_types import Gt, Lt
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field
-from pydantic.errors import PydanticSchemaGenerationError
 from pydantic.fields import Undefined
 
 NO_VALUE = object()
@@ -96,11 +95,6 @@ def test_annotated(hint_fn, value, expected_repr):
             5,
             pytest.raises(TypeError, match='Default may not be specified twice on the same field'),
         ),
-        (
-            lambda: Annotated[int, 0],
-            5,
-            pytest.raises(PydanticSchemaGenerationError, match=r'Metadata must be instances of annotated_types\.'),
-        ),
     ],
 )
 def test_annotated_model_exceptions(hint_fn, value, exc_handler):
@@ -109,6 +103,17 @@ def test_annotated_model_exceptions(hint_fn, value, exc_handler):
 
         class M(BaseModel):
             x: hint = value
+
+
+@pytest.mark.parametrize('metadata', [0, 'foo'])
+def test_annotated_allows_unknown(metadata):
+    class M(BaseModel):
+        x: Annotated[int, metadata] = 5
+
+    field_info = M.model_fields['x']
+    assert len(field_info.metadata) == 1
+    assert metadata in field_info.metadata, 'Records the unknown metadata'
+    assert metadata in M.__annotations__['x'].__metadata__, 'Annotated type is recorded'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a PR for pydantic v2. 

It fixes [issue 5008](https://github.com/pydantic/pydantic/issues/5008) by allowing, and ignoring, Annotated metadata that is of type(s) that pydantic does nothing with.
