### PR TITLE
connlist: add new option drop_duplicates

### DIFF
--- a/changes/5033-schlitzered.md
+++ b/changes/5033-schlitzered.md
@@ -1,0 +1,3 @@
+Add a new parameter 'drop_duplicates' to connlist.
+
+This parameter will drop duplicates from an input list

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -101,7 +101,6 @@ def flatten_errors(
 ) -> Generator['ErrorDict', None, None]:
     for error in errors:
         if isinstance(error, ErrorWrapper):
-
             if loc:
                 error_loc = loc + error.loc_tuple()
             else:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -120,6 +120,7 @@ class FieldInfo(Representation):
         'min_items',
         'max_items',
         'unique_items',
+        'drop_duplicates',
         'min_length',
         'max_length',
         'allow_mutation',
@@ -145,6 +146,7 @@ class FieldInfo(Representation):
         'min_items': None,
         'max_items': None,
         'unique_items': None,
+        'drop_duplicates': None,
         'allow_mutation': True,
     }
 
@@ -169,6 +171,7 @@ class FieldInfo(Representation):
         self.min_items = kwargs.pop('min_items', None)
         self.max_items = kwargs.pop('max_items', None)
         self.unique_items = kwargs.pop('unique_items', None)
+        self.drop_duplicates = kwargs.pop('drop_duplicates', None)
         self.min_length = kwargs.pop('min_length', None)
         self.max_length = kwargs.pop('max_length', None)
         self.allow_mutation = kwargs.pop('allow_mutation', True)
@@ -178,7 +181,6 @@ class FieldInfo(Representation):
         self.extra = kwargs
 
     def __repr_args__(self) -> 'ReprArgs':
-
         field_defaults_to_hide: Dict[str, Any] = {
             'repr': True,
             **self.__field_constraints__,
@@ -240,6 +242,7 @@ def Field(
     min_items: int = None,
     max_items: int = None,
     unique_items: bool = None,
+    drop_duplicates: bool = None,
     min_length: int = None,
     max_length: int = None,
     allow_mutation: bool = True,
@@ -286,6 +289,8 @@ def Field(
       elements. The schema will have a ``maxItems`` validation keyword
     :param unique_items: only applies to lists, requires the field not to have duplicated
       elements. The schema will have a ``uniqueItems`` validation keyword
+    :param drop_duplicates: only applies to lists, will drop duplicated from list
+      elements. The schema will have a ``dropDuplicates`` validation keyword
     :param min_length: only applies to strings, requires the field to have a minimum length. The
       schema will have a ``minLength`` validation keyword
     :param max_length: only applies to strings, requires the field to have a maximum length. The
@@ -319,6 +324,7 @@ def Field(
         min_items=min_items,
         max_items=max_items,
         unique_items=unique_items,
+        drop_duplicates=drop_duplicates,
         min_length=min_length,
         max_length=max_length,
         allow_mutation=allow_mutation,
@@ -405,7 +411,6 @@ class ModelField(Representation):
         alias: str = None,
         field_info: Optional[FieldInfo] = None,
     ) -> None:
-
         self.name: str = name
         self.has_alias: bool = alias is not None
         self.alias: str = alias if alias is not None else name
@@ -852,7 +857,6 @@ class ModelField(Representation):
     def validate(
         self, v: Any, values: Dict[str, Any], *, loc: 'LocStr', cls: Optional['ModelOrDc'] = None
     ) -> 'ValidateReturn':
-
         assert self.type_.__class__ is not DeferredType
 
         if self.type_.__class__ is ForwardRef:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -738,7 +738,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_defaults: bool,
         exclude_none: bool,
     ) -> Any:
-
         if isinstance(v, BaseModel):
             if to_dict:
                 v_dict = v.dict(
@@ -831,7 +830,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> 'TupleGenerator':
-
         # Merge field set excludes with explicit exclude parameter with explicit overriding field set options.
         # The extra "is not None" guards are not logically necessary but optimizes performance for the simple case.
         if exclude is not None or self.__exclude_fields__ is not None:

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -197,7 +197,6 @@ def model_schema(
 
 
 def get_field_info_schema(field: ModelField, schema_overrides: bool = False) -> Tuple[Dict[str, Any], bool]:
-
     # If no title is explicitly set, we don't set title in the schema for enums.
     # The behaviour is the same as `BaseModel` reference, where the default title
     # is in the definitions part of the schema.
@@ -1058,13 +1057,15 @@ def get_annotation_with_constraints(annotation: Any, field_info: FieldInfo) -> T
                 field_info.min_items is not None
                 or field_info.max_items is not None
                 or field_info.unique_items is not None
+                or field_info.drop_duplicates is not None
             ):
-                used_constraints.update({'min_items', 'max_items', 'unique_items'})
+                used_constraints.update({'min_items', 'max_items', 'unique_items', 'drop_duplicates'})
                 return conlist(
                     go(args[0]),
                     min_items=field_info.min_items,
                     max_items=field_info.max_items,
                     unique_items=field_info.unique_items,
+                    drop_duplicates=field_info.drop_duplicates,
                 )
 
             if issubclass(origin, Set) and (field_info.min_items is not None or field_info.max_items is not None):

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -577,9 +577,9 @@ class ConstrainedList(list):  # type: ignore
 
     @classmethod
     def __get_validators__(cls) -> 'CallableGenerator':
-        yield cls.list_length_validator
         if cls.drop_duplicates:
             yield cls.drop_duplicates_validator
+        yield cls.list_length_validator
         if cls.unique_items:
             yield cls.unique_items_validator
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -680,7 +680,6 @@ def test_generic_model_from_function_pickle_fail(create_module):
 
 
 def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
-
     # match identity checker otherwise we never get to the redefinition check
     monkeypatch.setattr('pydantic.generics.all_identical', lambda left, right: False)
 
@@ -910,7 +909,6 @@ def test_replace_types_with_user_defined_generic_type_field():
         pass
 
     class Model(GenericModel, Generic[T, KT, VT]):
-
         map_field: GenericMapping[KT, VT]
         list_field: GenericList[T]
 
@@ -1258,7 +1256,6 @@ def test_generic_with_user_defined_generic_field():
         pass
 
     class Model(GenericModel, Generic[T]):
-
         field: GenericList[T]
 
     model = Model[int](field=[5])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2186,7 +2186,6 @@ def test_class_kwargs_config_json_encoders():
 
 
 def test_class_kwargs_config_and_attr_conflict():
-
     with pytest.raises(
         TypeError, match='Specifying config in two places is ambiguous, use either Config attribute or class kwargs'
     ):

--- a/tests/test_rich_repr.py
+++ b/tests/test_rich_repr.py
@@ -25,7 +25,6 @@ def test_rich_repr() -> None:
 
 
 def test_rich_repr_color() -> None:
-
     color = Color((10, 20, 30, 0.1))
     rich_repr = list(color.__rich_repr__())
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -234,6 +234,13 @@ def test_constrained_list_too_short():
     ]
 
 
+def test_constrained_list_drop_duplicates_hashable_items():
+    class ConListModelDropDuplicates(BaseModel):
+        v: conlist(int, drop_duplicates=True)
+
+    assert ConListModelDropDuplicates(v=[1, 1, 2, 2, 2, 3]).v == [1, 2, 3]
+
+
 def test_constrained_list_not_unique_hashable_items():
     class ConListModelUnique(BaseModel):
         v: conlist(int, unique_items=True)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -103,7 +103,6 @@ def test_convert_generics(type_, expectations):
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='NewType class was added in python 3.10.')
 def test_convert_generics_unsettable_args():
     class User(NewType):
-
         __origin__ = type(list[str])
         __args__ = (list['Hero'],)
 


### PR DESCRIPTION
This option allows to drop duplicates in the validation step, in order to remove dups from input data.

FYI.1: i am using pydantic + fastapi, and in some cases in need to make sure that lists in post bodies only contain uniq items, instead of throwing an error to the user, i prefer to cleanup the list internally.

FYI.2: i used make format, this is why some files are changed, where i actually did not touch anything :-/

