### PR TITLE
Using `contextlib`'s suppress method to silence error

### DIFF
--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -3,8 +3,10 @@ Bucket of reusable internal utilities.
 
 This should be reduced as much as possible with functions only used in one place, moved to that place.
 """
+
 from __future__ import annotations as _annotations
 
+import contextlib
 import keyword
 import typing
 import weakref
@@ -368,14 +370,10 @@ def smart_deepcopy(obj: Obj) -> Obj:
     obj_type = obj.__class__
     if obj_type in IMMUTABLE_NON_COLLECTIONS_TYPES:
         return obj  # fastest case: obj is immutable and not collection therefore will not be copied anyway
-    try:
+    with contextlib.suppress(TypeError, ValueError, RuntimeError):
         if not obj and obj_type in BUILTIN_COLLECTIONS:
             # faster way for empty collections, no need to copy its members
             return obj if obj_type is tuple else obj.copy()  # type: ignore  # tuple doesn't have copy method
-    except (TypeError, ValueError, RuntimeError):
-        # do we really dare to catch ALL errors? Seems a bit risky
-        pass
-
     return deepcopy(obj)  # slowest way when we actually might need a deepcopy
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations as _annotations
 
+import contextlib
 import dataclasses as _dataclasses
 import re
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
@@ -193,11 +194,8 @@ class IPvAnyAddress:
     __slots__ = ()
 
     def __new__(cls, value: Any) -> IPv4Address | IPv6Address:  # type: ignore[misc]
-        try:
+        with contextlib.suppress(ValueError):
             return IPv4Address(value)
-        except ValueError:
-            pass
-
         try:
             return IPv6Address(value)
         except ValueError:
@@ -220,11 +218,8 @@ class IPvAnyInterface:
     __slots__ = ()
 
     def __new__(cls, value: NetworkType) -> IPv4Interface | IPv6Interface:  # type: ignore[misc]
-        try:
+        with contextlib.suppress(ValueError):
             return IPv4Interface(value)
-        except ValueError:
-            pass
-
         try:
             return IPv6Interface(value)
         except ValueError:
@@ -249,11 +244,8 @@ class IPvAnyNetwork:
     def __new__(cls, value: NetworkType) -> IPv4Network | IPv6Network:  # type: ignore[misc]
         # Assume IP Network is defined with a default value for ``strict`` argument.
         # Define your own class if you want to specify network address check strictness.
-        try:
+        with contextlib.suppress(ValueError):
             return IPv4Network(value)
-        except ValueError:
-            pass
-
         try:
             return IPv6Network(value)
         except ValueError:

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 import abc
+import contextlib
 import dataclasses as _dataclasses
 import re
 from datetime import date
@@ -673,11 +674,8 @@ class ByteSize(int):
 
     @classmethod
     def validate(cls, __input_value: Any, **_kwargs: Any) -> 'ByteSize':
-        try:
+        with contextlib.suppress(ValueError):
             return cls(int(__input_value))
-        except ValueError:
-            pass
-
         str_match = byte_string_re.match(str(__input_value))
         if str_match is None:
             raise PydanticCustomError('byte_size', 'could not parse value and unit from byte string')


### PR DESCRIPTION
`context manager` slightly shortens the code and significantly clarifies the author's intention to ignore the specific errors.

[PEP 409 – Suppressing exception context](https://peps.python.org/pep-0409/)

cc @samuelcolvin 
