### PR TITLE
Add discriminated union support (v2)

### DIFF
--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -1,0 +1,316 @@
+from __future__ import annotations as _annotations
+
+from enum import Enum
+from typing import Sequence
+
+from pydantic_core import core_schema
+
+from ..errors import PydanticUserError
+
+
+def apply_discriminator(schema: core_schema.CoreSchema, discriminator: str) -> core_schema.CoreSchema:
+    return _ApplyInferredDiscriminator(discriminator).apply(schema)
+
+
+class _ApplyInferredDiscriminator:
+    """
+    This class is used to convert an input schema containing a union schema into one where that union is
+    replaced with a tagged-union, with all the associated debugging and performance benefits.
+
+    This is done by:
+    * Validating that the input schema is compatible with the provided discriminator
+    * Introspecting the schema to determine which discriminator values should map to which union choices
+    * Handling various edge cases such as 'definitions', 'default', 'nullable' schemas, and more
+
+    I have chosen to implement the conversion algorithm in this class, rather than a function,
+    to make it easier to maintain state while recursively walking the provided CoreSchema.
+    """
+
+    def __init__(self, discriminator: str):
+        # `discriminator` should be the name of the field which will serve as the discriminator.
+        # It must be the python name of the field, and *not* the field's alias. Note that as of now,
+        # all members of a discriminated union _must_ use a field with the same name as the discriminator.
+        # This may change if/when we expose a way to manually specify the TaggedUnionSchema's choices.
+        self.discriminator = discriminator
+
+        # `_discriminator_alias` will hold the value, if present, of the alias for the discriminator
+        #
+        # Note: following the v1 implementation, we currently disallow the use of different aliases
+        # for different choices. This is not a limitation of pydantic_core, but if we try to handle
+        # this, the inference logic gets complicated very quickly, and could result in confusing
+        # debugging challenges for users making subtle mistakes.
+        #
+        # Rather than trying to do the most powerful inference possible, I think we should eventually
+        # expose a way to more-manually control the way the TaggedUnionSchema is constructed through
+        # the use of a new type which would be placed as an Annotation on the Union type. This would
+        # provide the full flexibility/power of pydantic_core's TaggedUnionSchema where necessary for
+        # more complex cases, without over-complicating the inference logic for the common cases.
+        self._discriminator_alias: str | None = None
+
+        # `_should_be_nullable` indicates whether the converted union has `None` as an allowed value.
+        # If `None` is an acceptable value of the (possibly-wrapped) union, we ignore it while
+        # constructing the TaggedUnionSchema, but set the `_should_be_nullable` attribute to True.
+        # Once we have constructed the TaggedUnionSchema, if `_should_be_nullable` is True, we ensure
+        # that the final schema gets wrapped as a NullableSchema. This has the same semantics on the
+        # python side, but resolves the issue that `None` cannot correspond to any discriminator values.
+        self._should_be_nullable = False
+
+        # `_is_nullable` is used to track if the final produced schema will definitely be nullable;
+        # we set it to True if the input schema is wrapped in a nullable schema that we know will be preserved
+        # as an indication that, even if None is discovered as one of the union choices, we will not need to wrap
+        # the final value in another nullable schema.
+        #
+        # This is more complicated than just checking for the final outermost schema having type 'nullable' thanks
+        # to the possible presence of other wrapper schemas such as DefinitionsSchema, WithDefaultSchema, etc.
+        self._is_nullable = False
+
+        # `_choices_to_handle` serves as a stack of choices to add to the tagged union. Initially, choices
+        # from the union in the wrapped schema will be appended to this list, and the recursive choice-handling
+        # algorithm may add more choices to this stack as (nested) unions are encountered.
+        self._choices_to_handle: list[core_schema.CoreSchema] = []
+
+        # `_tagged_union_choices` is built during the call to `apply`, and will hold the choices to be included
+        # in the output TaggedUnionSchema that will replace the union from the input schema
+        self._tagged_union_choices: dict[str | int, str | int | core_schema.CoreSchema] = {}
+
+        # `_used` is changed to True after applying the discriminator to prevent accidental re-use
+        self._used = False
+
+    def apply(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
+        """
+        Return a new CoreSchema based on `schema` that uses a tagged-union with the discriminator provided
+        to this class.
+        """
+        assert not self._used
+        schema = self._apply_to_root(schema)
+        if self._should_be_nullable and not self._is_nullable:
+            schema = core_schema.nullable_schema(schema)
+        self._used = True
+        return schema
+
+    def _apply_to_root(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
+        """
+        This method handles the outer-most stage of recursion over the input schema:
+        unwrapping nullable or definitions schemas, and calling the `_handle_choice`
+        method iteratively on the choices extracted (recursively) from the possibly-wrapped union.
+        """
+        if schema['type'] == 'nullable':
+            self._is_nullable = True
+            wrapped = self._apply_to_root(schema['schema'])
+            nullable_wrapper = schema.copy()
+            nullable_wrapper['schema'] = wrapped
+            return nullable_wrapper
+
+        if schema['type'] == 'definitions':
+            wrapped = self._apply_to_root(schema['schema'])
+            definitions_wrapper = schema.copy()
+            definitions_wrapper['schema'] = wrapped
+            return definitions_wrapper
+
+        if schema['type'] != 'union':
+            raise TypeError('`discriminator` can only be used with `Union` type with more than one variant')
+
+        if len(schema['choices']) < 2:
+            raise TypeError('`discriminator` can only be used with `Union` type with more than one variant')
+
+        # Reverse the choices list before extending the stack so that they get handled in the order they occur
+        self._choices_to_handle.extend(schema['choices'][::-1])
+        while self._choices_to_handle:
+            choice = self._choices_to_handle.pop()
+            self._handle_choice(choice)
+
+        if self._discriminator_alias is not None and self._discriminator_alias != self.discriminator:
+            # * We need to annotate `discriminator` as a union here to handle both branches of this conditional
+            # * We need to annotate `discriminator` as list[list[str | int]] and not list[list[str]] due to the
+            #   invariance of list, and because list[list[str | int]] is the type of the discriminator argument
+            #   to tagged_union_schema below
+            # * See the docstring of pydantic_core.core_schema.tagged_union_schema for more details about how to
+            #   interpret the value of the discriminator argument to tagged_union_schema. (The list[list[str]] here
+            #   is the appropriate way to provide a list of fallback attributes to check for a discriminator value.)
+            discriminator: str | list[list[str | int]] = [[self.discriminator], [self._discriminator_alias]]
+        else:
+            discriminator = self.discriminator
+        return core_schema.tagged_union_schema(
+            choices=self._tagged_union_choices,
+            discriminator=discriminator,
+            custom_error_type=schema.get('custom_error_type'),
+            custom_error_message=schema.get('custom_error_message'),
+            custom_error_context=schema.get('custom_error_context'),
+            strict=False,
+            ref=schema.get('ref'),
+            metadata=schema.get('metadata'),
+            serialization=schema.get('serialization'),
+        )
+
+    def _handle_choice(self, choice: core_schema.CoreSchema) -> None:
+        """
+        This method handles the "middle" stage of recursion over the input schema.
+        Specifically, it is responsible for handling each choice of the outermost union
+        (and any "coalesced" choices obtained from inner unions).
+
+        Here, "handling" entails:
+        * Coalescing nested unions and compatible tagged-unions
+        * Tracking the presence of 'none' and 'nullable' schemas occurring as choices
+        * Validating that each allowed discriminator value maps to a unique choice
+        * Updating the _tagged_union_choices mapping that will ultimately be used to build the TaggedUnionSchema.
+        """
+        if choice['type'] == 'none':
+            self._should_be_nullable = True
+        elif choice['type'] == 'nullable':
+            self._should_be_nullable = True
+            self._handle_choice(choice['schema'])  # unwrap the nullable schema
+        elif choice['type'] == 'union':
+            # Reverse the choices list before extending the stack so that they get handled in the order they occur
+            self._choices_to_handle.extend(choice['choices'][::-1])
+        elif choice['type'] not in {'model', 'typed-dict', 'tagged-union'}:
+            # Remaining cases I think we should eventually handle: 'definitions', 'definition-ref', 'lax-or-strict'
+            raise TypeError(
+                f'{choice["type"]!r} is not a valid discriminated union variant;'
+                ' should be a `BaseModel` or `dataclass`'
+            )
+        else:
+            if choice['type'] == 'tagged-union' and self._is_discriminator_shared(choice):
+                # In this case, this inner tagged-union is compatible with the outer tagged-union,
+                # and its choices can be coalesced into the outer TaggedUnionSchema.
+                subchoices = [x for x in choice['choices'].values() if not isinstance(x, (str, int))]
+                # Reverse the choices list before extending the stack so that they get handled in the order they occur
+                self._choices_to_handle.extend(subchoices[::-1])
+                return
+
+            inferred_discriminator_values = self._infer_discriminator_values_for_choice(choice)
+            self._set_unique_choice_for_values(choice, inferred_discriminator_values)
+
+    def _is_discriminator_shared(self, choice: core_schema.TaggedUnionSchema) -> bool:
+        """
+        This method returns a boolean indicating whether the discriminator for the `choice`
+        is the same as that being used for the outermost tagged union. This is used to
+        determine whether this TaggedUnionSchema choice should be "coalesced" into the top level,
+        or whether it should be treated as a separate (nested) choice.
+        """
+        inner_discriminator = choice['discriminator']
+        return inner_discriminator == self.discriminator or (
+            isinstance(inner_discriminator, list)
+            and (self.discriminator in inner_discriminator or [self.discriminator] in inner_discriminator)
+        )
+
+    def _infer_discriminator_values_for_choice(
+        self, choice: core_schema.CoreSchema, source_name: str | None = None
+    ) -> list[str | int]:
+        """
+        This function recurses over `choice`, extracting all discriminator values that should map to this choice.
+
+        `model_name` is accepted for the purpose of producing useful error messages.
+        """
+        if choice['type'] == 'definitions':
+            return self._infer_discriminator_values_for_choice(choice['schema'])
+
+        elif choice['type'] == 'tagged-union':
+            values: list[str | int] = []
+            subchoices = [x for x in choice['choices'].values() if not isinstance(x, (str, int))]
+            for subchoice in subchoices:
+                # Ignore str/int "choices" since these are just references to other choices
+                if not isinstance(subchoice, (str, int)):
+                    subchoice_values = self._infer_discriminator_values_for_choice(subchoice)
+                    values.extend(subchoice_values)
+            return values
+
+        elif choice['type'] == 'union':
+            values = []
+            for subchoice in choice['choices']:
+                subchoice_values = self._infer_discriminator_values_for_choice(subchoice)
+                values.extend(subchoice_values)
+            return values
+
+        elif choice['type'] == 'nullable':
+            self._should_be_nullable = True
+            return self._infer_discriminator_values_for_choice(choice['schema'])
+
+        elif choice['type'] == 'model':
+            return self._infer_discriminator_values_for_choice(choice['schema'], source_name=choice['cls'].__name__)
+
+        elif choice['type'] == 'typed-dict':
+            return self._infer_discriminator_values_for_typed_dict_choice(choice, source_name)
+
+        else:
+            raise PydanticUserError(f'Field {self.discriminator!r} of needs to be a `Literal`')
+
+    def _infer_discriminator_values_for_typed_dict_choice(
+        self, choice: core_schema.TypedDictSchema, source_name: str | None = None
+    ) -> list[str | int]:
+        """
+        This method just extracts the _infer_discriminator_values_for_choice logic specific to TypedDictSchema
+        for the sake of readability.
+        """
+        field = choice['fields'].get(self.discriminator)
+        if field is None:
+            if source_name is None:
+                source_name = 'TypedDict'  # We may eventually want to provide a more useful name
+            raise PydanticUserError(f'Model {source_name!r} needs a discriminator field for key {self.discriminator!r}')
+        alias = field.get('validation_alias', self.discriminator)
+        if not isinstance(alias, str):
+            raise TypeError(f'Alias {alias!r} is not supported in a discriminated union')
+        if self._discriminator_alias is None:
+            self._discriminator_alias = alias
+        elif self._discriminator_alias != alias:
+            raise PydanticUserError(
+                f'Aliases for discriminator {self.discriminator!r} must be the same '
+                f'(got {alias}, {self._discriminator_alias})'
+            )
+        return self._infer_discriminator_values_for_field(field['schema'], f'model {source_name!r}')
+
+    def _infer_discriminator_values_for_field(self, schema: core_schema.CoreSchema, source: str) -> list[str | int]:
+        """
+        When inferring discriminator values for a field, we typically extract the expected values from a literal schema.
+        This function does that, but also handles nested unions and defaults.
+        """
+        if schema['type'] == 'literal':
+            values = []
+            for v in schema['expected']:
+                if isinstance(v, Enum):
+                    v = v.value
+                if not isinstance(v, (str, int)):
+                    raise TypeError(f'Unsupported value for discriminator field: {v!r}')
+                values.append(v)
+            return values
+
+        elif schema['type'] == 'union':
+            # Generally when multiple values are allowed they should be placed in a single `Literal`, but
+            # we add this case to handle the situation where a field is annotated as a `Union` of `Literal`s.
+            # For example, this lets us handle `Union[Literal['key'], Union[Literal['Key'], Literal['KEY']]]`
+            values = []
+            for choice in schema['choices']:
+                choice_values = self._infer_discriminator_values_for_field(choice, source)
+                values.extend(choice_values)
+            return values
+
+        elif schema['type'] == 'default':
+            # This will happen if the field has a default value; we ignore it while extracting the discriminator values
+            return self._infer_discriminator_values_for_field(schema['schema'], source)
+
+        else:
+            raise PydanticUserError(f'Field {self.discriminator!r} of {source} needs to be a `Literal`')
+
+    def _set_unique_choice_for_values(self, choice: core_schema.CoreSchema, values: Sequence[str | int | Enum]) -> None:
+        primary_value: str | int | None = None
+        for discriminator_value in values:
+            while isinstance(discriminator_value, Enum):
+                discriminator_value = discriminator_value.value
+            if not isinstance(discriminator_value, (str, int)):
+                raise ValueError(f'Invalid discriminator value {discriminator_value!r}; must be a string, int, or Enum')
+            if discriminator_value in self._tagged_union_choices:
+                # It is okay if `value` is already in tagged_union_choices as long as it maps to the same value.
+                # Because tagged_union_choices may map values to other values, we need to walk the choices dict
+                # until we get to a "real" choice, and confirm that is equal to the one assigned.
+                existing_choice = self._tagged_union_choices[discriminator_value]
+                while isinstance(existing_choice, (str, int)):
+                    existing_choice = self._tagged_union_choices[existing_choice]
+                if existing_choice != choice:
+                    raise ValueError(
+                        f'Value {discriminator_value!r} for discriminator '
+                        f'{self.discriminator!r} mapped to multiple choices'
+                    )
+            elif primary_value is None:
+                self._tagged_union_choices[discriminator_value] = choice
+                primary_value = discriminator_value
+            else:
+                self._tagged_union_choices[discriminator_value] = primary_value

--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -291,6 +291,10 @@ class _ApplyInferredDiscriminator:
             raise PydanticUserError(f'Field {self.discriminator!r} of {source} needs to be a `Literal`')
 
     def _set_unique_choice_for_values(self, choice: core_schema.CoreSchema, values: Sequence[str | int | Enum]) -> None:
+        """
+        This method updates `self.tagged_union_choices` so that all provided (discriminator) `values` map to the
+        provided `choice`, validating that none of these values already map to another (different) choice.
+        """
         primary_value: str | int | None = None
         for discriminator_value in values:
             while isinstance(discriminator_value, Enum):

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -181,6 +181,7 @@ def complete_model_class(
     serialization_functions.check_for_unused()
 
     core_config = generate_config(cls)
+    pre_validator_core_config = core_config.copy()
     cls.model_fields = fields
     cls.__pydantic_validator__ = SchemaValidator(inner_schema, core_config)
     model_post_init = '__pydantic_post_init__' if hasattr(cls, '__pydantic_post_init__') else None
@@ -188,10 +189,12 @@ def complete_model_class(
     cls.__pydantic_core_schema__ = outer_schema = core_schema.model_schema(
         cls,
         inner_schema,
-        config=core_config,
+        config=pre_validator_core_config,
         call_after_init=model_post_init,
         metadata=build_metadata_dict(js_metadata=js_metadata),
     )
+    # print(cls.__pydantic_core_schema__)
+    print(cls.__name__, cls.__pydantic_core_schema__['config']['title'])
     cls.__pydantic_serializer__ = SchemaSerializer(outer_schema, core_config)
     cls.__pydantic_model_complete__ = True
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -193,8 +193,6 @@ def complete_model_class(
         call_after_init=model_post_init,
         metadata=build_metadata_dict(js_metadata=js_metadata),
     )
-    # print(cls.__pydantic_core_schema__)
-    print(cls.__name__, cls.__pydantic_core_schema__['config']['title'])
     cls.__pydantic_serializer__ = SchemaSerializer(outer_schema, core_config)
     cls.__pydantic_model_complete__ = True
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -181,7 +181,6 @@ def complete_model_class(
     serialization_functions.check_for_unused()
 
     core_config = generate_config(cls)
-    pre_validator_core_config = core_config.copy()
     cls.model_fields = fields
     cls.__pydantic_validator__ = SchemaValidator(inner_schema, core_config)
     model_post_init = '__pydantic_post_init__' if hasattr(cls, '__pydantic_post_init__') else None
@@ -189,7 +188,7 @@ def complete_model_class(
     cls.__pydantic_core_schema__ = outer_schema = core_schema.model_schema(
         cls,
         inner_schema,
-        config=pre_validator_core_config,
+        config=core_config,
         call_after_init=model_post_init,
         metadata=build_metadata_dict(js_metadata=js_metadata),
     )

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -497,6 +497,15 @@ class GenerateJsonSchema:
                     generated[str(k)] = self.generate_inner(v).copy()
                 except PydanticInvalidForJsonSchema:
                     pass
+
+        # Populate the schema with any "indirect" references
+        for k, v in schema['choices'].items():
+            if isinstance(v, (str, int)):
+                while isinstance(schema['choices'][v], (str, int)):
+                    v = schema['choices'][v]
+                if str(v) in generated:  # PydanticInvalidForJsonSchema may have been raised above
+                    generated[str(k)] = generated[str(v)]
+
         json_schema: JsonSchemaValue = {'oneOf': list(generated.values())}
 
         # This reflects the v1 behavior, but we may want to only include the discriminator based on dialect / etc.

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -503,7 +503,9 @@ class GenerateJsonSchema:
             if isinstance(v, (str, int)):
                 while isinstance(schema['choices'][v], (str, int)):
                     v = schema['choices'][v]
-                if str(v) in generated:  # PydanticInvalidForJsonSchema may have been raised above
+                if str(v) in generated:
+                    # while it might seem unnecessary to check `if str(v) in generated`, a PydanticInvalidForJsonSchema
+                    # may have been raised above, which would mean that the schema we want to reference won't be present
                     generated[str(k)] = generated[str(v)]
 
         json_schema: JsonSchemaValue = {'oneOf': _deduplicate_schemas(generated.values())}

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
     from .main import BaseModel
 
 JsonSchemaValue = Dict[str, Any]
-Json = Union[Dict[str, Any], List[Any], str, int, float, bool, None]
-HashableJson = Union[Tuple[Tuple[str, Any], ...], Tuple[Any, ...], str, int, float, bool, None]
 
 
 # ##### JSON Schema Metadata Manipulation #####
@@ -1075,11 +1073,15 @@ def model_schema(
     return model.model_json_schema(by_alias=by_alias, ref_template=ref_template, schema_generator=schema_generator)
 
 
-def _deduplicate_schemas(schemas: Iterable[Json]) -> list[Json]:
+_Json = Union[Dict[str, Any], List[Any], str, int, float, bool, None]
+_HashableJson = Union[Tuple[Tuple[str, Any], ...], Tuple[Any, ...], str, int, float, bool, None]
+
+
+def _deduplicate_schemas(schemas: Iterable[_Json]) -> list[_Json]:
     return list({_make_json_hashable(schema): schema for schema in schemas}.values())
 
 
-def _make_json_hashable(value: Json) -> HashableJson:
+def _make_json_hashable(value: _Json) -> _HashableJson:
     if isinstance(value, dict):
         return tuple(sorted((k, _make_json_hashable(v)) for k, v in value.items()))
     elif isinstance(value, list):

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1,5 +1,6 @@
 import re
-from enum import Enum
+import sys
+from enum import Enum, IntEnum
 from typing import Generic, TypeVar, Union
 
 import pytest
@@ -9,7 +10,6 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic.errors import PydanticUserError
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_only_union():
     with pytest.raises(
         TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
@@ -19,7 +19,6 @@ def test_discriminated_union_only_union():
             x: str = Field(..., discriminator='qwe')
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_single_variant():
     with pytest.raises(
         TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
@@ -29,15 +28,15 @@ def test_discriminated_union_single_variant():
             x: Union[str] = Field(..., discriminator='qwe')
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_invalid_type():
-    with pytest.raises(TypeError, match="Type 'str' is not a valid `BaseModel` or `dataclass`"):
+    with pytest.raises(
+        TypeError, match="'str' is not a valid discriminated union variant; should be a `BaseModel` or `dataclass`"
+    ):
 
         class Model(BaseModel):
             x: Union[str, int] = Field(..., discriminator='qwe')
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_defined_discriminator():
     class Cat(BaseModel):
         c: str
@@ -53,7 +52,6 @@ def test_discriminated_union_defined_discriminator():
             number: int
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_literal_discriminator():
     class Cat(BaseModel):
         pet_type: int
@@ -70,7 +68,7 @@ def test_discriminated_union_literal_discriminator():
             number: int
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='working on V2 - __root__')
 def test_discriminated_union_root_same_discriminator():
     class BlackCat(BaseModel):
         pet_type: Literal['blackcat']
@@ -90,7 +88,7 @@ def test_discriminated_union_root_same_discriminator():
             __root__: Union[Cat, Dog] = Field(..., discriminator='pet_type')
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='working on V2 - __root__')
 def test_discriminated_union_validation():
     class BlackCat(BaseModel):
         pet_type: Literal['cat']
@@ -181,7 +179,6 @@ def test_discriminated_union_validation():
     assert isinstance(m.pet.__root__, WhiteCat)
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_annotated_union():
     class BlackCat(BaseModel):
         pet_type: Literal['cat']
@@ -209,29 +206,36 @@ def test_discriminated_annotated_union():
         Model.model_validate({'pet': {'pet_typ': 'cat'}, 'number': 'x'})
     assert exc_info.value.errors() == [
         {
+            'ctx': {'discriminator': "'pet_type'"},
+            'input': {'pet_typ': 'cat'},
             'loc': ('pet',),
-            'msg': "Discriminator 'pet_type' is missing in value",
-            'type': 'value_error.discriminated_union.missing_discriminator',
-            'ctx': {'discriminator_key': 'pet_type'},
+            'msg': "Unable to extract tag using discriminator 'pet_type'",
+            'type': 'union_tag_not_found',
         },
-        {'loc': ('number',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'},
+        {
+            'input': 'x',
+            'loc': ('number',),
+            'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
+            'type': 'int_parsing',
+        },
     ]
 
     with pytest.raises(ValidationError) as exc_info:
         Model.model_validate({'pet': {'pet_type': 'fish'}, 'number': 2})
     assert exc_info.value.errors() == [
         {
+            'ctx': {'discriminator': "'pet_type'", 'expected_tags': "'cat', 'dog'", 'tag': 'fish'},
+            'input': {'pet_type': 'fish'},
             'loc': ('pet',),
-            'msg': "No match for discriminator 'pet_type' and value 'fish' " "(allowed values: 'cat', 'dog')",
-            'type': 'value_error.discriminated_union.invalid_discriminator',
-            'ctx': {'discriminator_key': 'pet_type', 'discriminator_value': 'fish', 'allowed_values': "'cat', 'dog'"},
-        },
+            'msg': "Input tag 'fish' found using 'pet_type' does not match any of the " "expected tags: 'cat', 'dog'",
+            'type': 'union_tag_invalid',
+        }
     ]
 
     with pytest.raises(ValidationError) as exc_info:
         Model.model_validate({'pet': {'pet_type': 'dog'}, 'number': 2})
     assert exc_info.value.errors() == [
-        {'loc': ('pet', 'Dog', 'dog_name'), 'msg': 'field required', 'type': 'value_error.missing'},
+        {'input': {'pet_type': 'dog'}, 'loc': ('pet', 'dog', 'dog_name'), 'msg': 'Field required', 'type': 'missing'}
     ]
     m = Model.model_validate({'pet': {'pet_type': 'dog', 'dog_name': 'milou'}, 'number': 2})
     assert isinstance(m.pet, Dog)
@@ -240,10 +244,11 @@ def test_discriminated_annotated_union():
         Model.model_validate({'pet': {'pet_type': 'cat', 'color': 'red'}, 'number': 2})
     assert exc_info.value.errors() == [
         {
-            'loc': ('pet', 'Union[BlackCat, WhiteCat]'),
-            'msg': "No match for discriminator 'color' and value 'red' " "(allowed values: 'black', 'white')",
-            'type': 'value_error.discriminated_union.invalid_discriminator',
-            'ctx': {'discriminator_key': 'color', 'discriminator_value': 'red', 'allowed_values': "'black', 'white'"},
+            'ctx': {'discriminator': "'color'", 'expected_tags': "'black', 'white'", 'tag': 'red'},
+            'input': {'color': 'red', 'pet_type': 'cat'},
+            'loc': ('pet', 'cat'),
+            'msg': "Input tag 'red' found using 'color' does not match any of the " "expected tags: 'black', 'white'",
+            'type': 'union_tag_invalid',
         }
     ]
 
@@ -251,9 +256,10 @@ def test_discriminated_annotated_union():
         Model.model_validate({'pet': {'pet_type': 'cat', 'color': 'white'}, 'number': 2})
     assert exc_info.value.errors() == [
         {
-            'loc': ('pet', 'Union[BlackCat, WhiteCat]', 'WhiteCat', 'white_infos'),
-            'msg': 'field required',
-            'type': 'value_error.missing',
+            'input': {'color': 'white', 'pet_type': 'cat'},
+            'loc': ('pet', 'cat', 'white', 'white_infos'),
+            'msg': 'Field required',
+            'type': 'missing',
         }
     ]
     m = Model.model_validate({'pet': {'pet_type': 'cat', 'color': 'white', 'white_infos': 'pika'}, 'number': 2})
@@ -290,7 +296,6 @@ def test_discriminated_union_basemodel_instance_value_with_alias():
     assert Top(sub=B(literal='b')).sub.literal == 'b'
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_discriminated_union_int():
     class A(BaseModel):
         m: Literal[1]
@@ -299,26 +304,46 @@ def test_discriminated_union_int():
         m: Literal[2]
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='l')
+        sub: Union[A, B] = Field(..., discriminator='m')
 
     assert isinstance(Top.model_validate({'sub': {'m': 2}}).sub, B)
     with pytest.raises(ValidationError) as exc_info:
         Top.model_validate({'sub': {'m': 3}})
     assert exc_info.value.errors() == [
         {
+            'ctx': {'discriminator': "'m'", 'expected_tags': '1, 2', 'tag': '3'},
+            'input': {'m': 3},
             'loc': ('sub',),
-            'msg': "No match for discriminator 'l' and value 3 (allowed values: 1, 2)",
-            'type': 'value_error.discriminated_union.invalid_discriminator',
-            'ctx': {'discriminator_key': 'm', 'discriminator_value': 3, 'allowed_values': '1, 2'},
+            'msg': "Input tag '3' found using 'm' does not match any of the expected " "tags: 1, 2",
+            'type': 'union_tag_invalid',
         }
     ]
 
 
-@pytest.mark.xfail(reason='working on V2')
-def test_discriminated_union_enum():
-    class EnumValue(Enum):
-        a = 1
-        b = 2
+class FooIntEnum(int, Enum):
+    pass
+
+
+class FooStrEnum(str, Enum):
+    pass
+
+
+ENUM_TEST_CASES = [
+    pytest.param(Enum, {'a': 1, 'b': 2}, marks=pytest.mark.xfail(reason='Plain Enum not yet supported')),
+    pytest.param(Enum, {'a': 'v_a', 'b': 'v_b'}, marks=pytest.mark.xfail(reason='Plain Enum not yet supported')),
+    (FooIntEnum, {'a': 1, 'b': 2}),
+    (IntEnum, {'a': 1, 'b': 2}),
+    (FooStrEnum, {'a': 'v_a', 'b': 'v_b'}),
+]
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+
+    ENUM_TEST_CASES.append((StrEnum, {'a': 'v_a', 'b': 'v_b'}))
+
+
+@pytest.mark.parametrize('base_class,choices', ENUM_TEST_CASES)
+def test_discriminated_union_enum(base_class, choices):
+    EnumValue = base_class('EnumValue', choices)
 
     class A(BaseModel):
         m: Literal[EnumValue.a]
@@ -330,23 +355,22 @@ def test_discriminated_union_enum():
         sub: Union[A, B] = Field(..., discriminator='m')
 
     assert isinstance(Top.model_validate({'sub': {'m': EnumValue.b}}).sub, B)
+    assert isinstance(Top.model_validate({'sub': {'m': EnumValue.b.value}}).sub, B)
     with pytest.raises(ValidationError) as exc_info:
         Top.model_validate({'sub': {'m': 3}})
+
+    expected_tags = f'{EnumValue.a.value!r}, {EnumValue.b.value!r}'
     assert exc_info.value.errors() == [
         {
+            'ctx': {'discriminator': "'m'", 'expected_tags': expected_tags, 'tag': '3'},
+            'input': {'m': 3},
             'loc': ('sub',),
-            'msg': "No match for discriminator 'm' and value 3 (allowed values: <EnumValue.a: 1>, <EnumValue.b: 2>)",
-            'type': 'value_error.discriminated_union.invalid_discriminator',
-            'ctx': {
-                'discriminator_key': 'm',
-                'discriminator_value': 3,
-                'allowed_values': '<EnumValue.a: 1>, <EnumValue.b: 2>',
-            },
+            'msg': f"Input tag '3' found using 'm' does not match any of the expected tags: {expected_tags}",
+            'type': 'union_tag_invalid',
         }
     ]
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_alias_different():
     class Cat(BaseModel):
         pet_type: Literal['cat'] = Field(alias='U')
@@ -356,12 +380,22 @@ def test_alias_different():
         pet_type: Literal['dog'] = Field(alias='T')
         d: str
 
-    with pytest.raises(
-        PydanticUserError, match=re.escape("Aliases for discriminator 'pet_type' must be the same (got T, U)")
-    ):
+    class Model(BaseModel):
+        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
 
-        class Model(BaseModel):
-            pet: Union[Cat, Dog] = Field(discriminator='pet_type')
+    Model.model_validate({'pet': {'U': 'cat', 'c': 'my_cat'}})
+    Model.model_validate({'pet': {'T': 'dog', 'd': 'my_dog'}})
+    with pytest.raises(ValidationError) as exc_info:
+        Model.model_validate({'pet': {'W': 'dog', 'd': 'my_dog'}})
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {'discriminator': "'pet_type' | 'U' | 'T'"},
+            'input': {'W': 'dog', 'd': 'my_dog'},
+            'loc': ('pet',),
+            'msg': "Unable to extract tag using discriminator 'pet_type' | 'U' | 'T'",
+            'type': 'union_tag_not_found',
+        }
+    ]
 
 
 def test_alias_same():
@@ -401,7 +435,6 @@ def test_nested():
     assert isinstance(Model(**{'pet': {'pet_type': 'dog', 'name': 'Milou'}, 'n': 5}).pet, Dog)
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_generic():
     T = TypeVar('T')
 
@@ -416,19 +449,38 @@ def test_generic():
     class Container(BaseModel, Generic[T]):
         result: Union[Success[T], Failure] = Field(discriminator='type')
 
-    with pytest.raises(ValidationError, match="Discriminator 'type' is missing in value"):
+    with pytest.raises(ValidationError, match="Unable to extract tag using discriminator 'type'"):
         Container[str].model_validate({'result': {}})
 
     with pytest.raises(
         ValidationError,
-        match=re.escape("No match for discriminator 'type' and value 'Other' (allowed values: 'Success', 'Failure')"),
+        match=re.escape(
+            "Input tag 'Other' found using 'type' does not match any of the expected tags: 'Success', 'Failure'"
+        ),
     ):
         Container[str].model_validate({'result': {'type': 'Other'}})
 
-    with pytest.raises(
-        ValidationError, match=re.escape('Container[str]\nresult -> Success[str] -> data\n  field required')
-    ):
-        Container[str].model_validate({'result': {'type': 'Success'}})
+    # See https://github.com/pydantic/pydantic-core/issues/425 for why this is set weirdly; this is an unrelated issue
+    # If/when the issue is fixed, the following line should replace the current title = 'Failure' line
+    # title = 'Container[str]'
+    title = 'Failure'
 
-    # coercion is done properly
-    assert Container[str].model_validate({'result': {'type': 'Success', 'data': 1}}).result.data == '1'
+    with pytest.raises(ValidationError, match=f'{title}\nresult -> Success -> data') as exc_info:
+        Container[str].model_validate({'result': {'type': 'Success'}})
+    assert exc_info.value.errors() == [
+        {'input': {'type': 'Success'}, 'loc': ('result', 'Success', 'data'), 'msg': 'Field required', 'type': 'missing'}
+    ]
+
+    # invalid types error
+    with pytest.raises(ValidationError) as exc_info:
+        Container[str].model_validate({'result': {'type': 'Success', 'data': 1}})
+    assert exc_info.value.errors() == [
+        {
+            'input': 1,
+            'loc': ('result', 'Success', 'data'),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type',
+        }
+    ]
+
+    assert Container[str].model_validate({'result': {'type': 'Success', 'data': '1'}}).result.data == '1'

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -579,3 +579,25 @@ def test_optional_union_with_defaults():
             'type': 'union_tag_invalid',
         }
     ]
+
+def test_nested_optional_unions() -> None:
+    class Cat(BaseModel):
+        pet_type: Literal['cat'] = 'cat'
+
+    class Dog(BaseModel):
+        pet_type: Literal['dog'] = 'dog'
+
+    class Lizard(BaseModel):
+        pet_type: Literal['lizard'] = 'lizard'
+
+    MaybeCatDog = Annotated[Optional[Union[Cat, Dog]], Field(discriminator='pet_type')]
+    MaybeDogLizard = Annotated[Union[Dog, Lizard, None], Field(discriminator='pet_type')]
+    class Pet(BaseModel):
+        pet: Union[MaybeCatDog, MaybeDogLizard] = Field(discriminator='pet_type')
+
+    Pet({'pet_type': 'dog'})
+    Pet({'pet_type': 'cat'})
+    Pet({'pet_type': 'lizard'})
+    Pet({'pet_type': None})
+    Pet({'pet_type': 'fox'})
+

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -570,10 +570,6 @@ def test_optional_union_with_defaults():
 
 
 def test_aliases_matching_is_not_sufficient() -> None:
-    from typing import Literal, Union
-
-    from pydantic import BaseModel, Field
-
     class Case1(BaseModel):
         kind_one: Literal['1'] = Field(alias='kind')
 

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -4,9 +4,12 @@ from enum import Enum, IntEnum
 from typing import Generic, Optional, TypeVar, Union
 
 import pytest
+from dirty_equals import HasRepr, IsStr
+from pydantic_core import SchemaValidator, core_schema
 from typing_extensions import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic._internal._discriminated_union import apply_discriminator
 from pydantic.errors import PydanticUserError
 
 
@@ -61,7 +64,7 @@ def test_discriminated_union_literal_discriminator():
         pet_type: Literal['dog']
         d: str
 
-    with pytest.raises(PydanticUserError, match="Field 'pet_type' of model 'Cat' needs to be a `Literal`"):
+    with pytest.raises(PydanticUserError, match="Model 'Cat' needs field 'pet_type' to be of type `Literal`"):
 
         class Model(BaseModel):
             pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
@@ -622,3 +625,400 @@ def test_nested_optional_unions() -> None:
             'type': 'union_tag_invalid',
         }
     ]
+
+
+def test_nested_discriminated_union() -> None:
+    class Cat(BaseModel):
+        pet_type: Literal['cat', 'CAT']
+
+    class Dog(BaseModel):
+        pet_type: Literal['dog', 'DOG']
+
+    class Lizard(BaseModel):
+        pet_type: Literal['lizard', 'LIZARD']
+
+    CatDog = Annotated[Union[Cat, Dog], Field(discriminator='pet_type')]
+    CatDogLizard = Annotated[Union[CatDog, Lizard], Field(discriminator='pet_type')]
+
+    class Pet(BaseModel):
+        pet: CatDogLizard
+
+    Pet.model_validate({'pet': {'pet_type': 'dog'}})
+    Pet.model_validate({'pet': {'pet_type': 'cat'}})
+    Pet.model_validate({'pet': {'pet_type': 'lizard'}})
+
+    with pytest.raises(ValidationError) as exc_info:
+        Pet.model_validate({'pet': {'pet_type': 'reptile'}})
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {
+                'discriminator': "'pet_type'",
+                'expected_tags': "'cat', 'dog', 'lizard', 'CAT', 'DOG', 'LIZARD'",
+                'tag': 'reptile',
+            },
+            'input': {'pet_type': 'reptile'},
+            'loc': ('pet',),
+            'msg': "Input tag 'reptile' found using 'pet_type' does not match any of the "
+            "expected tags: 'cat', 'dog', 'lizard', 'CAT', 'DOG', 'LIZARD'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+
+def test_unions_of_optionals() -> None:
+    class Cat(BaseModel):
+        pet_type: Literal['cat'] = Field(alias='typeOfPet')
+        c: str
+
+    class Dog(BaseModel):
+        pet_type: Literal['dog'] = Field(alias='typeOfPet')
+        d: str
+
+    class Lizard(BaseModel):
+        pet_type: Literal['lizard'] = Field(alias='typeOfPet')
+
+    MaybeCat = Annotated[Cat | None, 'some annotation']
+    MaybeDogLizard = Annotated[Optional[Union[Dog, Lizard]], 'some other annotation']
+
+    class Model(BaseModel):
+        maybe_pet: Union[MaybeCat, MaybeDogLizard] = Field(discriminator='pet_type')
+
+    assert Model(**{'maybe_pet': None}).maybe_pet is None
+    assert Model(**{'maybe_pet': {'typeOfPet': 'dog', 'd': 'milou'}}).maybe_pet.pet_type == 'dog'
+    assert Model(**{'maybe_pet': {'typeOfPet': 'lizard'}}).maybe_pet.pet_type == 'lizard'
+
+
+def test_union_discriminator_literals() -> None:
+    class Cat(BaseModel):
+        pet_type: Literal['cat'] | Literal['CAT'] = Field(alias='typeOfPet')
+
+    class Dog(BaseModel):
+        pet_type: Literal['dog'] = Field(alias='typeOfPet')
+
+    class Model(BaseModel):
+        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
+
+    assert Model(**{'pet': {'typeOfPet': 'dog'}}).pet.pet_type == 'dog'
+    assert Model(**{'pet': {'typeOfPet': 'cat'}}).pet.pet_type == 'cat'
+    assert Model(**{'pet': {'typeOfPet': 'CAT'}}).pet.pet_type == 'CAT'
+    with pytest.raises(ValidationError) as exc_info:
+        Model(**{'pet': {'typeOfPet': 'Cat'}})
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {'discriminator': "'pet_type' | 'typeOfPet'", 'expected_tags': "'cat', 'dog', 'CAT'", 'tag': 'Cat'},
+            'input': {'typeOfPet': 'Cat'},
+            'loc': ('pet',),
+            'msg': "Input tag 'Cat' found using 'pet_type' | 'typeOfPet' does not match "
+            "any of the expected tags: 'cat', 'dog', 'CAT'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+
+def test_none_schema() -> None:
+    cat_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('cat'))}
+    dog_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('dog'))}
+    cat = core_schema.typed_dict_schema(cat_fields)
+    dog = core_schema.typed_dict_schema(dog_fields)
+    schema = core_schema.union_schema(cat, dog, core_schema.none_schema())
+    schema = apply_discriminator(schema, 'kind')
+    validator = SchemaValidator(schema)
+    assert validator.validate_python({'kind': 'cat'})['kind'] == 'cat'
+    assert validator.validate_python({'kind': 'dog'})['kind'] == 'dog'
+    assert validator.validate_python(None) is None
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_python({'kind': 'lizard'})
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {'discriminator': "'kind'", 'expected_tags': "'cat', 'dog'", 'tag': 'lizard'},
+            'input': {'kind': 'lizard'},
+            'loc': (),
+            'msg': "Input tag 'lizard' found using 'kind' does not match any of the " "expected tags: 'cat', 'dog'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+
+def test_nested_unwrapping() -> None:
+    cat_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('cat'))}
+    dog_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('dog'))}
+    cat = core_schema.typed_dict_schema(cat_fields)
+    dog = core_schema.typed_dict_schema(dog_fields)
+    schema = core_schema.union_schema(cat, dog)
+    for _ in range(3):
+        schema = core_schema.nullable_schema(schema)
+        schema = core_schema.nullable_schema(schema)
+        schema = core_schema.definitions_schema(schema, [])
+        schema = core_schema.definitions_schema(schema, [])
+
+    schema = apply_discriminator(schema, 'kind')
+
+    validator = SchemaValidator(schema)
+    assert validator.validate_python({'kind': 'cat'})['kind'] == 'cat'
+    assert validator.validate_python({'kind': 'dog'})['kind'] == 'dog'
+    assert validator.validate_python(None) is None
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_python({'kind': 'lizard'})
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {'discriminator': "'kind'", 'expected_tags': "'cat', 'dog'", 'tag': 'lizard'},
+            'input': {'kind': 'lizard'},
+            'loc': (),
+            'msg': "Input tag 'lizard' found using 'kind' does not match any of the " "expected tags: 'cat', 'dog'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+
+def test_distinct_choices() -> None:
+    class Cat(BaseModel):
+        pet_type: Literal['cat', 'dog'] = Field(alias='typeOfPet')
+
+    class Dog(BaseModel):
+        pet_type: Literal['dog'] = Field(alias='typeOfPet')
+
+    with pytest.raises(TypeError, match="Value 'dog' for discriminator 'pet_type' mapped to multiple choices"):
+
+        class Model(BaseModel):
+            pet: Union[Cat, Dog] = Field(discriminator='pet_type')
+
+
+def test_invalid_discriminated_union_type() -> None:
+    class Cat(BaseModel):
+        pet_type: Literal['cat'] = Field(alias='typeOfPet')
+
+    class Dog(BaseModel):
+        pet_type: Literal['dog'] = Field(alias='typeOfPet')
+
+    with pytest.raises(
+        TypeError, match="'str' is not a valid discriminated union variant; should be a `BaseModel` or `dataclass`"
+    ):
+
+        class Model(BaseModel):
+            pet: Union[Cat, Dog, str] = Field(discriminator='pet_type')
+
+
+def test_single_item_union_error() -> None:
+    fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('only_choice'))}
+    schema = core_schema.union_schema(core_schema.typed_dict_schema(fields=fields))
+    with pytest.raises(
+        TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
+    ):
+        apply_discriminator(schema, 'kind')
+
+
+def test_invalid_alias() -> None:
+    cat_fields = {
+        'kind': core_schema.typed_dict_field(core_schema.literal_schema('cat'), validation_alias=['cat', 'CAT'])
+    }
+    dog_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('dog'))}
+    cat = core_schema.typed_dict_schema(cat_fields)
+    dog = core_schema.typed_dict_schema(dog_fields)
+    schema = core_schema.union_schema(cat, dog)
+
+    with pytest.raises(TypeError, match=re.escape("Alias ['cat', 'CAT'] is not supported in a discriminated union")):
+        apply_discriminator(schema, 'kind')
+
+
+def test_invalid_discriminator_type() -> None:
+    cat_fields = {'kind': core_schema.typed_dict_field(core_schema.int_schema())}
+    dog_fields = {'kind': core_schema.typed_dict_field(core_schema.str_schema())}
+    cat = core_schema.typed_dict_schema(cat_fields)
+    dog = core_schema.typed_dict_schema(dog_fields)
+
+    with pytest.raises(TypeError, match=re.escape("TypedDict needs field 'kind' to be of type `Literal`")):
+        apply_discriminator(core_schema.union_schema(cat, dog), 'kind')
+
+
+def test_missing_discriminator_field() -> None:
+    cat_fields = {'kind': core_schema.typed_dict_field(core_schema.int_schema())}
+    dog_fields = {}
+    cat = core_schema.typed_dict_schema(cat_fields)
+    dog = core_schema.typed_dict_schema(dog_fields)
+
+    with pytest.raises(TypeError, match=re.escape("TypedDict needs a discriminator field for key 'kind'")):
+        apply_discriminator(core_schema.union_schema(dog, cat), 'kind')
+
+
+def test_invalid_discriminator_value() -> None:
+    cat_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema(None))}
+    dog_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema(1.5))}
+    cat = core_schema.typed_dict_schema(cat_fields)
+    dog = core_schema.typed_dict_schema(dog_fields)
+
+    with pytest.raises(TypeError, match=re.escape('Unsupported value for discriminator field: None')):
+        apply_discriminator(core_schema.union_schema(cat, dog), 'kind')
+
+    with pytest.raises(TypeError, match=re.escape('Unsupported value for discriminator field: 1.5')):
+        apply_discriminator(core_schema.union_schema(dog, cat), 'kind')
+
+
+def test_wrap_function_schema() -> None:
+    cat_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('cat'))}
+    dog_fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema('dog'))}
+    cat = core_schema.function_wrap_schema(lambda x, y, z: None, core_schema.typed_dict_schema(cat_fields))
+    dog = core_schema.typed_dict_schema(dog_fields)
+    schema = core_schema.union_schema(cat, dog)
+
+    assert apply_discriminator(schema, 'kind') == {
+        'choices': {
+            'cat': {
+                'function': HasRepr(IsStr(regex=r'<function [a-z_]*\.<locals>\.<lambda> at 0x[0-9a-f]+>')),
+                'mode': 'wrap',
+                'schema': {
+                    'fields': {'kind': {'schema': {'expected': ('cat',), 'type': 'literal'}}},
+                    'type': 'typed-dict',
+                },
+                'type': 'function',
+            },
+            'dog': {'fields': {'kind': {'schema': {'expected': ('dog',), 'type': 'literal'}}}, 'type': 'typed-dict'},
+        },
+        'discriminator': 'kind',
+        'strict': False,
+        'type': 'tagged-union',
+    }
+
+
+def test_plain_function_schema_is_invalid() -> None:
+    with pytest.raises(
+        TypeError,
+        match="'function' with mode='plain' is not a valid discriminated union variant; "
+        "should be a `BaseModel` or `dataclass`",
+    ):
+        apply_discriminator(
+            core_schema.union_schema(
+                core_schema.function_plain_schema(lambda x, y: None),
+                core_schema.int_schema(),
+            ),
+            'kind',
+        )
+
+
+def test_invalid_str_choice_discriminator_values() -> None:
+    cat = core_schema.typed_dict_schema({'kind': core_schema.typed_dict_field(core_schema.literal_schema('cat'))})
+    dog = core_schema.str_schema()
+
+    schema = core_schema.union_schema(
+        cat,
+        # NOTE: Wrapping the union with a validator results in failure to more thoroughly decompose the tagged union.
+        # I think this would be difficult to avoid in the general case, and I would suggest that we not attempt to do
+        # more than this until presented with scenarios where it is helpful/necessary.
+        core_schema.function_wrap_schema(lambda x, y, z: x, dog),
+    )
+
+    with pytest.raises(
+        TypeError, match="'str' is not a valid discriminated union variant; should be a `BaseModel` or `dataclass`"
+    ):
+        apply_discriminator(schema, 'kind')
+
+
+def test_lax_or_strict_definitions() -> None:
+    cat = core_schema.typed_dict_schema({'kind': core_schema.typed_dict_field(core_schema.literal_schema('cat'))})
+    lax_dog = core_schema.typed_dict_schema({'kind': core_schema.typed_dict_field(core_schema.literal_schema('DOG'))})
+    strict_dog = core_schema.definitions_schema(
+        core_schema.typed_dict_schema({'kind': core_schema.typed_dict_field(core_schema.literal_schema('dog'))}),
+        [core_schema.int_schema(ref='my-int-definition')],
+    )
+    dog = core_schema.definitions_schema(
+        core_schema.lax_or_strict_schema(lax_schema=lax_dog, strict_schema=strict_dog),
+        [core_schema.str_schema(ref='my-str-definition')],
+    )
+    discriminated_schema = apply_discriminator(core_schema.union_schema(cat, dog), 'kind')
+    assert discriminated_schema == {
+        'choices': {
+            'DOG': {
+                'definitions': [{'ref': 'my-str-definition', 'type': 'str'}],
+                'schema': {
+                    'lax_schema': {
+                        'fields': {'kind': {'schema': {'expected': ('DOG',), 'type': 'literal'}}},
+                        'type': 'typed-dict',
+                    },
+                    'strict_schema': {
+                        'definitions': [{'ref': 'my-int-definition', 'type': 'int'}],
+                        'schema': {
+                            'fields': {'kind': {'schema': {'expected': ('dog',), 'type': 'literal'}}},
+                            'type': 'typed-dict',
+                        },
+                        'type': 'definitions',
+                    },
+                    'type': 'lax-or-strict',
+                },
+                'type': 'definitions',
+            },
+            'cat': {'fields': {'kind': {'schema': {'expected': ('cat',), 'type': 'literal'}}}, 'type': 'typed-dict'},
+            'dog': 'DOG',
+        },
+        'discriminator': 'kind',
+        'strict': False,
+        'type': 'tagged-union',
+    }
+
+
+def test_wrapped_nullable_union() -> None:
+    cat = core_schema.typed_dict_schema({'kind': core_schema.typed_dict_field(core_schema.literal_schema('cat'))})
+    dog = core_schema.typed_dict_schema({'kind': core_schema.typed_dict_field(core_schema.literal_schema('dog'))})
+    ant = core_schema.typed_dict_schema({'kind': core_schema.typed_dict_field(core_schema.literal_schema('ant'))})
+
+    schema = core_schema.union_schema(
+        ant,
+        # NOTE: Wrapping the union with a validator results in failure to more thoroughly decompose the tagged union.
+        # I think this would be difficult to avoid in the general case, and I would suggest that we not attempt to do
+        # more than this until presented with scenarios where it is helpful/necessary.
+        core_schema.function_wrap_schema(
+            lambda x, y, z: x, core_schema.nullable_schema(core_schema.union_schema(cat, dog))
+        ),
+    )
+    discriminated_schema = apply_discriminator(schema, 'kind')
+    validator = SchemaValidator(discriminated_schema)
+    assert validator.validate_python({'kind': 'ant'})['kind'] == 'ant'
+    assert validator.validate_python({'kind': 'cat'})['kind'] == 'cat'
+    assert validator.validate_python(None) is None
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_python({'kind': 'armadillo'})
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {'discriminator': "'kind'", 'expected_tags': "'ant', 'cat', 'dog'", 'tag': 'armadillo'},
+            'input': {'kind': 'armadillo'},
+            'loc': (),
+            'msg': "Input tag 'armadillo' found using 'kind' does not match any of the "
+            "expected tags: 'ant', 'cat', 'dog'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+    assert discriminated_schema == {
+        'schema': {
+            'choices': {
+                'ant': {
+                    'fields': {'kind': {'schema': {'expected': ('ant',), 'type': 'literal'}}},
+                    'type': 'typed-dict',
+                },
+                'cat': {
+                    'function': HasRepr(IsStr(regex=r'<function [a-z_]*\.<locals>\.<lambda> at 0x[0-9a-f]+>')),
+                    'mode': 'wrap',
+                    'schema': {
+                        'schema': {
+                            'choices': (
+                                {
+                                    'fields': {'kind': {'schema': {'expected': ('cat',), 'type': 'literal'}}},
+                                    'type': 'typed-dict',
+                                },
+                                {
+                                    'fields': {'kind': {'schema': {'expected': ('dog',), 'type': 'literal'}}},
+                                    'type': 'typed-dict',
+                                },
+                            ),
+                            'type': 'union',
+                        },
+                        'type': 'nullable',
+                    },
+                    'type': 'function',
+                },
+                'dog': 'cat',
+            },
+            'discriminator': 'kind',
+            'strict': False,
+            'type': 'tagged-union',
+        },
+        'type': 'nullable',
+    }

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -677,7 +677,7 @@ def test_unions_of_optionals() -> None:
     class Lizard(BaseModel):
         pet_type: Literal['lizard'] = Field(alias='typeOfPet')
 
-    MaybeCat = Annotated[Cat | None, 'some annotation']
+    MaybeCat = Annotated[Union[Cat, None], 'some annotation']
     MaybeDogLizard = Annotated[Optional[Union[Dog, Lizard]], 'some other annotation']
 
     class Model(BaseModel):
@@ -690,7 +690,7 @@ def test_unions_of_optionals() -> None:
 
 def test_union_discriminator_literals() -> None:
     class Cat(BaseModel):
-        pet_type: Literal['cat'] | Literal['CAT'] = Field(alias='typeOfPet')
+        pet_type: Union[Literal['cat'], Literal['CAT']] = Field(alias='typeOfPet')
 
     class Dog(BaseModel):
         pet_type: Literal['dog'] = Field(alias='typeOfPet')
@@ -863,7 +863,7 @@ def test_wrap_function_schema() -> None:
     assert apply_discriminator(schema, 'kind') == {
         'choices': {
             'cat': {
-                'function': HasRepr(IsStr(regex=r'<function [a-z_]*\.<locals>\.<lambda> at 0x[0-9a-f]+>')),
+                'function': HasRepr(IsStr(regex=r'<function [a-z_]*\.<locals>\.<lambda> at 0x[0-9a-fA-F]+>')),
                 'mode': 'wrap',
                 'schema': {
                     'fields': {'kind': {'schema': {'expected': ('cat',), 'type': 'literal'}}},
@@ -994,7 +994,7 @@ def test_wrapped_nullable_union() -> None:
                     'type': 'typed-dict',
                 },
                 'cat': {
-                    'function': HasRepr(IsStr(regex=r'<function [a-z_]*\.<locals>\.<lambda> at 0x[0-9a-f]+>')),
+                    'function': HasRepr(IsStr(regex=r'<function [a-z_]*\.<locals>\.<lambda> at 0x[0-9a-fA-F]+>')),
                     'mode': 'wrap',
                     'schema': {
                         'schema': {

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2713,7 +2713,6 @@ def test_discriminated_union():
                     {'$ref': '#/$defs/Cat'},
                     {'$ref': '#/$defs/Dog'},
                     {'$ref': '#/$defs/Lizard'},
-                    {'$ref': '#/$defs/Lizard'},
                 ],
                 'title': 'Pet',
             }
@@ -2772,7 +2771,6 @@ def test_discriminated_annotated_union():
                 'oneOf': [
                     {'$ref': '#/$defs/Cat'},
                     {'$ref': '#/$defs/Dog'},
-                    {'$ref': '#/$defs/Lizard'},
                     {'$ref': '#/$defs/Lizard'},
                 ],
                 'title': 'Pet',


### PR DESCRIPTION
**Note to self:** Once PR #5125 is merged, I'll want to merge in the changes from the `v2-discriminated-union-generics` branch.

There are still some remaining challenges, but I think this is mostly good:
* Handling models with `__root__` (I think this is getting removed in v2 though)
* Handling aliases properly (will do that in the future once more things with alias are handled properly)

fix #4675