### PR TITLE
Disable google analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,10 +29,6 @@ theme:
 repo_name: pydantic/pydantic
 repo_url: https://github.com/pydantic/pydantic
 edit_uri: edit/main/docs/
-extra:
-  analytics:
-    provider: google
-    property: UA-62733018-4
 
 extra_css:
 - 'extra/terminal.css'


### PR DESCRIPTION
Considering the documentation at https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#google-analytics says that this is all you need to do to enable Google analytics, I think deleting those lines should be all we need to do to remove it.

skip change file check