### PR TITLE
Fix mypy plugin for 1.1.0

### DIFF
--- a/changes/5077-cdce8p.md
+++ b/changes/5077-cdce8p.md
@@ -1,0 +1,1 @@
+Fix mypy plugin for v1.1.0

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -86,6 +86,9 @@ def parse_mypy_version(version: str) -> Tuple[int, ...]:
 MYPY_VERSION_TUPLE = parse_mypy_version(mypy_version)
 BUILTINS_NAME = 'builtins' if MYPY_VERSION_TUPLE >= (0, 930) else '__builtins__'
 
+# Increment version if plugin changes and mypy caches should be invalidated
+PLUGIN_VERSION = 1
+
 
 def plugin(version: str) -> 'TypingType[Plugin]':
     """
@@ -101,6 +104,7 @@ class PydanticPlugin(Plugin):
     def __init__(self, options: Options) -> None:
         self.plugin_config = PydanticPluginConfig(options)
         self._plugin_data = self.plugin_config.to_data()
+        self._plugin_data['version'] = PLUGIN_VERSION
         super().__init__(options)
 
     def get_base_class_hook(self, fullname: str) -> 'Optional[Callable[[ClassDefContext], None]]':

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -152,10 +152,9 @@ class PydanticPlugin(Plugin):
         if self.plugin_config.debug_dataclass_transform:
             return
         info_metaclass = ctx.cls.info.declared_metaclass
-        assert info_metaclass
+        assert info_metaclass, "callback not passed from 'get_metaclass_hook'"
         if getattr(info_metaclass.type, 'dataclass_transform_spec', None):
             info_metaclass.type.dataclass_transform_spec = None  # type: ignore[attr-defined]
-        return None
 
     def _pydantic_field_callback(self, ctx: FunctionContext) -> 'Type':
         """


### PR DESCRIPTION
The next mypy release will add better support for `dataclass_transform`.

Since `ModelMetaclass` is decorated with it, it means that mypy would use that instead of the custom plugin. The plugin is quite good at parsing `BaseModel`, so the result would be worse. Especially with regards to the of default arguments as `pydantic.field.Field` uses a slightly different syntax.

With this PR, the plugin will basically pretend `ModelMetaclass` isn't decorated and thus continue to use the plugin for it.
I've also added a new (undocumented) option `debug_dataclass_transform` to be able to toggle that behavior and test new future versions of mypy without modifying the plugin again.

If accepted, it would be great if this PR could be backported to `1.10.X` and a new version released. The next mypy release which would otherwise break this behavior is currently scheduled for the end of February.

--
```py
from __future__ import annotations

from pydantic import BaseModel, Field

class Event(BaseModel):
    id: int | None = Field(None, alias="id")

Event()
```

Without this PR mypy `1.1.0` would emit
```
error: Missing named argument "id" for "Event"  [call-arg]
```