### PR TITLE
Add tests demonstrating an approach to JSON schema error collection

### DIFF
--- a/tests/test_fastapi_json_schema.py
+++ b/tests/test_fastapi_json_schema.py
@@ -1,0 +1,137 @@
+"""
+This file contains an initial proposal that can be scrapped and reworked if/when appropriate.
+Either way, this test file should probably be removed once the actual FastAPI implementation
+is complete and has integration tests with pydantic v2. However, we are including it here for now
+to get an early warning if this approach would require modification for compatibility with
+any future changes to the JSON schema generation logic, etc.
+
+See the original PR for more details: https://github.com/pydantic/pydantic/pull/5094
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic_core import CoreSchema
+from pydantic_core.core_schema import TypedDictField
+
+from pydantic import BaseModel, ConfigDict
+from pydantic._internal._core_metadata import CoreMetadataHandler
+from pydantic.errors import PydanticInvalidForJsonSchema
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+
+
+class _ErrorKey(str):
+    pass
+
+
+class FastAPIGenerateJsonSchema(GenerateJsonSchema):
+    """
+    Idea: This class would be exported from FastAPI, and if users want to modify the way JSON schema is generated
+    in FastAPI, they should inherit from it and override it as appropriate.
+
+    In the JSON schema generation logic, FastAPI _could_ also attempt to work with classes that inherit directly from
+    GenerateJsonSchema by doing something like:
+
+        if UserGenerateJsonSchema.handle_invalid_for_json_schema is GenerateJsonSchema.handle_invalid_for_json_schema:
+            # The method has not been overridden; inherit from FastAPIGenerateJsonSchema
+            UserGenerateJsonSchema = type(
+                "UserGenerateJsonSchema", (FastAPIGenerateJsonSchema, UserGenerateJsonSchema), {}
+            )
+        else:
+            raise TypeError(f"{UserGenerateJsonSchema.__name__} should inherit from FastAPIGenerateJsonSchema")
+
+    I'm not sure which approach is better.
+    """
+
+    def handle_invalid_for_json_schema(self, schema: CoreSchema | TypedDictField, error_info: str) -> JsonSchemaValue:
+        # NOTE: I think it may be a good idea to rework this method to either not use CoreMetadataHandler,
+        #    and/or to make CoreMetadataHandler a public API.
+        if CoreMetadataHandler(schema).get_modify_js_function():
+            # Since there is a json schema modify function, assume that this type is meant to be handled,
+            # and the modify function will set all properties as appropriate
+            return {}
+        else:
+            error = PydanticInvalidForJsonSchema(f'Cannot generate a JsonSchema for {error_info}')
+            return {_ErrorKey('error'): error}
+
+
+@dataclass
+class ErrorDetails:
+    path: list[Any]
+    error: PydanticInvalidForJsonSchema
+
+
+def collect_errors(schema: JsonSchemaValue) -> list[ErrorDetails]:
+    errors: list[ErrorDetails] = []
+
+    def _collect_errors(schema: JsonSchemaValue, path: list[Any]) -> None:
+        if isinstance(schema, dict):
+            for k, v in schema.items():
+                if isinstance(k, _ErrorKey):
+                    errors.append(ErrorDetails(path, schema[k]))
+                _collect_errors(v, list(path) + [k])
+        elif isinstance(schema, list):
+            for i, v in enumerate(schema):
+                _collect_errors(v, list(path) + [i])
+
+    _collect_errors(schema, [])
+    return errors
+
+
+def test_inheritance_detection() -> None:
+    class GenerateJsonSchema2(GenerateJsonSchema):
+        pass
+
+    assert GenerateJsonSchema2.handle_invalid_for_json_schema is GenerateJsonSchema.handle_invalid_for_json_schema
+    # this is just a quick proof of the note above indicating that you can detect whether a specific method
+    # is overridden, for the purpose of allowing direct inheritance from GenerateJsonSchema.
+    assert (
+        FastAPIGenerateJsonSchema.handle_invalid_for_json_schema
+        is not GenerateJsonSchema.handle_invalid_for_json_schema
+    )
+
+
+def test_collect_errors() -> None:
+    class Car:
+        def __init__(self, make: str, model: str, year: int):
+            self.make = make
+            self.model = model
+            self.year = year
+
+    class Model(BaseModel):
+        f1: int = 1
+        f2: Car
+
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    expected_schema = {
+        'type': 'object',
+        'properties': {
+            'f1': {'type': 'integer', 'default': 1, 'title': 'F1'},
+            'f2': {
+                'error': PydanticInvalidForJsonSchema(
+                    "Cannot generate a JsonSchema for core_schema.IsInstanceSchema "
+                    "(<class 'tests.test_fastapi_json_schema.test_collect_errors.<locals>.Car'>)"
+                ),
+                'title': 'F2',
+            },
+        },
+        'required': ['f2'],
+        'title': 'Model',
+    }
+    actual_schema = Model.model_json_schema(schema_generator=FastAPIGenerateJsonSchema)
+    assert repr(actual_schema) == repr(expected_schema)
+
+    actual_collected_errors = collect_errors(actual_schema)
+    expected_collected_errors = [
+        ErrorDetails(
+            path=['properties', 'f2'],
+            error=PydanticInvalidForJsonSchema(
+                "Cannot generate a JsonSchema for core_schema.IsInstanceSchema "
+                "(<class 'tests.test_fastapi_json_schema.test_collect_errors.<locals>.Car'>)"
+            ),
+        )
+    ]
+    assert repr(actual_collected_errors) == repr(expected_collected_errors)


### PR DESCRIPTION
I have opened this pull request for the sake of gathering feedback on a proposed approach to @tiangolo's feature request brought up in #5029.

I found a way to implement it that I believe is 100% compatible with the current `GenerateJsonSchema` implementation with no lying to mypy or anything, just based on adding overrides. (@tiangolo the main difference with my initial implementation I shared is that by creating a custom subclass of `str` we can return something that is a valid `JsonSchemaValue` and yet can be detected as definitely-created-by-the-overridden-method).

There are two main issues on the pydantic side:
* `'PydanticInvalidForJsonSchema'` was not in `pydantic.json_schema.__all__`; that should almost certainly be changed.
* `CoreMetadataHandler` is needed in the override method, but is in `pydantic._internal`. We have at least two options for resolving this:
    * We could make `CoreMetadataHandler` public (might want/need to do this for other reasons, though it would be nice to make the API cleaner if we did)
    * We could change the `handle_invalid_for_json_schema` to more narrowly wrap the raising of the error. The main reason I didn't already do that was because I was uncertain about whether my approach of not raising an error if there was a custom `__pydantic_modify_json_schema__` function was good/going to stand the test of time.

I don't intend to merge the bulk of this PR, but I'd be happy to transform it into something we do want to merge to resolve the two points above. Or, once @tiangolo is satisfied that the JSON schema generation is sufficiently flexible for FastAPI integration, we can close this PR and keep it around for (his?) reference, and I can open a separate PR resolving the issues mentioned above.
