### PR TITLE
Raise `ValidationError` for unhashable discriminator values

### DIFF
--- a/changes/4773-kurtmckee.md
+++ b/changes/4773-kurtmckee.md
@@ -1,0 +1,1 @@
+Raise `ValidationError`, not `ConfigError`, when a discriminator value is unhashable.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1117,15 +1117,18 @@ class ModelField(Representation):
             except (AttributeError, TypeError):
                 return v, ErrorWrapper(MissingDiscriminator(discriminator_key=self.discriminator_key), loc)
 
-        try:
-            sub_field = self.sub_fields_mapping[discriminator_value]  # type: ignore[index]
-        except TypeError:
+        if self.sub_fields_mapping is None:
             assert cls is not None
             raise ConfigError(
                 f'field "{self.name}" not yet prepared so type is still a ForwardRef, '
                 f'you might need to call {cls.__name__}.update_forward_refs().'
             )
-        except KeyError:
+
+        try:
+            sub_field = self.sub_fields_mapping[discriminator_value]  # type: ignore[index]
+        except (KeyError, TypeError):
+            # KeyError: `discriminator_value` is not in the dictionary.
+            # TypeError: `discriminator_value` is unhashable.
             assert self.sub_fields_mapping is not None
             return v, ErrorWrapper(
                 InvalidDiscriminator(

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1125,7 +1125,7 @@ class ModelField(Representation):
             )
 
         try:
-            sub_field = self.sub_fields_mapping[discriminator_value]  # type: ignore[index]
+            sub_field = self.sub_fields_mapping[discriminator_value]
         except (KeyError, TypeError):
             # KeyError: `discriminator_value` is not in the dictionary.
             # TypeError: `discriminator_value` is unhashable.

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -439,7 +439,5 @@ def test_discriminator_with_unhashable_type():
     class Foo(BaseModel):
         foo: Union[Model1, Model2] = Field(discriminator='target')
 
-    with pytest.raises(
-        ValidationError, match=re.escape("No match for discriminator 'target' and value {}")
-    ):
+    with pytest.raises(ValidationError, match=re.escape("No match for discriminator 'target' and value {}")):
         Foo(**{'foo': {'target': {}}})

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -423,3 +423,23 @@ def test_generic():
 
     # coercion is done properly
     assert Container[str].parse_obj({'result': {'type': 'Success', 'data': 1}}).result.data == '1'
+
+
+def test_discriminator_with_unhashable_type():
+    """Verify an unhashable discriminator value raises a ValidationError."""
+
+    class Model1(BaseModel):
+        target: Literal['t1']
+        a: int
+
+    class Model2(BaseModel):
+        target: Literal['t2']
+        b: int
+
+    class Foo(BaseModel):
+        foo: Union[Model1, Model2] = Field(discriminator='target')
+
+    with pytest.raises(
+        ValidationError, match=re.escape("No match for discriminator 'target' and value {}")
+    ):
+        Foo(**{'foo': {'target': {}}})


### PR DESCRIPTION
As reported in #4773, unhashable discriminator values are incorrectly rejected with a `ConfigError`, rather than a `ValidationError`.

# The bug

The current code catches a `TypeError` at line 1121 and converts it to a `ConfigError`:

https://github.com/pydantic/pydantic/blob/7f3b754bea95fbb443772501b6176f2f4959f2a5/pydantic/fields.py#L1120-L1127

This can happen when `self.sub_fields_mapping` is `None`, in which case the `ConfigError` correctly suggests calling `.update_forward_refs()`. For reference, the exact error is:

```python
None[discriminator_value]  # TypeError: 'NoneType' object is not subscriptable
```

However, a `TypeError` can also be raised when `self.sub_fields_mapping` is a dictionary but `discriminator_value` is an unhashable type. For reference, the exact error is:

```python
{"valid": "dict"}[{}]  # TypeError: unhashable type: 'dict'
```

# The fix

This PR addresses the bug by first checking whether `self.sub_fields_mapping` is None. If it is, then a `ConfigError` is raised as expected. Then, both `KeyError` and `TypeError` are interpreted as an invalid discriminator value.

Please let me know if this needs to be separately forward-ported to `main`.

Thanks for your work on pydantic!

Fixes #4773