### PR TITLE
Enforce using typing_extensions.TypedDict for Python < 3.11

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -321,8 +321,7 @@ class GenerateSchema:
         # however it is buggy (https://github.com/python/typing_extensions/blob/ac52ac5f2cb0e00e7988bae1e2a1b8257ac88d6d/src/typing_extensions.py#L657-L666)  # noqa: E501
         # Hence to avoid creating validators that do not do what users expect we only
         # support typing.TypedDict on Python >= 3.11 or typing_extension.TypedDict on all versions
-        is_typing_typeddict = type(typed_dict_cls).__module__ == 'typing'
-        if not _SUPPORTS_TYPEDDICT and is_typing_typeddict:
+        if not _SUPPORTS_TYPEDDICT and type(typed_dict_cls).__module__ == 'typing':
             raise TypeError('Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.11.')
 
         required_keys: typing.FrozenSet[str] = typed_dict_cls.__required_keys__

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -15,7 +15,7 @@ from annotated_types import BaseMetadata, GroupedMetadata
 from pydantic_core import SchemaError, SchemaValidator, core_schema
 from typing_extensions import Annotated, Literal, get_args, get_origin, is_typeddict
 
-from ..errors import PydanticSchemaGenerationError
+from ..errors import PydanticSchemaGenerationError, PydanticUserError
 from ..fields import FieldInfo
 from ..json_schema import JsonSchemaMetadata, JsonSchemaValue
 from . import _fields, _typing_extra
@@ -313,16 +313,21 @@ class GenerateSchema:
     def _typed_dict_schema(self, typed_dict_cls: Any) -> core_schema.TypedDictSchema:
         """
         Generate schema for a TypedDict.
+
+        It is not possible to track required/optional keys in TypedDict without __required_keys__
+        since TypedDict.__new__ erases the base classes (it replaces them with just `dict`)
+        and thus we can track usage of total=True/False
+        __required_keys__ was added in Python 3.9
+        (https://github.com/miss-islington/cpython/blob/1e9939657dd1f8eb9f596f77c1084d2d351172fc/Doc/library/typing.rst?plain=1#L1546-L1548)
+        however it is buggy
+        (https://github.com/python/typing_extensions/blob/ac52ac5f2cb0e00e7988bae1e2a1b8257ac88d6d/src/typing_extensions.py#L657-L666).
+        Hence to avoid creating validators that do not do what users expect we only
+        support typing.TypedDict on Python >= 3.11 or typing_extension.TypedDict on all versions
         """
-        # It is not possible to track required/optional keys in TypedDict without __required_keys__
-        # since TypedDict.__new__ erases the base classes (it replaces them with just `dict`)
-        # and thus we can track usage of total=True/False
-        # __required_keys__ was added in Python 3.9 (https://github.com/miss-islington/cpython/blob/1e9939657dd1f8eb9f596f77c1084d2d351172fc/Doc/library/typing.rst?plain=1#L1546-L1548)  # noqa: E501
-        # however it is buggy (https://github.com/python/typing_extensions/blob/ac52ac5f2cb0e00e7988bae1e2a1b8257ac88d6d/src/typing_extensions.py#L657-L666)  # noqa: E501
-        # Hence to avoid creating validators that do not do what users expect we only
-        # support typing.TypedDict on Python >= 3.11 or typing_extension.TypedDict on all versions
         if not _SUPPORTS_TYPEDDICT and type(typed_dict_cls).__module__ == 'typing':
-            raise TypeError('Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.11.')
+            raise PydanticUserError(
+                'Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.11.'
+            )
 
         required_keys: typing.FrozenSet[str] = typed_dict_cls.__required_keys__
 

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -35,7 +35,7 @@ def fixture_typed_dict(TypedDictAll):
         foo: str
 
     if sys.version_info < (3, 11) and TypedDictAll.__module__ == 'typing':
-        pytest.xfail('typing.TypedDict does not track required keys correctly on Python < 3.11')
+        pytest.skip('typing.TypedDict does not track required keys correctly on Python < 3.11')
 
     if hasattr(TestTypedDict, '__required_keys__'):
         return TypedDictAll

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -1,6 +1,7 @@
 """
 Tests for TypedDict
 """
+import sys
 import typing
 from typing import Optional
 
@@ -33,6 +34,9 @@ def fixture_typed_dict(TypedDictAll):
     class TestTypedDict(TypedDictAll):
         foo: str
 
+    if sys.version_info < (3, 11) and TypedDictAll.__module__ == 'typing':
+        pytest.xfail('typing.TypedDict does not track required keys correctly on Python < 3.11')
+
     if hasattr(TestTypedDict, '__required_keys__'):
         return TypedDictAll
     else:
@@ -63,7 +67,7 @@ def test_typeddict_all(TypedDictAll):
             d: MyDict
 
     except TypeError as e:
-        assert str(e) == 'Please use `typing_extensions.TypedDict` instead of `typing.TypedDict`.'
+        assert str(e) == 'Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.11.'
     else:
         assert M(d=dict(foo='baz')).d == {'foo': 'baz'}
 


### PR DESCRIPTION
Extracting a bit of work out of #5058  and from discussion with @dmontagu 