### PR TITLE
Don't apply dataclass transform twice with plugin + mypy 1.1.1

### DIFF
--- a/changes/5162-cdce8p.md
+++ b/changes/5162-cdce8p.md
@@ -1,0 +1,1 @@
+Fix `InitVar` usage with pydantic dataclasses, mypy version `1.1.1` and the custom mypy plugin

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -104,7 +104,7 @@ def plugin(version: str) -> 'TypingType[Plugin]':
 
 
 class PydanticPlugin(Plugin):
-    mypy_version: tuple[int, ...]
+    mypy_version: Tuple[int, ...]
 
     def __init__(self, options: Options) -> None:
         self.plugin_config = PydanticPluginConfig(options)

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -99,7 +99,7 @@ def plugin(version: str) -> 'TypingType[Plugin]':
     We might want to use this to print a warning if the mypy version being used is
     newer, or especially older, than we expect (or need).
     """
-    PydanticPlugin.mypy_version = tuple(map(int, version.partition("+")[0].split(".")))
+    PydanticPlugin.mypy_version = tuple(map(int, version.partition('+')[0].split('.')))
     return PydanticPlugin
 
 

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -224,3 +224,16 @@ class FieldDefaultTestingModel(BaseModel):
     g: List[int] = Field(default_factory=_default_factory_list)
     h: str = Field(default_factory=_default_factory_str)
     i: str = Field(default_factory=lambda: 'test')
+
+
+# Include the import down here to reduce the effect on line numbers
+from dataclasses import InitVar  # noqa E402
+
+
+@dataclass
+class MyDataClass:
+    foo: InitVar[str]
+    bar: str
+
+
+MyDataClass(foo='foo', bar='bar')

--- a/tests/mypy/outputs/plugin_success.txt
+++ b/tests/mypy/outputs/plugin_success.txt
@@ -1,3 +1,5 @@
 122: error: Unexpected keyword argument "name" for "AddProject"  [call-arg]
 122: error: Unexpected keyword argument "slug" for "AddProject"  [call-arg]
 122: error: Unexpected keyword argument "description" for "AddProject"  [call-arg]
+239: error: Unexpected keyword argument "foo" for "MyDataClass"  [call-arg]
+239: error: Unexpected keyword argument "bar" for "MyDataClass"  [call-arg]


### PR DESCRIPTION
## Change Summary
Mypy `1.1.1` added support for `@dataclass_transform`. With the plugin active, the mypy dataclass transformer would be executed twice. As the first iteration already removes the `InitVar` annotation, the second one results in an error message.

The PR targets the `1.10.X-fixes` branch as that is much easier to test. If excepted, I'll also open a PR for `main`.

Fixes: #5161

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
