### PR TITLE
Use Validator in parse_obj_as

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -909,8 +909,8 @@ class Validator(Generic[T]):
         gen = _generate_schema.GenerateSchema(
             arbitrary_types=arbitrary_types, types_namespace=global_ns, typevars_map={}
         )
-        self.schema = gen.generate_schema(__type)
-        self._validator = SchemaValidator(self.schema, config=merged_config)
+        schema = gen.generate_schema(__type)
+        self._validator = SchemaValidator(schema, config=merged_config)
 
     def __call__(self, __input: Any) -> T:
         return self._validator.validate_python(__input)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -909,8 +909,8 @@ class Validator(Generic[T]):
         gen = _generate_schema.GenerateSchema(
             arbitrary_types=arbitrary_types, types_namespace=global_ns, typevars_map={}
         )
-        schema = gen.generate_schema(__type)
-        self._validator = SchemaValidator(schema, config=merged_config)
+        self.schema = gen.generate_schema(__type)
+        self._validator = SchemaValidator(self.schema, config=merged_config)
 
     def __call__(self, __input: Any) -> T:
         return self._validator.validate_python(__input)

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -1,6 +1,8 @@
+import warnings
 from functools import lru_cache
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
+from . import Validator
 from ._internal import _repr
 
 __all__ = 'parse_obj_as', 'schema_of', 'schema_json_of'
@@ -26,9 +28,12 @@ def _get_parsing_type(type_: Any, *, type_name: Optional[NameFactory] = None) ->
 T = TypeVar('T')
 
 
-def parse_obj_as(type_: Type[T], obj: Any, *, type_name: Optional[NameFactory] = None) -> T:
-    model_type = _get_parsing_type(type_, type_name=type_name)  # type: ignore[arg-type]
-    return model_type(__root__=obj).__root__
+def parse_obj_as(type_: Type[T], obj: Any, type_name: Optional[NameFactory] = None) -> T:
+    if type_name is not None:  # pragma: no cover
+        warnings.warn(
+            'The type_name parameter is deprecated. parse_obj_as not longer creates temporary models', stacklevel=2
+        )
+    return Validator(type_)(obj)
 
 
 def schema_of(type_: Any, *, title: Optional[NameFactory] = None, **schema_kwargs: Any) -> 'dict[str, Any]':

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,13 +7,11 @@ from pydantic.dataclasses import dataclass
 from pydantic.tools import parse_obj_as, schema_json_of, schema_of
 
 
-@pytest.mark.xfail(reason='working on V2')
 @pytest.mark.parametrize('obj,type_,parsed', [('1', int, 1), (['1'], List[int], [1])])
 def test_parse_obj(obj, type_, parsed):
     assert parse_obj_as(type_, obj) == parsed
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_as_model():
     class Model(BaseModel):
         x: int
@@ -38,14 +36,17 @@ def test_parse_obj_preserves_subclasses():
     assert parsed == [model_b]
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_parse_obj_fails():
     with pytest.raises(ValidationError) as exc_info:
         parse_obj_as(int, 'a')
     assert exc_info.value.errors() == [
-        {'loc': ('__root__',), 'msg': 'value is not a valid integer', 'type': 'type_error.integer'}
+        {
+            'input': 'a',
+            'loc': (),
+            'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
+            'type': 'int_parsing',
+        }
     ]
-    assert exc_info.value.model.__name__ == 'ParsingModel[int]'
 
 
 @pytest.mark.xfail(reason='working on V2')
@@ -73,7 +74,6 @@ def test_parse_as_dataclass():
     assert parse_obj_as(PydanticDataclass, inputs) == PydanticDataclass(1)
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_parse_mapping_as():
     inputs = {'1': '2'}
     assert parse_obj_as(Dict[int, int], inputs) == {1: 2}


### PR DESCRIPTION
The main question I still have: should we add a DeprecationWarning to `parse_obj_as` (telling people to use `Validator` instead)?

If I recall correctly, achieving similar functionality was the main reason this function was introduced.