### PR TITLE
Fix custom constr class schema

### DIFF
--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -79,7 +79,7 @@ from .typing import (
     is_none_type,
     is_union,
 )
-from .utils import ROOT_KEY, get_model, lenient_issubclass
+from .utils import ROOT_KEY, get_model, get_pattern, lenient_issubclass
 
 if TYPE_CHECKING:
     from .dataclasses import Dataclass
@@ -490,7 +490,7 @@ def field_type_schema(
         if regex:
             # Dict keys have a regex pattern
             # items_schema might be a schema or empty dict, add it either way
-            f_schema['patternProperties'] = {regex.pattern: items_schema}
+            f_schema['patternProperties'] = {get_pattern(regex): items_schema}
         if items_schema:
             # The dict values are not simply Any, so they need a schema
             f_schema['additionalProperties'] = items_schema

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -30,7 +30,7 @@ from weakref import WeakSet
 
 from . import errors
 from .datetime_parse import parse_date
-from .utils import import_string, update_not_none
+from .utils import get_pattern, import_string, update_not_none
 from .validators import (
     bytes_validator,
     constr_length_validator,
@@ -412,7 +412,7 @@ class ConstrainedStr(str):
             field_schema,
             minLength=cls.min_length,
             maxLength=cls.max_length,
-            pattern=cls.regex and cls._get_pattern(cls.regex),
+            pattern=cls.regex and get_pattern(cls.regex),
         )
 
     @classmethod
@@ -431,13 +431,9 @@ class ConstrainedStr(str):
 
         if cls.regex:
             if not re.match(cls.regex, value):
-                raise errors.StrRegexError(pattern=cls._get_pattern(cls.regex))
+                raise errors.StrRegexError(pattern=get_pattern(cls.regex))
 
         return value
-
-    @staticmethod
-    def _get_pattern(regex: Union[str, Pattern[str]]) -> str:
-        return regex if isinstance(regex, str) else regex.pattern
 
 
 def constr(

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -19,6 +19,7 @@ from typing import (
     Mapping,
     NoReturn,
     Optional,
+    Pattern,
     Set,
     Tuple,
     Type,
@@ -792,6 +793,10 @@ def get_discriminator_alias_and_values(tp: Any, discriminator_key: str) -> Tuple
             raise ConfigError(f'Field {discriminator_key!r} of model {tp.__name__!r} needs to be a `Literal`')
 
         return tp.__fields__[discriminator_key].alias, all_literal_values(t_discriminator_type)
+
+
+def get_pattern(regex: Union[str, Pattern[str]]) -> str:
+    return regex if isinstance(regex, str) else regex.pattern
 
 
 def _get_union_alias_and_all_values(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -820,6 +820,23 @@ def test_str_basic_types(field_type, expected_schema):
     assert Model.schema() == base_schema
 
 
+def test_constrained_str_class_dict():
+    class CustomStr(ConstrainedStr):
+        regex = '^text$'
+
+    class Model(BaseModel):
+        a: Dict[CustomStr, Any]
+
+    json_schema = Model.schema()
+
+    assert json_schema == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'patternProperties': {'^text$': {}}, 'title': 'A', 'type': 'object'}},
+        'required': ['a'],
+    }
+
+
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [


### PR DESCRIPTION
## Change Summary

Currently, schema creation fails if a model uses a ConstrainedStr Model as keys in a Dict:
```python
class CustomStr(ConstrainedStr):
    regex = '^text$'

class Model(BaseModel):
    a: Dict[CustomStr, Any]

json_schema = Model.schema()
# AttributeError: 'str' object has no attribute 'pattern'
```

ConstrainedStr `regex` field is typed as `Optional[Union[str, Pattern[str]]`, when accessing pattern generating the schema for patternProperty, regex.pattern is directly accessed.

This PR contains following changes:
- Move `ConstrainedStr._get_pattern` to `get_pattern` in `utils.py`
- Use it in schema.py when accessing the pattern
- Add a test case for the described scenario

## Related issue number
-

## Checklist

* [x] Unit tests for the changes exist
* [] Tests pass on CI and coverage remains at 100%
* [] Documentation reflects the changes where applicable
* [] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
