### PR TITLE
Fix dict coercion on copy with include/exclude

### DIFF
--- a/changes/5225-JacobHayes.md
+++ b/changes/5225-JacobHayes.md
@@ -1,0 +1,1 @@
+Update `Model._get_value` to preserve dict subclasses on copy (including defaultdict).

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -7,6 +7,7 @@ import sys
 import typing
 import warnings
 from abc import ABCMeta
+from collections import defaultdict
 from copy import deepcopy
 from enum import Enum
 from functools import partial
@@ -483,7 +484,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         value_include = _utils.ValueItems(v, include) if include else None
 
         if isinstance(v, dict):
-            return {
+            map_args = {
                 k_: cls._get_value(
                     v_,
                     to_dict=to_dict,
@@ -498,6 +499,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
                 if (not value_exclude or not value_exclude.is_excluded(k_))
                 and (not value_include or value_include.is_included(k_))
             }
+            return v.__class__(v.default_factory, map_args) if isinstance(v, defaultdict) else v.__class__(map_args)
 
         elif _utils.sequence_like(v):
             seq_args = (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1536,6 +1536,8 @@ def test_dict_subclasses_bare():
 
     assert repr(Model(a=MyDict({'a': 1})).a) == "MyDict({'a': 1})"
     assert repr(Model(a=MyDict({b'x': (1, 2)})).a) == "MyDict({b'x': (1, 2)})"
+    assert repr(Model(a=MyDict({b'x': (1, 2)})).copy().a) == "MyDict({b'x': (1, 2)})"
+    assert repr(Model(a=MyDict({b'x': (1, 2)})).copy(include={'a': True}).a) == "MyDict({b'x': (1, 2)})"
 
 
 def test_dict_subclasses_typed():


### PR DESCRIPTION
## Change Summary

Update `Model._get_value` to preserve dict subclasses on copy (including defaultdict).

## Related issue number

Fixes #5225, which appears in v1 and v2 (any chance for a v1 backport?).

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu