### PR TITLE
Add DeepChainMap and re-add LimitedDict

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
 
 else:
 
-    class DeepChainMap(ChainMap):  # type: ignore[type-arg]
+    class DeepChainMap(ChainMap):
         """
         Variant of ChainMap that allows direct updates to inner scopes
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -918,12 +918,12 @@ def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
             ...
 
         third_concrete = MyGeneric[Model]
-        assert concrete is not second_concrete, 1
-        assert concrete is not third_concrete, 2
-        assert second_concrete is not third_concrete, 3
-        assert globals()['MyGeneric[Model]'] is concrete, 4
-        assert globals()['MyGeneric[Model]_'] is second_concrete, 5
-        assert globals()['MyGeneric[Model]__'] is third_concrete, 6
+        assert concrete is not second_concrete
+        assert concrete is not third_concrete
+        assert second_concrete is not third_concrete
+        assert globals()['MyGeneric[Model]'] is concrete
+        assert globals()['MyGeneric[Model]_'] is second_concrete
+        assert globals()['MyGeneric[Model]__'] is third_concrete
 
 
 def test_generic_model_caching_detect_order_of_union_args_basic(create_module):


### PR DESCRIPTION
This gets more consistent behavior out of recursive generics, making it substantially more difficult for issues with generic caching to cause problems.

This was necessary to resolve an issue preventing #5235 from passing CI, which I was able to trace back to different behavior in a patch version of python 3.8. (Changing WeakValuesDict to dict in Python 3.8.16 makes the tests pass, and otherwise they fail; this is not necessary in Python 3.8.12.)

Selected Reviewer: @hramezani