### PR TITLE
Fix bug where incomplete subclasses of complete models don't rebuild properly

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -141,6 +141,8 @@ class ModelMetaclass(ABCMeta):
                     zip(_generics.iter_contained_typevars(__pydantic_generic_origin__), __pydantic_generic_args__ or ())
                 )
             )
+
+            cls.__pydantic_model_complete__ = False  # Ensure this specific class gets completed
             _model_construction.complete_model_class(
                 cls,
                 cls_name,

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -757,6 +757,22 @@ def test_force_rebuild():
     assert Foobar.model_rebuild(force=True) is True
 
 
+def test_rebuild_subclass_of_built_model():
+    class Model(BaseModel):
+        x: int
+
+    class FutureReferencingModel(Model):
+        y: 'FutureModel'
+        model_config = dict(undefined_types_warning=False)
+
+    class FutureModel(BaseModel):
+        pass
+
+    FutureReferencingModel.model_rebuild()
+
+    assert FutureReferencingModel(x=1, y=FutureModel()).model_dump() == {'x': 1, 'y': {}}
+
+
 def test_nested_annotation(create_module):
     module = create_module(
         # language=Python


### PR DESCRIPTION
Without this change, if you create a non-complete subclass of a complete model, it will be presumed complete because the `__pydantic_model_complete__` flag doesn't get reset to `False` when a new subclass is created.