### PR TITLE
(V1) Fix issue where constraints were not allowed on generic models

### DIFF
--- a/changes/2581-MaratBR.md
+++ b/changes/2581-MaratBR.md
@@ -1,2 +1,2 @@
-Fixes [#2581](/samuelcolvin/pydantic/issues/2581). Using constraints such as `gt` or `le` 
+Allow constraints such as `gt` or `le` on generic models.
 no longer raises `ValueError` due to unenforced constraint.

--- a/changes/2581-MaratBR.md
+++ b/changes/2581-MaratBR.md
@@ -1,0 +1,2 @@
+Fixes [#2581](/samuelcolvin/pydantic/issues/2581). Using constraints such as `gt` or `le` 
+no longer raises `ValueError` due to unenforced constraint.

--- a/changes/2581-MaratBR.md
+++ b/changes/2581-MaratBR.md
@@ -1,2 +1,1 @@
 Allow constraints such as `gt` or `le` on generic models.
-no longer raises `ValueError` due to unenforced constraint.

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -24,6 +24,7 @@ from typing_extensions import Annotated
 from .class_validators import gather_all_validators
 from .fields import DeferredType
 from .main import BaseModel, create_model
+from .schema import get_annotation_from_field_info
 from .types import JsonWrapper
 from .typing import display_as_type, get_all_type_hints, get_args, get_origin, typing_base
 from .utils import all_identical, lenient_issubclass
@@ -383,7 +384,12 @@ def _prepare_model_fields(
         assert field.type_.__class__ is DeferredType, field.type_.__class__
 
         field_type_hint = instance_type_hints[key]
-        concrete_type = replace_types(field_type_hint, typevars_map)
+        concrete_type = get_annotation_from_field_info(
+            replace_types(field_type_hint, typevars_map),
+            field.field_info,
+            field.name,
+            created_model.__config__.validate_assignment,
+        )
         field.type_ = concrete_type
         field.outer_type_ = concrete_type
         field.prepare()

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1503,6 +1503,12 @@ def test_generics_memory_use():
 def test_construct_generic_model_with_validation_and_unenforced_constraint():
     T = TypeVar('T')
 
+    expected_args = (
+        'On field "unenforced" the following field constraints are set but not enforced: lt. \n'
+        'For more details see https://docs.pydantic.dev/usage/schema/#unenforced-field-constraints',
+    )
+
+    # Demonstrate the expected error behavior on generic models
     with pytest.raises(ValueError) as exc_info:
 
         class Page(GenericModel, Generic[T]):
@@ -1510,10 +1516,15 @@ def test_construct_generic_model_with_validation_and_unenforced_constraint():
             items: Sequence[T]
             unenforced: PositiveInt = Field(..., lt=10)
 
-    assert exc_info.value.args == (
-        'On field "unenforced" the following field constraints are set but not enforced: lt. \n'
-        'For more details see https://docs.pydantic.dev/usage/schema/#unenforced-field-constraints',
-    )
+    # Demonstrate that this exact same behavior also happens with a standard BaseModel subclass
+    with pytest.raises(ValueError) as exc_info:
+
+        class ConcretePage(BaseModel):
+            page: int = Field(ge=42)
+            items: Sequence[str]
+            unenforced: PositiveInt = Field(..., lt=10)
+
+    assert exc_info.value.args == expected_args
 
 
 def test_construct_generic_model_with_validation():

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -25,7 +25,7 @@ from typing import (
 import pytest
 from typing_extensions import Annotated, Literal
 
-from pydantic import BaseModel, Field, Json, ValidationError, create_model, root_validator, validator
+from pydantic import BaseModel, Field, Json, PositiveInt, ValidationError, create_model, root_validator, validator
 from pydantic.generics import (
     GenericModel,
     _assigned_parameters,
@@ -1498,3 +1498,47 @@ def test_generics_memory_use():
 
         class _(Outer[Foo]):
             pass
+
+
+def test_construct_generic_model_with_validation_and_unenforced_constraint():
+    T = TypeVar('T')
+
+    with pytest.raises(ValueError) as exc_info:
+
+        class Page(GenericModel, Generic[T]):
+            page: int = Field(ge=42)
+            items: Sequence[T]
+            unenforced: PositiveInt = Field(..., lt=10)
+
+    assert exc_info.value.args == (
+        'On field "unenforced" the following field constraints are set but not enforced: lt. \n'
+        'For more details see https://docs.pydantic.dev/usage/schema/#unenforced-field-constraints',
+    )
+
+
+def test_construct_generic_model_with_validation():
+    # based on the test-case from https://github.com/samuelcolvin/pydantic/issues/2581
+    T = TypeVar('T')
+
+    class Page(GenericModel, Generic[T]):
+        page: int = Field(ge=42)
+        items: Sequence[T]
+
+    # Check we can perform this assignment, this is the actual test
+    concrete_model = Page[str]
+    assert concrete_model.__name__ == 'Page[str]'
+
+    # Sanity check the resulting type works as expected
+    valid = concrete_model(page=42, items=[])
+    assert valid.page == 42
+
+    with pytest.raises(ValidationError) as exc_info:
+        concrete_model(page=41, items=[])
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('page',),
+            'msg': 'ensure this value is greater than or equal to 42',
+            'type': 'value_error.number.not_ge',
+            'ctx': {'limit_value': 42},
+        }
+    ]

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1516,6 +1516,8 @@ def test_construct_generic_model_with_validation_and_unenforced_constraint():
             items: Sequence[T]
             unenforced: PositiveInt = Field(..., lt=10)
 
+    assert exc_info.value.args == expected_args
+
     # Demonstrate that this exact same behavior also happens with a standard BaseModel subclass
     with pytest.raises(ValueError) as exc_info:
 


### PR DESCRIPTION
This is a slightly simplified, brought-up-to-date implementation of #3593 (and closes #3358 and #2581).

fix #3358, fix #2581.

I think this should be safe to merge.

I have verified that the added tests are already behaving as desired in v2. (Actually they work better than in v1 — you can add a constraint on a `PositiveInt` without an error in v2, unlike what's happening in the tests here, and which happens on non-generic models in v1 as well.)

If we merge this I will open a separate PR to v2 adding similar tests, but no changes are necessary to the v2 source code for it to handle this all correctly.

skip change file check

Selected Reviewer: @samuelcolvin