### PR TITLE
Update remaining test xfail reasons

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -88,7 +88,7 @@ class CustomValidator(ABC):
         attrs = attrs or set(self.__slots__)  # type: ignore[attr-defined]
         for k, v in constraints.items():
             if k not in attrs:
-                raise TypeError(f'{self.__class__.__name__} has no attribute {k!r}')
+                raise TypeError(f'{k!r} is not a valid constraint for {self.__class__.__name__}')
             setattr(self, k, v)
 
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -480,7 +480,7 @@ def test_default_factory_singleton_field():
     assert Foo().singleton is Foo().singleton
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_schema():
     @pydantic.dataclasses.dataclass
     class User:
@@ -522,7 +522,7 @@ def test_schema():
     }
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_nested_schema():
     @pydantic.dataclasses.dataclass
     class Nested:
@@ -771,7 +771,7 @@ def test_override_builtin_dataclass_nested():
     assert foo.file.meta.seen_count == 7
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_override_builtin_dataclass_nested_schema():
     @dataclasses.dataclass
     class Meta:
@@ -950,7 +950,7 @@ class ModelForPickle(pydantic.BaseModel):
         restored_obj.dataclass.value = 'value of a wrong type'
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_config_field_info_create_model():
     # works
     class A1(BaseModel):
@@ -1090,7 +1090,7 @@ def test_issue_2541():
         e.item.infos.id = 2
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_issue_2555():
     @dataclasses.dataclass
     class Span:
@@ -1130,7 +1130,7 @@ def test_issue_2594():
     assert isinstance(M(e={}).e, Empty)
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_schema_description_unset():
     @pydantic.dataclasses.dataclass
     class A:
@@ -1146,7 +1146,7 @@ def test_schema_description_unset():
     assert 'description' not in B.__pydantic_model__.model_json_schema()
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_schema_description_set():
     @pydantic.dataclasses.dataclass
     class A:
@@ -1185,7 +1185,7 @@ def test_issue_3011():
     assert c.thing.thing_a == 'Thing A'
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_issue_3162():
     @dataclasses.dataclass
     class User:
@@ -1212,7 +1212,7 @@ def test_issue_3162():
     }
 
 
-@pytest.mark.xfail(reason='JSON schema')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_discriminated_union_basemodel_instance_value():
     @pydantic.dataclasses.dataclass
     class A:
@@ -1434,7 +1434,7 @@ def test_validator():
     assert d.b == 5.0
 
 
-@pytest.mark.xfail(reason='working on V2 - validator in child not applied')
+@pytest.mark.xfail(reason='validator in child not applied')
 def test_parent_post_init():
     @dataclasses.dataclass
     class A:
@@ -1456,7 +1456,7 @@ def test_parent_post_init():
     assert B(a=1).a == 5  # 1 * 2 + 3
 
 
-@pytest.mark.xfail(reason='working on V2 - validator in child not applied')
+@pytest.mark.xfail(reason='validator in child not applied')
 def test_subclass_post_init():
     @dataclasses.dataclass
     class A:
@@ -1476,7 +1476,7 @@ def test_subclass_post_init():
     assert B().a == 5  # 1 * 2 + 3
 
 
-@pytest.mark.xfail(reason='working on V2 - validator in child not applied')
+@pytest.mark.xfail(reason='validator in child not applied')
 def test_subclass_post_init_inheritance():
     @dataclasses.dataclass
     class A:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -4,10 +4,11 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, get_args
 
 import pytest
 from dirty_equals import HasRepr, IsStr
+from pydantic_core import core_schema
 
 from pydantic import (
     BaseModel,
@@ -15,6 +16,7 @@ from pydantic import (
     Extra,
     PydanticSchemaGenerationError,
     ValidationError,
+    Validator,
     constr,
     errors,
 )
@@ -576,7 +578,7 @@ def test_include_exclude_defaults():
     assert m.model_dump(exclude=['a'], exclude_unset=True) == {'b': 2, 'e': 5, 'f': 7}
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='pydantic-core include/exclude does not wrap negative ints')
 def test_advanced_exclude():
     class SubSubModel(BaseModel):
         a: str
@@ -592,7 +594,6 @@ def test_advanced_exclude():
 
     m = Model(e='e', f=SubModel(c='foo', d=[SubSubModel(a='a', b='b'), SubSubModel(a='c', b='e')]))
 
-    # TODO: Need to add wrapping support to pydantic_core to get this test to pass
     assert m.model_dump(exclude={'f': {'c': ..., 'd': {-1: {'a'}}}}) == {
         'e': 'e',
         'f': {'d': [{'a': 'a', 'b': 'b'}, {'b': 'e'}]},
@@ -600,7 +601,7 @@ def test_advanced_exclude():
     assert m.model_dump(exclude={'e': ..., 'f': {'d'}}) == {'f': {'c': 'foo'}}
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='pydantic-core include/exclude does not wrap negative ints')
 def test_advanced_exclude_by_alias():
     class SubSubModel(BaseModel):
         a: str
@@ -629,7 +630,7 @@ def test_advanced_exclude_by_alias():
     assert m.model_dump(exclude=excludes, by_alias=True) == {'f_alias': {'c_alias': 'foo'}}
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='pydantic-core include/exclude does not wrap negative ints')
 def test_advanced_value_include():
     class SubSubModel(BaseModel):
         a: str
@@ -647,11 +648,10 @@ def test_advanced_value_include():
 
     assert m.model_dump(include={'f'}) == {'f': {'c': 'foo', 'd': [{'a': 'a', 'b': 'b'}, {'a': 'c', 'b': 'e'}]}}
     assert m.model_dump(include={'e'}) == {'e': 'e'}
-    # TODO: Need to add wrapping support to pydantic_core to get this test to pass
     assert m.model_dump(include={'f': {'d': {0: ..., -1: {'b'}}}}) == {'f': {'d': [{'a': 'a', 'b': 'b'}, {'b': 'e'}]}}
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='pydantic-core include/exclude does not wrap negative ints')
 def test_advanced_value_exclude_include():
     class SubSubModel(BaseModel):
         a: str
@@ -672,7 +672,6 @@ def test_advanced_value_exclude_include():
     }
     assert m.model_dump(exclude={'e': ..., 'f': {'d'}}, include={'e', 'f'}) == {'f': {'c': 'foo'}}
 
-    # TODO: Need to add wrapping support to pydantic_core to get this test to pass
     assert m.model_dump(exclude={'f': {'d': {-1: {'a'}}}}, include={'f': {'d'}}) == {
         'f': {'d': [{'a': 'a', 'b': 'b'}, {'b': 'e'}]}
     }
@@ -1149,7 +1148,7 @@ def test_optional_required():
     assert exc_info.value.errors() == [{'input': {}, 'loc': ('bar',), 'msg': 'Field required', 'type': 'missing'}]
 
 
-@pytest.mark.xfail(reason='working on V2 - validators')
+@pytest.mark.xfail(reason='items yielded by __get_validators__ are not inspected for valid signatures')
 def test_invalid_validator():
     class InvalidValidator:
         @classmethod
@@ -1160,12 +1159,11 @@ def test_invalid_validator():
         def has_wrong_arguments(cls, value, bar):
             pass
 
-    with pytest.raises(errors.PydanticUserError) as exc_info:
+    with pytest.raises(errors.PydanticUserError, match='Invalid signature for validator'):
 
         class InvalidValidatorModel(BaseModel):
+            model_config = dict(arbitrary_types_allowed=True)
             x: InvalidValidator = ...
-
-    assert exc_info.value.args[0].startswith('Invalid signature for validator')
 
 
 @pytest.mark.xfail(reason='working on V2')
@@ -1339,7 +1337,7 @@ def test_self_recursive():
     assert m.model_dump() == {'sm': {'self': 123}}
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='need to detect and error if you override __init__; need to suggest a migration path')
 def test_nested_init():
     class NestedModel(BaseModel):
         self: str
@@ -1899,7 +1897,7 @@ def test_required_any():
     }
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='need to modify loc of ValidationError')
 def test_custom_generic_validators():
     T1 = TypeVar('T1')
     T2 = TypeVar('T2')
@@ -1910,27 +1908,25 @@ def test_custom_generic_validators():
             self.t2 = t2
 
         @classmethod
-        def __get_validators__(cls):
-            yield cls.validate
+        def __get_pydantic_core_schema__(cls, source, **kwargs):
+            schema = core_schema.is_instance_schema(cls)
 
-        @classmethod
-        def validate(cls, v, field):
-            if not isinstance(v, cls):
-                raise TypeError('Invalid value')
-            if not field.sub_fields:
+            args = get_args(source)
+            if not args:
+                return schema
+
+            t1_f = Validator(args[0])
+            t2_f = Validator(args[1])
+
+            def validate(v, info):
+                if not args:
+                    return v
+                # TODO: Collect these errors, rather than stopping early, and modify the loc to make the test pass
+                t1_f(v.t1)
+                t2_f(v.t2)
                 return v
-            t1_f = field.sub_fields[0]
-            t2_f = field.sub_fields[1]
-            errors = []
-            _, error = t1_f.validate(v.t1, {}, loc='t1')
-            if error:
-                errors.append(error)
-            _, error = t2_f.validate(v.t2, {}, loc='t2')
-            if error:
-                errors.append(error)
-            if errors:
-                raise ValidationError(errors, cls)
-            return v
+
+            return core_schema.general_after_validator_function(validate, schema)
 
     class Model(BaseModel):
         a: str
@@ -1946,14 +1942,14 @@ def test_custom_generic_validators():
             'ctx': {'class': 'test_custom_generic_validators.<locals>.MyGen'},
             'input': 'invalid',
             'loc': ('gen',),
-            'msg': 'Input should be an instance of ' 'test_custom_generic_validators.<locals>.MyGen',
+            'msg': 'Input should be an instance of test_custom_generic_validators.<locals>.MyGen',
             'type': 'is_instance_of',
         },
         {
             'ctx': {'class': 'test_custom_generic_validators.<locals>.MyGen'},
             'input': 'invalid',
             'loc': ('gen2',),
-            'msg': 'Input should be an instance of ' 'test_custom_generic_validators.<locals>.MyGen',
+            'msg': 'Input should be an instance of test_custom_generic_validators.<locals>.MyGen',
             'type': 'is_instance_of',
         },
     ]
@@ -1961,7 +1957,12 @@ def test_custom_generic_validators():
     with pytest.raises(ValidationError) as exc_info:
         Model(a='foo', gen=MyGen(t1='bar', t2='baz'), gen2=MyGen(t1='bar', t2='baz'))
     assert exc_info.value.errors() == [
-        {'loc': ('gen', 't2'), 'msg': 'value could not be parsed to a boolean', 'type': 'type_error.bool'}
+        {
+            'input': 'baz',
+            'loc': ('gen', 't2'),
+            'msg': 'Input should be a valid boolean, unable to interpret input',
+            'type': 'bool_parsing',
+        }
     ]
 
     m = Model(a='foo', gen=MyGen(t1='bar', t2=True), gen2=MyGen(t1=1, t2=2))
@@ -2068,7 +2069,7 @@ def test_hashable_optional(default):
     Model()
 
 
-@pytest.mark.xfail(reason='working on V2 - validators')
+@pytest.mark.xfail(reason='validate_all')
 def test_default_factory_called_once():
     """It should never call `default_factory` more than once even when `validate_all` is set"""
 
@@ -2098,15 +2099,14 @@ def test_default_factory_called_once():
     ]
 
 
-@pytest.mark.xfail(reason='working on V2 - validators')
 def test_default_factory_validator_child():
     class Parent(BaseModel):
         foo: List[str] = Field(default_factory=list)
 
-        @field_validator('foo', pre=True, each_item=True)
+        @field_validator('foo', mode='before')
         @classmethod
         def mutate_foo(cls, v):
-            return f'{v}-1'
+            return [f'{x}-1' for x in v]
 
     assert Parent(foo=['a', 'b']).foo == ['a-1', 'b-1']
 
@@ -2146,7 +2146,7 @@ def test_iter_coverage():
     assert list(MyModel()._iter(by_alias=True)) == [('x', 1), ('y', 'a')]
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='field frozen')
 def test_frozen_config_and_field():
     class Foo(BaseModel):
         model_config = ConfigDict(frozen=False, validate_assignment=True)
@@ -2197,7 +2197,7 @@ def test_bytes_subclass():
     assert m.my_bytes.__class__ == BytesSubclass
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='subclass not preserved for field of type int')
 def test_int_subclass():
     class MyModel(BaseModel):
         my_int: int
@@ -2228,7 +2228,7 @@ def test_model_issubclass():
     assert not issubclass(Custom, BaseModel)
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='"long int", see details below')
 def test_long_int():
     """
     see https://github.com/pydantic/pydantic/issues/1477 and in turn, https://github.com/python/cpython/issues/95778

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -4,11 +4,12 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, get_args
+from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
 
 import pytest
 from dirty_equals import HasRepr, IsStr
 from pydantic_core import core_schema
+from typing_extensions import get_args
 
 from pydantic import (
     BaseModel,

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -477,13 +477,12 @@ class Filter(BaseModel):
     assert isinstance(Filter(p={'sort': 'some_field:asc', 'fields': []}), Filter)
 
 
-@pytest.mark.xfail(reason='TODO create_model')
 def test_forward_ref_with_create_model(create_module):
     @create_module
     def module():
         import pydantic
 
-        Sub = pydantic.create_model('Sub', foo='bar', __module__=__name__)
+        Sub = pydantic.create_model('Sub', foo=(str, 'bar'), __module__=__name__)
         assert Sub  # get rid of "local variable 'Sub' is assigned to but never used"
         Main = pydantic.create_model('Main', sub=('Sub', ...), __module__=__name__)
         instance = Main(sub={})
@@ -597,7 +596,7 @@ class Model(BaseModel):
     assert module.Model.__class_vars__ == {'a'}
 
 
-@pytest.mark.xfail(reason='TODO json encoding')
+@pytest.mark.xfail(reason='json encoder stuff')
 def test_json_encoder_str(create_module):
     module = create_module(
         # language=Python
@@ -617,7 +616,7 @@ class User(BaseModel):
 
 
 class Model(BaseModel):
-    model_config=ConfigDict(json_encoders={ 'User': lambda v: f'User({v.y})'})
+    model_config=ConfigDict(json_encoders={'User': lambda v: f'User({v.y})'})
     foo_user: FooUser
     user: User
 
@@ -629,7 +628,7 @@ class Model(BaseModel):
     assert m.model_dump_json(models_as_dict=False) == '{"foo_user": {"x": "user1"}, "user": "User(user2)"}'
 
 
-@pytest.mark.xfail(reason='working on v2')
+@pytest.mark.xfail(reason='json encoder stuff')
 def test_json_encoder_forward_ref(create_module):
     # TODO: Replace the use of json_encoders with a root_serializer
     module = create_module(

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -32,7 +32,15 @@ from dirty_equals import HasRepr
 from pydantic_core import core_schema
 from typing_extensions import Annotated, Literal, OrderedDict
 
-from pydantic import BaseModel, Field, Json, PositiveInt, ValidationError, ValidationInfo, root_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    Json,
+    PositiveInt,
+    ValidationError,
+    ValidationInfo,
+    root_validator,
+)
 from pydantic._internal._core_utils import collect_invalid_schemas
 from pydantic._internal._generics import (
     _GENERIC_TYPES_CACHE,
@@ -1651,8 +1659,9 @@ def test_generic_recursive_models_with_a_concrete_parameter(create_module):
 
 def test_generic_recursive_models_complicated(create_module):
     """
-    TODO: this test will fail if run by itself. This is due to weird behavior with the WeakValueDictionary
-        used for caching. As part of the next batch of generics work, we should attempt to fix this if possible.
+    TODO: If we drop the use of LimitedDict and use WeakValueDictionary only, this test will fail if run by itself.
+        This is due to weird behavior with the WeakValueDictionary used for caching.
+        As part of the next batch of generics work, we should attempt to fix this if possible.
         In the meantime, if this causes issues, or the test otherwise starts failing, please make it xfail
         with strict=False
     """

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2050,7 +2050,7 @@ def test_subfield_field_info():
     }
 
 
-@pytest.mark.xfail(reason='working on V2 - dataclasses')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_dataclass():
     @dataclass
     class Model:
@@ -2617,7 +2617,7 @@ def test_complex_nested_generic():
     }
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='need to pass FieldInfo when calling __pydantic_modify_json_schema__')
 def test_schema_with_field_parameter():
     # TODO: Update so that __pydantic_modify_json_schema__ gets called with the FieldInfo when handling fields
     class RestrictedAlphabetStr(str):
@@ -3273,7 +3273,7 @@ def test_alias_same():
     }
 
 
-@pytest.mark.xfail(reason='working on V2 - dataclasses')
+@pytest.mark.xfail(reason='dataclasses JSON schema')
 def test_nested_python_dataclasses():
     """
     Test schema generation for nested python dataclasses

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -906,9 +906,8 @@ def test_model_iteration():
         pytest.param(
             {'foos': {0: 1}},
             TypeError,
-            '`exclude` argument must a set or dict',
+            '`exclude` argument must be a set or dict',
             id='value as int should be an error',
-            marks=pytest.mark.xfail(reason='working on V2'),
         ),
         pytest.param(
             {'foos': {'__all__': {1}}},
@@ -1392,7 +1391,7 @@ def test_base_config_type_hinting():
     get_type_hints(type(M.model_config))
 
 
-@pytest.mark.xfail(reason='https://github.com/pydantic/pydantic-core/pull/237')
+@pytest.mark.xfail(reason='frozen field; https://github.com/pydantic/pydantic-core/pull/237')
 def test_frozen_field():
     """assigning a frozen=True field should raise a TypeError"""
 

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -68,13 +68,13 @@ def test_custom_init_signature_with_no_var_kw():
     assert _equals(str(signature(Model)), '(a: float, b: int) -> None')
 
 
-@pytest.mark.xfail(reason='TODO create_model')
 def test_invalid_identifiers_signature():
     model = create_model(
-        'Model', **{'123 invalid identifier!': Field(123, alias='valid_identifier'), '!': Field(0, alias='yeah')}
+        'Model',
+        **{'123 invalid identifier!': (int, Field(123, alias='valid_identifier')), '!': (int, Field(0, alias='yeah'))},
     )
     assert _equals(str(signature(model)), '(*, valid_identifier: int = 123, yeah: int = 0) -> None')
-    model = create_model('Model', **{'123 invalid identifier!': 123, '!': Field(0, alias='yeah')})
+    model = create_model('Model', **{'123 invalid identifier!': (int, 123), '!': (int, Field(0, alias='yeah'))})
     assert _equals(str(signature(model)), '(*, yeah: int = 0, **extra_data: Any) -> None')
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -43,7 +43,7 @@ def test_model_validate_wrong_model():
     assert exc_info.value.errors() == [{'input': {'c': 123}, 'loc': ('a',), 'msg': 'Field required', 'type': 'missing'}]
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='__root__ model')
 def test_model_validate_root():
     class MyModel(BaseModel):
         __root__: str
@@ -53,7 +53,7 @@ def test_model_validate_root():
     assert m.__root__ == 'a'
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='__root__ model')
 def test_parse_root_list():
     class MyModel(BaseModel):
         __root__: List[str]
@@ -63,7 +63,7 @@ def test_parse_root_list():
     assert m.__root__ == ['a']
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='__root__ model')
 def test_parse_nested_root_list():
     class NestedData(BaseModel):
         id: str
@@ -79,7 +79,7 @@ def test_parse_nested_root_list():
     assert isinstance(m.nested.__root__[0], NestedData)
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='__root__ model')
 def test_parse_nested_root_tuple():
     class NestedData(BaseModel):
         id: str
@@ -99,7 +99,7 @@ def test_parse_nested_root_tuple():
     assert isinstance(nested, NestedModel)
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='__root__ model')
 def test_parse_nested_custom_root():
     class NestedModel(BaseModel):
         __root__: List[str]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,7 +22,7 @@ def test_parse_obj_as_model():
     assert parse_obj_as(Model, model_inputs) == Model(**model_inputs)
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='model subclass instances fail validation')
 def test_parse_obj_preserves_subclasses():
     class ModelA(BaseModel):
         a: Mapping[int, str]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1159,15 +1159,8 @@ def test_invalid_schema_constraints(kwargs, type_):
             a: type_ = Field('foo', title='A title', description='A description', **kwargs)
 
 
-@pytest.mark.xfail(reason='Do we want to make this a SchemaError?')
 def test_invalid_decimal_constraint():
-    # Using the following line instead of the uncommented one below would make the test pass:
-    # with pytest.raises(TypeError, match="DecimalValidator has no attribute 'max_length'"):
-    with pytest.raises(SchemaError, match='Invalid Schema:\n.*\n  Extra inputs are not permitted'):
-        # TODO: This error comes from pydantic._internal._fields.CustomValidator._update_attrs
-        #   Should we modify how that works to produce SchemaError like in the cases above?
-        #   If so, do we need to expose a way to create a SchemaError from python?
-        #   Right now this can only be done from the Rust side of pydantic_core
+    with pytest.raises(TypeError, match="'max_length' is not a valid constraint for DecimalValidator"):
 
         class Foo(BaseModel):
             a: Decimal = Field('foo', title='A title', description='A description', max_length=5)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -380,7 +380,7 @@ def test_duplicates():
                 return v
 
 
-@pytest.mark.xfail(reason='working on V2 - validator always')
+@pytest.mark.xfail(reason='validator always')
 def test_validate_always():
     check_calls = 0
 
@@ -402,7 +402,7 @@ def test_validate_always():
     assert check_calls == 2
 
 
-@pytest.mark.xfail(reason='working on V2 - validator always')
+@pytest.mark.xfail(reason='validator always')
 def test_validate_always_on_inheritance():
     check_calls = 0
 
@@ -784,7 +784,7 @@ def test_key_validation():
     assert Model(foobar={1: 1}).foobar == {2: 2}
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='validator always')
 def test_validator_always_optional():
     check_calls = 0
 
@@ -804,7 +804,7 @@ def test_validator_always_optional():
     assert check_calls == 2
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='validator always')
 def test_validator_always_pre():
     check_calls = 0
 
@@ -823,7 +823,7 @@ def test_validator_always_pre():
     assert check_calls == 2
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='validator always')
 def test_validator_always_post():
     class Model(BaseModel):
         a: str = None
@@ -837,7 +837,7 @@ def test_validator_always_post():
     assert Model().a == 'default value'
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='validator always')
 def test_validator_always_post_optional():
     class Model(BaseModel):
         a: Optional[str] = None
@@ -851,7 +851,7 @@ def test_validator_always_post_optional():
     assert Model().a == 'default value'
 
 
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='validator always')
 def test_datetime_validator():
     check_calls = 0
 
@@ -1275,7 +1275,7 @@ def test_nested_literal_validator():
 # TODO: this test fails because our union schema
 # doesn't accept `frozen` as an argument
 # Do we need to add `frozen` to every schema?
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='frozen field')
 def test_union_literal_with_constraints():
     class Model(BaseModel, validate_assignment=True):
         x: Union[Literal[42], Literal['pika']] = Field(frozen=True)
@@ -1380,7 +1380,7 @@ def test_overridden_root_validators():
 
 # TODO: I think this is real bug in pydantic-core
 # the root validator doesn't get called on assignment
-@pytest.mark.xfail(reason='working on V2')
+@pytest.mark.xfail(reason='root validator not called during assignment')
 def test_validating_assignment_pre_root_validator_fail():
     class Model(BaseModel):
         current_value: float = Field(..., alias='current')
@@ -1439,7 +1439,7 @@ def test_root_validator_skip_on_failure_valid(kwargs: Dict[str, Any]):
             return values
 
 
-@pytest.mark.xfail(reason='working on V2 - pydantic-core bug?')
+@pytest.mark.xfail(reason='root validator not called during assignment')
 def test_root_validator_many_values_change():
     """It should run root_validator on assignment and update ALL concerned fields"""
 


### PR DESCRIPTION
The only place where I've left non-updated xfail tests is in `test_orm_mode.py`, which I'm not quite sure what we're going to do with yet, but clearly it's going to get an overhaul.

I was able to fix at least a handful of tests along the way here. There was one place where I changed an error message to make things a little more clear, in a way that I felt was good enough to change a test from xfailing to passing. (I'll point this out below.)

Selected Reviewer: @adriangb