### PR TITLE
Validate always

### DIFF
--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -336,6 +336,8 @@ In this case you should set `check_fields=False` on the validator.
 
 Validators also work with *pydantic* dataclasses.
 
+# TODO: Change this example so that it _should_ use a validator; right now it would be better off with default_factory..
+
 ```py
 from datetime import datetime
 

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -336,16 +336,16 @@ In this case you should set `check_fields=False` on the validator.
 
 Validators also work with *pydantic* dataclasses.
 
-```py test="xfail - currently decorators are messing up dataclass field defaults #5271"
+```py
 from datetime import datetime
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic.dataclasses import dataclass
 
 
 @dataclass
 class DemoDataclass:
-    ts: datetime = None
+    ts: datetime = Field(None, validate_default=True)
 
     @field_validator('ts', mode='before')
     def set_ts_now(cls, v):
@@ -353,5 +353,7 @@ class DemoDataclass:
 
 
 print(DemoDataclass())
+#> DemoDataclass(ts=datetime.datetime(2032, 1, 2, 3, 4, 5, 6))
 print(DemoDataclass(ts='2017-11-08T14:00'))
+#> DemoDataclass(ts=datetime.datetime(2017, 11, 8, 14, 0))
 ```

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -59,8 +59,9 @@ class ValidatorDecoratorInfo(Representation):
         fields: tuple[str, ...],
         # pre=True/False in v1 should be converted to mode='before'/'after' in v2
         mode: Literal['before', 'after'],
-        check_fields: bool | None,
         each_item: bool,
+        always: bool,
+        check_fields: bool | None,
     ) -> None:
         """
         :param mode: the pydantic-core validator mode.
@@ -70,8 +71,9 @@ class ValidatorDecoratorInfo(Representation):
         """
         self.fields = fields
         self.mode = mode
-        self.check_fields = check_fields
         self.each_item = each_item
+        self.always = always
+        self.check_fields = check_fields
 
 
 class FieldValidatorDecoratorInfo(Representation):

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -934,6 +934,16 @@ def apply_validators(
 
 
 def _validators_require_validate_default(validators: Iterable[Decorator[ValidatorDecoratorInfo]]) -> bool:
+    """
+    In v1, if any of the validators for a field had `always=True`, the default value would be validated.
+
+    This serves as an auxiliary function for re-implementing that logic, by looping over a provided
+    collection of (v1-style) ValidatorDecoratorInfo's and checking if any of them have `always=True`.
+
+    We should be able to drop this function and the associated logic calling it once we drop support
+    for v1-style validator decorators. (Or we can extend it and keep it if we add something equivalent
+    to the v1-validator `always` kwarg to `field_validator`.)
+    """
     for validator in validators:
         if validator.info.always:
             return True

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -78,6 +78,7 @@ class _ConfigDict(TypedDict, total=False):
     # new in V2
     ser_json_timedelta: Literal['iso8601', 'float']
     ser_json_bytes: Literal['utf8', 'base64']
+    validate_default: bool
 
 
 config_keys = set(_ConfigDict.__annotations__.keys())
@@ -122,6 +123,7 @@ _default_config = ConfigDict(
     post_init_call='before_validation',
     ser_json_timedelta='iso8601',
     ser_json_bytes='utf8',
+    validate_default=False,
 )
 
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -42,6 +42,7 @@ class FieldInfo(_repr.Representation):
         'json_schema_extra',
         'init_var',
         'kw_only',
+        'validate_default',
     )
 
     # used to convert kwargs to metadata/constraints,
@@ -93,6 +94,7 @@ class FieldInfo(_repr.Representation):
         # currently only used on dataclasses
         self.init_var = kwargs.get('init_var', None)
         self.kw_only = kwargs.get('kw_only', None)
+        self.validate_default = kwargs.get('validate_default', None)
 
     @classmethod
     def from_field(cls, default: Any = Undefined, **kwargs: Any) -> FieldInfo:
@@ -309,6 +311,7 @@ def Field(
     repr: bool = True,
     strict: bool | None = None,
     json_schema_extra: dict[str, Any] | None = None,
+    validate_default: bool | None = None,
 ) -> Any:
     """
     Used to provide extra information about a field, either for the model schema or complex validation. Some arguments
@@ -359,6 +362,7 @@ def Field(
     :param repr: show this field in the representation
     :param json_schema_extra: extra dict to be merged with the JSON Schema for this field
     :param strict: enable or disable strict parsing mode
+    :param validate_default: whether the default value should be validated for this field
     """
     return FieldInfo.from_field(
         default,
@@ -388,6 +392,7 @@ def Field(
         repr=repr,
         json_schema_extra=json_schema_extra,
         strict=strict,
+        validate_default=validate_default,
     )
 
 

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -136,17 +136,16 @@ def test_inheritance_validators():
         model(a='something else')
 
 
-@pytest.mark.xfail(reason='working on V2')
 def test_inheritance_validators_always():
     class BarModel(BaseModel):
-        @field_validator('a', check_fields=False, always=True)
+        @field_validator('a', check_fields=False)
         @classmethod
         def check_a(cls, v):
             if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
             return v
 
-    model = create_model('FooModel', a='cake', __base__=BarModel)
+    model = create_model('FooModel', a=(str, Field('cake', validate_default=True)), __base__=BarModel)
     with pytest.raises(ValidationError):
         model()
     assert model(a='this is foobar good').a == 'this is foobar good'

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,3 +1,4 @@
+import re
 from collections import deque
 from datetime import datetime
 from enum import Enum
@@ -405,7 +406,7 @@ def test_use_bare_field_validator():
 
 
 def test_use_no_fields():
-    with pytest.raises(TypeError, match='validator with no fields specified'):
+    with pytest.raises(TypeError, match=re.escape("validator() missing 1 required positional argument: '__field'")):
 
         class Model(BaseModel):
             a: str
@@ -418,7 +419,9 @@ def test_use_no_fields():
 
 
 def test_use_no_fields_field_validator():
-    with pytest.raises(TypeError, match='field_validator with no fields specified'):
+    with pytest.raises(
+        TypeError, match=re.escape("field_validator() missing 1 required positional argument: '__field'")
+    ):
 
         class Model(BaseModel):
             a: str


### PR DESCRIPTION
Implements the handling of `validate_default` for fields and the `always=True` argument to v1-style `@validator` decorator. Also adds the `validate_default` as a keyword argument to model_config.

Selected Reviewer: @samuelcolvin