### PR TITLE
Drop mdx_truly_sane_lists dependency

### DIFF
--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -622,39 +622,35 @@ except ValidationError as e:
 ### Datetime Types
 
 *Pydantic* supports the following [datetime](https://docs.python.org/library/datetime.html#available-types)
-types:
+types.
 
-* `datetime` fields can be:
+`datetime` fields can be:
 
-  * `datetime`, existing `datetime` object
-  * `int` or `float`, assumed as Unix time, i.e. seconds (if >= `-2e10` or <= `2e10`) or milliseconds (if < `-2e10`or > `2e10`) since 1 January 1970
-  * `str`, following formats work:
-
+* `datetime`, existing `datetime` object
+* `int` or `float`, assumed as Unix time, i.e. seconds (if >= `-2e10` or <= `2e10`) or milliseconds (if < `-2e10`or > `2e10`) since 1 January 1970
+* `str`, following formats work:
     * `YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]`
     * `int` or `float` as a string (assumed as Unix time)
 
-* `date` fields can be:
+`date` fields can be:
 
-  * `date`, existing `date` object
-  * `int` or `float`, see `datetime`
-  * `str`, following formats work:
-
+* `date`, existing `date` object
+* `int` or `float`, see `datetime`
+* `str`, following formats work:
     * `YYYY-MM-DD`
     * `int` or `float`, see `datetime`
 
-* `time` fields can be:
+`time` fields can be:
 
-  * `time`, existing `time` object
-  * `str`, following formats work:
-
+* `time`, existing `time` object
+* `str`, following formats work:
     * `HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]`
 
-* `timedelta` fields can be:
+`timedelta` fields can be:
 
-  * `timedelta`, existing `timedelta` object
-  * `int` or `float`, assumed as seconds
-  * `str`, following formats work:
-
+* `timedelta`, existing `timedelta` object
+* `int` or `float`, assumed as seconds
+* `str`, following formats work:
     * `[-][DD ][HH:MM]SS[.ffffff]`
     * `[±]P[DD]DT[HH]H[MM]M[SS]S` ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format for timedelta)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,6 @@ markdown_extensions:
 - admonition
 - pymdownx.highlight
 - pymdownx.extra
-- mdx_truly_sane_lists
 - pymdownx.emoji:
     emoji_index: !!python/name:materialx.emoji.twemoji
     emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
Removes mdx_truly_sane_lists dependency from docs

## Change Summary

There was a markdown version dependency mismatch between mkdocs and mdx_truly_sane_lists, resulting in a warning during docs build. To my knowledge we're not using mdx_truly_sane_lists except for bool docs, which will be reworked soon anyway. 

I'm also not a fan of multiple nested lists to the extent mdx_truly_sane_lists is needed anyway. Typically the information could be presented in a better way.

please review

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
