### PR TITLE
Fix validate_all test

### DIFF
--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2079,7 +2079,6 @@ def test_hashable_optional(default):
     Model()
 
 
-@pytest.mark.xfail(reason='validate_all')
 def test_default_factory_called_once():
     """It should never call `default_factory` more than once even when `validate_all` is set"""
 
@@ -2091,21 +2090,21 @@ def test_default_factory_called_once():
         return v
 
     class MyModel(BaseModel):
-        model_config = ConfigDict(validate_all=True)
+        model_config = ConfigDict(validate_default=True)
         id: int = Field(default_factory=factory)
 
     m1 = MyModel()
     assert m1.id == 1
 
     class MyBadModel(BaseModel):
-        model_config = ConfigDict(validate_all=True)
+        model_config = ConfigDict(validate_default=True)
         id: List[str] = Field(default_factory=factory)
 
     with pytest.raises(ValidationError) as exc_info:
         MyBadModel()
     assert v == 2  # `factory` has been called to run validation
     assert exc_info.value.errors() == [
-        {'loc': ('id',), 'msg': 'value is not a valid list', 'type': 'type_error.list'},
+        {'input': 2, 'loc': ('id',), 'msg': 'Input should be a valid list/array', 'type': 'list_type'}
     ]
 
 


### PR DESCRIPTION
Discovered this while looking through failing tests; it just needed argument name changes, etc.

I'm going to auto-merge it.