### PR TITLE
Config migration warning

### DIFF
--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -91,6 +91,39 @@ if TYPE_CHECKING:
 else:
 
     class ConfigDict(dict):
+        _V2_REMOVED_KEYS = {
+            'allow_mutation',
+            'error_msg_templates',
+            'fields',
+            'getter_dict',
+            'schema_extra',
+            'smart_union',
+            'underscore_attrs_are_private',
+        }
+        _V2_RENAMED_KEYS = {
+            'allow_population_by_field_name': 'populate_by_name',
+            'anystr_lower': 'str_to_lower',
+            'anystr_strip_whitespace': 'str_strip_whitespace',
+            'anystr_upper': 'str_to_upper',
+            'keep_untouched': 'ignored_types',
+            'max_anystr_length': 'str_max_length',
+            'min_anystr_length': 'str_min_length',
+            'orm_mode': 'from_attributes',
+            'validate_all': 'validate_default',
+        }
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            deprecated_removed_keys = ConfigDict._V2_REMOVED_KEYS & self.keys()
+            deprecated_renamed_keys = ConfigDict._V2_RENAMED_KEYS.keys() & self.keys()
+            if deprecated_removed_keys or deprecated_renamed_keys:
+                renamings = {k: self._V2_RENAMED_KEYS[k] for k in sorted(deprecated_renamed_keys)}
+                renamed_bullets = [f'* {k!r} has been renamed to {v!r}' for k, v in renamings.items()]
+                removed_bullets = [f'* {k!r} has been removed' for k in sorted(deprecated_removed_keys)]
+                message = '\n'.join(['Valid config keys have changed in V2:'] + renamed_bullets + removed_bullets)
+                warnings.warn(message, UserWarning)
+
         def __missing__(self, key: str) -> Any:
             if key in _default_config:  # need this check to prevent a recursion error
                 return _default_config[key]
@@ -170,7 +203,7 @@ class BaseConfig(metaclass=ConfigMetaclass):
         return super().__init_subclass__(**kwargs)
 
 
-def get_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> ConfigDict:
+def get_config(config: ConfigDict | dict[str, Any] | type[Any] | None, error_label: str | None = None) -> ConfigDict:
     if config is None:
         return ConfigDict()
 
@@ -183,6 +216,7 @@ def get_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> Config
         )
         config_dict = {k: getattr(config, k) for k in dir(config) if not k.startswith('__')}
 
+    prepare_config(config_dict, error_label or 'ConfigDict')
     return ConfigDict(config_dict)  # type: ignore
 
 
@@ -234,9 +268,10 @@ def build_config(
     return new_model_config
 
 
-def prepare_config(config: ConfigDict, cls_name: str) -> None:
-    if not isinstance(config['extra'], (Extra, type(None))):
+def prepare_config(config: ConfigDict | dict[str, Any], error_label: str) -> None:
+    extra = config.get('extra')
+    if extra is not None and not isinstance(extra, Extra):
         try:
-            config['extra'] = Extra(config['extra'])
+            config['extra'] = Extra(extra)
         except ValueError:
-            raise ValueError(f'"{cls_name}": {config["extra"]} is not a valid value for "extra"')
+            raise ValueError(f'{error_label!r}: {extra!r} is not a valid value for config[{"extra"!r}]')

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -171,7 +171,7 @@ class ConfigMetaclass(type):
         try:
             return _default_config[item]  # type: ignore[literal-required]
         except KeyError as exc:
-            raise AttributeError(f"type object '{self.__name__}' has no attribute {exc}")
+            raise AttributeError(f"type object '{self.__name__}' has no attribute {exc}") from exc
 
 
 class BaseConfig(metaclass=ConfigMetaclass):
@@ -193,7 +193,7 @@ class BaseConfig(metaclass=ConfigMetaclass):
                 return getattr(type(self), item)
             except AttributeError:
                 # reraising changes the displayed text to reflect that `self` is not a type
-                raise AttributeError(str(exc))
+                raise AttributeError(str(exc)) from exc
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         warnings.warn(
@@ -273,5 +273,5 @@ def prepare_config(config: ConfigDict | dict[str, Any], error_label: str) -> Non
     if extra is not None and not isinstance(extra, Extra):
         try:
             config['extra'] = Extra(extra)
-        except ValueError:
-            raise ValueError(f'{error_label!r}: {extra!r} is not a valid value for config[{"extra"!r}]')
+        except ValueError as e:
+            raise ValueError(f'{error_label!r}: {extra!r} is not a valid value for config[{"extra"!r}]') from e

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -146,7 +146,7 @@ def dataclass(
         else:
             setattr(cls, '__pydantic_decorators__', decorators)
 
-        config_dict = get_config(config)
+        config_dict = get_config(config, cls.__name__)
         _pydantic_dataclasses.prepare_dataclass(cls, config_dict, kw_only)
 
         if sys.version_info >= (3, 10):

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -210,11 +210,11 @@ class ValidatedFunction:
     def create_model(self, fields: Dict[str, Any], takes_args: bool, takes_kwargs: bool, config: 'ConfigType') -> None:
         pos_args = len(self.arg_mapping)
 
-        config_dict = get_config(config)
+        config_dict = get_config(config, getattr(self.raw_function, '__name__', 'validate_arguments'))
 
-        if 'fields' in config_dict or 'alias_generator' in config_dict:
+        if 'alias_generator' in config_dict:
             raise PydanticUserError(
-                'Setting the "fields" and "alias_generator" property on custom Config for '
+                'Setting the "alias_generator" property on custom Config for '
                 '@validate_arguments is not yet supported, please remove.'
             )
         if 'extra' not in config_dict:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -920,7 +920,7 @@ def create_model(
         namespace.update(__validators__)
     namespace.update(fields)
     if __config__:
-        namespace['model_config'] = get_config(__config__)
+        namespace['model_config'] = get_config(__config__, __model_name)
     resolved_bases = resolve_bases(__base__)
     meta, ns, kwds = prepare_class(__model_name, resolved_bases, kwds=__cls_kwargs__)
     if resolved_bases is not __base__:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -329,11 +329,9 @@ def test_config_title_cls():
 
 
 def test_config_fields():
-    with pytest.raises(
-        PydanticUserError, match='Setting the "fields" and "alias_generator" property on custom Config for @'
-    ):
+    with pytest.raises(PydanticUserError, match='Setting the "alias_generator" property on custom Config for @'):
 
-        @validate_arguments(config=dict(fields={'b': 'bang'}))
+        @validate_arguments(config=dict(alias_generator=lambda x: x))
         def foo(a: int, b: int):
             return f'{a}, {b}'
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1226,10 +1226,9 @@ def test_multiple_errors():
     assert Model(a=None).a is None
 
 
-def test_validate_all():
-    # TODO remove or rename, validate_all doesn't exist anymore
+def test_validate_default():
     class Model(BaseModel):
-        model_config = ConfigDict(validate_all=True)
+        model_config = ConfigDict(validate_default=True)
         a: int
         b: int
 
@@ -1250,7 +1249,7 @@ def test_force_extra():
 
 
 def test_illegal_extra_value():
-    with pytest.raises(ValueError, match='is not a valid value for "extra"'):
+    with pytest.raises(ValueError, match=re.escape("is not a valid value for config['extra']")):
 
         class Model(BaseModel):
             model_config = ConfigDict(extra='foo')

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -79,8 +79,6 @@ def test_private_attribute_annotation():
 
         _foo: str
 
-        model_config = ConfigDict(underscore_attrs_are_private=True)
-
     assert Model.__slots__ == {'_foo'}
     if platform.python_implementation() == 'PyPy':
         repr(Model._foo).startswith('<member_descriptor object at')
@@ -115,8 +113,6 @@ def test_underscore_attrs_are_private():
     class Model(BaseModel):
         _foo: str = 'abc'
         _bar: ClassVar[str] = 'cba'
-
-        model_config = ConfigDict(underscore_attrs_are_private=True)
 
     assert Model.__slots__ == {'_foo'}
     if platform.python_implementation() == 'PyPy':
@@ -210,8 +206,6 @@ def test_config_override_init():
             super().__init__(**data)
             self._private_attr = 123
 
-        model_config = ConfigDict(underscore_attrs_are_private=True)
-
     m = MyModel(x='hello')
     assert m.model_dump() == {'x': 'hello'}
     assert m._private_attr == 123
@@ -223,8 +217,6 @@ def test_generic_private_attribute():
     class Model(BaseModel, Generic[T]):
         value: T
         _private_value: T
-
-        model_config = ConfigDict(underscore_attrs_are_private=True)
 
     m = Model[int](value=1, _private_attr=3)
     m._private_value = 3


### PR DESCRIPTION
This adds migration warnings for configs that make use of config fields that have been removed or renamed in v2.

Selected Reviewer: @samuelcolvin