### PR TITLE
Config cleanup

### DIFF
--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -348,13 +348,13 @@ When substituting usage of `dataclasses.dataclass` with `pydantic.dataclasses.da
 
 _Pydantic_ dataclasses do not feature a `.json()` function. To dump them as JSON, you will need to make use of the `pydantic_encoder` as follows:
 
-```py
+```py output="json"
 import dataclasses
-import json
 from typing import List
 
+import pydantic_core
+
 from pydantic.dataclasses import dataclass
-from pydantic.json import pydantic_encoder
 
 
 @dataclass
@@ -365,7 +365,8 @@ class User:
 
 
 user = User(id='42')
-print(json.dumps(user, indent=4, default=pydantic_encoder))
+# TODO replace this with methods or equivalent
+print(pydantic_core.to_json(user, indent=4).decode())
 """
 {
     "id": 42,

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -161,36 +161,6 @@ for validation, for use with `from_attributes`; see [Data binding](models.md#dat
 custom descriptors (classes that behave like `property`). If an attribute is set on a class without an annotation
 and has a type that is not in this tuple (or otherwise recognized by pydantic), an error will be raised.
 
-**`schema_extra`**
-: a `dict` used to extend/update the generated JSON Schema, or a callable to post-process it; see [schema customization](schema.md#schema-customization)
-
-**`json_loads`**
-: a custom function for decoding JSON; see [custom JSON (de)serialisation](exporting_models.md#custom-json-deserialisation)
-
-**`json_dumps`**
-: a custom function for encoding JSON; see [custom JSON (de)serialisation](exporting_models.md#custom-json-deserialisation)
-
-**`json_encoders`**
-: a `dict` used to customise the way types are encoded to JSON; see [JSON Serialisation](exporting_models.md#modeljson)
-
-**`underscore_attrs_are_private`**
-: whether to treat any underscore non-class var attrs as private, or leave them as is; see [Private model attributes](models.md#private-model-attributes)
-
-**`copy_on_model_validation`**
-: string literal to control how models instances are processed during validation,
-with the following means (see [#4093](https://github.com/pydantic/pydantic/pull/4093) for a full discussion of the changes to this field):
-
-* `'none'` - models are not copied on validation, they're simply kept "untouched"
-* `'shallow'` - models are shallow copied, this is the default
-* `'deep'` - models are deep copied
-
-**`smart_union`**
-: whether _pydantic_ should try to check all types inside `Union` to prevent undesired coercion; see [the dedicated section](#smart-union)
-
-**`post_init_call`**
-: whether stdlib dataclasses `__post_init__` should be run before (default behaviour with value `'before_validation'`)
-  or after (value `'after_validation'`) parsing and validation when they are [converted](dataclasses.md#stdlib-dataclasses-and-_pydantic_-dataclasses).
-
 **`allow_inf_nan`**
 : whether to allow infinity (`+inf` an `-inf`) and NaN values to float fields, defaults to `True`,
   set to `False` for compatibility with `JSON`,

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -77,7 +77,6 @@ __all__ = [
     'MySQLDsn',
     'MariaDBDsn',
     'validate_email',
-    # parse
     # tools
     'parse_obj_as',
     'schema_of',

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -164,9 +164,10 @@ def generate_config(config: ConfigDict, cls: type[Any]) -> core_schema.CoreConfi
             ser_json_bytes=config['ser_json_bytes'],
             from_attributes=config['from_attributes'],
             loc_by_alias=config['loc_by_alias'],
+            revalidate_instances=config['revalidate_instances'],
             validate_default=config['validate_default'],
-            str_max_length=config.get('str_max_length'),
-            str_min_length=config.get('str_min_length'),
+            str_max_length=config['str_max_length'],
+            str_min_length=config['str_min_length'],
         )
     )
     return core_config

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -166,8 +166,8 @@ def generate_config(config: ConfigDict, cls: type[Any]) -> core_schema.CoreConfi
             loc_by_alias=config['loc_by_alias'],
             revalidate_instances=config['revalidate_instances'],
             validate_default=config['validate_default'],
-            str_max_length=config['str_max_length'],
-            str_min_length=config['str_min_length'],
+            str_max_length=config.get('str_max_length'),
+            str_min_length=config.get('str_min_length'),
         )
     )
     return core_config

--- a/pydantic/analyzed_type.py
+++ b/pydantic/analyzed_type.py
@@ -85,6 +85,7 @@ def _translate_config(config: ConfigDict) -> core_schema.CoreConfig:
         ser_json_bytes=config['ser_json_bytes'] if 'ser_json_bytes' in config else unset,
         from_attributes=config['from_attributes'] if 'from_attributes' in config else unset,
         loc_by_alias=config['loc_by_alias'] if 'loc_by_alias' in config else unset,
+        revalidate_instances=config['revalidate_instances'] if 'revalidate_instances' in config else unset,
         validate_default=config['validate_default'] if 'validate_default' in config else unset,
         str_max_length=(
             config['str_max_length'] if 'str_max_length' in config and config['str_max_length'] is not None else unset

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -9,9 +9,9 @@ from types import GeneratorType
 from typing import Any, Callable, Dict, Type, Union
 from uuid import UUID
 
-from .color import Color
-from .networks import NameEmail
-from .types import SecretBytes, SecretStr
+from ..color import Color
+from ..networks import NameEmail
+from ..types import SecretBytes, SecretStr
 
 __all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
 
@@ -73,7 +73,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
 def pydantic_encoder(obj: Any) -> Any:
     from dataclasses import asdict, is_dataclass
 
-    from .main import BaseModel
+    from ..main import BaseModel
 
     if isinstance(obj, BaseModel):
         return obj.model_dump()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -59,7 +59,7 @@ _base_class_defined = False
 
 @typing_extensions.dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class ModelMetaclass(ABCMeta):
-    def __new__(  # C901
+    def __new__(
         mcs,
         cls_name: str,
         bases: tuple[type[Any], ...],

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -7,7 +7,6 @@ import typing
 import warnings
 from abc import ABCMeta
 from copy import copy, deepcopy
-from functools import partial
 from inspect import getdoc
 from pathlib import Path
 from types import prepare_class, resolve_bases
@@ -32,7 +31,6 @@ from .deprecated import copy_internals as _deprecated_copy_internals
 from .deprecated import parse as _deprecated_parse
 from .errors import PydanticUndefinedAnnotation, PydanticUserError
 from .fields import Field, FieldInfo, ModelPrivateAttr
-from .json import custom_pydantic_encoder, pydantic_encoder
 from .json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMetadata
 
 if typing.TYPE_CHECKING:
@@ -61,7 +59,7 @@ _base_class_defined = False
 
 @typing_extensions.dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class ModelMetaclass(ABCMeta):
-    def __new__(  # noqa C901
+    def __new__(  # C901
         mcs,
         cls_name: str,
         bases: tuple[type[Any], ...],

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -782,7 +782,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
             'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.',
             DeprecationWarning,
         )
-        from .json import pydantic_encoder
+        from .deprecated.json import pydantic_encoder
 
         return json.dumps(
             cls.model_json_schema(by_alias=by_alias, ref_template=ref_template),

--- a/tests/mypy/modules/dataclass_no_any.py
+++ b/tests/mypy/modules/dataclass_no_any.py
@@ -6,6 +6,6 @@ class Foo:
     foo: int
 
 
-@dataclass(config={})
+@dataclass(config=dict(title='Bar Title'))
 class Bar:
     bar: str

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -44,9 +44,7 @@ cases = [
     ('mypy-default.ini', 'fail3.py', 'fail3.txt'),
     ('mypy-default.ini', 'fail4.py', 'fail4.txt'),
     ('mypy-default.ini', 'plugin_success.py', 'plugin_success.txt'),
-    pytest.param(
-        'mypy-plugin-strict-no-any.ini', 'dataclass_no_any.py', None, marks=pytest.mark.xfail(reason='TODO dataclasses')
-    ),
+    pytest.param('mypy-plugin-strict-no-any.ini', 'dataclass_no_any.py', None),
     pytest.param(
         'pyproject-default.toml',
         'success.py',

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1257,48 +1257,34 @@ def test_illegal_extra_value():
 
 
 def test_multiple_inheritance_config():
-    def int_encoder(x):
-        return x + 1
-
-    def int2_encoder(x):
-        return x + 2
-
-    def str_encoder(x):
-        return x.upper()
-
     class Parent(BaseModel):
-        model_config = ConfigDict(frozen=True, extra=Extra.forbid, json_encoders={int: int_encoder})
+        model_config = ConfigDict(frozen=True, extra=Extra.forbid)
 
     class Mixin(BaseModel):
-        model_config = ConfigDict(use_enum_values=True, json_encoders={int: int2_encoder})
+        model_config = ConfigDict(use_enum_values=True)
 
-    class Child(Mixin, Parent, json_encoders={str: str_encoder}):
+    class Child(Mixin, Parent):
         model_config = ConfigDict(populate_by_name=True)
 
     assert BaseModel.model_config['frozen'] is False
     assert BaseModel.model_config['populate_by_name'] is False
     assert BaseModel.model_config['extra'] is None
     assert BaseModel.model_config['use_enum_values'] is False
-    assert BaseModel.model_config['json_encoders'] == {}
 
     assert Parent.model_config['frozen'] is True
     assert Parent.model_config['populate_by_name'] is False
     assert Parent.model_config['extra'] is Extra.forbid
     assert Parent.model_config['use_enum_values'] is False
-    assert Parent.model_config['json_encoders'][int] is int_encoder
 
     assert Mixin.model_config['frozen'] is False
     assert Mixin.model_config['populate_by_name'] is False
     assert Mixin.model_config['extra'] is None
     assert Mixin.model_config['use_enum_values'] is True
-    assert Mixin.model_config['json_encoders'][int] is int2_encoder
 
     assert Child.model_config['frozen'] is True
     assert Child.model_config['populate_by_name'] is True
     assert Child.model_config['extra'] is Extra.forbid
     assert Child.model_config['use_enum_values'] is True
-    assert Child.model_config['json_encoders'][str] is str_encoder
-    assert Child.model_config['json_encoders'][int] is int_encoder
 
 
 def test_submodel_different_type():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict, NameEmail, field_serializer
 from pydantic._internal._generate_schema import GenerateSchema
 from pydantic.color import Color
 from pydantic.dataclasses import dataclass as pydantic_dataclass
-from pydantic.json import pydantic_encoder, timedelta_isoformat
+from pydantic.deprecated.json import pydantic_encoder, timedelta_isoformat
 from pydantic.types import DirectoryPath, FilePath, SecretBytes, SecretStr, condecimal
 
 try:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -498,7 +498,7 @@ def test_json_schema():
         'type': 'object',
         'properties': {
             'a': {'title': 'A', 'default': 'foobar', 'type': 'string', 'format': 'binary'},
-            'b': {'title': 'B', 'default': 12.34, 'type': 'number'},
+            'b': {'title': 'B', 'default': '12.34', 'type': 'number'},
         },
     }
 
@@ -2341,10 +2341,9 @@ def test_namedtuple_default():
         y: float
 
     class LocationBase(BaseModel):
-        coords: Coordinates = Coordinates(0, 0)
+        coords: Coordinates = Coordinates(34, 42)
 
     assert LocationBase(coords=Coordinates(1, 2)).coords == Coordinates(1, 2)
-    # assert LocationBase.__pydantic_core_schema__ == {}
 
     assert LocationBase.model_json_schema() == {
         'title': 'LocationBase',
@@ -2352,7 +2351,7 @@ def test_namedtuple_default():
         'properties': {
             'coords': {
                 'title': 'Coords',
-                'default': Coordinates(x=0, y=0),
+                'default': [34, 42],
                 'type': 'array',
                 'prefixItems': [{'title': 'X', 'type': 'number'}, {'title': 'Y', 'type': 'number'}],
                 'minItems': 2,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1032,25 +1032,30 @@ def test_field_exclude():
     assert my_user.model_dump() == {'id': 42, 'username': 'JohnDoe', 'hobbies': ['scuba diving']}
 
 
-@pytest.mark.skip(reason='not implemented')
-def test_model_exclude_copy_on_model_validation_shallow():
-    """When `Config.copy_on_model_validation` is set and `Config.copy_on_model_validation_shallow` is set,
-    do the same as the previous test but perform a shallow copy"""
-
+def test_revalidate_instances_never():
     class User(BaseModel):
-        model_config = ConfigDict(copy_on_model_validation='shallow')
-
         hobbies: List[str]
 
     my_user = User(hobbies=['scuba diving'])
 
     class Transaction(BaseModel):
-        user: User = Field(...)
+        user: User
 
     t = Transaction(user=my_user)
 
-    assert t.user is not my_user
-    assert t.user.hobbies is my_user.hobbies  # unlike above, this should be a shallow copy
+    assert t.user is my_user
+    assert t.user.hobbies is my_user.hobbies
+
+    class SubUser(User):
+        sins: List[str]
+
+    my_sub_user = SubUser(hobbies=['scuba diving'], sins=['lying'])
+
+    t = Transaction(user=my_sub_user)
+
+    assert t.user is my_sub_user
+    assert t.user.hobbies is my_sub_user.hobbies
+
 
 
 @pytest.mark.skip(reason='not implemented')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1057,6 +1057,57 @@ def test_revalidate_instances_never():
     assert t.user.hobbies is my_sub_user.hobbies
 
 
+def test_revalidate_instances_sub_instances():
+    class User(BaseModel, revalidate_instances='subclass-instances'):
+        hobbies: List[str]
+
+    my_user = User(hobbies=['scuba diving'])
+
+    class Transaction(BaseModel):
+        user: User
+
+    t = Transaction(user=my_user)
+
+    assert t.user is my_user
+    assert t.user.hobbies is my_user.hobbies
+
+    class SubUser(User):
+        sins: List[str]
+
+    my_sub_user = SubUser(hobbies=['scuba diving'], sins=['lying'])
+
+    t = Transaction(user=my_sub_user)
+
+    assert t.user is not my_sub_user
+    assert t.user.hobbies is not my_sub_user.hobbies
+    assert not hasattr(t.user, 'sins')
+
+
+def test_revalidate_instances_always():
+    class User(BaseModel, revalidate_instances='always'):
+        hobbies: List[str]
+
+    my_user = User(hobbies=['scuba diving'])
+
+    class Transaction(BaseModel):
+        user: User
+
+    t = Transaction(user=my_user)
+
+    assert t.user is not my_user
+    assert t.user.hobbies is not my_user.hobbies
+
+    class SubUser(User):
+        sins: List[str]
+
+    my_sub_user = SubUser(hobbies=['scuba diving'], sins=['lying'])
+
+    t = Transaction(user=my_sub_user)
+
+    assert t.user is not my_sub_user
+    assert t.user.hobbies is not my_sub_user.hobbies
+    assert not hasattr(t.user, 'sins')
+
 
 @pytest.mark.skip(reason='not implemented')
 @pytest.mark.parametrize('comv_value', [True, False])
@@ -1495,29 +1546,6 @@ def test_inherited_model_field_copy():
     assert id(image_2) in {id(image) for image in item.images}
 
 
-def test_inherited_model_field_untouched():
-    """It should not copy models used as fields if explicitly asked"""
-
-    class Image(BaseModel):
-        model_config = ConfigDict(copy_on_model_validation='none')
-        path: str
-
-        def __hash__(self):
-            return id(self)
-
-    class Item(BaseModel):
-        images: List[Image]
-
-    image_1 = Image(path='my_image1.png')
-    image_2 = Image(path='my_image2.png')
-
-    item = Item(images=(image_1, image_2))
-    assert image_1 in item.images
-
-    assert id(image_1) == id(item.images[0])
-    assert id(image_2) == id(item.images[1])
-
-
 def test_mapping_retains_type_subclass():
     class CustomMap(dict):
         pass
@@ -1647,13 +1675,6 @@ def test_class_kwargs_config():
     assert Model.model_config['extra'] is Extra.allow  # overwritten as intended
     assert Model.model_config['alias_generator'] is str.upper  # inherited as intended
     # assert Model.model_fields['b'].alias == 'B'  # alias_generator still works
-
-
-def test_class_kwargs_config_json_encoders():
-    class Model(BaseModel, json_encoders={int: str}):
-        pass
-
-    assert Model.model_config['json_encoders'] == {int: str}
 
 
 def test_class_kwargs_config_and_attr_conflict():


### PR DESCRIPTION
changes:
* Remove more stuff from config that is no longer used
* move `json.py` in to `deprecated`
* use `to_python_jsonable` to generate json_schema

Causes the following changes:
* Decimal defaults in JSON Schema are now strings (lots of old issues with people (rightly) depanding that decimals are encoded to strings not floats)
* named tuples in JSON schema are now lists, ref #2711

selected reviewer: @dmontagu