### PR TITLE
Massively simplify JSON schema generation

### DIFF
--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -291,6 +291,7 @@ class Character(Voice):
 print(Character.model_json_schema(by_alias=True))
 """
 {
+    'title': 'Character',
     'type': 'object',
     'properties': {
         'ActorName': {'type': 'string', 'default': None, 'title': 'Actorname'},
@@ -298,7 +299,6 @@ print(Character.model_json_schema(by_alias=True))
         'Mood': {'type': 'string', 'default': None, 'title': 'Mood'},
         'Act': {'type': 'integer', 'default': 1, 'title': 'Act'},
     },
-    'title': 'Character',
 }
 """
 ```

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -40,6 +40,8 @@ class MainModel(BaseModel):
 print(json.dumps(MainModel.model_json_schema(), indent=2))
 """
 {
+  "title": "Main",
+  "description": "This is the description of the main model",
   "type": "object",
   "properties": {
     "foo_bar": {
@@ -65,10 +67,9 @@ print(json.dumps(MainModel.model_json_schema(), indent=2))
   "required": [
     "foo_bar"
   ],
-  "title": "Main",
-  "description": "This is the description of the main model",
   "$defs": {
     "FooBar": {
+      "title": "FooBar",
       "type": "object",
       "properties": {
         "count": {
@@ -83,8 +84,7 @@ print(json.dumps(MainModel.model_json_schema(), indent=2))
       },
       "required": [
         "count"
-      ],
-      "title": "FooBar"
+      ]
     },
     "Gender": {
       "enum": [
@@ -176,6 +176,7 @@ print(schema_json_of(Pet, title='The Pet Schema', indent=2))
   },
   "$defs": {
     "Cat": {
+      "title": "Cat",
       "type": "object",
       "properties": {
         "pet_type": {
@@ -190,10 +191,10 @@ print(schema_json_of(Pet, title='The Pet Schema', indent=2))
       "required": [
         "pet_type",
         "cat_name"
-      ],
-      "title": "Cat"
+      ]
     },
     "Dog": {
+      "title": "Dog",
       "type": "object",
       "properties": {
         "pet_type": {
@@ -208,8 +209,7 @@ print(schema_json_of(Pet, title='The Pet Schema', indent=2))
       "required": [
         "pet_type",
         "dog_name"
-      ],
-      "title": "Dog"
+      ]
     }
   },
   "title": "The Pet Schema"
@@ -318,6 +318,7 @@ class ModelB(BaseModel):
 print(ModelB.model_json_schema())
 """
 {
+    'title': 'ModelB',
     'type': 'object',
     'properties': {
         'foo': {
@@ -328,7 +329,6 @@ print(ModelB.model_json_schema())
         }
     },
     'required': ['foo'],
-    'title': 'ModelB',
 }
 """
 ```
@@ -387,10 +387,11 @@ class RestrictedAlphabetStr(str):
     @classmethod
     def __pydantic_modify_json_schema__(
         cls, field_schema: Dict[str, Any], field: Optional[ModelField]
-    ):
+    ) -> Dict[str, Any]:
         if field:
             alphabet = field.field_info.extra['alphabet']
             field_schema['examples'] = [c * 3 for c in alphabet]
+        return field_schema
 
 
 class MyModel(BaseModel):
@@ -423,7 +424,8 @@ sub-models in its `definitions`:
 ```py output="json"
 import json
 
-from pydantic import AnalyzedType, BaseModel
+from pydantic import BaseModel
+from pydantic.json_schema import models_json_schema
 
 
 class Foo(BaseModel):
@@ -438,13 +440,13 @@ class Bar(BaseModel):
     c: int
 
 
-analyzed_types = [AnalyzedType(tp) for tp in [Model, Bar]]
-top_level_schema = AnalyzedType.json_schemas(analyzed_types, title='My Schema')
+top_level_schema = models_json_schema([Model, Bar], title='My Schema')
 print(json.dumps(top_level_schema, indent=2))
 """
 {
   "$defs": {
     "Foo": {
+      "title": "Foo",
       "type": "object",
       "properties": {
         "a": {
@@ -452,10 +454,10 @@ print(json.dumps(top_level_schema, indent=2))
           "default": null,
           "title": "A"
         }
-      },
-      "title": "Foo"
+      }
     },
     "Model": {
+      "title": "Model",
       "type": "object",
       "properties": {
         "b": {
@@ -464,10 +466,10 @@ print(json.dumps(top_level_schema, indent=2))
       },
       "required": [
         "b"
-      ],
-      "title": "Model"
+      ]
     },
     "Bar": {
+      "title": "Bar",
       "type": "object",
       "properties": {
         "c": {
@@ -477,8 +479,7 @@ print(json.dumps(top_level_schema, indent=2))
       },
       "required": [
         "c"
-      ],
-      "title": "Bar"
+      ]
     }
   },
   "title": "My Schema"

--- a/docs/usage/types.md
+++ b/docs/usage/types.md
@@ -2065,6 +2065,7 @@ class PostCode(str):
             # some example postcodes
             examples=['SP11 9DG', 'w1j7bu'],
         )
+        return field_schema
 
     @classmethod
     def validate(cls, v):

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -17,7 +17,7 @@ from typing_extensions import Annotated, Literal, TypedDict, get_args, get_origi
 
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import FieldInfo
-from ..json_schema import JsonSchemaMetadata, JsonSchemaValue
+from ..json_schema import JsonSchemaValue, update_json_schema
 from . import _discriminated_union, _typing_extra
 from ._core_metadata import CoreMetadataHandler, build_metadata_dict
 from ._core_utils import (
@@ -191,13 +191,13 @@ class GenerateSchema:
 
         schema = remove_unnecessary_invalid_definitions(schema)
 
-        modify_js_function = _get_pydantic_modify_json_schema(obj)
-        if modify_js_function is None:
+        js_modify_function = _get_pydantic_modify_json_schema(obj)
+        if js_modify_function is None:
             # Need to do this to handle custom generics:
             if hasattr(obj, '__origin__'):
-                modify_js_function = _get_pydantic_modify_json_schema(obj.__origin__)
+                js_modify_function = _get_pydantic_modify_json_schema(obj.__origin__)
 
-        CoreMetadataHandler(schema).combine_modify_js_functions(modify_js_function)
+        CoreMetadataHandler(schema).combine_js_modify_functions(js_modify_function)
 
         if 'ref' in schema:
             # definitions and definition-ref schemas don't have 'ref', causing the type error ignored on the next line
@@ -240,7 +240,6 @@ class GenerateSchema:
 
         core_config = generate_config(cls.model_config, cls)
         model_post_init = '__pydantic_post_init__' if hasattr(cls, '__pydantic_post_init__') else None
-        js_metadata = cls.model_json_schema_metadata()
 
         return core_schema.model_schema(
             cls,
@@ -248,7 +247,7 @@ class GenerateSchema:
             ref=model_ref,
             config=core_config,
             post_init=model_post_init,
-            metadata=build_metadata_dict(js_metadata=js_metadata),
+            metadata=build_metadata_dict(js_modify_function=cls.model_modify_json_schema),
         )
 
     def _generate_schema_from_property(self, obj: Any, source: Any) -> core_schema.CoreSchema | None:
@@ -513,13 +512,14 @@ class GenerateSchema:
             schema = wrap_default(field_info, schema)
 
         schema = apply_serializers(schema, filter_field_decorator_info_by_field(decorators.serializer.values(), name))
-        misc = JsonSchemaMetadata(
-            title=field_info.title,
-            description=field_info.description,
-            examples=field_info.examples,
-            extra_updates=field_info.json_schema_extra,
-        )
-        metadata = build_metadata_dict(js_metadata=misc)
+        json_schema_updates = {
+            'title': field_info.title,
+            'description': field_info.description,
+            'examples': field_info.examples,
+        }
+        json_schema_updates = {k: v for k, v in json_schema_updates.items() if v is not None}
+        json_schema_updates.update(field_info.json_schema_extra or {})
+        metadata = build_metadata_dict(js_modify_function=lambda s: update_json_schema(s, json_schema_updates))
         return _common_field(
             schema,
             serialization_exclude=True if field_info.exclude else None,
@@ -626,7 +626,9 @@ class GenerateSchema:
             fields,
             extra_behavior='forbid',
             ref=typed_dict_ref,
-            metadata=build_metadata_dict(js_metadata=JsonSchemaMetadata(title=typed_dict_cls.__name__)),
+            metadata=build_metadata_dict(
+                js_modify_function=lambda s: update_json_schema(s, {'title': typed_dict_cls.__name__}),
+            ),
         )
 
     def _namedtuple_schema(self, namedtuple_cls: Any) -> core_schema.CallSchema:
@@ -646,7 +648,7 @@ class GenerateSchema:
                 self._generate_parameter_schema(field_name, annotation)
                 for field_name, annotation in annotations.items()
             ],
-            metadata=build_metadata_dict(js_metadata=JsonSchemaMetadata(source_class=namedtuple_cls)),
+            metadata=build_metadata_dict(js_prefer_positional_arguments=True),
         )
         return core_schema.call_schema(arguments_schema, namedtuple_cls)
 
@@ -855,7 +857,7 @@ class GenerateSchema:
     def _pattern_schema(self, pattern_type: Any) -> core_schema.CoreSchema:
         from . import _serializers, _validators
 
-        metadata = build_metadata_dict(js_metadata={'source_class': pattern_type, 'type': 'string', 'format': 'regex'})
+        metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'regex'})
         ser = core_schema.general_plain_serializer_function_ser_schema(
             _serializers.pattern_serializer, json_return_type='str'
         )
@@ -1025,8 +1027,8 @@ def apply_annotations(
     for metadata in annotations:
         schema = apply_single_annotation(schema, metadata, definitions)
 
-        metadata_modify_js_function = _get_pydantic_modify_json_schema(metadata)
-        handler.combine_modify_js_functions(metadata_modify_js_function)
+        metadata_js_modify_function = _get_pydantic_modify_json_schema(metadata)
+        handler.combine_js_modify_functions(metadata_js_modify_function)
 
     return schema
 
@@ -1075,7 +1077,7 @@ def apply_single_annotation(  # noqa C901
         return schema
 
     handler = CoreMetadataHandler(schema)
-    update_schema_function = handler.update_cs_function
+    update_schema_function = handler.cs_update_function
     if update_schema_function is not None:
         new_schema = update_schema_function(schema, **metadata_dict)
         if new_schema is not None:
@@ -1119,17 +1121,17 @@ def get_first_arg(type_: Any) -> Any:
         return Any
 
 
-def _get_pydantic_modify_json_schema(obj: Any) -> typing.Callable[[JsonSchemaValue], None] | None:
-    modify_js_function = getattr(obj, '__pydantic_modify_json_schema__', None)
+def _get_pydantic_modify_json_schema(obj: Any) -> typing.Callable[[JsonSchemaValue], JsonSchemaValue] | None:
+    js_modify_function = getattr(obj, '__pydantic_modify_json_schema__', None)
 
-    if modify_js_function is None and hasattr(obj, '__modify_schema__'):
+    if js_modify_function is None and hasattr(obj, '__modify_schema__'):
         warnings.warn(
             'The __modify_schema__ method is deprecated, use __pydantic_modify_json_schema__ instead',
             DeprecationWarning,
         )
         return obj.__modify_schema__
 
-    return modify_js_function
+    return js_modify_function
 
 
 class _CommonField(TypedDict):

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -19,9 +19,10 @@ from uuid import UUID
 from pydantic_core import CoreSchema, MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Literal, get_args
 
-from ..json_schema import JsonSchemaMetadata
+from ..json_schema import update_json_schema
 from . import _serializers, _validators
 from ._core_metadata import build_metadata_dict
+from ._core_utils import get_type_ref
 
 if typing.TYPE_CHECKING:
     from ._generate_schema import GenerateSchema
@@ -69,24 +70,20 @@ def enum_schema(_schema_generator: GenerateSchema, enum_type: type[Enum]) -> cor
         except ValueError:
             raise PydanticCustomError('enum', 'Input is not a valid enum member')
 
-    enum_ref = f'{getattr(enum_type, "__module__", None)}.{enum_type.__qualname__}:{id(enum_type)}'
+    enum_ref = get_type_ref(enum_type)
     literal_schema = core_schema.literal_schema(
         [m.value for m in enum_type.__members__.values()],
-        ref=enum_ref,
     )
-    js_metadata = JsonSchemaMetadata(
-        core_schema_override=literal_schema.copy(),
-        source_class=enum_type,
-        title=enum_type.__name__,
-        description=inspect.cleandoc(enum_type.__doc__ or 'An enumeration.'),
+    updates = {'title': enum_type.__name__, 'description': inspect.cleandoc(enum_type.__doc__ or 'An enumeration.')}
+    metadata = build_metadata_dict(
+        js_cs_override=literal_schema.copy(), js_modify_function=lambda s: update_json_schema(s, updates)
     )
-    metadata = build_metadata_dict(js_metadata=js_metadata)
 
     lax: CoreSchema
     json_type: Literal['int', 'float', 'str']
     if issubclass(enum_type, int):
         # this handles `IntEnum`, and also `Foobar(int, Enum)`
-        js_metadata['extra_updates'] = {'type': 'integer'}
+        updates['type'] = 'integer'
         lax = core_schema.chain_schema(
             [core_schema.int_schema(), literal_schema, core_schema.general_plain_validator_function(to_enum)],
             metadata=metadata,
@@ -94,8 +91,7 @@ def enum_schema(_schema_generator: GenerateSchema, enum_type: type[Enum]) -> cor
         json_type = 'int'
     elif issubclass(enum_type, str):
         # this handles `StrEnum` (3.11 only), and also `Foobar(str, Enum)`
-        # TODO: add test for StrEnum in 3.11, and also for enums that inherit from str/int
-        js_metadata['extra_updates'] = {'type': 'string'}
+        updates['type'] = 'string'
         lax = core_schema.chain_schema(
             [core_schema.str_schema(), literal_schema, core_schema.general_plain_validator_function(to_enum)],
             metadata=metadata,
@@ -107,6 +103,7 @@ def enum_schema(_schema_generator: GenerateSchema, enum_type: type[Enum]) -> cor
     return core_schema.lax_or_strict_schema(
         lax_schema=lax,
         strict_schema=core_schema.is_instance_schema(enum_type, json_types={json_type}),
+        ref=enum_ref,
         metadata=metadata,
     )
 
@@ -115,11 +112,9 @@ def enum_schema(_schema_generator: GenerateSchema, enum_type: type[Enum]) -> cor
 def decimal_schema(_schema_generator: GenerateSchema, _decimal_type: type[Decimal]) -> core_schema.LaxOrStrictSchema:
     decimal_validator = _validators.DecimalValidator()
     metadata = build_metadata_dict(
-        update_cs_function=decimal_validator.__pydantic_update_schema__,
-        js_metadata=JsonSchemaMetadata(
-            # Use a lambda here so `apply_metadata` is called on the decimal_validator before the override is generated
-            core_schema_override=lambda: decimal_validator.json_schema_override_schema()
-        ),
+        cs_update_function=decimal_validator.__pydantic_update_schema__,
+        # Use a lambda here so `apply_metadata` is called on the decimal_validator before the override is generated
+        js_cs_override=lambda: decimal_validator.json_schema_override_schema(),
     )
     lax = core_schema.general_after_validator_function(
         decimal_validator,
@@ -146,11 +141,7 @@ def decimal_schema(_schema_generator: GenerateSchema, _decimal_type: type[Decima
 
 @schema_function(UUID)
 def uuid_schema(_schema_generator: GenerateSchema, uuid_type: type[UUID]) -> core_schema.LaxOrStrictSchema:
-    metadata = build_metadata_dict(
-        js_metadata=JsonSchemaMetadata(
-            source_class=UUID, type='string', format='uuid', modify_js_function=lambda schema: schema.pop('anyOf', None)
-        )
-    )
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'uuid'})
     # TODO, is this actually faster than `function_after(union(is_instance, is_str, is_bytes))`?
     lax = core_schema.union_schema(
         [
@@ -190,7 +181,7 @@ def uuid_schema(_schema_generator: GenerateSchema, uuid_type: type[UUID]) -> cor
 
 @schema_function(PurePath)
 def path_schema(_schema_generator: GenerateSchema, path_type: type[PurePath]) -> core_schema.LaxOrStrictSchema:
-    metadata = build_metadata_dict(js_metadata=JsonSchemaMetadata(source_class=PurePath, type='string', format='path'))
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'path'})
     # TODO, is this actually faster than `function_after(...)` as above?
     lax = core_schema.union_schema(
         [
@@ -257,13 +248,8 @@ def deque_schema(schema_generator: GenerateSchema, obj: Any) -> core_schema.Core
     else:
         # `Deque[Something]`
         inner_schema = schema_generator.generate_schema(arg)
-        metadata = build_metadata_dict(
-            js_metadata=JsonSchemaMetadata(
-                # Use a lambda here so `apply_metadata` is called on the decimal_validator
-                # before the override is generated
-                core_schema_override=lambda: core_schema.list_schema(inner_schema)
-            ),
-        )
+        # Use a lambda here so `apply_metadata` is called on the decimal_validator before the override is generated
+        metadata = build_metadata_dict(js_cs_override=lambda: core_schema.list_schema(inner_schema))
         return core_schema.lax_or_strict_schema(
             lax_schema=core_schema.general_after_validator_function(
                 _validators.deque_typed_validator,
@@ -345,9 +331,7 @@ def make_strict_ip_schema(tp: type[Any], metadata: Any) -> CoreSchema:
 
 @schema_function(IPv4Address)
 def ip_v4_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
-    metadata = build_metadata_dict(
-        js_metadata=JsonSchemaMetadata(source_class=IPv4Address, type='string', format='ipv4')
-    )
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'ipv4'})
     return core_schema.lax_or_strict_schema(
         lax_schema=core_schema.general_plain_validator_function(_validators.ip_v4_address_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv4Address, metadata=metadata),
@@ -357,9 +341,7 @@ def ip_v4_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_s
 
 @schema_function(IPv4Interface)
 def ip_v4_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
-    metadata = build_metadata_dict(
-        js_metadata=JsonSchemaMetadata(source_class=IPv4Interface, type='string', format='ipv4interface')
-    )
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'ipv4interface'})
     return core_schema.lax_or_strict_schema(
         lax_schema=core_schema.general_plain_validator_function(
             _validators.ip_v4_interface_validator, metadata=metadata
@@ -371,9 +353,7 @@ def ip_v4_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core
 
 @schema_function(IPv4Network)
 def ip_v4_network_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
-    metadata = build_metadata_dict(
-        js_metadata=JsonSchemaMetadata(source_class=IPv4Network, type='string', format='ipv4network')
-    )
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'ipv4network'})
     return core_schema.lax_or_strict_schema(
         lax_schema=core_schema.general_plain_validator_function(_validators.ip_v4_network_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv4Network, metadata=metadata),
@@ -383,9 +363,7 @@ def ip_v4_network_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_s
 
 @schema_function(IPv6Address)
 def ip_v6_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
-    metadata = build_metadata_dict(
-        js_metadata=JsonSchemaMetadata(source_class=IPv6Address, type='string', format='ipv6')
-    )
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'ipv6'})
     return core_schema.lax_or_strict_schema(
         lax_schema=core_schema.general_plain_validator_function(_validators.ip_v6_address_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv6Address, metadata=metadata),
@@ -395,9 +373,7 @@ def ip_v6_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_s
 
 @schema_function(IPv6Interface)
 def ip_v6_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
-    metadata = build_metadata_dict(
-        js_metadata=JsonSchemaMetadata(source_class=IPv6Interface, type='string', format='ipv6interface')
-    )
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'ipv6interface'})
     return core_schema.lax_or_strict_schema(
         lax_schema=core_schema.general_plain_validator_function(
             _validators.ip_v6_interface_validator, metadata=metadata
@@ -409,9 +385,7 @@ def ip_v6_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core
 
 @schema_function(IPv6Network)
 def ip_v6_network_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
-    metadata = build_metadata_dict(
-        js_metadata=JsonSchemaMetadata(source_class=IPv6Network, type='string', format='ipv6network')
-    )
+    metadata = build_metadata_dict(js_override={'type': 'string', 'format': 'ipv6network'})
     return core_schema.lax_or_strict_schema(
         lax_schema=core_schema.general_plain_validator_function(_validators.ip_v6_network_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv6Network, metadata=metadata),

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -10,7 +10,7 @@ eg. Color((0, 255, 255)).as_named() == 'cyan' because "cyan" comes after "aqua".
 import math
 import re
 from colorsys import hls_to_rgb, rgb_to_hls
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Optional, Tuple, Union, cast
 
 from pydantic_core import PydanticCustomError, core_schema
 
@@ -84,8 +84,9 @@ class Color(_repr.Representation):
         self._original = value
 
     @classmethod
-    def __pydantic_modify_json_schema__(cls, field_schema: Dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
         field_schema.update(type='string', format='color')
+        return field_schema
 
     def original(self) -> ColorType:
         """

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -26,14 +26,13 @@ from ._internal import (
     _utils,
 )
 from ._internal._fields import Undefined
-from .analyzed_type import AnalyzedType
 from .config import BaseConfig, ConfigDict, Extra, build_config, get_config
 from .deprecated import copy_internals as _deprecated_copy_internals
 from .deprecated import parse as _deprecated_parse
 from .errors import PydanticUndefinedAnnotation, PydanticUserError
 from .fields import Field, FieldInfo, ModelPrivateAttr
 from .json import custom_pydantic_encoder, pydantic_encoder
-from .json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMetadata
+from .json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaValue, model_json_schema
 
 if typing.TYPE_CHECKING:
     from inspect import Signature
@@ -366,27 +365,22 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         with your desired modifications, then override this method on a custom base class and set the default
         value of `schema_generator` to be your subclass.
         """
-        return AnalyzedType(cls).json_schema(
-            by_alias=by_alias, ref_template=ref_template, schema_generator=schema_generator
-        )
+        return model_json_schema(cls, by_alias=by_alias, ref_template=ref_template, schema_generator=schema_generator)
 
     @classmethod
-    def model_json_schema_metadata(cls) -> JsonSchemaMetadata | None:
+    def model_modify_json_schema(cls, json_schema: JsonSchemaValue) -> JsonSchemaValue:
         """
-        Overriding this method provides a simple way to modify certain aspects of the JSON schema generation.
+        Overriding this method provides a simple way to modify the JSON schema generated for the model.
 
-        This is a convenience method primarily intended to control how the "generic" properties
-        of the JSON schema are populated, or apply minor transformations through `extra_updates` or
-        `modify_js_function`. See https://json-schema.org/understanding-json-schema/reference/generic.html
-        and the comments surrounding the definition of `JsonSchemaMetadata` for more details.
+        This is a convenience method primarily intended to control how the "generic" properties of the JSON schema
+        are populated. See https://json-schema.org/understanding-json-schema/reference/generic.html for more details.
 
-        If you want to make more sweeping changes to how the JSON schema is generated, you will probably
-        want to subclass `GenerateJsonSchema` and pass your subclass in the `schema_generator` argument to the
-        `model_json_schema` method.
+        If you want to make more sweeping changes to how the JSON schema is generated, you will probably want to create
+        a subclass of `GenerateJsonSchema` and pass it as `schema_generator` in `BaseModel.model_json_schema`.
         """
-        title = cls.model_config['title'] or cls.__name__
-        description = getdoc(cls) or None
-        return {'title': title, 'description': description}
+        metadata = {'title': cls.model_config['title'] or cls.__name__, 'description': getdoc(cls) or None}
+        metadata = {k: v for k, v in metadata.items() if v is not None}
+        return {**metadata, **json_schema}
 
     @classmethod
     def model_rebuild(

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -143,8 +143,9 @@ else:
                 return core_schema.general_after_validator_function(cls.validate, schema)
 
         @classmethod
-        def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> None:
+        def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
             field_schema.update(type='string', format='email')
+            return field_schema
 
         @classmethod
         def validate(cls, __input_value: str, _: core_schema.ValidationInfo) -> str:
@@ -162,8 +163,9 @@ class NameEmail(_repr.Representation):
         return isinstance(other, NameEmail) and (self.name, self.email) == (other.name, other.email)
 
     @classmethod
-    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
         field_schema.update(type='string', format='name-email')
+        return field_schema
 
     @classmethod
     def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.AfterValidatorFunctionSchema:
@@ -201,8 +203,9 @@ class IPvAnyAddress:
             raise PydanticCustomError('ip_any_address', 'value is not a valid IPv4 or IPv6 address')
 
     @classmethod
-    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
         field_schema.update(type='string', format='ipvanyaddress')
+        return field_schema
 
     @classmethod
     def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
@@ -228,8 +231,9 @@ class IPvAnyInterface:
             raise PydanticCustomError('ip_any_interface', 'value is not a valid IPv4 or IPv6 interface')
 
     @classmethod
-    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
         field_schema.update(type='string', format='ipvanyinterface')
+        return field_schema
 
     @classmethod
     def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
@@ -257,8 +261,9 @@ class IPvAnyNetwork:
             raise PydanticCustomError('ip_any_network', 'value is not a valid IPv4 or IPv6 network')
 
     @classmethod
-    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
         field_schema.update(type='string', format='ipvanynetwork')
+        return field_schema
 
     @classmethod
     def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -41,7 +41,8 @@ def schema_of(
     else:
         core_schema = _generate_schema.GenerateSchema(True, None).generate_schema(type_)
     json_schema = json_schema_generator.generate(core_schema)
-    json_schema['title'] = title
+    if title is not None:
+        json_schema['title'] = title
     return json_schema
 
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -74,7 +74,6 @@ __all__ = [
 
 from ._internal._core_metadata import build_metadata_dict
 from ._internal._utils import update_not_none
-from .json_schema import JsonSchemaMetadata
 
 
 @_dataclasses.dataclass
@@ -295,9 +294,10 @@ def condecimal(
 class UuidVersion:
     uuid_version: Literal[1, 3, 4, 5]
 
-    def __pydantic_modify_json_schema__(self, field_schema: dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(self, field_schema: dict[str, Any]) -> dict[str, Any]:
         field_schema.pop('anyOf', None)  # remove the bytes/str union
         field_schema.update(type='string', format=f'uuid{self.uuid_version}')
+        return field_schema
 
     def __get_pydantic_core_schema__(
         self, schema: core_schema.CoreSchema, **_kwargs: Any
@@ -327,9 +327,10 @@ UUID5 = Annotated[UUID, UuidVersion(5)]
 class PathType:
     path_type: Literal['file', 'dir', 'new']
 
-    def __pydantic_modify_json_schema__(self, field_schema: dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(self, field_schema: dict[str, Any]) -> dict[str, Any]:
         format_conversion = {'file': 'file-path', 'dir': 'directory-path'}
         field_schema.update(format=format_conversion.get(self.path_type, 'path'), type='string')
+        return field_schema
 
     def __get_pydantic_core_schema__(
         self, schema: core_schema.CoreSchema, **_kwargs: Any
@@ -393,8 +394,9 @@ else:
             return core_schema.json_schema(schema)
 
         @classmethod
-        def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> None:
+        def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
             field_schema.update(type='string', format='json-string')
+            return field_schema
 
         def __repr__(self) -> str:
             return 'Json'
@@ -425,20 +427,19 @@ class SecretField(abc.ABC, Generic[SecretType]):
         validator = SecretFieldValidator(cls)
         if issubclass(cls, SecretStr):
             # Use a lambda here so that `apply_metadata` can be called on the validator before the override is generated
-            override = lambda: core_schema.str_schema(  # noqa E731
+            js_cs_override = lambda: core_schema.str_schema(  # noqa E731
                 min_length=validator.min_length,
                 max_length=validator.max_length,
             )
         elif issubclass(cls, SecretBytes):
-            override = lambda: core_schema.bytes_schema(  # noqa E731
+            js_cs_override = lambda: core_schema.bytes_schema(  # noqa E731
                 min_length=validator.min_length,
                 max_length=validator.max_length,
             )
         else:
-            override = None
+            js_cs_override = None
         metadata = build_metadata_dict(
-            update_cs_function=validator.__pydantic_update_schema__,
-            js_metadata=JsonSchemaMetadata(core_schema_override=override),
+            cs_update_function=validator.__pydantic_update_schema__, js_cs_override=js_cs_override
         )
         return core_schema.general_after_validator_function(
             validator,
@@ -470,13 +471,14 @@ class SecretField(abc.ABC, Generic[SecretType]):
         ...
 
     @classmethod
-    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> None:
+    def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
         update_not_none(
             field_schema,
             type='string',
             writeOnly=True,
             format='password',
         )
+        return field_schema
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, self.__class__) and self.get_secret_value() == other.get_secret_value()

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -11,9 +11,10 @@ import pytest
 from typing_extensions import Literal
 
 import pydantic
-from pydantic import AnalyzedType, BaseModel, ConfigDict, Extra, FieldValidationInfo, ValidationError
+from pydantic import BaseModel, ConfigDict, Extra, FieldValidationInfo, ValidationError
 from pydantic.decorators import field_validator
 from pydantic.fields import Field, FieldInfo
+from pydantic.json_schema import model_json_schema
 
 
 def test_simple():
@@ -538,7 +539,7 @@ def test_schema():
         height: Optional[int] = pydantic.Field(None, title='The height in cm', ge=50, le=300)
 
     User(id=123)
-    assert AnalyzedType(User).json_schema() == {
+    assert model_json_schema(User) == {
         'properties': {
             'age': {
                 'anyOf': [{'type': 'integer'}, {'type': 'null'}],
@@ -576,7 +577,7 @@ def test_nested_schema():
     class Outer:
         n: Nested
 
-    assert AnalyzedType(Outer).json_schema() == {
+    assert model_json_schema(Outer) == {
         '$defs': {
             'Nested': {
                 'properties': {'number': {'title': 'Number', 'type': 'integer'}},
@@ -827,7 +828,7 @@ def test_override_builtin_dataclass_nested_schema():
         meta: Meta
 
     FileChecked = pydantic.dataclasses.dataclass(File)
-    assert AnalyzedType(FileChecked).json_schema() == {
+    assert model_json_schema(FileChecked) == {
         '$defs': {
             'Meta': {
                 'properties': {
@@ -1184,14 +1185,14 @@ def test_schema_description_unset():
     class A:
         x: int
 
-    assert 'description' not in AnalyzedType(A).json_schema()
+    assert 'description' not in model_json_schema(A)
 
     @pydantic.dataclasses.dataclass
     @dataclasses.dataclass
     class B:
         x: int
 
-    assert 'description' not in AnalyzedType(B).json_schema()
+    assert 'description' not in model_json_schema(B)
 
 
 def test_schema_description_set():
@@ -1201,7 +1202,7 @@ def test_schema_description_set():
 
         x: int
 
-    assert AnalyzedType(A).json_schema()['description'] == 'my description'
+    assert model_json_schema(A)['description'] == 'my description'
 
     @pydantic.dataclasses.dataclass
     @dataclasses.dataclass
@@ -1210,7 +1211,7 @@ def test_schema_description_set():
 
         x: int
 
-    assert AnalyzedType(A).json_schema()['description'] == 'my description'
+    assert model_json_schema(A)['description'] == 'my description'
 
 
 def test_issue_3011():
@@ -1273,7 +1274,7 @@ def test_discriminated_union_basemodel_instance_value():
 
     t = Top(sub=A(l='a'))
     assert isinstance(t, Top)
-    assert AnalyzedType(Top).json_schema() == {
+    assert model_json_schema(Top) == {
         'title': 'Top',
         'type': 'object',
         'properties': {

--- a/tests/test_fastapi_json_schema.py
+++ b/tests/test_fastapi_json_schema.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from dirty_equals import HasRepr, IsInstance, IsStr
 from pydantic_core import CoreSchema
 from pydantic_core.core_schema import TypedDictField
 
@@ -48,7 +49,7 @@ class FastAPIGenerateJsonSchema(GenerateJsonSchema):
     def handle_invalid_for_json_schema(self, schema: CoreSchema | TypedDictField, error_info: str) -> JsonSchemaValue:
         # NOTE: I think it may be a good idea to rework this method to either not use CoreMetadataHandler,
         #    and/or to make CoreMetadataHandler a public API.
-        if CoreMetadataHandler(schema).get_modify_js_function():
+        if CoreMetadataHandler(schema).js_modify_function is not None:
             # Since there is a json schema modify function, assume that this type is meant to be handled,
             # and the modify function will set all properties as appropriate
             return {}
@@ -106,32 +107,24 @@ def test_collect_errors() -> None:
 
         model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    expected_schema = {
+    schema = Model.model_json_schema(schema_generator=FastAPIGenerateJsonSchema)
+    assert schema == {
+        'title': 'Model',
         'type': 'object',
         'properties': {
             'f1': {'type': 'integer', 'default': 1, 'title': 'F1'},
             'f2': {
-                'error': PydanticInvalidForJsonSchema(
-                    "Cannot generate a JsonSchema for core_schema.IsInstanceSchema "
-                    "(<class 'tests.test_fastapi_json_schema.test_collect_errors.<locals>.Car'>)"
-                ),
+                'error': HasRepr(IsStr(regex=r'PydanticInvalidForJsonSchema\(.*\)')),
                 'title': 'F2',
             },
         },
         'required': ['f2'],
-        'title': 'Model',
     }
-    actual_schema = Model.model_json_schema(schema_generator=FastAPIGenerateJsonSchema)
-    assert repr(actual_schema) == repr(expected_schema)
 
-    actual_collected_errors = collect_errors(actual_schema)
-    expected_collected_errors = [
+    collected_errors = collect_errors(schema)
+    assert collected_errors == [
         ErrorDetails(
             path=['properties', 'f2'],
-            error=PydanticInvalidForJsonSchema(
-                "Cannot generate a JsonSchema for core_schema.IsInstanceSchema "
-                "(<class 'tests.test_fastapi_json_schema.test_collect_errors.<locals>.Car'>)"
-            ),
+            error=IsInstance(PydanticInvalidForJsonSchema),
         )
     ]
-    assert repr(actual_collected_errors) == repr(expected_collected_errors)

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -130,20 +130,15 @@ def test_self_forward_ref_module(create_module):
 def test_self_forward_ref_collection(create_module):
     @create_module
     def module():
-        from typing import Dict, List, Optional
+        from typing import Dict, List
 
         from pydantic import BaseModel
-        from pydantic.json_schema import JsonSchemaMetadata
 
         class Foo(BaseModel):
             a: int = 123
             b: 'Foo' = None
             c: 'List[Foo]' = []
             d: 'Dict[str, Foo]' = {}
-
-            @classmethod
-            def model_json_schema_metadata(cls) -> Optional[JsonSchemaMetadata]:
-                return None
 
     assert module.Foo().model_dump() == {'a': 123, 'b': None, 'c': [], 'd': {}}
     assert module.Foo(b={'a': '321'}, c=[{'a': 234}], d={'bar': {'a': 345}}).model_dump() == {


### PR DESCRIPTION
* Completely eliminates the JsonSchemaMetadata struct, relying solely on the CoreSchema metadata, and reducing the smattering of ways the JSON schema could be updated.
* Replaces `model_json_schema_metadata` with `model_modify_json_schema`
    * Perhaps this should be renamed to `__pydantic_modify_json_schema__`, perhaps not
* Re-adds non-`AnalyzedType` functions for computing JSON schema, called `model_json_schema` and `models_json_schema`. These are added into the `json_schema.py` but can be moved elsewhere, or reverted to being `AnalyzedType` methods, but I think having a free-standing function is simpler for docs, etc.