### PR TITLE
Prevent multiple field serializers for a field in same class

### DIFF
--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -35,6 +35,7 @@ from pydantic_core.core_schema import (
 )
 from typing_extensions import Protocol, TypeAlias
 
+from pydantic._internal._core_utils import get_type_ref
 from pydantic._internal._repr import Representation
 
 if TYPE_CHECKING:
@@ -252,13 +253,13 @@ class Decorator(Generic[DecoratorInfoType], Representation):
 
     def __init__(
         self,
-        cls_name: str,
+        cls_ref: str,
         cls_var_name: str,
         func: Callable[..., Any],
         unwrapped_func: Callable[..., Any],
         info: DecoratorInfoType,
     ) -> None:
-        self.cls_name = cls_name
+        self.cls_ref = cls_ref
         self.cls_var_name = cls_var_name
         self.func = func
         self.unwrapped_func = unwrapped_func
@@ -321,31 +322,33 @@ def gather_decorator_functions(cls: type[Any]) -> DecoratorInfos:
     for var_name, var_value in vars(cls).items():
         if isinstance(var_value, PydanticDecoratorMarker):
             func = var_value.wrapped.__get__(None, cls)
+            cls_ref = get_type_ref(cls)
             shimmed_func = var_value.shim(func) if var_value.shim is not None else func
             info = var_value.decorator_info
             if isinstance(info, ValidatorDecoratorInfo):
-                res.validator[var_name] = Decorator(cls.__name__, var_name, shimmed_func, func, info)
+                res.validator[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
             elif isinstance(info, FieldValidatorDecoratorInfo):
-                res.field_validator[var_name] = Decorator(cls.__name__, var_name, shimmed_func, func, info)
+                res.field_validator[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
             elif isinstance(info, RootValidatorDecoratorInfo):
-                res.root_validator[var_name] = Decorator(cls.__name__, var_name, shimmed_func, func, info)
+                res.root_validator[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
             elif isinstance(info, FieldSerializerDecoratorInfo):
-                # check whether a serializer function is already registered for fileds
-                for field_ser_dec in res.field_serializer.values():
-                    # check serializers function only in same model. serializer functions
-                    # for same field in subclass won't be cosiderd as duplicate
-                    if field_ser_dec.cls_name != cls.__name__:
+                # check whether a serializer function is already registered for fields
+                for field_serializer_decorator in res.field_serializer.values():
+                    # check that each field has at most one serializer function.
+                    # serializer functions for the same field in subclasses are allowed,
+                    # and are treated as overrides
+                    if field_serializer_decorator.cls_ref != cls_ref:
                         continue
                     for f in info.fields:
-                        if f in field_ser_dec.info.fields:
+                        if f in field_serializer_decorator.info.fields:
                             raise TypeError(
-                                'Duplicate field serializer function '
-                                f'"{func.__module__}::{func.__qualname__}" for field "{f}"'
+                                'Multiple field serializer functions were defined '
+                                f'for field {f!r}, this is not allowed.'
                             )
-                res.field_serializer[var_name] = Decorator(cls.__name__, var_name, shimmed_func, func, info)
+                res.field_serializer[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
             else:
                 assert isinstance(info, ModelSerializerDecoratorInfo)
-                res.model_serializer[var_name] = Decorator(cls.__name__, var_name, shimmed_func, func, info)
+                res.model_serializer[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
             # replace our marker with the bound, concrete function
             setattr(cls, var_name, func)
 

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -332,7 +332,8 @@ def gather_decorator_functions(cls: type[Any]) -> DecoratorInfos:
             elif isinstance(info, FieldSerializerDecoratorInfo):
                 # check whether a serializer function is already registered for fileds
                 for field_ser_dec in res.field_serializer.values():
-                    # check serializers only in same model
+                    # check serializers function only in same model. serializer functions
+                    # for same field in subclass won't be cosiderd as duplicate
                     if field_ser_dec.cls_name != cls.__name__:
                         continue
                     for f in info.fields:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -421,12 +421,12 @@ def test_field_multiple_serializer_subclass():
         x: int
 
         @field_serializer('x', json_return_type='str')
-        def customise_x_serialisation(v, _info):
+        def serializer1(v, _info):
             return f'{v:,}'
 
     class MySubModel(MyModel):
         @field_serializer('x', json_return_type='str')
-        def customise_x_serialisation(v, _info):
+        def serializer2(v, _info):
             return f'{v}'
 
     assert MyModel(x=1234).model_dump() == {'x': '1,234'}

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -397,10 +397,7 @@ def test_model_serializer_classmethod():
 
 
 def test_field_multiple_serializer():
-    m = (
-        'Duplicate field serializer function '
-        '"tests.test_serialize::test_field_multiple_serializer.<locals>.MyModel.serializer2" for field "x"'
-    )
+    m = "Multiple field serializer functions were defined for field 'x', this is not allowed."
     with pytest.raises(TypeError, match=m):
 
         class MyModel(BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary
Prevent multiple field serializers for a field in same class
<!-- Please give a short summary of the changes. -->

## Related issue number
Fixes https://github.com/pydantic/pydantic/issues/5337
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu