### PR TITLE
Only call __pydantic_post_init__ with positional arguments

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -214,6 +214,8 @@ class GenerateSchema:
         """
         Generate schema for a pydantic model.
         """
+        from pydantic.main import BaseModel
+
         model_ref = get_type_ref(cls)
         cached_def = self.recursion_cache.get(model_ref)
         if cached_def is not None:
@@ -247,7 +249,7 @@ class GenerateSchema:
         inner_schema = define_expected_missing_refs(inner_schema, recursively_defined_type_refs())
 
         core_config = generate_config(cls.model_config, cls)
-        model_post_init = '__pydantic_post_init__' if hasattr(cls, '__pydantic_post_init__') else None
+        model_post_init = None if cls.model_post_init is BaseModel.model_post_init else 'model_post_init'
 
         model_schema = core_schema.model_schema(
             cls,

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -29,7 +29,7 @@ IGNORED_TYPES: tuple[Any, ...] = (FunctionType, property, type, classmethod, sta
 object_setattr = object.__setattr__
 
 
-def init_private_attributes(self: BaseModel, _context: Any) -> None:
+def init_private_attributes(self: BaseModel, __context: Any) -> None:
     """
     This function is meant to behave like a BaseModel method to initialise private attributes.
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -29,16 +29,16 @@ IGNORED_TYPES: tuple[Any, ...] = (FunctionType, property, type, classmethod, sta
 object_setattr = object.__setattr__
 
 
-def init_private_attributes(self_: Any, _context: Any) -> None:
+def init_private_attributes(self: BaseModel, _context: Any) -> None:
     """
-    This method is bound to model classes to initialise private attributes.
+    This function is meant to behave like a BaseModel method to initialise private attributes.
 
     It takes context as an argument since that's what pydantic-core passes when calling it.
     """
-    for name, private_attr in self_.__private_attributes__.items():
+    for name, private_attr in self.__private_attributes__.items():
         default = private_attr.get_default()
         if default is not Undefined:
-            object_setattr(self_, name, default)
+            object_setattr(self, name, default)
 
 
 def inspect_namespace(  # noqa C901

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -233,7 +233,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
 
     def model_post_init(self, __context: Any) -> None:
         """
-        # If you override `model_post_init`, it will be called at the end of `__init__`
+        # If you override `model_post_init`, it will be called at the end of `__init__` and `model_construct`
         """
         pass
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -85,12 +85,12 @@ class ModelMetaclass(ABCMeta):
                     # if there are private_attributes and a model_post_init function, we handle both
                     original_model_post_init = namespace['model_post_init']
 
-                    def wrapped_model_post_init(self: BaseModel, context: Any) -> None:
+                    def wrapped_model_post_init(self: BaseModel, __context: Any) -> None:
                         """
                         We need to both initialize private attributes and call the user-defined model_post_init method
                         """
-                        _model_construction.init_private_attributes(self, context)
-                        original_model_post_init(self, context)
+                        _model_construction.init_private_attributes(self, __context)
+                        original_model_post_init(self, __context)
 
                     namespace['model_post_init'] = wrapped_model_post_init
                 else:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -82,13 +82,11 @@ class ModelMetaclass(ABCMeta):
                 namespace['__slots__'] = slots | private_attributes.keys()
 
                 if 'model_post_init' in namespace:
-                    # if there are private_attributes and a model_post_init function, we wrap them both
-                    # in a single function
-                    namespace['_init_private_attributes'] = _model_construction.init_private_attributes
+                    # if there are private_attributes and a model_post_init function, we handle both
 
-                    def __pydantic_post_init__(self_: Any, context: Any) -> None:
-                        self_._init_private_attributes(context)
-                        self_.model_post_init(context)
+                    def __pydantic_post_init__(self: BaseModel, context: Any) -> None:
+                        _model_construction.init_private_attributes(self, context)
+                        self.model_post_init(context)
 
                     namespace['__pydantic_post_init__'] = __pydantic_post_init__
                 else:
@@ -101,8 +99,8 @@ class ModelMetaclass(ABCMeta):
 
             if '__hash__' not in namespace and config_new['frozen']:
 
-                def hash_func(self_: Any) -> int:
-                    return hash(self_.__class__) + hash(tuple(self_.__dict__.values()))
+                def hash_func(self: Any) -> int:
+                    return hash(self.__class__) + hash(tuple(self.__dict__.values()))
 
                 namespace['__hash__'] = hash_func
 
@@ -349,7 +347,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
             _fields_set = set(values.keys())
         _object_setattr(m, '__fields_set__', _fields_set)
         if hasattr(m, '__pydantic_post_init__'):
-            m.__pydantic_post_init__(context=None)
+            m.__pydantic_post_init__(None)
         return m
 
     @classmethod

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -233,7 +233,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
 
     def model_post_init(self, __context: Any) -> None:
         """
-        # If you override `model_post_init`, it will be called at the end of `__init__` and `model_construct`
+        If you override `model_post_init`, it will be called at the end of `__init__` and `model_construct`
         """
         pass
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -349,7 +349,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         if _fields_set is None:
             _fields_set = set(values.keys())
         _object_setattr(m, '__fields_set__', _fields_set)
-        if hasattr(m, 'model_post_init'):
+        if type(m).model_post_init is not BaseModel.model_post_init:
             m.model_post_init(None)
         return m
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1805,8 +1805,8 @@ def test_post_init():
             calls.append('model_post_init')
 
     m = Model(c=1, d='2', sub={'a': 3, 'b': '4'})
-    assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
     assert calls == ['inner_model_post_init', 'model_post_init']
+    assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
 
     class SubModel(Model):
         def model_post_init(self, __context) -> None:
@@ -1816,8 +1816,8 @@ def test_post_init():
 
     calls.clear()
     m = SubModel(c=1, d='2', sub={'a': 3, 'b': '4'})
-    assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
     assert calls == ['inner_model_post_init', 'model_post_init', 'submodel_post_init']
+    assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
 
 
 @pytest.mark.parametrize('include_private_attribute', [True, False])
@@ -1834,6 +1834,7 @@ def test_post_init_call_signatures(include_private_attribute):
             calls.append((args, kwargs))
 
     Model(a=1, b=2)
+    assert calls == [((None,), {})]
     Model.model_construct(a=3, b=4)
     assert calls == [((None,), {}), ((None,), {})]
 
@@ -1860,6 +1861,7 @@ def test_post_init_not_called_without_override():
                 calls.append('WithOverrideModel.model_post_init')
 
         WithOverrideModel()
+        assert calls == ['WithOverrideModel.model_post_init']
         WithOverrideModel.model_construct()
         assert calls == ['WithOverrideModel.model_post_init', 'WithOverrideModel.model_post_init']
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1820,14 +1820,8 @@ def test_post_init():
     assert calls == ['inner_model_post_init', 'model_post_init', 'submodel_post_init']
 
 
-@pytest.mark.parametrize(
-    'include_private_attribute,expected_calls',
-    [
-        (True, [((None,), {}), ((None,), {})]),
-        (False, [((None,), {}), ((None,), {})]),
-    ],
-)
-def test_post_init_call_signatures(include_private_attribute, expected_calls):
+@pytest.mark.parametrize('include_private_attribute', [True, False])
+def test_post_init_call_signatures(include_private_attribute):
     calls = []
 
     class Model(BaseModel):
@@ -1841,7 +1835,7 @@ def test_post_init_call_signatures(include_private_attribute, expected_calls):
 
     Model(a=1, b=2)
     Model.model_construct(a=3, b=4)
-    assert calls == expected_calls
+    assert calls == [((None,), {}), ((None,), {})]
 
 
 def test_post_init_not_called_without_override():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1790,8 +1790,8 @@ def test_post_init():
         a: int
         b: int
 
-        def model_post_init(self, _context) -> None:
-            super().model_post_init(_context)  # this is included just to show it doesn't error
+        def model_post_init(self, __context) -> None:
+            super().model_post_init(__context)  # this is included just to show it doesn't error
             assert self.model_dump() == {'a': 3, 'b': 4}
             calls.append('inner_model_post_init')
 
@@ -1800,7 +1800,7 @@ def test_post_init():
         d: int
         sub: InnerModel
 
-        def model_post_init(self, _context) -> None:
+        def model_post_init(self, __context) -> None:
             assert self.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
             calls.append('model_post_init')
 
@@ -1809,9 +1809,9 @@ def test_post_init():
     assert calls == ['inner_model_post_init', 'model_post_init']
 
     class SubModel(Model):
-        def model_post_init(self, _context) -> None:
+        def model_post_init(self, __context) -> None:
             assert self.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
-            super().model_post_init(_context)
+            super().model_post_init(__context)
             calls.append('submodel_post_init')
 
     calls.clear()


### PR DESCRIPTION
Meant to replace #5380.

* Removes all references to `__pydantic_post_init__` and only refers to `model_post_init`.
* Ensures we only call the `model_post_init` using positional arguments.
* Changes free functions intended to behave as bound BaseModel methods to use `self: BaseModel` as the annotation, rather than `self_: Any`.
* Doesn't add `_init_private_attributes` into the model namespace (I think this would be _super_ confusing for a user if they happened to try to declare a method with the same name for any reason, and it got replaced due to the use of private attributes)
* Adds a (parametrized) test demonstrating the full spectrum of calls involving `model_post_init` during class instantiation.
* Takes `model_post_init` out of the `if TYPE_CHECKING:` block _without_ resulting in always calling it, by explicitly checking for overriding, rather than just the presence of the attribute. (This ensures calling `super().model_post_init` won't error even in direct subclasses of `BaseModel`.)


Selected Reviewer: @hramezani