### PR TITLE
Add _types_namespace argument to model_rebuild

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -389,6 +389,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         force: bool = False,
         raise_errors: bool = True,
         _parent_namespace_depth: int = 2,
+        _types_namespace: dict[str, Any] | None = None,
     ) -> bool | None:
         """
         Try to (Re)construct the model schema.
@@ -396,14 +397,17 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         if not force and cls.__pydantic_model_complete__:
             return None
         else:
-            if _parent_namespace_depth > 0:
-                frame_parent_ns = _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth) or {}
-                cls_parent_ns = cls.__pydantic_parent_namespace__ or {}
-                cls.__pydantic_parent_namespace__ = {**cls_parent_ns, **frame_parent_ns}
+            if _types_namespace is not None:
+                types_namespace: dict[str, Any] | None = _types_namespace.copy()
+            else:
+                if _parent_namespace_depth > 0:
+                    frame_parent_ns = _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth) or {}
+                    cls_parent_ns = cls.__pydantic_parent_namespace__ or {}
+                    cls.__pydantic_parent_namespace__ = {**cls_parent_ns, **frame_parent_ns}
 
-            types_namespace = cls.__pydantic_parent_namespace__
+                types_namespace = cls.__pydantic_parent_namespace__
 
-            types_namespace = _model_construction.get_model_types_namespace(cls, types_namespace)
+                types_namespace = _model_construction.get_model_types_namespace(cls, types_namespace)
             return _model_construction.complete_model_class(
                 cls,
                 cls.__name__,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1839,6 +1839,20 @@ def test_deeper_recursive_model():
     assert m.model_dump() == {'b': {'c': {'a': None}}}
 
 
+def test_model_rebuild_localns():
+    class A(BaseModel, undefined_types_warning=False):
+        x: int
+
+    class B(BaseModel, undefined_types_warning=False):
+        a: 'Model'  # noqa F821
+
+    B.model_rebuild(_types_namespace={'Model': A})
+
+    m = B(a={'x': 1})
+    assert m.model_dump() == {'a': {'x': 1}}
+    assert isinstance(m.a, A)
+
+
 @pytest.fixture(scope='session', name='InnerEqualityModel')
 def inner_equality_fixture():
     class InnerEqualityModel(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,6 +32,7 @@ from pydantic import (
     Extra,
     Field,
     PrivateAttr,
+    PydanticUndefinedAnnotation,
     PydanticUserError,
     SecretStr,
     ValidationError,
@@ -1851,6 +1852,12 @@ def test_model_rebuild_localns():
     m = B(a={'x': 1})
     assert m.model_dump() == {'a': {'x': 1}}
     assert isinstance(m.a, A)
+
+    class C(BaseModel, undefined_types_warning=False):
+        a: 'Model'  # noqa F821
+
+    with pytest.raises(PydanticUndefinedAnnotation, match="name 'Model' is not defined"):
+        C.model_rebuild(_types_namespace={'A': A})
 
 
 @pytest.fixture(scope='session', name='InnerEqualityModel')


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/5383

I called the argument `_types_namespace` instead of `_types_namespace` to try to discourage people from using it (like `_parent_namespace_depth`, you probably shouldn't change the value unless you know what you are doing).

But I would be open to changing this (and `_parent_namespace_depth`) to take the more standard approach of not including a leading `_` if anyone prefers.

@commonism If the unit test I added here isn't representative of your usage (e.g., if you use `create_model` to create the classes you mentioned in #5383) could you share a more representative unit test and/or some code that shows how you use this functionality? Want to make sure this change actually fixes things for you (and it doesn't get re-broken in the future).

Selected Reviewer: @adriangb