### PR TITLE
Add __pydantic_init_subclass__ classmethod

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -225,6 +225,9 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         This is necessary because `__init_subclass__` will always be called by `type.__new__`,
         and it would require a prohibitively large refactor to the `ModelMetaclass` to ensure that
         `type.__new__` was called in such a manner that the class would already be sufficiently initialized.
+
+        This will receive the same `kwargs` that would be passed to the standard `__init_subclass__`, namely,
+        any kwargs passed to the class definition that aren't existing config attributes.
         """
         pass
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -225,9 +225,6 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         This is necessary because `__init_subclass__` will always be called by `type.__new__`,
         and it would require a prohibitively large refactor to the `ModelMetaclass` to ensure that
         `type.__new__` was called in such a manner that the class would already be sufficiently initialized.
-
-        You can override this method in subclasses of `BaseModel` to perform any initialization logic,
-        in which case you should make it a `classmethod` and pass `cls` as the first argument.
         """
         pass
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -227,7 +227,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         `type.__new__` was called in such a manner that the class would already be sufficiently initialized.
 
         This will receive the same `kwargs` that would be passed to the standard `__init_subclass__`, namely,
-        any kwargs passed to the class definition that aren't existing config attributes.
+        any kwargs passed to the class definition that aren't used internally by pydantic.
         """
         pass
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -155,7 +155,7 @@ class ModelMetaclass(ABCMeta):
             # using super(cls, cls) on the next line ensures we only call the parent class's __pydantic_init_subclass__
             # I believe the `type: ignore` is only necessary because mypy doesn't realize that this code branch is
             # only hit for _proper_ subclasses of BaseModel
-            super(cls, cls).__pydantic_init_subclass__(**kwargs)  # type: ignore
+            super(cls, cls).__pydantic_init_subclass__(**kwargs)  # type: ignore[misc]
             return cls
         else:
             # this is the BaseModel class itself being created, no logic required

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2060,3 +2060,25 @@ def test_validate_json_context() -> None:
     Model.model_validate_json(json.dumps({'x': 1}), context=None)
     Model.model_validate_json(json.dumps({'x': 1}), context={'foo': 'bar'})
     assert contexts == []
+
+
+def test_pydantic_init_subclass() -> None:
+    calls = []
+
+    class MyModel(BaseModel):
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()  # can't pass kwargs to object.__init_subclass__, weirdly
+            calls.append((cls.__name__, '__init_subclass__', kwargs))
+
+        @classmethod
+        def __pydantic_init_subclass__(cls, **kwargs):
+            super().__pydantic_init_subclass__(**kwargs)
+            calls.append((cls.__name__, '__pydantic_init_subclass__', kwargs))
+
+    class MySubModel(MyModel, a=1):
+        pass
+
+    assert calls == [
+        ('MySubModel', '__init_subclass__', {'a': 1}),
+        ('MySubModel', '__pydantic_init_subclass__', {'a': 1}),
+    ]


### PR DESCRIPTION
Closes #5369.

@samuelcolvin let me know if you think we should change this to be a non-dunder name (e.g., `model_init_subclass`). Should be trivial to change.

The only argument I see for keeping it as a dunder like this is to help draw users' attention to the fact that it really is meant to be similar to `__init_subclass__`. Otherwise I suspect it will be easier to skim over the definition without realizing that. But I see the argument either way.

(Presumably if/when we implement `BareModel` we'll use this name though.)

Selected Reviewer: @samuelcolvin