### PR TITLE
Fix root validators & subclasses

### DIFF
--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -279,7 +279,14 @@ class Decorator(Generic[DecoratorInfoType], Representation):
         val = getattr(cls_, cls_var_name)
         if isinstance(val, PydanticDecoratorMarker):
             val = val.wrapped
-        func = val.__get__(None, cls_)
+        try:
+            func = val.__get__(None, cls_)
+        except AttributeError:
+            if isinstance(val, partial):
+                # don't bind the class
+                func = val
+            else:
+                raise
         if shim is not None:
             func = shim(func)
         return Decorator(

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -318,7 +318,7 @@ class DecoratorInfos(Representation):
         self.model_serializer = {}
 
 
-def gather_decorator_functions(cls: type[Any]) -> DecoratorInfos:  # noqa: C901
+def gather_decorator_functions(cls: type[Any]) -> DecoratorInfos:
     """
     We want to collect all DecFunc instances that exist as
     attributes in the namespace of the class (a BaseModel or dataclass)
@@ -363,7 +363,7 @@ def gather_decorator_functions(cls: type[Any]) -> DecoratorInfos:  # noqa: C901
                     # check that each field has at most one serializer function.
                     # serializer functions for the same field in subclasses are allowed,
                     # and are treated as overrides
-                    if field_serializer_decorator.cls_ref != get_type_ref(cls):
+                    if field_serializer_decorator.cls_var_name == var_name:
                         continue
                     for f in info.fields:
                         if f in field_serializer_decorator.info.fields:

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -258,6 +258,7 @@ class Decorator(Generic[DecoratorInfoType], Representation):
         cls_ref: str,
         cls_var_name: str,
         func: Callable[..., Any],
+        shim: Callable[[Any], Any] | None,
         unwrapped_func: Callable[..., Any],
         info: DecoratorInfoType,
     ) -> None:
@@ -266,15 +267,37 @@ class Decorator(Generic[DecoratorInfoType], Representation):
         self.func = func
         self.unwrapped_func = unwrapped_func
         self.info = info
+        self.shim = shim
 
+    @staticmethod
+    def build(
+        cls_: Any,
+        cls_var_name: str,
+        shim: Callable[[Any], Any] | None,
+        info: DecoratorInfoType,
+    ) -> Decorator[DecoratorInfoType]:
+        val = getattr(cls_, cls_var_name)
+        if isinstance(val, PydanticDecoratorMarker):
+            val = val.wrapped
+        func = val.__get__(None, cls_)
+        if shim is not None:
+            func = shim(func)
+        return Decorator(
+            cls_ref=get_type_ref(cls_),
+            cls_var_name=cls_var_name,
+            func=func,
+            shim=shim,
+            unwrapped_func=val,
+            info=info,
+        )
 
-AnyDecorator = Union[
-    Decorator[ValidatorDecoratorInfo],
-    Decorator[FieldValidatorDecoratorInfo],
-    Decorator[RootValidatorDecoratorInfo],
-    Decorator[FieldSerializerDecoratorInfo],
-    Decorator[ModelSerializerDecoratorInfo],
-]
+    def bind_to_cls(self, cls: Any) -> Decorator[DecoratorInfoType]:
+        return self.build(
+            cls,
+            cls_var_name=self.cls_var_name,
+            shim=self.shim,
+            info=self.info,
+        )
 
 
 class DecoratorInfos(Representation):
@@ -312,41 +335,35 @@ def gather_decorator_functions(cls: type[Any]) -> DecoratorInfos:  # noqa: C901
 
     # reminder: dicts are ordered and replacement does not alter the order
     res = DecoratorInfos()
-    for base in cls.__bases__:
+    for base in cls.__bases__[::-1]:
         existing = cast(Union[DecoratorInfos, None], getattr(base, '__pydantic_decorators__', None))
         if existing is not None:
-            res.validator.update(existing.validator)
-            res.field_validator.update(existing.field_validator)
-            res.root_validator.update(existing.root_validator)
-            res.field_serializer.update(existing.field_serializer)
-            res.model_serializer.update(existing.model_serializer)
+            res.validator.update({k: v.bind_to_cls(cls) for k, v in existing.validator.items()})
+            res.field_validator.update({k: v.bind_to_cls(cls) for k, v in existing.field_validator.items()})
+            res.root_validator.update({k: v.bind_to_cls(cls) for k, v in existing.root_validator.items()})
+            res.field_serializer.update({k: v.bind_to_cls(cls) for k, v in existing.field_serializer.items()})
+            res.model_serializer.update({k: v.bind_to_cls(cls) for k, v in existing.model_serializer.items()})
 
     for var_name, var_value in vars(cls).items():
         if isinstance(var_value, PydanticDecoratorMarker):
-            cls_ref = get_type_ref(cls)
-            try:
-                func = var_value.wrapped.__get__(None, cls)
-            except AttributeError:
-                if isinstance(var_value.wrapped, partial):
-                    # don't bind the class
-                    func = var_value.wrapped
-                else:
-                    raise
-            shimmed_func = var_value.shim(func) if var_value.shim is not None else func
             info = var_value.decorator_info
             if isinstance(info, ValidatorDecoratorInfo):
-                res.validator[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
+                res.validator[var_name] = Decorator.build(cls, cls_var_name=var_name, shim=var_value.shim, info=info)
             elif isinstance(info, FieldValidatorDecoratorInfo):
-                res.field_validator[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
+                res.field_validator[var_name] = Decorator.build(
+                    cls, cls_var_name=var_name, shim=var_value.shim, info=info
+                )
             elif isinstance(info, RootValidatorDecoratorInfo):
-                res.root_validator[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
+                res.root_validator[var_name] = Decorator.build(
+                    cls, cls_var_name=var_name, shim=var_value.shim, info=info
+                )
             elif isinstance(info, FieldSerializerDecoratorInfo):
                 # check whether a serializer function is already registered for fields
                 for field_serializer_decorator in res.field_serializer.values():
                     # check that each field has at most one serializer function.
                     # serializer functions for the same field in subclasses are allowed,
                     # and are treated as overrides
-                    if field_serializer_decorator.cls_ref != cls_ref:
+                    if field_serializer_decorator.cls_ref != get_type_ref(cls):
                         continue
                     for f in info.fields:
                         if f in field_serializer_decorator.info.fields:
@@ -355,13 +372,15 @@ def gather_decorator_functions(cls: type[Any]) -> DecoratorInfos:  # noqa: C901
                                 f'for field {f!r}, this is not allowed.',
                                 code='multiple-field-serializers',
                             )
-                res.field_serializer[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
+                res.field_serializer[var_name] = Decorator.build(
+                    cls, cls_var_name=var_name, shim=var_value.shim, info=info
+                )
             else:
                 assert isinstance(info, ModelSerializerDecoratorInfo)
-                res.model_serializer[var_name] = Decorator(cls_ref, var_name, shimmed_func, func, info)
-            # replace our marker with the bound, concrete function
-            setattr(cls, var_name, func)
-
+                res.model_serializer[var_name] = Decorator.build(
+                    cls, cls_var_name=var_name, shim=var_value.shim, info=info
+                )
+            setattr(cls, var_name, var_value.wrapped)
     return res
 
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -85,7 +85,7 @@ def check_decorator_fields_exist(decorators: Iterable[AnyFieldDecorator], fields
         for field in dec.info.fields:
             if field not in fields:
                 raise PydanticUserError(
-                    f'Validators defined with incorrect fields: {dec.cls_var_name}'
+                    f'Validators defined with incorrect fields: {dec.cls_ref}.{dec.cls_var_name}'
                     " (use check_fields=False if you're inheriting from the model and intended this)",
                     code='decorator-missing-field',
                 )

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -85,7 +85,7 @@ def check_decorator_fields_exist(decorators: Iterable[AnyFieldDecorator], fields
         for field in dec.info.fields:
             if field not in fields:
                 raise PydanticUserError(
-                    f'Validators defined with incorrect fields: {dec.unwrapped_func.__name__}'
+                    f'Validators defined with incorrect fields: {dec.cls_var_name}'
                     " (use check_fields=False if you're inheriting from the model and intended this)",
                     code='decorator-missing-field',
                 )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -233,22 +233,6 @@ def test_json_encoder_simple_inheritance():
     assert Child().model_dump_json() == '{"dt":"parent_encoder","timedt":"child_encoder"}'
 
 
-def test_json_encoder_inheritance_override():
-    class Parent(BaseModel):
-        dt: datetime = datetime.now()
-
-        @field_serializer('dt')
-        def serialize_dt(self, _v: datetime, _info):
-            return 'parent_encoder'
-
-    class Child(Parent):
-        @field_serializer('dt')
-        def serialize_dt(self, _v: datetime, _info):
-            return 'child_encoder'
-
-    assert Child().model_dump_json() == '{"dt":"child_encoder"}'
-
-
 def test_encode_dataclass():
     @vanilla_dataclass
     class Foo:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -624,7 +624,12 @@ def test_wildcard_validator_error():
 
 
 def test_invalid_field():
-    with pytest.raises(errors.PydanticUserError) as exc_info:
+    msg = (
+        r'Validators defined with incorrect fields:'
+        r' tests.test_validators.test_invalid_field.<locals>.Model:\d+.check_b'
+        r" \(use check_fields=False if you're inheriting from the model and intended this\)"
+    )
+    with pytest.raises(errors.PydanticUserError, match=msg):
 
         class Model(BaseModel):
             a: str
@@ -632,11 +637,6 @@ def test_invalid_field():
             @field_validator('b')
             def check_b(cls, v: Any):
                 return v
-
-    assert exc_info.value.message == (
-        "Validators defined with incorrect fields: check_b "
-        "(use check_fields=False if you're inheriting from the model and intended this)"
-    )
 
 
 def test_validate_child():


### PR DESCRIPTION
Fixes #5388.

The most important point is that this PR fundamentally changes what our decorators mean semantically. Currently they're a mix of "call this function by reference" and "call whatever is under this attribute name on this class". The second option is more in line with how regular python classes and inheritance work, I think that's the right path to go down and that's what this PR adopts. This has implications for duplicate validator detection / allow re-use which we can handle later.

Selected Reviewer: @dmontagu