### PR TITLE
Rework allow_reuse in decorators

### DIFF
--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -548,7 +548,7 @@ from pydantic import BaseModel, ValidationError, field_validator
 class Model(BaseModel):
     foo: str
 
-    @field_validator('foo', allow_reuse=True)  # TODO remove after #4436
+    @field_validator('foo')
     def value_must_equal_bar(cls, v):
         if v != 'bar':
             raise PydanticCustomError(

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -238,14 +238,14 @@ class Producer(BaseModel):
     name: str
 
     # validators
-    normalize_name = field_validator('name', allow_reuse=True)(normalize)
+    normalize_name = field_validator('name')(normalize)
 
 
 class Consumer(BaseModel):
     name: str
 
     # validators
-    normalize_name = field_validator('name', allow_reuse=True)(normalize)
+    normalize_name = field_validator('name')(normalize)
 
 
 jane_doe = Producer(name='JaNe DOE')

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -223,7 +223,7 @@ class ValidatedFunction:
             config_dict['extra'] = Extra.forbid
 
         class DecoratorBaseModel(BaseModel):
-            @field_validator(self.v_args_name, check_fields=False, allow_reuse=True)
+            @field_validator(self.v_args_name, check_fields=False)
             @classmethod
             def check_args(cls, v: Optional[List[Any]]) -> Optional[List[Any]]:
                 if takes_args or v is None:
@@ -231,7 +231,7 @@ class ValidatedFunction:
 
                 raise TypeError(f'{pos_args} positional arguments expected but {pos_args + len(v)} given')
 
-            @field_validator(self.v_kwargs_name, check_fields=False, allow_reuse=True)
+            @field_validator(self.v_kwargs_name, check_fields=False)
             @classmethod
             def check_kwargs(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
                 if takes_kwargs or v is None:
@@ -241,7 +241,7 @@ class ValidatedFunction:
                 keys = ', '.join(map(repr, v.keys()))
                 raise TypeError(f'unexpected keyword argument{plural}: {keys}')
 
-            @field_validator(V_POSITIONAL_ONLY_NAME, check_fields=False, allow_reuse=True)
+            @field_validator(V_POSITIONAL_ONLY_NAME, check_fields=False)
             @classmethod
             def check_positional_only(cls, v: Optional[List[str]]) -> None:
                 if v is None:
@@ -251,7 +251,7 @@ class ValidatedFunction:
                 keys = ', '.join(map(repr, v))
                 raise TypeError(f'positional-only argument{plural} passed as keyword argument{plural}: {keys}')
 
-            @field_validator(V_DUPLICATE_KWARGS, check_fields=False, allow_reuse=True)
+            @field_validator(V_DUPLICATE_KWARGS, check_fields=False)
             @classmethod
             def check_duplicate_kwargs(cls, v: Optional[List[str]]) -> None:
                 if v is None:

--- a/pydantic/decorators.py
+++ b/pydantic/decorators.py
@@ -134,6 +134,8 @@ def validator(
     :param check_fields: whether to check that the fields actually exist on the model
     :param allow_reuse: whether to track and raise an error if another validator refers to the decorated function
     """
+    if allow_reuse is True:  # pragma: no cover
+        warn('`allow_reuse` is deprecated and will be ignored', DeprecationWarning)
     fields = tuple((__field, *fields))
     if isinstance(fields[0], FunctionType):
         raise PydanticUserError(
@@ -163,7 +165,6 @@ def validator(
             raise PydanticUserError(
                 '`@validator` cannot be applied to instance methods', code='validator-instance-method'
             )
-        _decorators.check_for_duplicate_decorator_function(f, allow_reuse=allow_reuse, type='validator')
         # auto apply the @classmethod decorator
         f = _decorators.ensure_classmethod_based_on_signature(f)
         wrap = _decorators.make_generic_v1_field_validator
@@ -186,7 +187,6 @@ def field_validator(
     mode: Literal['before', 'after', 'plain'] = ...,
     check_fields: bool | None = ...,
     sub_path: tuple[str | int, ...] | None = ...,
-    allow_reuse: bool = False,
 ) -> Callable[[_V2BeforeAfterOrPlainValidatorType], _V2BeforeAfterOrPlainValidatorType]:
     ...
 
@@ -198,7 +198,6 @@ def field_validator(
     mode: Literal['wrap'],
     check_fields: bool | None = ...,
     sub_path: tuple[str | int, ...] | None = ...,
-    allow_reuse: bool = False,
 ) -> Callable[[_V2WrapValidatorType], _V2WrapValidatorType]:
     ...
 
@@ -209,7 +208,6 @@ def field_validator(
     mode: Literal['before', 'after', 'wrap', 'plain'] = 'after',
     check_fields: bool | None = None,
     sub_path: tuple[str | int, ...] | None = None,
-    allow_reuse: bool = False,
 ) -> Callable[[Any], Any]:
     """
     Decorate methods on the class indicating that they should be used to validate fields
@@ -240,7 +238,6 @@ def field_validator(
             raise PydanticUserError(
                 '`@field_validator` cannot be applied to instance methods', code='validator-instance-method'
             )
-        _decorators.check_for_duplicate_decorator_function(f, allow_reuse=allow_reuse, type='validator')
         # auto apply the @classmethod decorator and warn users if we had to do so
         f = _decorators.ensure_classmethod_based_on_signature(f)
 
@@ -298,6 +295,8 @@ def root_validator(
     Decorate methods on a model indicating that they should be used to validate (and perhaps modify) data either
     before or after standard model parsing/validation is performed.
     """
+    if allow_reuse is True:  # pragma: no cover
+        warn('`allow_reuse` is deprecated and will be ignored', DeprecationWarning)
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
     if pre is False and skip_on_failure is not True:
         raise PydanticUserError(
@@ -310,7 +309,6 @@ def root_validator(
     def dec(f: Callable[..., Any] | classmethod[Any] | staticmethod[Any]) -> Any:
         if _decorators.is_instance_method_from_sig(f):
             raise TypeError('`@root_validator` cannot be applied to instance methods')
-        _decorators.check_for_duplicate_decorator_function(f, allow_reuse=allow_reuse, type='validator')
         # auto apply the @classmethod decorator and warn users if we had to do so
         res = _decorators.ensure_classmethod_based_on_signature(f)
         validator_wrapper_info = _decorators.RootValidatorDecoratorInfo(mode=mode)
@@ -349,7 +347,6 @@ def field_serializer(
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = ...,
     sub_path: tuple[str | int, ...] | None = ...,
     check_fields: bool | None = ...,
-    allow_reuse: bool = ...,
 ) -> Callable[[_PlainSerializeMethodType], _PlainSerializeMethodType]:
     ...
 
@@ -363,7 +360,6 @@ def field_serializer(
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = ...,
     sub_path: tuple[str | int, ...] | None = ...,
     check_fields: bool | None = ...,
-    allow_reuse: bool = ...,
 ) -> Callable[[_PlainSerializeMethodType], _PlainSerializeMethodType]:
     ...
 
@@ -377,7 +373,6 @@ def field_serializer(
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = ...,
     sub_path: tuple[str | int, ...] | None = ...,
     check_fields: bool | None = ...,
-    allow_reuse: bool = ...,
 ) -> Callable[[_WrapSerializeMethodType], _WrapSerializeMethodType]:
     ...
 
@@ -389,7 +384,6 @@ def field_serializer(
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always',
     sub_path: tuple[str | int, ...] | None = None,
     check_fields: bool | None = None,
-    allow_reuse: bool = False,
 ) -> Callable[[Any], Any]:
     """
     Decorate methods on the class indicating that they should be used to serialize fields.
@@ -410,7 +404,6 @@ def field_serializer(
     """
 
     def dec(f: Callable[..., Any] | staticmethod[Any] | classmethod[Any]) -> _decorators.PydanticDecoratorMarker[Any]:
-        _decorators.check_for_duplicate_decorator_function(f, allow_reuse, type='serialzier')
         type_: Literal['field', 'general'] = 'field' if _decorators.is_instance_method_from_sig(f) else 'general'
 
         dec_info = _decorators.FieldSerializerDecoratorInfo(
@@ -434,7 +427,6 @@ def model_serializer(
     *,
     mode: Literal['plain', 'wrap'] = 'plain',
     json_return_type: _core_schema.JsonReturnTypes | None = None,
-    allow_reuse: bool = False,
 ) -> Callable[[Any], _decorators.PydanticDecoratorMarker[Any]] | _decorators.PydanticDecoratorMarker[Any]:
     """
     Function decorate to add a function which will be called to serialize the model.
@@ -452,8 +444,6 @@ def model_serializer(
             raise PydanticUserError(
                 '`@model_serializer` must be applied to instance methods', code='model-serializer-instance-method'
             )
-
-        _decorators.check_for_duplicate_decorator_function(f, allow_reuse, type='serialzier')
 
         dec_info = _decorators.ModelSerializerDecoratorInfo(
             mode=mode,

--- a/pydantic/decorators.py
+++ b/pydantic/decorators.py
@@ -18,6 +18,8 @@ from typing_extensions import Literal, Protocol, TypeAlias
 from ._internal import _decorators
 from .errors import PydanticUserError
 
+_ALLOW_REUSE_WARNING_MESSAGE = '`allow_reuse` is deprecated and will be ignored; it should no longer be necessary'
+
 
 class _OnlyValueValidatorClsMethod(Protocol):
     def __call__(self, __cls: Any, __value: Any) -> Any:
@@ -135,7 +137,7 @@ def validator(
     :param allow_reuse: whether to track and raise an error if another validator refers to the decorated function
     """
     if allow_reuse is True:  # pragma: no cover
-        warn('`allow_reuse` is deprecated and will be ignored', DeprecationWarning)
+        warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
     fields = tuple((__field, *fields))
     if isinstance(fields[0], FunctionType):
         raise PydanticUserError(
@@ -296,7 +298,7 @@ def root_validator(
     before or after standard model parsing/validation is performed.
     """
     if allow_reuse is True:  # pragma: no cover
-        warn('`allow_reuse` is deprecated and will be ignored; it should no longer be necessary', DeprecationWarning)
+        warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
     if pre is False and skip_on_failure is not True:
         raise PydanticUserError(

--- a/pydantic/decorators.py
+++ b/pydantic/decorators.py
@@ -296,7 +296,7 @@ def root_validator(
     before or after standard model parsing/validation is performed.
     """
     if allow_reuse is True:  # pragma: no cover
-        warn('`allow_reuse` is deprecated and will be ignored', DeprecationWarning)
+        warn('`allow_reuse` is deprecated and will be ignored; it should no longer be necessary', DeprecationWarning)
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
     if pre is False and skip_on_failure is not True:
         raise PydanticUserError(

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -463,7 +463,7 @@ class PydanticModelTransformer:
                 and stmt.rvalue.callee.callee.fullname in DECORATOR_FULLNAMES
             ):
                 # This is a (possibly-reused) validator or serializer, not a field
-                # In particular, it looks something like: my_validator = validator('my_field', allow_reuse=True)(f)
+                # In particular, it looks something like: my_validator = validator('my_field')(f)
                 # Eventually, we may want to attempt to respect model_config['ignored_types']
                 return None
 

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -194,7 +194,7 @@ def f(name: str) -> str:
 
 class ModelWithAllowReuseValidator(BaseModel):
     name: str
-    normalize_name = field_validator('name', allow_reuse=True)(f)
+    normalize_name = field_validator('name')(f)
 
 
 model_with_allow_reuse_validator = ModelWithAllowReuseValidator(name='xyz')

--- a/tests/mypy/modules/plugin_success_baseConfig.py
+++ b/tests/mypy/modules/plugin_success_baseConfig.py
@@ -200,7 +200,7 @@ def f(name: str) -> str:
 
 class ModelWithAllowReuseValidator(BaseModel):
     name: str
-    normalize_name = field_validator('name', allow_reuse=True)(f)
+    normalize_name = field_validator('name')(f)
 
 
 model_with_allow_reuse_validator = ModelWithAllowReuseValidator(name='xyz')

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1586,19 +1586,19 @@ def test_inheritance_replace(decorator1: Callable[[Any], Any], expected_parent: 
     class Parent:
         a: List[str]
 
-        @field_validator('a', allow_reuse=True)
+        @field_validator('a')
         @classmethod
         def parent_val_before(cls, v: List[str]):
             v.append('parent before')
             return v
 
-        @field_validator('a', allow_reuse=True)
+        @field_validator('a')
         @classmethod
         def val(cls, v: List[str]):
             v.append('parent')
             return v
 
-        @field_validator('a', allow_reuse=True)
+        @field_validator('a')
         @classmethod
         def parent_val_after(cls, v: List[str]):
             v.append('parent after')
@@ -1606,19 +1606,19 @@ def test_inheritance_replace(decorator1: Callable[[Any], Any], expected_parent: 
 
     @pydantic.dataclasses.dataclass
     class Child(Parent):
-        @field_validator('a', allow_reuse=True)
+        @field_validator('a')
         @classmethod
         def child_val_before(cls, v: List[str]):
             v.append('child before')
             return v
 
-        @field_validator('a', allow_reuse=True)
+        @field_validator('a')
         @classmethod
         def val(cls, v: List[str]):
             v.append('child')
             return v
 
-        @field_validator('a', allow_reuse=True)
+        @field_validator('a')
         @classmethod
         def child_val_after(cls, v: List[str]):
             v.append('child after')


### PR DESCRIPTION
Closes #4436.

This implements pretty much the same behavior that pyright and ruff/flake8 (via `F811`) enforce.