### PR TITLE
Add pre-commit hooks installation to Contribute page

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,21 +49,25 @@ source env/bin/activate
 # 3. Install pydantic, dependencies, test dependencies and doc dependencies
 make install
 
-# 4. Checkout a new branch and make your changes
+# 4. Install pre-commit hooks
+pip install pre-commit
+pre-commit install
+
+# 5. Checkout a new branch and make your changes
 git checkout -b my-new-feature-branch
 # make your changes...
 
-# 5. Fix formatting and imports
+# 6. Fix formatting and imports
 make format
 # Pydantic uses black to enforce formatting and isort to fix imports
 # (https://github.com/ambv/black, https://github.com/timothycrosley/isort)
 
-# 6. Run tests and linting
+# 7. Run tests and linting
 make
 # there are a few sub-commands in Makefile like `test`, `testcov` and `lint`
 # which you might want to use, but generally just `make` should be all you need
 
-# 7. Build documentation
+# 8. Build documentation
 make docs
 # if you have changed the documentation make sure it builds successfully
 # you can also use `make docs-serve` to serve the documentation at localhost:8000


### PR DESCRIPTION
Adds a step to install pre-commit hooks to setup instructions for contributors.

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
