### PR TITLE
Build API docs with mkdocstrings

### DIFF
--- a/docs/api/analyzed_type.md
+++ b/docs/api/analyzed_type.md
@@ -1,0 +1,1 @@
+::: pydantic.analyzed_type

--- a/docs/api/color.md
+++ b/docs/api/color.md
@@ -1,0 +1,1 @@
+::: pydantic.color

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,0 +1,1 @@
+::: pydantic.config

--- a/docs/api/dataclasses.md
+++ b/docs/api/dataclasses.md
@@ -1,0 +1,1 @@
+::: pydantic.dataclasses

--- a/docs/api/decorator.md
+++ b/docs/api/decorator.md
@@ -1,0 +1,1 @@
+::: pydantic.decorator

--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -1,0 +1,1 @@
+::: pydantic.decorators

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,0 +1,1 @@
+::: pydantic.errors

--- a/docs/api/fields.md
+++ b/docs/api/fields.md
@@ -1,0 +1,1 @@
+::: pydantic.fields

--- a/docs/api/json_schema.md
+++ b/docs/api/json_schema.md
@@ -1,0 +1,1 @@
+::: pydantic.json_schema

--- a/docs/api/main.md
+++ b/docs/api/main.md
@@ -1,0 +1,1 @@
+::: pydantic.main

--- a/docs/api/mypy.md
+++ b/docs/api/mypy.md
@@ -1,0 +1,1 @@
+::: pydantic.mypy

--- a/docs/api/networks.md
+++ b/docs/api/networks.md
@@ -1,0 +1,1 @@
+::: pydantic.networks

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1,0 +1,1 @@
+::: pydantic.tools

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,0 +1,1 @@
+::: pydantic.types

--- a/docs/api/version.md
+++ b/docs/api/version.md
@@ -1,0 +1,1 @@
+::: pydantic.version

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,22 @@ nav:
 - Contribute: contributing.md
 - Blog:
   - blog/pydantic-v2.md
+- API:
+  - 'pydantic.analyzed_type': api/analyzed_type.md
+  - 'pydantic.color': api/color.md
+  - 'pydantic.config': api/config.md
+  - 'pydantic.dataclasses': api/dataclasses.md
+  - 'pydantic.decorator': api/decorator.md
+  - 'pydantic.decorators': api/decorators.md
+  - 'pydantic.errors': api/errors.md
+  - 'pydantic.fields': api/fields.md
+  - 'pydantic.json_schema': api/json_schema.md
+  - 'pydantic.main': api/main.md
+  - 'pydantic.mypy': api/mypy.md
+  - 'pydantic.networks': api/networks.md
+  - 'pydantic.tools': api/tools.md
+  - 'pydantic.types': api/types.md
+  - 'pydantic.version': api/version.md
 
 
 markdown_extensions:
@@ -117,6 +133,10 @@ plugins:
     - theme/announce.html
     - plugins/*
     - __pycache__/*
+- mkdocstrings:
+    handlers:
+      python:
+        path: .
 - mkdocs-simple-hooks:
     hooks:
       on_pre_build: 'docs.plugins.main:on_pre_build'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,9 @@ markdown_extensions:
 - pymdownx.tabbed:
     alternate_style: true
 
+watch:
+- pydantic
+
 plugins:
 - search
 - exclude:

--- a/pydantic/analyzed_type.py
+++ b/pydantic/analyzed_type.py
@@ -1,3 +1,4 @@
+"""A class representing the analyzed type."""
 from __future__ import annotations as _annotations
 
 import sys

--- a/pydantic/analyzed_type.py
+++ b/pydantic/analyzed_type.py
@@ -214,19 +214,20 @@ class AnalyzedType(Generic[T]):
         """Serialize the given instance to JSON.
 
         Args:
-            __instance: The instance to be serialized.
-            indent: Number of spaces for JSON indentation (default: None).
-            include: Fields to include (default: None).
-            exclude: Fields to exclude (default: None).
-            by_alias: Whether to use alias names (default: False).
-            exclude_unset: Whether to exclude unset fields (default: False).
-            exclude_defaults: Whether to exclude fields with default values (default: False).
-            exclude_none: Whether to exclude fields with a value of None (default: False).
-            round_trip: Whether to serialize and deserialize the instance to ensure round-tripping (default: False).
-            warnings: Whether to emit serialization warnings (default: True).
+            __instance (T): The instance to be serialized.
+            indent (Optional[int]): Number of spaces for JSON indentation (default: None).
+            include (Optional[IncEx]): Fields to include (default: None).
+            exclude (Optional[IncEx]): Fields to exclude (default: None).
+            by_alias (bool): Whether to use alias names (default: False).
+            exclude_unset (bool): Whether to exclude unset fields (default: False).
+            exclude_defaults (bool): Whether to exclude fields with default values (default: False).
+            exclude_none (bool): Whether to exclude fields with a value of None (default: False).
+            round_trip (bool): Whether to serialize and deserialize the instance to ensure
+                round-tripping (default: False).
+            warnings (bool): Whether to emit serialization warnings (default: True).
 
         Returns:
-            The JSON representation of the given instance as bytes.
+            bytes: The JSON representation of the given instance as bytes.
         """
         return self.serializer.to_json(
             __instance,
@@ -251,12 +252,13 @@ class AnalyzedType(Generic[T]):
         """Generate a JSON schema for the model.
 
         Args:
-            by_alias: Whether to use alias names (default: True).
-            ref_template: The format string used for generating $ref strings (default: DEFAULT_REF_TEMPLATE).
-            schema_generator: The generator class used for creating the schema (default: GenerateJsonSchema).
+            by_alias (bool): Whether to use alias names (default: True).
+            ref_template (str): The format string used for generating $ref strings (default: DEFAULT_REF_TEMPLATE).
+            schema_generator (Type[GenerateJsonSchema]): The generator class used for creating the schema
+                (default: GenerateJsonSchema).
 
         Returns:
-            The JSON schema for the model as a dictionary.
+            Dict[str, Any]: The JSON schema for the model as a dictionary.
         """
         schema_generator_instance = schema_generator(by_alias=by_alias, ref_template=ref_template)
         return schema_generator_instance.generate(self.core_schema)
@@ -274,16 +276,18 @@ class AnalyzedType(Generic[T]):
         """Generate JSON schemas for multiple models.
 
         Args:
-            __analyzed_types: The types to generate schemas for.
-            by_alias: Whether to use alias names (default: True).
-            ref_template: The format string used for generating $ref strings (default: DEFAULT_REF_TEMPLATE).
-            title: The title for the schema (default: None).
-            description: The description for the schema (default: None).
-            schema_generator: The generator class used for creating the schema (default: GenerateJsonSchema).
+            __analyzed_types (Iterable[AnalyzedType[Any]]): The types to generate schemas for.
+            by_alias (bool): Whether to use alias names (default: True).
+            ref_template (str): The format string used for generating $ref strings (default: DEFAULT_REF_TEMPLATE).
+            title (Optional[str]): The title for the schema (default: None).
+            description (Optional[str]): The description for the schema (default: None).
+            schema_generator (Type[GenerateJsonSchema]): The generator class used for creating the
+                schema (default: GenerateJsonSchema).
 
         Returns:
-            The JSON schema for the models as a dictionary.
+            Dict[str, Any]: The JSON schema for the models as a dictionary.
         """
+        # TODO: can we use model.__schema_cache__?
         schema_generator_instance = schema_generator(by_alias=by_alias, ref_template=ref_template)
 
         core_schemas = [at.core_schema for at in __analyzed_types]

--- a/pydantic/analyzed_type.py
+++ b/pydantic/analyzed_type.py
@@ -19,16 +19,17 @@ if TYPE_CHECKING:
 
 
 def _get_schema(type_: Any, config: CoreConfig | None, parent_depth: int) -> CoreSchema:
-    """
-      BaseModel uses it's own __module__ to find out where it was defined
-    and then look for symbols to resolve forward references in those globals
+    """`BaseModel` uses its own `__module__` to find out where it was defined
+    and then look for symbols to resolve forward references in those globals.
     On the other hand this function can be called with arbitrary objects,
-    including type aliases where __module__ (always `typing.py`) is not useful
-    So instead we look at the globals in our parent stack frame
+    including type aliases where `__module__` (always `typing.py`) is not useful.
+    So instead we look at the globals in our parent stack frame.
+
     This works for the case where this function is called in a module that
-    has the target of forward references in its scope but
-    does not work for more complex cases
-    for example, take the following:
+    has the target of forward references in its scope, but
+    does not work for more complex cases.
+
+    For example, take the following:
 
     a.py
     ```python
@@ -46,16 +47,18 @@ def _get_schema(type_: Any, config: CoreConfig | None, parent_depth: int) -> Cor
     v({"x": 1})  # should fail but doesn't
     ```
 
-    If OuterDict were a BaseModel this would work because it would resolve
+    If OuterDict were a `BaseModel`, this would work because it would resolve
     the forward reference within the `a.py` namespace.
     But `AnalyzedType(OuterDict)`
     can't know what module OuterDict came from.
+
     In other words, the assumption that _all_ forward references exist in the
-    module we are being called from is not technically always true
-    Although most of the time it is and it works fine for recursive models and such/
-    BaseModel's behavior isn't perfect either and _can_ break in similar ways,
+    module we are being called from is not technically always true.
+    Although most of the time it is and it works fine for recursive models and such,
+    `BaseModel`'s behavior isn't perfect either and _can_ break in similar ways,
     so there is no right or wrong between the two.
-    But at the very least this behavior is _subtly_ different from BaseModel's.
+
+    But at the very least this behavior is _subtly_ different from `BaseModel`'s.
     """
     arbitrary_types = bool((config or {}).get('arbitrary_types_allowed', False))
     local_ns = _typing_extra.parent_frame_namespace(parent_depth=parent_depth)
@@ -68,9 +71,7 @@ def _get_schema(type_: Any, config: CoreConfig | None, parent_depth: int) -> Cor
 # TODO: merge / replace this with _internal/_generate_schema.py::generate_config
 # once we change the config logic to make ConfigDict not be a partial
 def _translate_config(config: ConfigDict) -> core_schema.CoreConfig:
-    """
-    Create a pydantic-core config from a pydantic config.
-    """
+    """Create a pydantic-core config from a pydantic config."""
     unset: Any = object()
     core_config: dict[str, Any] = dict(
         title=config['title'] if 'title' in config and config['title'] is not None else unset,
@@ -98,6 +99,14 @@ def _translate_config(config: ConfigDict) -> core_schema.CoreConfig:
 
 
 class AnalyzedType(Generic[T]):
+    """A class representing the analyzed type.
+
+    Attributes:
+        core_schema (CoreSchema): The core schema for the analyzed data.
+        validator (SchemaValidator): The schema validator for the analyzed data.
+        serializer (SchemaSerializer): The schema serializer for the analyzed data.
+    """
+
     if TYPE_CHECKING:
 
         @overload
@@ -115,6 +124,13 @@ class AnalyzedType(Generic[T]):
             raise NotImplementedError
 
     def __init__(self, __type: Any, *, config: ConfigDict | None = None, _parent_depth: int = 2) -> None:
+        """Initializes the AnalyzedType object.
+
+        Args:
+            __type (Any): The data type to analyze.
+            config (ConfigDict, optional): A configuration dictionary for the analyzed data. Defaults to None.
+            _parent_depth (int, optional): The depth of the parent data type. Defaults to 2.
+        """
         core_config: CoreConfig
         if config is not None:
             core_config = _translate_config(config)
@@ -148,11 +164,34 @@ class AnalyzedType(Generic[T]):
         self.serializer = serializer
 
     def validate_python(self, __object: Any, *, strict: bool | None = None, context: dict[str, Any] | None = None) -> T:
+        """
+        Validate a Python object against the model.
+
+        Args:
+            __object (Any): The Python object to validate against the model.
+            strict (bool | None, optional): Whether to strictly check types. Defaults to None.
+            context (dict[str, Any] | None, optional): Additional context to use during validation. Defaults to None.
+
+        Returns:
+            T: The validated object.
+
+        """
         return self.validator.validate_python(__object, strict=strict, context=context)
 
     def validate_json(
         self, __data: str | bytes, *, strict: bool | None = None, context: dict[str, Any] | None = None
     ) -> T:
+        """Validate a JSON string or bytes against the model.
+
+        Args:
+            __data (str | bytes): The JSON data to validate against the model.
+            strict (bool | None, optional): Whether to strictly check types. Defaults to None.
+            context (dict[str, Any] | None, optional): Additional context to use during validation. Defaults to None.
+
+        Returns:
+            T: The validated object.
+
+        """
         return self.validator.validate_json(__data, strict=strict, context=context)
 
     def dump_python(
@@ -169,6 +208,25 @@ class AnalyzedType(Generic[T]):
         round_trip: bool = False,
         warnings: bool = True,
     ) -> Any:
+        """Dump a Python object to a serialized format.
+
+        Args:
+            __instance (T): The Python object to serialize.
+            mode (Literal['json', 'python'], optional): The output format. Defaults to 'python'.
+            include (IncEx | None, optional): Fields to include in the output. Defaults to None.
+            exclude (IncEx | None, optional): Fields to exclude from the output. Defaults to None.
+            by_alias (bool, optional): Whether to use alias names for field names. Defaults to False.
+            exclude_unset (bool, optional): Whether to exclude unset fields. Defaults to False.
+            exclude_defaults (bool, optional): Whether to exclude fields with default values. Defaults to False.
+            exclude_none (bool, optional): Whether to exclude fields with None values. Defaults to False.
+            round_trip (bool, optional): Whether to output the serialized data in a way that is compatible with
+                deserialization. Defaults to False.
+            warnings (bool, optional): Whether to display serialization warnings. Defaults to True.
+
+        Returns:
+            Any: The serialized object.
+
+        """
         return self.serializer.to_python(
             __instance,
             mode=mode,
@@ -196,6 +254,23 @@ class AnalyzedType(Generic[T]):
         round_trip: bool = False,
         warnings: bool = True,
     ) -> bytes:
+        """Serialize the given instance to JSON.
+
+        Args:
+            __instance: The instance to be serialized.
+            indent: Number of spaces for JSON indentation (default: None).
+            include: Fields to include (default: None).
+            exclude: Fields to exclude (default: None).
+            by_alias: Whether to use alias names (default: False).
+            exclude_unset: Whether to exclude unset fields (default: False).
+            exclude_defaults: Whether to exclude fields with default values (default: False).
+            exclude_none: Whether to exclude fields with a value of None (default: False).
+            round_trip: Whether to serialize and deserialize the instance to ensure round-tripping (default: False).
+            warnings: Whether to emit serialization warnings (default: True).
+
+        Returns:
+            The JSON representation of the given instance as bytes.
+        """
         return self.serializer.to_json(
             __instance,
             indent=indent,
@@ -216,6 +291,16 @@ class AnalyzedType(Generic[T]):
         ref_template: str = DEFAULT_REF_TEMPLATE,
         schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
     ) -> dict[str, Any]:
+        """Generate a JSON schema for the model.
+
+        Args:
+            by_alias: Whether to use alias names (default: True).
+            ref_template: The format string used for generating $ref strings (default: DEFAULT_REF_TEMPLATE).
+            schema_generator: The generator class used for creating the schema (default: GenerateJsonSchema).
+
+        Returns:
+            The JSON schema for the model as a dictionary.
+        """
         schema_generator_instance = schema_generator(by_alias=by_alias, ref_template=ref_template)
         return schema_generator_instance.generate(self.core_schema)
 
@@ -229,7 +314,19 @@ class AnalyzedType(Generic[T]):
         description: str | None = None,
         schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
     ) -> dict[str, Any]:
-        # TODO: can we use model.__schema_cache__?
+        """Generate JSON schemas for multiple models.
+
+        Args:
+            __analyzed_types: The types to generate schemas for.
+            by_alias: Whether to use alias names (default: True).
+            ref_template: The format string used for generating $ref strings (default: DEFAULT_REF_TEMPLATE).
+            title: The title for the schema (default: None).
+            description: The description for the schema (default: None).
+            schema_generator: The generator class used for creating the schema (default: GenerateJsonSchema).
+
+        Returns:
+            The JSON schema for the models as a dictionary.
+        """
         schema_generator_instance = schema_generator(by_alias=by_alias, ref_template=ref_template)
 
         core_schemas = [at.core_schema for at in __analyzed_types]

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -160,13 +160,13 @@ class Color(_repr.Representation):
         Returns the color as an RGB or RGBA tuple.
 
         Args:
-            alpha: Whether to include the alpha channel. There are three options for this input:
+            alpha (Optional[bool]): Whether to include the alpha channel. There are three options for this input:
                 `None` (default): Include alpha only if it's set. (e.g. not `None`)
                 `True`: Always include alpha.
                 `False`: Always omit alpha.
 
         Returns:
-            A tuple that contains the values of the red, green, and blue channels in the range 0 to 255.
+            ColorTuple: A tuple that contains the values of the red, green, and blue channels in the range 0 to 255.
             If alpha is included, it is in the range 0 to 1.
         """
         r, g, b = (float_to_255(c) for c in self._rgba[:3])
@@ -197,7 +197,7 @@ class Color(_repr.Representation):
         Returns the color as an HSL or HSLA tuple.
 
         Args:
-            alpha: Whether to include the alpha channel.
+            alpha (Optional[bool]): Whether to include the alpha channel.
                 `None` (default): Include the alpha channel only if it's set (e.g. not `None`).
                 `True`: Always include alpha.
                 `False`: Always omit alpha.
@@ -251,10 +251,10 @@ def parse_tuple(value: Tuple[Any, ...]) -> RGBA:
     """Parse a tuple or list to get RGBA values.
 
     Args:
-        value: A tuple or list.
+        value (Tuple[Any, ...]): A tuple or list.
 
     Returns:
-        Return RGBA values.
+        RGBA: An RGBA tuple parsed from the input tuple.
 
     Raises:
         PydanticCustomError: If tuple is not valid.
@@ -282,10 +282,10 @@ def parse_str(value: str) -> RGBA:
     * `rgba(<r>, <g>, <b>, <a>)`
 
     Args:
-        value: A string representing a color.
+        value (str): A string representing a color.
 
     Returns:
-        An RGBA tuple parsed from the input string.
+        RGBA: An RGBA tuple parsed from the input string.
 
     Raises:
         ValueError: If the input string cannot be parsed to an RGBA tuple.
@@ -409,14 +409,14 @@ def parse_hsl(h: str, h_units: str, sat: str, light: str, alpha: Optional[float]
     Parse raw hue, saturation, lightness, and alpha values and convert to RGBA.
 
     Args:
-        h: str, the hue value.
-        h_units: str, the unit for hue value.
-        sat: str, the saturation value.
-        light: str, the lightness value.
-        alpha: Optional[float], alpha value.
+        h (str): The hue value.
+        h_units (str): The unit for hue value.
+        sat (str): The saturation value.
+        light (str): The lightness value.
+        alpha (Optional[float]): Alpha value.
 
     Returns:
-        An instance of `RGBA`.
+        RGBA: An instance of `RGBA`.
     """
     s_value, l_value = parse_color_value(sat, 100), parse_color_value(light, 100)
 

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -63,6 +63,10 @@ rads = 2 * math.pi
 
 
 class Color(_repr.Representation):
+    """
+    Represents a color.
+    """
+
     __slots__ = '_original', '_rgba'
 
     def __init__(self, value: ColorType) -> None:
@@ -95,6 +99,20 @@ class Color(_repr.Representation):
         return self._original
 
     def as_named(self, *, fallback: bool = False) -> str:
+        """
+        Returns the name of the color if it can be found in `COLORS_BY_VALUE` dictionary,
+        otherwise returns the hexadecimal representation of the color or raises `ValueError`.
+
+        Args:
+            fallback (bool): If True, falls back to returning the hexadecimal representation of
+                the color instead of raising a ValueError when no named color is found.
+
+        Returns:
+            str: The name of the color, or the hexadecimal representation of the color.
+
+        Raises:
+            ValueError: When no named color is found and fallback is `False`.
+        """
         if self._rgba.alpha is None:
             rgb = cast(Tuple[int, int, int], self.as_rgb_tuple())
             try:
@@ -108,9 +126,13 @@ class Color(_repr.Representation):
             return self.as_hex()
 
     def as_hex(self) -> str:
-        """
+        """Returns the hexadecimal representation of the color.
+
         Hex string representing the color can be 3, 4, 6, or 8 characters depending on whether the string
         a "short" representation of the color is possible and whether there's an alpha channel.
+
+        Returns:
+            str: The hexadecimal representation of the color.
         """
         values = [float_to_255(c) for c in self._rgba[:3]]
         if self._rgba.alpha is not None:

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -1,11 +1,11 @@
 """
-Color definitions are  used as per CSS3 specification:
-http://www.w3.org/TR/css3-color/#svg-color
+Color definitions are used as per the CSS3
+[CSS Color Module Level 3](http://www.w3.org/TR/css3-color/#svg-color) specification.
 
 A few colors have multiple names referring to the sames colors, eg. `grey` and `gray` or `aqua` and `cyan`.
 
-In these cases the LAST color when sorted alphabetically takes preferences,
-eg. Color((0, 255, 255)).as_named() == 'cyan' because "cyan" comes after "aqua".
+In these cases the _last_ color when sorted alphabetically takes preferences,
+eg. `Color((0, 255, 255)).as_named() == 'cyan'` because "cyan" comes after "aqua".
 """
 import math
 import re
@@ -90,7 +90,7 @@ class Color(_repr.Representation):
 
     def original(self) -> ColorType:
         """
-        Original value passed to Color
+        Original value passed to `Color`.
         """
         return self._original
 
@@ -109,7 +109,7 @@ class Color(_repr.Representation):
 
     def as_hex(self) -> str:
         """
-        Hex string representing the color can be 3, 4, 6 or 8 characters depending on whether the string
+        Hex string representing the color can be 3, 4, 6, or 8 characters depending on whether the string
         a "short" representation of the color is possible and whether there's an alpha channel.
         """
         values = [float_to_255(c) for c in self._rgba[:3]]
@@ -123,7 +123,7 @@ class Color(_repr.Representation):
 
     def as_rgb(self) -> str:
         """
-        Color as an rgb(<r>, <g>, <b>) or rgba(<r>, <g>, <b>, <a>) string.
+        Color as an `rgb(<r>, <g>, <b>)` or `rgba(<r>, <g>, <b>, <a>)` string.
         """
         if self._rgba.alpha is None:
             return f'rgb({float_to_255(self._rgba.r)}, {float_to_255(self._rgba.g)}, {float_to_255(self._rgba.b)})'
@@ -135,13 +135,17 @@ class Color(_repr.Representation):
 
     def as_rgb_tuple(self, *, alpha: Optional[bool] = None) -> ColorTuple:
         """
-        Color as an RGB or RGBA tuple; red, green and blue are in the range 0 to 255, alpha if included is
-        in the range 0 to 1.
+        Returns the color as an RGB or RGBA tuple.
 
-        :param alpha: whether to include the alpha channel, options are
-          None - (default) include alpha only if it's set (e.g. not None)
-          True - always include alpha,
-          False - always omit alpha,
+        Args:
+            alpha: Whether to include the alpha channel. There are three options for this input:
+                `None` (default): Include alpha only if it's set. (e.g. not `None`)
+                `True`: Always include alpha.
+                `False`: Always omit alpha.
+
+        Returns:
+            A tuple that contains the values of the red, green, and blue channels in the range 0 to 255.
+            If alpha is included, it is in the range 0 to 1.
         """
         r, g, b = (float_to_255(c) for c in self._rgba[:3])
         if alpha is None:
@@ -157,7 +161,7 @@ class Color(_repr.Representation):
 
     def as_hsl(self) -> str:
         """
-        Color as an hsl(<h>, <s>, <l>) or hsl(<h>, <s>, <l>, <a>) string.
+        Color as an `hsl(<h>, <s>, <l>)` or `hsl(<h>, <s>, <l>, <a>)` string.
         """
         if self._rgba.alpha is None:
             h, s, li = self.as_hsl_tuple(alpha=False)  # type: ignore
@@ -168,15 +172,20 @@ class Color(_repr.Representation):
 
     def as_hsl_tuple(self, *, alpha: Optional[bool] = None) -> HslColorTuple:
         """
-        Color as an HSL or HSLA tuple, e.g. hue, saturation, lightness and optionally alpha; all elements are in
-        the range 0 to 1.
+        Returns the color as an HSL or HSLA tuple.
 
-        NOTE: this is HSL as used in HTML and most other places, not HLS as used in python's colorsys.
+        Args:
+            alpha: Whether to include the alpha channel.
+                `None` (default): Include the alpha channel only if it's set (e.g. not `None`).
+                `True`: Always include alpha.
+                `False`: Always omit alpha.
 
-        :param alpha: whether to include the alpha channel, options are
-          None - (default) include alpha only if it's set (e.g. not None)
-          True - always include alpha,
-          False - always omit alpha,
+        Returns:
+            HslColorTuple: The color as a tuple of hue, saturation, lightness, and alpha (if included).
+                All elements are in the range 0 to 1.
+
+        Note:
+            This is HSL as used in HTML and most other places, not HLS as used in Python's `colorsys`.
         """
         h, l, s = rgb_to_hls(self._rgba.r, self._rgba.g, self._rgba.b)  # noqa: E741
         if alpha is None:
@@ -217,8 +226,16 @@ class Color(_repr.Representation):
 
 
 def parse_tuple(value: Tuple[Any, ...]) -> RGBA:
-    """
-    Parse a tuple or list as a color.
+    """Parse a tuple or list to get RGBA values.
+
+    Args:
+        value: A tuple or list.
+
+    Returns:
+        Return RGBA values.
+
+    Raises:
+        PydanticCustomError: If tuple is not valid.
     """
     if len(value) == 3:
         r, g, b = (parse_color_value(v) for v in value)
@@ -232,12 +249,24 @@ def parse_tuple(value: Tuple[Any, ...]) -> RGBA:
 
 def parse_str(value: str) -> RGBA:
     """
-    Parse a string to an RGBA tuple, trying the following formats (in this order):
-    * named color, see COLORS_BY_NAME below
+    Parse a string representing a color to an RGBA tuple.
+
+    Possible formats for the input string include:
+
+    * named color, see `COLORS_BY_NAME`
     * hex short eg. `<prefix>fff` (prefix can be `#`, `0x` or nothing)
     * hex long eg. `<prefix>ffffff` (prefix can be `#`, `0x` or nothing)
-    * `rgb(<r>, <g>, <b>) `
+    * `rgb(<r>, <g>, <b>)`
     * `rgba(<r>, <g>, <b>, <a>)`
+
+    Args:
+        value: A string representing a color.
+
+    Returns:
+        An RGBA tuple parsed from the input string.
+
+    Raises:
+        ValueError: If the input string cannot be parsed to an RGBA tuple.
     """
     value_lower = value.lower()
     try:
@@ -279,13 +308,34 @@ def parse_str(value: str) -> RGBA:
 
 
 def ints_to_rgba(r: Union[int, str], g: Union[int, str], b: Union[int, str], alpha: Optional[float] = None) -> RGBA:
+    """
+    Converts integer or string values for RGB color and an optional alpha value to an `RGBA` object.
+
+    Args:
+        r (Union[int, str]): An integer or string representing the red color value.
+        g (Union[int, str]): An integer or string representing the green color value.
+        b (Union[int, str]): An integer or string representing the blue color value.
+        alpha (float, optional): A float representing the alpha value. Defaults to None.
+
+    Returns:
+        RGBA: An instance of the `RGBA` class with the corresponding color and alpha values.
+    """
     return RGBA(parse_color_value(r), parse_color_value(g), parse_color_value(b), parse_float_alpha(alpha))
 
 
 def parse_color_value(value: Union[int, str], max_val: int = 255) -> float:
     """
-    Parse a value checking it's a valid int in the range 0 to max_val and divide by max_val to give a number
-    in the range 0 to 1
+    Parse the color value provided and return a number between 0 and 1.
+
+    Args:
+        value (Union[int, str]): An integer or string color value.
+        max_val (int, optional): Maximum range value. Defaults to 255.
+
+    Raises:
+        PydanticCustomError: If the value is not a valid color.
+
+    Returns:
+        float: A number between 0 and 1.
     """
     try:
         color = float(value)
@@ -303,7 +353,16 @@ def parse_color_value(value: Union[int, str], max_val: int = 255) -> float:
 
 def parse_float_alpha(value: Union[None, str, float, int]) -> Optional[float]:
     """
-    Parse a value checking it's a valid float in the range 0 to 1
+    Parse an alpha value checking it's a valid float in the range 0 to 1.
+
+    Args:
+        value (Union[None, str, float, int]): The input value to parse.
+
+    Returns:
+        Optional[float]: The parsed value as a float, or `None` if the value was None or equal 1.
+
+    Raises:
+        PydanticCustomError: If the input value cannot be successfully parsed as a float in the expected range.
     """
     if value is None:
         return None
@@ -325,7 +384,17 @@ def parse_float_alpha(value: Union[None, str, float, int]) -> Optional[float]:
 
 def parse_hsl(h: str, h_units: str, sat: str, light: str, alpha: Optional[float] = None) -> RGBA:
     """
-    Parse raw hue, saturation, lightness and alpha values and convert to RGBA.
+    Parse raw hue, saturation, lightness, and alpha values and convert to RGBA.
+
+    Args:
+        h: str, the hue value.
+        h_units: str, the unit for hue value.
+        sat: str, the saturation value.
+        light: str, the lightness value.
+        alpha: Optional[float], alpha value.
+
+    Returns:
+        An instance of `RGBA`.
     """
     s_value, l_value = parse_color_value(sat, 100), parse_color_value(light, 100)
 
@@ -343,6 +412,18 @@ def parse_hsl(h: str, h_units: str, sat: str, light: str, alpha: Optional[float]
 
 
 def float_to_255(c: float) -> int:
+    """
+    Converts a float value between 0 and 1 (inclusive) to an integer between 0 and 255 (inclusive).
+
+    Args:
+        c (float): The float value to be converted. Must be between 0 and 1 (inclusive).
+
+    Returns:
+        int: The integer equivalent of the given float value rounded to the nearest whole number.
+
+    Raises:
+        ValueError: If the given float value is outside the acceptable range of 0 to 1 (inclusive).
+    """
     return int(round(c * 255))
 
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,3 +1,4 @@
+"""Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
 from typing import Any, Callable
@@ -27,6 +28,36 @@ ExtraValues = Literal['allow', 'ignore', 'forbid']
 
 
 class ConfigDict(TypedDict, total=False):
+    """A dictionary-like class for configuring Pydantic models.
+
+    Attributes:
+        title (Optional[str]): Optional title for the configuration. Defaults to None.
+        str_to_lower (bool): Whether to convert strings to lowercase. Defaults to False.
+        str_to_upper (bool): Whether to convert strings to uppercase. Defaults to False.
+        str_strip_whitespace (bool): Whether to strip whitespace from strings. Defaults to False.
+        str_min_length (int): The minimum length for strings. Defaults to None.
+        str_max_length (int): The maximum length for strings. Defaults to None.
+        extra (ExtraValues): Extra values to include in this configuration. Defaults to None.
+        frozen (bool): Whether to freeze the configuration. Defaults to False.
+        populate_by_name (bool): Whether to populate fields by name. Defaults to False.
+        use_enum_values (bool): Whether to use enum values. Defaults to False.
+        validate_assignment (bool): Whether to validate assignments. Defaults to False.
+        arbitrary_types_allowed (bool): Whether to allow arbitrary types. Defaults to True.
+        undefined_types_warning (bool): Whether to show a warning for undefined types. Defaults to True.
+        from_attributes (bool): Whether to set attributes from the configuration. Defaults to False.
+        loc_by_alias (bool): Whether to use the alias for error `loc`s. Defaults to True.
+        alias_generator (Optional[Callable[[str], str]]): A function to generate aliases. Defaults to None.
+        ignored_types (Tuple[type, ...]): A tuple of types to ignore. Defaults to ().
+        allow_inf_nan (bool): Whether to allow infinity and NaN. Defaults to False.
+        strict (bool): Whether to make the configuration strict. Defaults to False.
+        revalidate_instances (Literal['always', 'never', 'subclass-instances']):
+            When and how to revalidate models and dataclasses during validation. Defaults to 'never'.
+        ser_json_timedelta (Literal['iso8601', 'float']): The format of JSON serialized timedeltas.
+            Defaults to 'iso8601'.
+        ser_json_bytes (Literal['utf8', 'base64']): The encoding of JSON serialized bytes. Defaults to 'utf8'.
+        validate_default (bool): Whether to validate default values during validation. Defaults to False.
+    """
+
     title: str | None
     str_to_lower: bool
     str_to_upper: bool

--- a/pydantic/decorators.py
+++ b/pydantic/decorators.py
@@ -229,7 +229,6 @@ def field_validator(
         mode (Literal['before', 'after', 'wrap', 'plain'], optional): TODO. Defaults to 'after'.
         check_fields (bool | None, optional): Whether to check that the fields actually exist on
             the model. Defaults to None.
-        sub_path (tuple[str | int, ...] | None, optional): TODO. Defaults to None.
 
     Returns:
         Callable[[Any], Any]: A decorator that can be used to decorate a function to be used as a field_validator.
@@ -427,7 +426,6 @@ def field_serializer(
                 default serialization logic.
         json_return_type (str): The type that the function returns if the serialization mode is JSON.
         when_used (str): When the function should be called.
-        sub_path (tuple[str | int, ...]): TODO
         check_fields (bool): Whether to check that the fields actually exist on the model.
     """
 

--- a/pydantic/decorators.py
+++ b/pydantic/decorators.py
@@ -1,5 +1,6 @@
 """
 Public methods related to:
+
 * `validator` - a decorator to add validation to a field on a model
 * `root_validator` - a decorator to add validation to a model as a whole
 * `serializer` - a decorator to add serialization to a field on a model
@@ -125,16 +126,26 @@ def validator(
     allow_reuse: bool = False,
 ) -> Callable[[_V1ValidatorType], _V1ValidatorType]:
     """
-    Decorate methods on the class indicating that they should be used to validate fields
-    :param __field: the first field the validator should be called on;
-        this is separate from `fields` to ensure an error is raised if you don't pass at least one
-    :param fields: additional field(s) the validator should be called on
-    :param pre: whether or not this validator should be called before the standard validators (else after)
-    :param each_item: for complex objects (sets, lists etc.) whether to validate individual elements rather than the
-      whole object
-    :param always: whether this method and other validators should be called even if the value is missing
-    :param check_fields: whether to check that the fields actually exist on the model
-    :param allow_reuse: whether to track and raise an error if another validator refers to the decorated function
+    Decorate methods on the class indicating that they should be used to validate fields.
+
+    Args:
+        __field (str): The first field the validator should be called on; this is separate
+            from `fields` to ensure an error is raised if you don't pass at least one.
+        *fields (str): Additional field(s) the validator should be called on.
+        pre (bool, optional): Whether or not this validator should be called before the standard
+            validators (else after). Defaults to False.
+        each_item (bool, optional): For complex objects (sets, lists etc.) whether to validate
+            individual elements rather than the whole object. Defaults to False.
+        always (bool, optional): Whether this method and other validators should be called even if
+            the value is missing. Defaults to False.
+        check_fields (bool | None, optional): Whether to check that the fields actually exist on the model.
+            Defaults to None.
+        allow_reuse (bool, optional): Whether to track and raise an error if another validator refers to
+            the decorated function. Defaults to False.
+
+    Returns:
+        Callable[[_V1ValidatorType], _V1ValidatorType]: A decorator that can be used to decorate a
+            function to be used as a validator.
     """
     if allow_reuse is True:  # pragma: no cover
         warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
@@ -212,14 +223,19 @@ def field_validator(
     sub_path: tuple[str | int, ...] | None = None,
 ) -> Callable[[Any], Any]:
     """
-    Decorate methods on the class indicating that they should be used to validate fields
-    :param __field: the first field the field_validator should be called on;
-        this is separate from `fields` to ensure an error is raised if you don't pass at least one
-    :param fields: additional field(s) the field_validator should be called on
-    :param mode: TODO
-    :param check_fields: whether to check that the fields actually exist on the model
-    :param sub_path: TODO
-    :param allow_reuse: whether to track and raise an error if another validator refers to the decorated function
+    Decorate methods on the class indicating that they should be used to validate fields.
+
+    Args:
+        __field (str): The first field the field_validator should be called on; this is separate
+            from `fields` to ensure an error is raised if you don't pass at least one.
+        *fields (str): Additional field(s) the field_validator should be called on.
+        mode (Literal['before', 'after', 'wrap', 'plain'], optional): TODO. Defaults to 'after'.
+        check_fields (bool | None, optional): Whether to check that the fields actually exist on
+            the model. Defaults to None.
+        sub_path (tuple[str | int, ...] | None, optional): TODO. Defaults to None.
+
+    Returns:
+        Callable[[Any], Any]: A decorator that can be used to decorate a function to be used as a field_validator.
     """
     fields = tuple((__field, *fields))
     if isinstance(fields[0], FunctionType):
@@ -296,8 +312,19 @@ def root_validator(
     allow_reuse: bool = False,
 ) -> Any:
     """
-    Decorate methods on a model indicating that they should be used to validate (and perhaps modify) data either
-    before or after standard model parsing/validation is performed.
+    Decorate methods on a model indicating that they should be used to validate (and perhaps
+    modify) data either before or after standard model parsing/validation is performed.
+
+    Args:
+        pre (bool, optional): Whether or not this validator should be called before the standard
+            validators (else after). Defaults to False.
+        skip_on_failure (bool, optional): Whether to stop validation and return as soon as a
+            failure is encountered. Defaults to False.
+        allow_reuse (bool, optional): Whether to track and raise an error if another validator
+            refers to the decorated function. Defaults to False.
+
+    Returns:
+        Any: A decorator that can be used to decorate a function to be used as a root_validator.
     """
     if allow_reuse is True:  # pragma: no cover
         warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
@@ -391,20 +418,24 @@ def field_serializer(
 ) -> Callable[[Any], Any]:
     """
     Decorate methods on the class indicating that they should be used to serialize fields.
-    Four signatures are supported:
-    - (self, value: Any, info: FieldSerializationInfo)
-    - (self, value: Any, nxt: SerializerFunctionWrapHandler, info: FieldSerializationInfo)
-    - (value: Any, info: SerializationInfo)
-    - (value: Any, nxt: SerializerFunctionWrapHandler, info: SerializationInfo)
 
-    :param fields: which field(s) the method should be called on
-    :param mode: `'plain'` means the function will be called instead of the default serialization logic,
-        `'wrap'` means the function will be called with an argument to optionally call the default serialization logic.
-    :param json_return_type: The type that the function returns if the serialization mode is JSON.
-    :param when_used: When the function should be called
-    :param sub_path: TODO
-    :param check_fields: whether to check that the fields actually exist on the model
-    :param allow_reuse: whether to track and raise an error if another validator refers to the decorated function
+    Four signatures are supported:
+
+    - `(self, value: Any, info: FieldSerializationInfo)`
+    - `(self, value: Any, nxt: SerializerFunctionWrapHandler, info: FieldSerializationInfo)`
+    - `(value: Any, info: SerializationInfo)`
+    - `(value: Any, nxt: SerializerFunctionWrapHandler, info: SerializationInfo)`
+
+    Args:
+        fields (str): Which field(s) the method should be called on.
+        mode (str):
+            - `'plain'` means the function will be called instead of the default serialization logic,
+            - `'wrap'` means the function will be called with an argument to optionally call the
+                default serialization logic.
+        json_return_type (str): The type that the function returns if the serialization mode is JSON.
+        when_used (str): When the function should be called.
+        sub_path (tuple[str | int, ...]): TODO
+        check_fields (bool): Whether to check that the fields actually exist on the model.
     """
 
     def dec(
@@ -435,14 +466,21 @@ def model_serializer(
     json_return_type: _core_schema.JsonReturnTypes | None = None,
 ) -> Callable[[Any], _decorators.PydanticDecoratorMarker[Any]] | _decorators.PydanticDecoratorMarker[Any]:
     """
-    Function decorate to add a function which will be called to serialize the model.
+    Decorator to add a function which will be called to serialize the model.
 
-    (`when_used` is not permitted here since it make no sense)
+    (`when_used` is not permitted here since it makes no sense.)
 
-    :param mode: `'plain'` means the function will be called instead of the default serialization logic,
-        `'wrap'` means the function will be called with an argument to optionally call the default serialization logic.
-    :param json_return_type: The type that the function returns if the serialization mode is JSON.
-    :param allow_reuse: whether to track and raise an error if another validator refers to the decorated function
+    Args:
+        __f (Callable[..., Any] | None): The function to be decorated.
+        mode (Literal['plain', 'wrap']): The serialization mode. `'plain'` means the function will be called
+            instead of the default serialization logic, `'wrap'` means the function will be called with an argument
+            to optionally call the default serialization logic.
+        json_return_type (_core_schema.JsonReturnTypes | None): The type that the function returns if the
+            serialization mode is JSON.
+
+    Returns:
+        Callable[[Any], _decorators.PydanticDecoratorMarker[Any]] | _decorators.PydanticDecoratorMarker[Any]:
+            The decorated function.
     """
 
     def dec(f: Callable[..., Any]) -> _decorators.PydanticDecoratorMarker[Any]:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -369,6 +369,9 @@ def Field(
         alias (str | None): The alias for the field. Defaults to `None`.
         alias_priority (int | None): The priority score for the field if it is an alias for another field. Defaults to
             `None`.
+        validation_alias (str | list[str | int] | list[list[str | int]] | None): The alias(es) to use to find the field
+            value during validation. Defaults to `None`. TODO: Add documentation reference for non-str alias variants
+        serialization_alias (str | None): The alias to use as a key when serializing. Defaults to `None`.
         title (str | None): The title for the field. Defaults to `None`.
         description (str | None): The description for the field. Defaults to `None`.
         examples (list[Any] | None): Examples of the field values. Defaults to `None`.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -347,52 +347,49 @@ def Field(
     Used to provide extra information about a field, either for the model schema or complex validation. Some arguments
     apply only to number fields (``int``, ``float``, ``Decimal``) and some apply only to ``str``.
 
-    :param default: since this is replacing the field's default, its first argument is used
-      to set the default, use ellipsis (``...``) to indicate the field is required
-    :param default_factory: callable that will be called when a default value is needed for this field
-      If both `default` and `default_factory` are set, an error is raised.
-    :param alias: the public name of the field
-    :param title: can be any string, used in the schema
-    :param description: can be any string, used in the schema
-    :param examples: can be any list of json-encodable data, used in the schema
-    :param exclude: exclude this field while dumping.
-      Takes same values as the ``include`` and ``exclude`` arguments on the ``.dict`` method.
-    :param include: include this field while dumping.
-      Takes same values as the ``include`` and ``exclude`` arguments on the ``.dict`` method.
-    :param gt: only applies to numbers, requires the field to be "greater than". The schema
-      will have an ``exclusiveMinimum`` validation keyword
-    :param ge: only applies to numbers, requires the field to be "greater than or equal to". The
-      schema will have a ``minimum`` validation keyword
-    :param lt: only applies to numbers, requires the field to be "less than". The schema
-      will have an ``exclusiveMaximum`` validation keyword
-    :param le: only applies to numbers, requires the field to be "less than or equal to". The
-      schema will have a ``maximum`` validation keyword
-    :param multiple_of: only applies to numbers, requires the field to be "a multiple of". The
-      schema will have a ``multipleOf`` validation keyword
-    :param allow_inf_nan: only applies to numbers, allows the field to be NaN or infinity (+inf or -inf),
-        which is a valid Python float. Default True, set to False for compatibility with JSON.
-    :param max_digits: only applies to Decimals, requires the field to have a maximum number
-      of digits within the decimal. It does not include a zero before the decimal point or trailing decimal zeroes.
-    :param decimal_places: only applies to Decimals, requires the field to have at most a number of decimal places
-      allowed. It does not include trailing decimal zeroes.
-    :param min_items: only applies to lists, requires the field to have a minimum number of
-      elements. The schema will have a ``minItems`` validation keyword
-    :param max_items: only applies to lists, requires the field to have a maximum number of
-      elements. The schema will have a ``maxItems`` validation keyword
-    :param min_length: only applies to strings, requires the field to have a minimum length. The
-      schema will have a ``minLength`` validation keyword
-    :param max_length: only applies to strings, requires the field to have a maximum length. The
-      schema will have a ``maxLength`` validation keyword
-    :param frozen: a boolean which defaults to True. When False, the field raises a TypeError if the field is
-      assigned on an instance.  The BaseModel Config must set validate_assignment to True
-    :param pattern: only applies to strings, requires the field match against a regular expression
-      pattern string. The schema will have a ``pattern`` validation keyword
-    :param discriminator: only useful with a (discriminated a.k.a. tagged) `Union` of sub models with a common field.
-      The `discriminator` is the name of this common field to shorten validation and improve generated schema
-    :param repr: show this field in the representation
-    :param json_schema_extra: extra dict to be merged with the JSON Schema for this field
-    :param strict: enable or disable strict parsing mode
-    :param validate_default: whether the default value should be validated for this field
+    Args:
+        default (Any): The default value is returned if the corresponding field value is not present in the input data
+            or if the data value is None. Defaults to `Undefined`.
+        default_factory (typing.Callable[[], Any] | None): A callable that returns the default value for the field.
+            Only used if default is not set. Defaults to `None`.
+        alias (str | None): The alias for the field. Defaults to `None`.
+        alias_priority (int | None): The priority score for the field if it is an alias for another field. Defaults to
+            `None`.
+        title (str | None): The title for the field. Defaults to `None`.
+        description (str | None): The description for the field. Defaults to `None`.
+        examples (list[Any] | None): Examples of the field values. Defaults to `None`.
+        exclude (typing.AbstractSet[int | str] | typing.Mapping[int | str, Any] | Any): A set or mapping of keys that
+            should be excluded from the input data. Defaults to `None`.
+        include (typing.AbstractSet[int | str] | typing.Mapping[int | str, Any] | Any): A set or mapping of keys that
+            should be included in the input data. Defaults to `None`.
+        gt (float | None): The minimum value of the field. Defaults to `None`.
+        ge (float | None): The minimum value of the field (inclusive). Defaults to `None`.
+        lt (float | None): The maximum value of the field. Defaults to `None`.
+        le (float | None): The maximum value of the field (inclusive). Defaults to `None`.
+        multiple_of (float | None): The field value must be a multiple of this value. Defaults to `None`.
+        allow_inf_nan (bool | None): Determines whether the field can be populated with infinity or NaN values.
+            Defaults to `None`.
+        max_digits (int | None): The maximum number of digits in a decimal number. Defaults to `None`.
+        decimal_places (int | None): The maximum number of decimal places allowed in a decimal number.
+            Defaults to `None`.
+        min_items (int | None): The minimum number of items allowed in a sequence. Defaults to `None`.
+        max_items (int | None): The maximum number of items allowed in a sequence. Defaults to `None`.
+        min_length (int | None): The minimum length of a string field. Defaults to `None`.
+        max_length (int | None): The maximum length of a string field. Defaults to `None`.
+        frozen (bool | None): Determines whether the value is immutable. Defaults to `None`.
+        pattern (str | None): A regular expression pattern used to validate string fields. Defaults to `None`.
+        discriminator (str | None): The discriminator value for a polymorphic model. Defaults to `None`.
+        repr (bool): Determines whether the field value should be included in the object's string representation.
+            Defaults to True.
+        strict (bool | None): Used to determine whether the object should be marked as invalid if an unknown field is
+            detected. Defaults to `None`.
+        json_schema_extra (dict[str, Any] | None): A dictionary containing any additional metadata about the field.
+            Defaults to `None`.
+        validate_default (bool | None): Determines whether the default value for the field should be validated.
+            Defaults to `None`.
+
+    Returns:
+        Any: The field for the attribute.
     """
     return FieldInfo.from_field(
         default,

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -6,5 +6,6 @@ mkdocs-exclude
 mkdocs-material
 mkdocs-redirects
 mkdocs-simple-hooks
+mkdocstrings-python
 pyupgrade
 tomli

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -23,11 +23,14 @@ click==8.1.3
 colorama==0.4.6
     # via
     #   -c requirements/all.txt
+    #   griffe
     #   mkdocs-material
 ghp-import==2.1.0
     # via
     #   -c requirements/all.txt
     #   mkdocs
+griffe==0.26.0
+    # via mkdocstrings-python
 idna==3.4
     # via
     #   -c requirements/all.txt
@@ -37,16 +40,20 @@ jinja2==3.1.2
     #   -c requirements/all.txt
     #   mkdocs
     #   mkdocs-material
+    #   mkdocstrings
 markdown==3.3.7
     # via
     #   -c requirements/all.txt
     #   mkdocs
+    #   mkdocs-autorefs
     #   mkdocs-material
+    #   mkdocstrings
     #   pymdown-extensions
 markupsafe==2.1.2
     # via
     #   -c requirements/all.txt
     #   jinja2
+    #   mkdocstrings
 mergedeep==1.3.4
     # via
     #   -c requirements/all.txt
@@ -55,10 +62,14 @@ mkdocs==1.4.2
     # via
     #   -c requirements/all.txt
     #   -r requirements/docs.in
+    #   mkdocs-autorefs
     #   mkdocs-exclude
     #   mkdocs-material
     #   mkdocs-redirects
     #   mkdocs-simple-hooks
+    #   mkdocstrings
+mkdocs-autorefs==0.4.1
+    # via mkdocstrings
 mkdocs-exclude==1.0.2
     # via
     #   -c requirements/all.txt
@@ -79,6 +90,10 @@ mkdocs-simple-hooks==0.1.5
     # via
     #   -c requirements/all.txt
     #   -r requirements/docs.in
+mkdocstrings==0.21.2
+    # via mkdocstrings-python
+mkdocstrings-python==0.9.0
+    # via -r requirements/docs.in
 packaging==23.0
     # via
     #   -c requirements/all.txt
@@ -99,6 +114,7 @@ pymdown-extensions==9.10
     # via
     #   -c requirements/all.txt
     #   mkdocs-material
+    #   mkdocstrings
 python-dateutil==2.8.2
     # via
     #   -c requirements/all.txt


### PR DESCRIPTION
Builds docs from docstrings as an API guide. 

This is WIP to highlight what's building from existing docstrings. Only builds docs for elements with valid docstrings.

Preview: https://smokeshow.helpmanual.io/2b2n0w590e055e6m6c1g/api/analyzed_type/

## Change Summary

* adds API tab to navigation
* adds a page under API for each public code file
* builds docs from docstrings

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb