### PR TITLE
Make Extra a literal

### DIFF
--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -22,10 +22,10 @@ except ValidationError as e:
 
 Also, you can specify config options as model class kwargs:
 ```py
-from pydantic import BaseModel, Extra, ValidationError
+from pydantic import BaseModel, ValidationError
 
 
-class Model(BaseModel, extra=Extra.forbid):
+class Model(BaseModel, extra='forbid'):
     a: str
 
 

--- a/docs/usage/types_fields.md
+++ b/docs/usage/types_fields.md
@@ -52,7 +52,7 @@ except ValidationError as e:
 ```py
 from typing_extensions import TypedDict
 
-from pydantic import BaseModel, Extra, ValidationError
+from pydantic import BaseModel, ValidationError
 
 
 # `total=False` means keys are non-required
@@ -67,7 +67,7 @@ class User(TypedDict):
 
 
 class Model(BaseModel):
-    model_config = dict(extra=Extra.forbid)
+    model_config = dict(extra='forbid')
     u: User
 
 

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal, Self
 
 from pydantic.errors import PydanticUserError
 
-from ..config import ConfigDict, Extra
+from ..config import ConfigDict, ExtraValues
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
 
@@ -30,7 +30,7 @@ class ConfigWrapper:
     str_strip_whitespace: bool
     str_min_length: int
     str_max_length: int | None
-    extra: Extra | None
+    extra: ExtraValues | None
     frozen: bool
     populate_by_name: bool
     use_enum_values: bool
@@ -118,7 +118,7 @@ class ConfigWrapper:
         core_config = core_schema.CoreConfig(
             **core_schema.dict_not_none(
                 title=self.config_dict.get('title') or (obj and obj.__name__),
-                extra_fields_behavior=extra and extra.value,
+                extra_fields_behavior=extra,
                 allow_inf_nan=self.config_dict.get('allow_inf_nan'),
                 populate_by_name=self.config_dict.get('populate_by_name'),
                 str_strip_whitespace=self.config_dict.get('str_strip_whitespace'),
@@ -183,24 +183,10 @@ def prepare_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> Co
 
     config_dict = cast(ConfigDict, config)
     check_deprecated(config_dict)
-    prepare_config_extra(config_dict)
     return config_dict
 
 
 config_keys = set(ConfigDict.__annotations__.keys())
-
-
-def prepare_config_extra(config: ConfigDict | dict[str, Any]) -> None:
-    """
-    Prepare the "extra" key in a config by converting it to an `Extra`.
-    """
-    # note `extra=None` is the same as omitting `extra` from the config.
-    extra = config.get('extra')
-    if extra is not None and not isinstance(extra, Extra):
-        try:
-            config['extra'] = Extra(extra)
-        except ValueError as e:
-            raise ValueError(f"{extra!r} is not a valid value for `config['extra']`") from e
 
 
 V2_REMOVED_KEYS = {

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -219,8 +219,6 @@ def generate_model_signature(
     from inspect import Parameter, Signature, signature
     from itertools import islice
 
-    from ..config import Extra
-
     present_params = signature(init).parameters.values()
     merged_params: dict[str, Parameter] = {}
     var_kw = None
@@ -255,7 +253,7 @@ def generate_model_signature(
                 param_name, Parameter.KEYWORD_ONLY, annotation=field.rebuild_annotation(), **kwargs
             )
 
-    if config_wrapper.extra is Extra.allow:
+    if config_wrapper.extra == 'allow':
         use_var_kw = True
 
     if var_kw and use_var_kw:

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,17 +1,27 @@
 from __future__ import annotations as _annotations
 
-from typing import Callable
+from typing import Any, Callable
+from warnings import warn
 
 from typing_extensions import Literal, TypedDict
 
 __all__ = 'ConfigDict', 'Extra'
 
 
-class Extra:
+class _Extra:
     allow: Literal['allow'] = 'allow'
     ignore: Literal['ignore'] = 'ignore'
     forbid: Literal['forbid'] = 'forbid'
 
+    def __getattribute__(self, __name: str) -> Any:
+        warn(
+            '`pydantic.config.Extra` is deprecated, use literal values instead' " (e.g. `extra='allow'`)",
+            DeprecationWarning,
+        )
+        return super().__getattribute__(__name)
+
+
+Extra = _Extra()
 
 ExtraValues = Literal['allow', 'ignore', 'forbid']
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-from enum import Enum
 from typing import Callable
 
 from typing_extensions import Literal, TypedDict
@@ -8,10 +7,13 @@ from typing_extensions import Literal, TypedDict
 __all__ = 'ConfigDict', 'Extra'
 
 
-class Extra(str, Enum):
-    allow = 'allow'
-    ignore = 'ignore'
-    forbid = 'forbid'
+class Extra:
+    allow: Literal['allow'] = 'allow'
+    ignore: Literal['ignore'] = 'ignore'
+    forbid: Literal['forbid'] = 'forbid'
+
+
+ExtraValues = Literal['allow', 'ignore', 'forbid']
 
 
 class ConfigDict(TypedDict, total=False):
@@ -21,7 +23,7 @@ class ConfigDict(TypedDict, total=False):
     str_strip_whitespace: bool
     str_min_length: int
     str_max_length: int | None
-    extra: Extra | None
+    extra: ExtraValues | None
     frozen: bool
     populate_by_name: bool
     use_enum_values: bool

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -5,7 +5,6 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, overload
 
 from ._internal import _config, _typing_extra, _utils
-from .config import Extra
 from .decorators import field_validator
 from .errors import PydanticUserError
 from .main import BaseModel, create_model
@@ -220,7 +219,7 @@ class ValidatedFunction:
                 code=None,
             )
         if config_wrapper.extra is None:
-            config_wrapper.config_dict['extra'] = Extra.forbid
+            config_wrapper.config_dict['extra'] = 'forbid'
 
         class DecoratorBaseModel(BaseModel):
             @field_validator(self.v_args_name, check_fields=False)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -26,7 +26,7 @@ from ._internal import (
     _utils,
 )
 from ._internal._fields import Undefined
-from .config import ConfigDict, Extra
+from .config import ConfigDict
 from .deprecated import copy_internals as _deprecated_copy_internals
 from .deprecated import parse as _deprecated_parse
 from .errors import PydanticUndefinedAnnotation, PydanticUserError
@@ -295,7 +295,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
             raise TypeError(f'"{self.__class__.__name__}" is frozen and does not support item assignment')
         elif self.model_config.get('validate_assignment', None):
             self.__pydantic_validator__.validate_assignment(self, name, value)
-        elif self.model_config.get('extra') is not Extra.allow and name not in self.model_fields:
+        elif self.model_config.get('extra') != 'allow' and name not in self.model_fields:
             # TODO - matching error
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
         else:

--- a/tests/mypy/modules/plugin_fail.py
+++ b/tests/mypy/modules/plugin_fail.py
@@ -37,7 +37,7 @@ KwargsModel.from_orm({})  # type: ignore[pydantic-orm]
 
 
 class ForbidExtraModel(BaseModel):
-    model_config = ConfigDict(extra='forbid')  # type: ignore[typeddict-item]
+    model_config = ConfigDict(extra=Extra.forbid)
 
 
 ForbidExtraModel(x=1)

--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -17,7 +17,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     DirectoryPath,
-    Extra,
     FilePath,
     FutureDate,
     ImportString,
@@ -274,7 +273,7 @@ obj: SomeDict = {
 }
 
 
-config = ConfigDict(title='Record', extra=Extra.ignore, str_max_length=1234)
+config = ConfigDict(title='Record', extra='ignore', str_max_length=1234)
 
 
 class CustomPath(PurePath):

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -4,7 +4,7 @@ from typing import Any, ContextManager, List, Optional
 import pytest
 from dirty_equals import IsStr
 
-from pydantic import BaseModel, ConfigDict, Extra, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 from pydantic.fields import Field
 
 
@@ -98,7 +98,7 @@ def test_annotation_config():
 
 def test_pop_by_field_name():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.forbid, populate_by_name=True)
+        model_config = ConfigDict(extra='forbid', populate_by_name=True)
         last_updated_by: Optional[str] = Field(None, alias='lastUpdatedBy')
 
     assert Model(lastUpdatedBy='foo').model_dump() == {'last_updated_by': 'foo'}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -532,7 +532,7 @@ def test_multiple_inheritance_config():
 
     assert Parent.model_config.get('frozen') is True
     assert Parent.model_config.get('populate_by_name') is None
-    assert Parent.model_config.get('extra') is Extra.forbid
+    assert Parent.model_config.get('extra') == 'forbid'
     assert Parent.model_config.get('use_enum_values') is None
 
     assert Mixin.model_config.get('frozen') is None
@@ -542,7 +542,7 @@ def test_multiple_inheritance_config():
 
     assert Child.model_config.get('frozen') is True
     assert Child.model_config.get('populate_by_name') is True
-    assert Child.model_config.get('extra') is Extra.forbid
+    assert Child.model_config.get('extra') == 'forbid'
     assert Child.model_config.get('use_enum_values') is True
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,6 @@ from pydantic_core import SchemaError
 from pydantic import (
     BaseConfig,
     BaseModel,
-    Extra,
     Field,
     PrivateAttr,
     PydanticSchemaGenerationError,
@@ -106,7 +105,7 @@ class TestsBaseConfig:
             f__: str = Field(..., alias='foo')
 
             class Config:
-                extra = Extra.allow
+                extra = 'allow'
 
             def __init__(self, id: int = 1, bar=2, *, baz: Any, **data):
                 super().__init__(id=id, **data)
@@ -130,7 +129,7 @@ class TestsBaseConfig:
                 super().__init__(a=a, b=b, c=1)
 
             class Config:
-                extra = Extra.allow
+                extra = 'allow'
 
         assert _equals(str(signature(Model)), '(a: float, b: int) -> None')
 
@@ -157,7 +156,7 @@ class TestsBaseConfig:
             spam: str
 
             class Config:
-                extra = Extra.allow
+                extra = 'allow'
 
         assert _equals(str(signature(Model)), '(*, spam: str, **extra_data: Any) -> None')
 
@@ -167,7 +166,7 @@ class TestsBaseConfig:
             extra_data_: str
 
             class Config:
-                extra = Extra.allow
+                extra = 'allow'
 
         assert _equals(str(signature(Model)), '(*, extra_data: str, extra_data_: str, **extra_data__: Any) -> None')
 
@@ -179,7 +178,7 @@ class TestsBaseConfig:
                 super().__init__(extra_data=extra_data, **foobar)
 
             class Config:
-                extra = Extra.allow
+                extra = 'allow'
 
         assert _equals(str(signature(Model)), '(extra_data: int = 1, **foobar: Any) -> None')
 
@@ -188,7 +187,7 @@ class TestsBaseConfig:
             _foo = PrivateAttr('private_attribute')
 
             class Config:
-                extra = Extra.allow
+                extra = 'allow'
 
         assert Model.__slots__ == {'_foo'}
         m = Model(_foo='field')
@@ -517,7 +516,7 @@ def test_invalid_config_keys():
 
 def test_multiple_inheritance_config():
     class Parent(BaseModel):
-        model_config = ConfigDict(frozen=True, extra=Extra.forbid)
+        model_config = ConfigDict(frozen=True, extra='forbid')
 
     class Mixin(BaseModel):
         model_config = ConfigDict(use_enum_values=True)

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import pytest
 
-from pydantic import BaseModel, ConfigDict, Extra, Field, PydanticUserError, ValidationError, create_model, errors
+from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, ValidationError, create_model, errors
 from pydantic.decorators import field_validator, validator
 from pydantic.fields import ModelPrivateAttr
 
@@ -113,7 +113,7 @@ def test_custom_config_inherits():
 
 
 def test_custom_config_extras():
-    config = ConfigDict(extra=Extra.forbid)
+    config = ConfigDict(extra='forbid')
 
     model = create_model('FooModel', foo=(int, ...), __config__=config)
     assert model(foo=654)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -11,7 +11,7 @@ import pytest
 from typing_extensions import Literal
 
 import pydantic
-from pydantic import BaseModel, ConfigDict, Extra, FieldValidationInfo, ValidationError
+from pydantic import BaseModel, ConfigDict, FieldValidationInfo, ValidationError
 from pydantic.decorators import field_validator
 from pydantic.fields import Field, FieldInfo
 from pydantic.json_schema import model_json_schema
@@ -139,13 +139,13 @@ def test_validate_assignment_value_change():
     [
         ConfigDict(validate_assignment=False),
         ConfigDict(extra=None),
-        ConfigDict(extra=Extra.forbid),
-        ConfigDict(extra=Extra.ignore),
+        ConfigDict(extra='forbid'),
+        ConfigDict(extra='ignore'),
         ConfigDict(validate_assignment=False, extra=None),
-        ConfigDict(validate_assignment=False, extra=Extra.forbid),
-        ConfigDict(validate_assignment=False, extra=Extra.ignore),
-        ConfigDict(validate_assignment=False, extra=Extra.allow),
-        ConfigDict(validate_assignment=True, extra=Extra.allow),
+        ConfigDict(validate_assignment=False, extra='forbid'),
+        ConfigDict(validate_assignment=False, extra='ignore'),
+        ConfigDict(validate_assignment=False, extra='allow'),
+        ConfigDict(validate_assignment=True, extra='allow'),
     ],
 )
 def test_validate_assignment_extra_unknown_field_assigned_allowed(config: ConfigDict):
@@ -165,8 +165,8 @@ def test_validate_assignment_extra_unknown_field_assigned_allowed(config: Config
     [
         ConfigDict(validate_assignment=True),
         ConfigDict(validate_assignment=True, extra=None),
-        ConfigDict(validate_assignment=True, extra=Extra.forbid),
-        ConfigDict(validate_assignment=True, extra=Extra.ignore),
+        ConfigDict(validate_assignment=True, extra='forbid'),
+        ConfigDict(validate_assignment=True, extra='ignore'),
     ],
 )
 def test_validate_assignment_extra_unknown_field_assigned_errors(config: ConfigDict):
@@ -1336,7 +1336,7 @@ def test_keeps_custom_properties():
 
 @pytest.mark.xfail(reason='model_config["extra"] is not respected')
 def test_ignore_extra():
-    @pydantic.dataclasses.dataclass(config=dict(extra=Extra.ignore))
+    @pydantic.dataclasses.dataclass(config=dict(extra='ignore'))
     class Foo:
         x: int
 
@@ -1345,11 +1345,11 @@ def test_ignore_extra():
 
 
 def test_ignore_extra_subclass():
-    @pydantic.dataclasses.dataclass(config=ConfigDict(extra=Extra.ignore))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='ignore'))
     class Foo:
         x: int
 
-    @pydantic.dataclasses.dataclass(config=ConfigDict(extra=Extra.ignore))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='ignore'))
     class Bar(Foo):
         y: int
 
@@ -1358,7 +1358,7 @@ def test_ignore_extra_subclass():
 
 
 def test_allow_extra():
-    @pydantic.dataclasses.dataclass(config=ConfigDict(extra=Extra.allow))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='allow'))
     class Foo:
         x: int
 
@@ -1367,11 +1367,11 @@ def test_allow_extra():
 
 
 def test_allow_extra_subclass():
-    @pydantic.dataclasses.dataclass(config=ConfigDict(extra=Extra.allow))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='allow'))
     class Foo:
         x: int
 
-    @pydantic.dataclasses.dataclass(config=ConfigDict(extra=Extra.allow))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='allow'))
     class Bar(Foo):
         y: int
 
@@ -1380,7 +1380,7 @@ def test_allow_extra_subclass():
 
 
 def test_forbid_extra():
-    @pydantic.dataclasses.dataclass(config=ConfigDict(extra=Extra.forbid))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='forbid'))
     class Foo:
         x: int
 
@@ -1417,7 +1417,7 @@ def test_kw_only():
 
 
 def test_extra_forbid_list_no_error():
-    @pydantic.dataclasses.dataclass(config=dict(extra=Extra.forbid))
+    @pydantic.dataclasses.dataclass(config=dict(extra='forbid'))
     class Bar:
         ...
 
@@ -1429,7 +1429,7 @@ def test_extra_forbid_list_no_error():
 
 
 def test_extra_forbid_list_error():
-    @pydantic.dataclasses.dataclass(config=ConfigDict(extra=Extra.forbid))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='forbid'))
     class Bar:
         ...
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -9,7 +9,7 @@ import pytest
 from dirty_equals import IsInstance
 from typing_extensions import Annotated, TypedDict
 
-from pydantic import BaseModel, Extra, Field, ValidationError, validate_arguments
+from pydantic import BaseModel, Field, ValidationError, validate_arguments
 from pydantic.decorator import ValidatedFunction
 from pydantic.errors import PydanticUserError
 
@@ -447,13 +447,13 @@ def test_validate_extra():
     class TypedTest(TypedDict):
         y: str
 
-    @validate_arguments(config={'extra': Extra.allow})
+    @validate_arguments(config={'extra': 'allow'})
     def test(other: TypedTest):
         return other
 
     assert test(other={'y': 'b', 'z': 'a'}) == {'y': 'b', 'z': 'a'}
 
-    @validate_arguments(config={'extra': Extra.ignore})
+    @validate_arguments(config={'extra': 'ignore'})
     def test(other: TypedTest):
         return other
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import pytest
 
 from pydantic import BaseModel, ConfigDict, PydanticUserError, ValidationError, model_serializer, root_validator
+from pydantic.config import Extra
 
 
 def deprecated_from_orm(model_type, obj):
@@ -391,3 +392,15 @@ def test_fields_set():
     match = '^The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.$'
     with pytest.warns(DeprecationWarning, match=match):
         assert m.__fields_set__ == {'x'}
+
+
+@pytest.mark.parametrize('attribute,value', [('allow', 'allow'), ('ignore', 'ignore'), ('forbid', 'forbid')])
+def test_extra_used_as_enum(
+    attribute: str,
+    value: str,
+) -> None:
+    with pytest.raises(
+        DeprecationWarning,
+        match=re.escape("`pydantic.config.Extra` is deprecated, use literal values instead (e.g. `extra='allow'`)"),
+    ):
+        assert getattr(Extra, attribute) == value

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -15,7 +15,6 @@ from pydantic import (
     AnalyzedType,
     BaseModel,
     ConfigDict,
-    Extra,
     PydanticSchemaGenerationError,
     ValidationError,
     constr,
@@ -865,7 +864,7 @@ def test_advanced_include_nested_lists(include, expected):
 
 def test_field_set_ignore_extra():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.ignore)
+        model_config = ConfigDict(extra='ignore')
         a: int
         b: int
         c: int = 3
@@ -883,7 +882,7 @@ def test_field_set_ignore_extra():
 
 def test_field_set_allow_extra():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
         a: int
         b: int
         c: int = 3
@@ -1103,7 +1102,7 @@ def test_annotation_inheritance():
 
 def test_string_none():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.ignore)
+        model_config = ConfigDict(extra='ignore')
         a: constr(min_length=20, max_length=1000) = ...
 
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1243,7 +1243,7 @@ def test_force_extra():
         model_config = ConfigDict(extra='ignore')
         foo: int
 
-    assert Model.model_config['extra'] is Extra.ignore
+    assert Model.model_config['extra'] == 'ignore'
 
 
 def test_submodel_different_type():

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -33,7 +33,6 @@ from typing_extensions import Annotated, Literal
 
 from pydantic import (
     BaseModel,
-    Extra,
     Field,
     ImportString,
     ValidationError,
@@ -1927,7 +1926,7 @@ def test_color_type():
 
 def test_model_with_extra_forbidden():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.forbid)
+        model_config = ConfigDict(extra='forbid')
         a: str
 
     assert Model.model_json_schema() == {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,7 +29,6 @@ from typing_extensions import Annotated, Final, Literal
 from pydantic import (
     BaseModel,
     ConfigDict,
-    Extra,
     Field,
     PrivateAttr,
     PydanticUndefinedAnnotation,
@@ -218,7 +217,7 @@ def test_not_required():
 
 def test_allow_extra():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
         a: float = ...
 
     assert Model(a='10.2', b=12).model_dump() == {'a': 10.2, 'b': 12}
@@ -226,7 +225,7 @@ def test_allow_extra():
 
 def test_allow_extra_repr():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
         a: float = ...
 
     assert str(Model(a='10.2', b=12)) == 'a=10.2 b=12'
@@ -234,7 +233,7 @@ def test_allow_extra_repr():
 
 def test_forbidden_extra_success():
     class ForbiddenExtra(BaseModel):
-        model_config = ConfigDict(extra=Extra.forbid)
+        model_config = ConfigDict(extra='forbid')
         foo: str = 'whatever'
 
     m = ForbiddenExtra()
@@ -243,7 +242,7 @@ def test_forbidden_extra_success():
 
 def test_forbidden_extra_fails():
     class ForbiddenExtra(BaseModel):
-        model_config = ConfigDict(extra=Extra.forbid)
+        model_config = ConfigDict(extra='forbid')
         foo: str = 'whatever'
 
     with pytest.raises(ValidationError) as exc_info:
@@ -286,7 +285,7 @@ def test_assign_extra_validate():
 
 def test_extra_allowed():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
         a: float
 
     model = Model(a=0.2, b=0.1)
@@ -300,7 +299,7 @@ def test_extra_allowed():
 
 def test_extra_ignored():
     class Model(BaseModel):
-        model_config = ConfigDict(extra=Extra.ignore)
+        model_config = ConfigDict(extra='ignore')
         a: float
 
     model = Model(a=0.2, b=0.1)
@@ -383,7 +382,7 @@ def test_mutability():
     class TestModel(BaseModel):
         a: int = 10
 
-        model_config = ConfigDict(extra=Extra.forbid, frozen=False)
+        model_config = ConfigDict(extra='forbid', frozen=False)
 
     m = TestModel()
 
@@ -394,7 +393,7 @@ def test_mutability():
 
 def test_frozen_model():
     class FrozenModel(BaseModel):
-        model_config = ConfigDict(extra=Extra.forbid, frozen=True)
+        model_config = ConfigDict(extra='forbid', frozen=True)
 
         a: int = 10
 
@@ -855,7 +854,7 @@ def test_dir_fields():
 
 def test_dict_with_extra_keys():
     class MyModel(BaseModel):
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
         a: str = Field(None, alias='alias_a')
 
     m = MyModel(extra_key='extra')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1669,14 +1669,14 @@ def test_class_kwargs_config():
     class Base(BaseModel, extra='forbid', alias_generator=str.upper):
         a: int
 
-    assert Base.model_config['extra'] is Extra.forbid
+    assert Base.model_config['extra'] == 'forbid'
     assert Base.model_config['alias_generator'] is str.upper
     # assert Base.model_fields['a'].alias == 'A'
 
     class Model(Base, extra='allow'):
         b: int
 
-    assert Model.model_config['extra'] is Extra.allow  # overwritten as intended
+    assert Model.model_config['extra'] == 'allow'  # overwritten as intended
     assert Model.model_config['alias_generator'] is str.upper  # inherited as intended
     # assert Model.model_fields['b'].alias == 'B'  # alias_generator still works
 
@@ -1686,7 +1686,7 @@ def test_class_kwargs_config_and_attr_conflict():
         model_config = ConfigDict(extra='forbid', title='Foobar')
         b: int
 
-    assert Model.model_config['extra'] is Extra.allow
+    assert Model.model_config['extra'] == 'allow'
     assert Model.model_config['alias_generator'] is str.upper
     assert Model.model_config['title'] == 'Foobar'
 

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, Optional, Union
 import pytest
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, ConfigDict, Extra, Field, create_model
+from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic._internal._typing_extra import is_annotated
 
 
@@ -38,7 +38,7 @@ def test_custom_init_signature():
         name: str = 'John Doe'
         f__: str = Field(..., alias='foo')
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
         def __init__(self, id: int = 1, bar=2, *, baz: Any, **data):
             super().__init__(id=id, **data)
@@ -63,7 +63,7 @@ def test_custom_init_signature_with_no_var_kw():
         def __init__(self, a: float, b: int):
             super().__init__(a=a, b=b, c=1)
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
     assert _equals(str(signature(Model)), '(a: float, b: int) -> None')
 
@@ -100,7 +100,7 @@ def test_extra_allow_no_conflict():
     class Model(BaseModel):
         spam: str
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
     assert _equals(str(signature(Model)), '(*, spam: str, **extra_data: Any) -> None')
 
@@ -109,7 +109,7 @@ def test_extra_allow_conflict():
     class Model(BaseModel):
         extra_data: str
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
     assert _equals(str(signature(Model)), '(*, extra_data: str, **extra_data_: Any) -> None')
 
@@ -119,7 +119,7 @@ def test_extra_allow_conflict_twice():
         extra_data: str
         extra_data_: str
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
     assert _equals(str(signature(Model)), '(*, extra_data: str, extra_data_: str, **extra_data__: Any) -> None')
 
@@ -131,7 +131,7 @@ def test_extra_allow_conflict_custom_signature():
         def __init__(self, extra_data: int = 1, **foobar: Any):
             super().__init__(extra_data=extra_data, **foobar)
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
     assert _equals(str(signature(Model)), '(extra_data: int = 1, **foobar: Any) -> None')
 

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -3,7 +3,7 @@ from typing import ClassVar, Generic, TypeVar
 
 import pytest
 
-from pydantic import BaseModel, ConfigDict, Extra, PrivateAttr
+from pydantic import BaseModel, ConfigDict, PrivateAttr
 from pydantic.fields import Undefined
 
 
@@ -141,7 +141,7 @@ def test_private_attribute_intersection_with_extra_field():
     class Model(BaseModel):
         _foo = PrivateAttr('private_attribute')
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
     assert Model.__slots__ == {'_foo'}
     m = Model(_foo='field')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -13,7 +13,6 @@ from typing_extensions import Annotated, Literal
 from pydantic import (
     BaseModel,
     ConfigDict,
-    Extra,
     Field,
     FieldValidationInfo,
     ValidationError,
@@ -340,7 +339,7 @@ def validate_assignment_model_fixture():
         def double_c(cls, v: Any):
             return v * 2
 
-        model_config = ConfigDict(validate_assignment=True, extra=Extra.allow)
+        model_config = ConfigDict(validate_assignment=True, extra='allow')
 
     return ValidateAssignmentModel
 
@@ -1365,7 +1364,7 @@ def test_root_validator_types():
             root_val_values = cls, values
             return values
 
-        model_config = ConfigDict(extra=Extra.allow)
+        model_config = ConfigDict(extra='allow')
 
     assert Model(b='bar', c='wobble').model_dump() == {'a': 1, 'b': 'bar', 'c': 'wobble'}
 


### PR DESCRIPTION
The only use case this breaks is if users were doing `Extra.allow.value` and such. I don't see any reason why they'd want to do that.

Selected Reviewer: @hramezani