### PR TITLE
Fix aliases and add `validation_alias` and `serialization_alias` to `Field`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -533,9 +533,7 @@ class GenerateSchema:
             schema,
             serialization_exclude=True if field_info.exclude else None,
             validation_alias=field_info.validation_alias,
-            serialization_alias=(
-                field_info.serialization_alias if isinstance(field_info.serialization_alias, str) else None
-            ),
+            serialization_alias=field_info.serialization_alias,
             frozen=field_info.frozen or field_info.final,
             metadata=metadata,
         )

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -532,8 +532,10 @@ class GenerateSchema:
         return _common_field(
             schema,
             serialization_exclude=True if field_info.exclude else None,
-            validation_alias=field_info.alias,
-            serialization_alias=field_info.alias,
+            validation_alias=field_info.validation_alias,
+            serialization_alias=(
+                field_info.serialization_alias if isinstance(field_info.serialization_alias, str) else None
+            ),
             frozen=field_info.frozen or field_info.final,
             metadata=metadata,
         )

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -237,7 +237,7 @@ def generate_model_signature(
     if var_kw:  # if custom init has no var_kw, fields which are not declared in it cannot be passed through
         allow_names = config_wrapper.populate_by_name
         for field_name, field in fields.items():
-            # alis have to be used for signature generation when it's a str
+            # when alias is a str it should be used for signature generation
             if isinstance(field.alias, str):
                 param_name = field.alias
             else:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -237,6 +237,7 @@ def generate_model_signature(
     if var_kw:  # if custom init has no var_kw, fields which are not declared in it cannot be passed through
         allow_names = config_wrapper.populate_by_name
         for field_name, field in fields.items():
+            # alis have to be used for signature generation when it's a str
             if isinstance(field.alias, str):
                 param_name = field.alias
             else:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -307,4 +307,6 @@ def apply_alias_generator(config: ConfigDict, fields: dict[str, FieldInfo]) -> N
             if not isinstance(alias, str):
                 raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
             field_info.alias = alias
+            field_info.validation_alias = alias
+            field_info.serialization_alias = alias
             field_info.alias_priority = 1

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -237,7 +237,10 @@ def generate_model_signature(
     if var_kw:  # if custom init has no var_kw, fields which are not declared in it cannot be passed through
         allow_names = config_wrapper.populate_by_name
         for field_name, field in fields.items():
-            param_name = field.alias or field_name
+            if isinstance(field.alias, str):
+                param_name = field.alias
+            else:
+                param_name = field_name
             if field_name in merged_params or param_name in merged_params:
                 continue
             elif not is_valid_identifier(param_name):

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -319,11 +319,13 @@ def Field(
     default: Any = Undefined,
     *,
     default_factory: typing.Callable[[], Any] | None = None,
-    alias: str | None = None,
+    alias: str | list[str | int] | list[list[str | int]] | None = None,
     # TODO:
     #  Alternative 1: we could drop alias_priority and tell people to manually override aliases in child classes
     #  Alternative 2: we could add a new argument `override_with_alias_generator=True` equivalent to `alias_priority=1`
     alias_priority: int | None = None,
+    validation_alias: str | list[str | int] | list[list[str | int]] | None = None,
+    serialization_alias: str | None = None,
     title: str | None = None,
     description: str | None = None,
     examples: list[Any] | None = None,
@@ -348,8 +350,6 @@ def Field(
     strict: bool | None = None,
     json_schema_extra: dict[str, Any] | None = None,
     validate_default: bool | None = None,
-    validation_alias: str | list[str | int] | list[list[str | int]] | None = None,
-    serialization_alias: str | None = None,
     const: bool | None = None,
     unique_items: bool | None = None,
     allow_mutation: bool = True,
@@ -449,11 +449,16 @@ def Field(
         if not json_schema_extra:
             json_schema_extra = extra
 
+    if serialization_alias is None and isinstance(alias, str):
+        serialization_alias = alias
+
     return FieldInfo.from_field(
         default,
         default_factory=default_factory,
         alias=alias,
         alias_priority=alias_priority,
+        validation_alias=validation_alias or alias,
+        serialization_alias=serialization_alias,
         title=title,
         description=description,
         examples=examples,
@@ -478,8 +483,6 @@ def Field(
         json_schema_extra=json_schema_extra,
         strict=strict,
         validate_default=validate_default,
-        validation_alias=validation_alias or alias,
-        serialization_alias=serialization_alias or alias,
     )
 
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -323,10 +323,7 @@ def Field(
     default: Any = Undefined,
     *,
     default_factory: typing.Callable[[], Any] | None = None,
-    alias: str | list[str | int] | list[list[str | int]] | None = None,
-    # TODO:
-    #  Alternative 1: we could drop alias_priority and tell people to manually override aliases in child classes
-    #  Alternative 2: we could add a new argument `override_with_alias_generator=True` equivalent to `alias_priority=1`
+    alias: str | None = None,
     alias_priority: int | None = None,
     validation_alias: str | list[str | int] | list[list[str | int]] | None = None,
     serialization_alias: str | None = None,
@@ -369,7 +366,8 @@ def Field(
     :param default_factory: callable that will be called when a default value is needed for this field
       If both `default` and `default_factory` are set, an error is raised.
     :param alias: the public name of the field
-    :param validation_alias: the alias(es) to use to find the field in the validation data
+    # TODO: Add documentation reference for non-str alias variants
+    :param validation_alias: the alias(es) to use to find the field value during validation
     :param serialization_alias: The alias to use as a key when serializing
     :param title: can be any string, used in the schema
     :param description: can be any string, used in the schema
@@ -453,6 +451,8 @@ def Field(
         if not json_schema_extra:
             json_schema_extra = extra
 
+    if validation_alias is None:
+        validation_alias = alias
     if serialization_alias is None and isinstance(alias, str):
         serialization_alias = alias
 
@@ -461,7 +461,7 @@ def Field(
         default_factory=default_factory,
         alias=alias,
         alias_priority=alias_priority,
-        validation_alias=validation_alias or alias,
+        validation_alias=validation_alias,
         serialization_alias=serialization_alias,
         title=title,
         description=description,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -33,6 +33,8 @@ class FieldInfo(_repr.Representation):
         'default_factory',
         'alias',
         'alias_priority',
+        'validation_alias',
+        'serialization_alias',
         'title',
         'description',
         'examples',
@@ -47,8 +49,6 @@ class FieldInfo(_repr.Representation):
         'validate_default',
         'frozen',
         'final',
-        'validation_alias',
-        'serialization_alias',
     )
 
     # used to convert kwargs to metadata/constraints,
@@ -86,6 +86,8 @@ class FieldInfo(_repr.Representation):
         self.alias = kwargs.get('alias')
         self.alias_priority = kwargs.get('alias_priority') or 2 if self.alias is not None else None
         self.title = kwargs.get('title')
+        self.validation_alias = kwargs.get('validation_alias', None)
+        self.serialization_alias = kwargs.get('serialization_alias', None)
         self.description = kwargs.get('description')
         self.examples = kwargs.get('examples')
         self.exclude = kwargs.get('exclude')
@@ -100,8 +102,6 @@ class FieldInfo(_repr.Representation):
         self.validate_default = kwargs.get('validate_default', None)
         self.frozen = kwargs.get('frozen', None)
         self.final = kwargs.get('final', None)
-        self.validation_alias = kwargs.get('validation_alias', None)
-        self.serialization_alias = kwargs.get('serialization_alias', None)
 
     @classmethod
     def from_field(cls, default: Any = Undefined, **kwargs: Any) -> FieldInfo:
@@ -307,6 +307,10 @@ class FieldInfo(_repr.Representation):
                 continue
             if s == 'frozen' and self.frozen is False:
                 continue
+            if s == 'validation_alias' and self.validation_alias == self.alias:
+                continue
+            if s == 'serialization_alias' and self.serialization_alias == self.alias:
+                continue
             if s == 'default_factory' and self.default_factory is not None:
                 yield 'default_factory', _repr.PlainRepr(_repr.display_as_type(self.default_factory))
             else:
@@ -365,6 +369,8 @@ def Field(
     :param default_factory: callable that will be called when a default value is needed for this field
       If both `default` and `default_factory` are set, an error is raised.
     :param alias: the public name of the field
+    :param validation_alias: the alias(es) to use to find the field in the validation data
+    :param serialization_alias: The alias to use as a key when serializing
     :param title: can be any string, used in the schema
     :param description: can be any string, used in the schema
     :param examples: can be any list of json-encodable data, used in the schema
@@ -408,8 +414,6 @@ def Field(
     :param json_schema_extra: extra dict to be merged with the JSON Schema for this field
     :param strict: enable or disable strict parsing mode
     :param validate_default: whether the default value should be validated for this field
-    :param validation_alias: the alias(es) to use to find the field in the validation data
-    :param serialization_alias: The alias to use as a key when serializing
     :param const: removed, use `Literal` instead'
     :param unique_items: removed, use `Set` instead
     :param allow_mutation: deprecated, use `frozen` instead

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -47,6 +47,8 @@ class FieldInfo(_repr.Representation):
         'validate_default',
         'frozen',
         'final',
+        'validation_alias',
+        'serialization_alias',
     )
 
     # used to convert kwargs to metadata/constraints,
@@ -98,6 +100,8 @@ class FieldInfo(_repr.Representation):
         self.validate_default = kwargs.get('validate_default', None)
         self.frozen = kwargs.get('frozen', None)
         self.final = kwargs.get('final', None)
+        self.validation_alias = kwargs.get('validation_alias', None)
+        self.serialization_alias = kwargs.get('serialization_alias', None)
 
     @classmethod
     def from_field(cls, default: Any = Undefined, **kwargs: Any) -> FieldInfo:
@@ -344,6 +348,8 @@ def Field(
     strict: bool | None = None,
     json_schema_extra: dict[str, Any] | None = None,
     validate_default: bool | None = None,
+    validation_alias: str | list[str | int] | list[list[str | int]] | None = None,
+    serialization_alias: str | None = None,
     const: bool | None = None,
     unique_items: bool | None = None,
     allow_mutation: bool = True,
@@ -402,6 +408,8 @@ def Field(
     :param json_schema_extra: extra dict to be merged with the JSON Schema for this field
     :param strict: enable or disable strict parsing mode
     :param validate_default: whether the default value should be validated for this field
+    :param validation_alias: the alias(es) to use to find the field in the validation data
+    :param serialization_alias: The alias to use as a key when serializing
     :param const: removed, use `Literal` instead'
     :param unique_items: removed, use `Set` instead
     :param allow_mutation: deprecated, use `frozen` instead
@@ -470,6 +478,8 @@ def Field(
         json_schema_extra=json_schema_extra,
         strict=strict,
         validate_default=validate_default,
+        validation_alias=validation_alias or alias,
+        serialization_alias=serialization_alias or alias,
     )
 
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -45,8 +45,17 @@ def test_basic_alias():
     assert Model().a == 'foobar'
     assert Model(_a='different').a == 'different'
     assert repr(Model.model_fields['a']) == (
+        "FieldInfo(annotation=str, required=False, default='foobar', alias='_a', alias_priority=2)"
+    )
+
+
+def test_field_info_repr_with_aliases():
+    class Model(BaseModel):
+        a: str = Field('foobar', alias='_a', validation_alias='a_val', serialization_alias='a_ser')
+
+    assert repr(Model.model_fields['a']) == (
         "FieldInfo(annotation=str, required=False, default='foobar', alias='_a', "
-        "alias_priority=2, validation_alias='_a', serialization_alias='_a')"
+        "alias_priority=2, validation_alias='a_val', serialization_alias='a_ser')"
     )
 
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -312,7 +312,7 @@ def test_validation_alias_with_alias():
     ]
 
 
-def test_validation_alias_from_alias():
+def test_validation_alias_from_str_alias():
     class Model(BaseModel):
         x: str = Field(alias='foo')
 
@@ -332,6 +332,26 @@ def test_validation_alias_from_alias():
             'input': {'x': 'bar'},
         }
     ]
+
+
+def test_validation_alias_from_list_alias():
+    class Model(BaseModel):
+        x: str = Field(alias=['foo', 'bar'])
+
+    data = {'foo': {'bar': 'test'}}
+    m = Model(**data)
+    assert m.x == 'test'
+    sig = signature(Model)
+    assert 'x' in sig.parameters
+
+    class Model(BaseModel):
+        x: str = Field(alias=['foo', 1])
+
+    data = {'foo': ['bar0', 'bar1']}
+    m = Model(**data)
+    assert m.x == 'bar1'
+    sig = signature(Model)
+    assert 'x' in sig.parameters
 
 
 def test_serialization_alias():

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -212,8 +212,10 @@ def test_low_priority_alias():
     #  Alternative 1: we could drop alias_priority and tell people to manually override aliases in child classes
     #  Alternative 2: we could add a new argument `override_with_alias_generator=True` equivalent to `alias_priority=1`
     class Parent(BaseModel):
-        w: bool = Field(..., alias='w_')
-        x: bool = Field(..., alias='abc', alias_priority=1)
+        w: bool = Field(..., alias='w_', validation_alias='w_val_alias', serialization_alias='w_ser_alias')
+        x: bool = Field(
+            ..., alias='abc', alias_priority=1, validation_alias='x_val_alias', serialization_alias='x_ser_alias'
+        )
         y: str
 
     class Child(Parent):
@@ -223,7 +225,11 @@ def test_low_priority_alias():
         z: str
 
     assert [f.alias for f in Parent.model_fields.values()] == ['w_', 'abc', None]
+    assert [f.validation_alias for f in Parent.model_fields.values()] == ['w_val_alias', 'x_val_alias', None]
+    assert [f.serialization_alias for f in Parent.model_fields.values()] == ['w_ser_alias', 'x_ser_alias', None]
     assert [f.alias for f in Child.model_fields.values()] == ['w_', 'X', 'Y', 'Z']
+    assert [f.validation_alias for f in Child.model_fields.values()] == ['w_val_alias', 'X', 'Y', 'Z']
+    assert [f.serialization_alias for f in Child.model_fields.values()] == ['w_ser_alias', 'X', 'Y', 'Z']
 
 
 def test_empty_string_alias():


### PR DESCRIPTION
Fix aliases and add `validation_alias` and `serialization_alias` to `Field`
Fixes https://github.com/pydantic/pydantic/issues/5426

Selected Reviewer: @samuelcolvin