### PR TITLE
Fix internal error with mypy

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -390,13 +390,6 @@ class PydanticModelTransformer:
             if not isinstance(lhs, NameExpr) or not is_valid_field(lhs.name):
                 continue
 
-            # rhs = stmt.rvalue
-            # if hasattr(rhs, 'analyzed') and not rhs.analyzed:
-            #     print(ctx.api.anal_type(rhs))
-            # print("here")
-            #     ctx.api.defer()
-            #     continue
-
             if not stmt.new_syntax and self.plugin_config.warn_untyped_fields:
                 error_untyped_fields(ctx.api, stmt)
 

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -307,15 +307,14 @@ class PydanticModelTransformer:
         * stores the fields, config, and if the class is settings in the mypy metadata for access by subclasses
         """
         ctx = self._ctx
-        info = self._ctx.cls.info
+        info = ctx.cls.info
 
         self.adjust_validator_signatures()
         config = self.collect_config()
         fields = self.collect_fields(config)
         for field in fields:
             if info[field.name].type is None:
-                if not ctx.api.final_iteration:
-                    ctx.api.defer()
+                continue
         is_settings = any(get_fullname(base) == BASESETTINGS_FULLNAME for base in info.mro[:-1])
         self.add_initializer(fields, config, is_settings)
         self.add_construct_method(fields)
@@ -390,6 +389,13 @@ class PydanticModelTransformer:
             lhs = stmt.lvalues[0]
             if not isinstance(lhs, NameExpr) or not is_valid_field(lhs.name):
                 continue
+
+            # rhs = stmt.rvalue
+            # if hasattr(rhs, 'analyzed') and not rhs.analyzed:
+            #     print(ctx.api.anal_type(rhs))
+            # print("here")
+            #     ctx.api.defer()
+            #     continue
 
             if not stmt.new_syntax and self.plugin_config.warn_untyped_fields:
                 error_untyped_fields(ctx.api, stmt)

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -312,9 +312,6 @@ class PydanticModelTransformer:
         self.adjust_validator_signatures()
         config = self.collect_config()
         fields = self.collect_fields(config)
-        for field in fields:
-            if info[field.name].type is None:
-                continue
         is_settings = any(get_fullname(base) == BASESETTINGS_FULLNAME for base in info.mro[:-1])
         self.add_initializer(fields, config, is_settings)
         self.add_construct_method(fields)

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -264,7 +264,7 @@ class Sample(BaseModel):
 Sample(foo='hello world')
 
 
-def get_my_custom_validator(field_name: str) -> classmethod:  # type: ignore
+def get_my_custom_validator(field_name: str) -> Any:
     @validator(field_name, allow_reuse=True)
     def my_custom_validator(cls: Any, v: int) -> int:
         return v

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -262,3 +262,19 @@ class Sample(BaseModel):
 
 
 Sample(foo='hello world')
+
+
+def get_my_custom_validator(field_name: str) -> classmethod:  # type: ignore
+    @validator(field_name, allow_reuse=True)
+    def my_custom_validator(cls: Any, v: int) -> int:
+        return v
+
+    return my_custom_validator
+
+
+def foo() -> None:
+    class MyModel(BaseModel):
+        number: int
+        custom_validator = get_my_custom_validator('number')
+
+    MyModel(number=2)

--- a/tests/mypy/outputs/plugin-success-strict.txt
+++ b/tests/mypy/outputs/plugin-success-strict.txt
@@ -1,3 +1,4 @@
 30: error: Unexpected keyword argument "z" for "Model"  [call-arg]
 65: error: Untyped fields disallowed  [pydantic-field]
 80: error: Argument "x" to "OverrideModel" has incompatible type "float"; expected "int"  [arg-type]
+278: error: Untyped fields disallowed  [pydantic-field]

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -64,7 +64,15 @@ def test_mypy_results(config_filename: str, python_filename: str, output_filenam
     # Specifying a different cache dir for each configuration dramatically speeds up subsequent execution
     # It also prevents cache-invalidation-related bugs in the tests
     cache_dir = f'.mypy_cache/test-{os.path.splitext(config_filename)[0]}'
-    command = [full_filename, '--config-file', full_config_filename, '--cache-dir', cache_dir, '--show-error-codes']
+    command = [
+        full_filename,
+        '--config-file',
+        full_config_filename,
+        '--cache-dir',
+        cache_dir,
+        '--show-error-codes',
+        '--show-traceback',
+    ]
     print(f"\nExecuting: mypy {' '.join(command)}")  # makes it easier to debug as necessary
     actual_result = mypy_api.run(command)
     actual_out, actual_err, actual_returncode = actual_result


### PR DESCRIPTION
Closes #5446 

I'm not sure why the `ctx.api.defer()` was ever added in v1, but it's been there since the very first commit, and no tests fail when I remove it (perhaps mypy changed in a way that eliminated the need for this some time prior to the oldest version we currently test in, 0.910).

Considering I have no idea why it's there I think we should make this change and if it breaks anything we can add a test demonstrating the reported issue.

skip change file check