### PR TITLE
Fix mypy issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ test.py
 pydantic/*.c
 pydantic/*.so
 /fastapi/
+.mypy-configs/
 
 # Other files and folders
 .python-version

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -306,15 +306,14 @@ class PydanticModelTransformer:
         * stores the fields, config, and if the class is settings in the mypy metadata for access by subclasses
         """
         ctx = self._ctx
-        info = self._ctx.cls.info
+        info = ctx.cls.info
 
         self.adjust_validator_signatures()
         config = self.collect_config()
         fields = self.collect_fields(config)
         for field in fields:
             if info[field.name].type is None:
-                if not ctx.api.final_iteration:
-                    ctx.api.defer()
+                continue
         self.add_initializer(fields, config)
         self.add_model_construct_method(fields)
         self.set_frozen(fields, frozen=config.frozen is True)

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -311,9 +311,6 @@ class PydanticModelTransformer:
         self.adjust_validator_signatures()
         config = self.collect_config()
         fields = self.collect_fields(config)
-        for field in fields:
-            if info[field.name].type is None:
-                continue
         self.add_initializer(fields, config)
         self.add_model_construct_method(fields)
         self.set_frozen(fields, frozen=config.frozen is True)

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -278,12 +278,12 @@ class MyDataClass:
 MyDataClass(foo='foo', bar='bar')
 
 
-def get_my_custom_validator(field_name: str) -> classmethod:  # type: ignore
+def get_my_custom_validator(field_name: str) -> Any:
     @validator(field_name, allow_reuse=True)
     def my_custom_validator(cls: Any, v: int) -> int:
         return v
 
-    return my_custom_validator  # type: ignore
+    return my_custom_validator
 
 
 def foo() -> None:

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Generic, List, Optional, TypeVar, Union, Any
+from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, validator
 from pydantic.dataclasses import dataclass
@@ -289,6 +289,6 @@ def get_my_custom_validator(field_name: str) -> classmethod:  # type: ignore
 def foo() -> None:
     class MyModel(BaseModel):
         number: int
-        custom_validator = get_my_custom_validator("number")  # type: ignore[pydantic-field]
+        custom_validator = get_my_custom_validator('number')  # type: ignore[pydantic-field]
 
     MyModel(number=2)

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -1,6 +1,6 @@
-from typing import ClassVar, Generic, List, Optional, TypeVar, Union
+from typing import ClassVar, Generic, List, Optional, TypeVar, Union, Any
 
-from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator
+from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, validator
 from pydantic.dataclasses import dataclass
 
 
@@ -276,3 +276,19 @@ class MyDataClass:
 
 
 MyDataClass(foo='foo', bar='bar')
+
+
+def get_my_custom_validator(field_name: str) -> classmethod:  # type: ignore
+    @validator(field_name, allow_reuse=True)
+    def my_custom_validator(cls: Any, v: int) -> int:
+        return v
+
+    return my_custom_validator  # type: ignore
+
+
+def foo() -> None:
+    class MyModel(BaseModel):
+        number: int
+        custom_validator = get_my_custom_validator("number")  # type: ignore[pydantic-field]
+
+    MyModel(number=2)

--- a/tests/mypy/outputs/latest/plugin_success.txt
+++ b/tests/mypy/outputs/latest/plugin_success.txt
@@ -4,3 +4,4 @@
 86: error: Cannot inherit non-frozen dataclass from a frozen one  [misc]
 90: error: Property "x" defined in "KwargsNoMutationModel" is read-only  [misc]
 175: error: Cannot inherit frozen dataclass from a non-frozen one  [misc]
+292: error: Unused "type: ignore" comment

--- a/tests/mypy/outputs/v1.0.1/plugin_success.txt
+++ b/tests/mypy/outputs/v1.0.1/plugin_success.txt
@@ -3,3 +3,4 @@
 136: error: Unexpected keyword argument "description" for "AddProject"  [call-arg]
 278: error: Unexpected keyword argument "foo" for "MyDataClass"  [call-arg]
 278: error: Unexpected keyword argument "bar" for "MyDataClass"  [call-arg]
+292: error: Unused "type: ignore" comment

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -19,7 +19,7 @@ except ImportError:
 
 MYPY_VERSION_TUPLE = parse_mypy_version(mypy_version)
 
-pytestmark = pytest.mark.skipif('--test-mypy' not in sys.argv, reason='Test only with "--test-mypy" flag')
+pytestmark = pytest.mark.skipif(False and '--test-mypy' not in sys.argv, reason='Test only with "--test-mypy" flag')
 
 # This ensures mypy can find the test files, no matter where tests are run from:
 os.chdir(Path(__file__).parent.parent.parent)

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -141,7 +141,15 @@ def test_mypy_results(config_filename: str, python_filename: str, output_filenam
     # Specifying a different cache dir for each configuration dramatically speeds up subsequent execution
     # It also prevents cache-invalidation-related bugs in the tests
     cache_dir = f'.mypy_cache/test-{os.path.splitext(config_filename)[0]}'
-    command = [full_filename, '--config-file', full_config_filename, '--cache-dir', cache_dir, '--show-error-codes']
+    command = [
+        full_filename,
+        '--config-file',
+        full_config_filename,
+        '--cache-dir',
+        cache_dir,
+        '--show-error-codes',
+        '--show-traceback',
+    ]
     if MYPY_VERSION_TUPLE >= (0, 990):
         command.append('--disable-recursive-aliases')
     print(f"\nExecuting: mypy {' '.join(command)}")  # makes it easier to debug as necessary

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -19,7 +19,11 @@ except ImportError:
 
 MYPY_VERSION_TUPLE = parse_mypy_version(mypy_version)
 
-pytestmark = pytest.mark.skipif(False and '--test-mypy' not in sys.argv, reason='Test only with "--test-mypy" flag')
+pytestmark = pytest.mark.skipif(
+    '--test-mypy' not in sys.argv
+    and os.environ.get('PYCHARM_HOSTED') != '1',  # never skip when running via the PyCharm runner
+    reason='Test only with "--test-mypy" flag',
+)
 
 # This ensures mypy can find the test files, no matter where tests are run from:
 os.chdir(Path(__file__).parent.parent.parent)


### PR DESCRIPTION
Manual cherry pick of #5449 for v2.

This isn't necessary in v2 to prevent internal errors, but I'm not sure why the `ctx.api.defer()` was ever added in v1, but it's been there since the very first commit, and no tests fail when I remove it (perhaps mypy changed in a way that eliminated the need for this some time prior to the oldest version we currently test in v1, 0.910).

Considering I have no idea why it's there I think we should make this change and if it breaks anything we can add a test demonstrating the reported issue.