### PR TITLE
Defer evaluation of dataclasses for test 2162

### DIFF
--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -967,6 +967,11 @@ class BuiltInDataclassForPickle:
 
 
 def lazy_cases_for_dataclass_equality_checks():
+    """
+    The reason for the convoluted structure of this function is to avoid
+    creating the classes while collecting tests, which may trigger breakpoints
+    etc. while working on one specific test.
+    """
     cases = []
 
     def get_cases():


### PR DESCRIPTION
Right now, the "issue 2162" dataclass tests cause both pydantic and non-pydantic dataclasses to get initialized any time you run any test from the test_dataclasses file.

This is super painful while trying to use a debugger to debug things like schema generation for one specific test, and I don't want to hit my breakpoints for the schema building for those dataclasses.

This PR changes it so that those don't get evaluated unless you run the specific test they are relevant to.

While I was at it, I gave it a more interpretable name than "issue 2162" as well.

Selected Reviewer: @kludex