### PR TITLE
Get basic non-recursive generic dataclasses functionality working

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -340,6 +340,15 @@ class WalkAndApply:
         schema['fields'] = replaced_fields
         return schema
 
+    def handle_dataclass_args_schema(self, schema: core_schema.DataclassArgsSchema) -> CoreSchema:
+        replaced_fields: list[core_schema.DataclassField] = []
+        for field in schema['fields']:
+            replaced_field = field.copy()
+            replaced_field['schema'] = self._walk(field['schema'])
+            replaced_fields.append(replaced_field)
+        schema['fields'] = replaced_fields
+        return schema
+
     def handle_arguments_schema(self, schema: core_schema.ArgumentsSchema) -> CoreSchema:
         replaced_arguments_schema = []
         for param in schema['arguments_schema']:

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -9,6 +9,7 @@ from functools import wraps
 from typing import Any, Callable, ClassVar, cast
 
 from pydantic_core import ArgsKwargs, SchemaSerializer, SchemaValidator, core_schema
+from typing_extensions import TypeGuard
 
 from ..errors import PydanticUndefinedAnnotation
 from ..fields import FieldInfo
@@ -70,7 +71,7 @@ def prepare_dataclass(
 
     dataclass_ref = get_type_ref(cls)
     self_schema = core_schema.definition_reference_schema(dataclass_ref)
-    types_namespace = {**(types_namespace or {}), name: PydanticForwardRef(self_schema, cls)}
+    types_namespace = {name: PydanticForwardRef(self_schema, cls), **(types_namespace or {})}
     try:
         fields, _ = collect_fields(cls, bases, types_namespace, is_dataclass=True, dc_kw_only=kw_only)
     except PydanticUndefinedAnnotation as e:
@@ -123,7 +124,7 @@ def prepare_dataclass(
     return True
 
 
-def is_builtin_dataclass(_cls: type[Any]) -> bool:
+def is_builtin_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
     """
     Whether a class is a stdlib dataclass
     (useful to discriminated a pydantic dataclass that is actually a wrapper around a stdlib dataclass)

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic_core import core_schema
 
 from ._forward_ref import PydanticForwardRef
-from ._generics import get_typevars_map, replace_types
+from ._generics import replace_types
 from ._repr import Representation
 from ._typing_extra import get_cls_type_hints_lenient, get_type_hints, is_classvar, is_finalvar
 
@@ -118,6 +118,7 @@ def collect_fields(  # noqa: C901
     *,
     is_dataclass: bool = False,
     dc_kw_only: bool | None = None,
+    typevars_map: dict[Any, Any] | None = None,
 ) -> tuple[dict[str, FieldInfo], set[str]]:
     """
     Collect the fields of:
@@ -250,18 +251,15 @@ def collect_fields(  # noqa: C901
             field_info.kw_only = kw_only
         fields[ann_name] = field_info
 
-    generic_metadata = getattr(cls, '__pydantic_generic_metadata__', None)
-    if generic_metadata:
-        typevars_map = get_typevars_map(generic_metadata['origin'], generic_metadata['args'])
-        if typevars_map:
-            for field in fields.values():
-                try:
-                    field.annotation = typing._eval_type(  # type: ignore[attr-defined]
-                        field.annotation, types_namespace, None
-                    )
-                except NameError:
-                    pass
-                field.annotation = replace_types(field.annotation, typevars_map)
+    if typevars_map:
+        for field in fields.values():
+            try:
+                field.annotation = typing._eval_type(  # type: ignore[attr-defined]
+                    field.annotation, types_namespace, None
+                )
+            except NameError:
+                pass
+            field.annotation = replace_types(field.annotation, typevars_map)
 
     return fields, class_vars
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -373,6 +373,9 @@ class GenerateSchema:
         if std_schema is not None:
             return std_schema
 
+        if _typing_extra.is_dataclass(obj):
+            return self._dataclass_schema(obj, None)
+
         origin = get_origin(obj)
         if origin is None:
             if self.arbitrary_types:
@@ -382,6 +385,13 @@ class GenerateSchema:
                     f'Unable to generate pydantic-core schema for {obj!r}. '
                     f'Setting `arbitrary_types_allowed=True` in the model_config may prevent this error.'
                 )
+
+        # Need to handle generic dataclasses before looking for the schema properties because attribute accesses
+        # on _GenericAlias delegate to the origin type, so lose the information about the concrete parametrization
+        # As a result, currently, there is no way to cache the schema for generic dataclasses. This may be possible
+        # to resolve by modifying the value returned by `Generic.__class_getitem__`, but that is a dangerous game.
+        if _typing_extra.is_dataclass(origin):
+            return self._dataclass_schema(obj, origin)
 
         from_property = self._generate_schema_from_property(origin, obj)
         if from_property is not None:
@@ -898,8 +908,6 @@ class GenerateSchema:
             return None
 
         # Import here to avoid the extra import time earlier since _std_validators imports lots of things globally
-        import dataclasses
-
         from ._std_types_schema import SCHEMA_LOOKUP
 
         # instead of iterating over a list and calling is_instance, this should be somewhat faster,
@@ -911,17 +919,33 @@ class GenerateSchema:
             except KeyError:
                 continue
             return encoder(self, obj)
-        if dataclasses.is_dataclass(obj):
-            return self._dataclass_schema(obj)  # type: ignore
         return None
 
-    def _dataclass_schema(self, dataclass: type[StandardDataclass]) -> core_schema.CoreSchema:
+    def _dataclass_schema(
+        self, dataclass: type[StandardDataclass], origin: type[StandardDataclass] | None
+    ) -> core_schema.CoreSchema:
         """
         Generate schema for a dataclass.
         """
+
+        if origin is not None:
+            # In this case, we know that dataclass is a _GenericAlias, and origin is the generic type
+            # So it is safe to access dataclass.__args__ and origin.__parameters__
+            args: tuple[Any, ...] = dataclass.__args__  # type: ignore
+            parameters: tuple[_typing_extra.TypeVarType, ...] = origin.__parameters__  # type: ignore
+            typevars_map = dict(zip(parameters, args))
+            dataclass = origin
+        else:
+            typevars_map = None
+
         # FIXME we need a way to make sure kw_only info is propagated through to fields
         fields, _ = collect_fields(
-            dataclass, dataclass.__bases__, self.types_namespace, dc_kw_only=True, is_dataclass=True
+            dataclass,
+            dataclass.__bases__,
+            self.types_namespace,
+            dc_kw_only=True,
+            is_dataclass=True,
+            typevars_map=typevars_map,
         )
 
         return dataclass_schema(

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -143,7 +143,12 @@ def set_model_fields(cls: type[BaseModel], bases: tuple[type[Any], ...], types_n
     """
     Collect and set `cls.model_fields` and `cls.__class_vars__`.
     """
-    fields, class_vars = collect_fields(cls, bases, types_namespace)
+    generic_metadata = getattr(cls, '__pydantic_generic_metadata__', None)
+    if generic_metadata:
+        typevars_map = get_typevars_map(generic_metadata['origin'], generic_metadata['args'])
+    else:
+        typevars_map = None
+    fields, class_vars = collect_fields(cls, bases, types_namespace, typevars_map=typevars_map)
 
     apply_alias_generator(cls.model_config, fields)
     cls.model_fields = fields

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -8,9 +8,12 @@ import types
 import typing
 from collections.abc import Callable
 from types import GetSetDescriptorType
-from typing import Any, ForwardRef
+from typing import TYPE_CHECKING, Any, ForwardRef
 
-from typing_extensions import Annotated, Final, Literal, get_args, get_origin
+from typing_extensions import Annotated, Final, Literal, TypeGuard, get_args, get_origin
+
+if TYPE_CHECKING:
+    from ._dataclasses import StandardDataclass
 
 __all__ = (
     'NoneType',
@@ -445,3 +448,11 @@ else:
         ref: ForwardRef, globalns: dict[str, Any] | None = None, localns: dict[str, Any] | None = None
     ) -> Any:
         return ref._evaluate(globalns=globalns, localns=localns, recursive_guard=frozenset())
+
+
+def is_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
+    # The dataclasses.is_dataclass function doesn't seem to provide TypeGuard functionality,
+    # so I created this convenience function
+    import dataclasses
+
+    return dataclasses.is_dataclass(_cls)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -5,13 +5,13 @@ import sys
 from collections.abc import Hashable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Dict, FrozenSet, List, Optional, Set, Union
+from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, List, Optional, Set, TypeVar, Union
 
 import pytest
 from typing_extensions import Literal
 
 import pydantic
-from pydantic import BaseModel, ConfigDict, FieldValidationInfo, ValidationError
+from pydantic import AnalyzedType, BaseModel, ConfigDict, FieldValidationInfo, ValidationError
 from pydantic.decorators import field_validator
 from pydantic.fields import Field, FieldInfo
 from pydantic.json_schema import model_json_schema
@@ -1395,17 +1395,54 @@ def test_forbid_extra():
         Foo(**{'x': '1', 'y': '2'})
 
 
-@pytest.mark.xfail(reason='recursive references need rebuilding?')
+@pytest.mark.xfail(reason='need to make it possible to rebuild dataclasses')
 def test_self_reference_dataclass():
     @pydantic.dataclasses.dataclass
     class MyDataclass:
-        self_reference: 'MyDataclass'
+        self_reference: Optional['MyDataclass'] = None
 
-    annotation = MyDataclass.__pydantic_fields__['self_reference'].annotation
-    # Currently, this is true:
-    # assert isinstance(MyDataclass, PydanticForwardRef)
-    # TODO: Probably need a way to "model_rebuild" a dataclass
-    assert annotation is MyDataclass
+    # rebuild_pydantic_dataclass(MyDataclass)
+
+    assert MyDataclass.__pydantic_fields__['self_reference'].annotation == Optional[MyDataclass]
+
+    instance = MyDataclass(self_reference=MyDataclass(self_reference=MyDataclass()))
+    assert AnalyzedType(MyDataclass).dump_python(instance) == {
+        'self_reference': {'self_reference': {'self_reference': None}}
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        MyDataclass(self_reference=MyDataclass(self_reference=1))
+
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {'dataclass_name': 'MyDataclass'},
+            'input': 1,
+            'loc': ('self_reference',),
+            'msg': 'Input should be a dictionary or an instance of MyDataclass',
+            'type': 'dataclass_type',
+        }
+    ]
+
+
+@pytest.mark.xfail(reason='need to make it possible to rebuild dataclasses')
+def test_cyclic_reference_dataclass():
+    @pydantic.dataclasses.dataclass
+    class D1:
+        d2: Optional['D2'] = None
+
+    @pydantic.dataclasses.dataclass
+    class D2:
+        d1: Optional[D1] = None
+
+    # rebuild_pydantic_dataclass(D1)
+
+    instance = D1(d2=D2(d1=D1(d2=D2(d1=D1()))))
+
+    assert AnalyzedType(D1).dump_python(instance) == {...}
+
+    with pytest.raises(ValidationError) as exc_info:
+        D1(d2=D2(d1=D1(d2=D2(d1=D2()))))
+    assert exc_info.value.errors() == [...]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='kw_only is not available in python < 3.10')
@@ -1693,3 +1730,79 @@ def test_dataclass_config_validate_default():
             'type': 'assertion_error',
         }
     ]
+
+
+def dataclass_decorators():
+    def combined(cls):
+        """
+        Should be equivalent to:
+        @pydantic.dataclasses.dataclass
+        @dataclasses.dataclass
+        """
+        return pydantic.dataclasses.dataclass(dataclasses.dataclass(cls))
+
+    decorators = [pydantic.dataclasses.dataclass, dataclasses.dataclass, combined]
+    ids = ['pydantic', 'stdlib', 'combined']
+    # decorators = [pydantic.dataclasses.dataclass]
+    # ids = ['pydantic']
+    # decorators = [dataclasses.dataclass]
+    # ids = ['stdlib']
+    return {'argvalues': decorators, 'ids': ids}
+
+
+@pytest.mark.parametrize('dataclass_decorator', **dataclass_decorators())
+def test_unparametrized_generic_dataclass(dataclass_decorator):
+    T = TypeVar('T')
+
+    @dataclass_decorator
+    class GenericDataclass(Generic[T]):
+        x: T
+
+    validator = pydantic.AnalyzedType(GenericDataclass)
+
+    assert validator.validate_python({'x': None}).x is None
+    assert validator.validate_python({'x': 1}).x == 1
+
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_python({'y': None})
+    assert exc_info.value.errors() == [
+        {'input': {'y': None}, 'loc': ('x',), 'msg': 'Field required', 'type': 'missing'}
+    ]
+
+
+@pytest.mark.parametrize('dataclass_decorator', **dataclass_decorators())
+@pytest.mark.parametrize(
+    'annotation,input_value,error,output_value',
+    [
+        (int, 1, False, 1),
+        (str, 'a', False, 'a'),
+        (
+            int,
+            'a',
+            True,
+            [
+                {
+                    'input': 'a',
+                    'loc': ('x',),
+                    'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
+                    'type': 'int_parsing',
+                }
+            ],
+        ),
+    ],
+)
+def test_parametrized_generic_dataclass(dataclass_decorator, annotation, input_value, error, output_value):
+    T = TypeVar('T')
+
+    @dataclass_decorator
+    class GenericDataclass(Generic[T]):
+        x: T
+
+    validator = pydantic.AnalyzedType(GenericDataclass[annotation])
+
+    if not error:
+        assert validator.validate_python({'x': input_value}).x == output_value
+    else:
+        with pytest.raises(ValidationError) as exc_info:
+            validator.validate_python({'x': input_value})
+        assert exc_info.value.errors() == output_value


### PR DESCRIPTION
This PR includes various modifications to the dataclasses module that I think should be easier to review (and hopefully less controversial) than the changes to come for supporting recursive/recursive generic dataclasses, and other refactors to the dataclass schema building process.

Note this is currently a subset of #5447, but I think I will close #5447 as I think we need to make some bigger changes. This PR has the things from that PR that I would like to keep around.

I would like to get this PR (or at least a subset of it) merged before continuing on generic/recursive dataclasses for the sake of keeping the diffs as easy to review as possible.

Changes:
* Fix the core_utils `WalkAndApply` to handle dataclasses properly
* Update the handling of types_namespace in `prepare_dataclass` to be more compatible with recursive references
* Add a typeguarded `is_dataclass` function for better compatibility with our StandardDataclass protocol
* Add support for reading a typevars_map off of a dataclass and using it while building the core schema.
* Lightly rework `create_dataclass` to be compatible with generic dataclasses
* Add tests using AnalyzedType to validate data with generic dataclasses with each possible dataclass decorator: pydantic, stdlib, and pydantic + stdlib. 
* Add some failing tests for recursive dataclasses


Selected Reviewer: @adriangb