### PR TITLE
Add docstring coverage for dataclasses

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -110,7 +110,7 @@ def dataclass(
     kw_only: bool = False,
 ) -> Callable[[type[_T]], type[PydanticDataclass]] | type[PydanticDataclass]:
     """
-    Returns a decorator that creates a Pydantic-enhanced dataclass, similar to the standard Python `dataclasses`,
+    A decorator used to create a Pydantic-enhanced dataclass, similar to the standard Python `dataclasses`,
     but with added validation.
 
     Args:
@@ -145,7 +145,7 @@ def dataclass(
             cls (type[Any]): The class to create the Pydantic dataclass from.
 
         Returns:
-            type[PydanticDataclass]: Returns a Pydantic dataclass.
+            type[PydanticDataclass]: A Pydantic dataclass.
 
         Raises:
             TypeError: If a non-class value is provided.

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -38,6 +38,7 @@ if sys.version_info >= (3, 10):
         validate_on_init: bool | None = None,
         kw_only: bool = ...,
     ) -> Callable[[type[_T]], type[PydanticDataclass]]:  # type: ignore
+        """Overload for `dataclass`."""
         ...
 
     @dataclass_transform(field_specifiers=(dataclasses.field, Field))
@@ -55,6 +56,7 @@ if sys.version_info >= (3, 10):
         validate_on_init: bool | None = None,
         kw_only: bool = ...,
     ) -> type[PydanticDataclass]:
+        """Overload for `dataclass`."""
         ...
 
 else:
@@ -72,6 +74,7 @@ else:
         config: ConfigDict | type[object] | None = None,
         validate_on_init: bool | None = None,
     ) -> Callable[[type[_T]], type[PydanticDataclass]]:  # type: ignore
+        """Overload for `dataclass`."""
         ...
 
     @dataclass_transform(field_specifiers=(dataclasses.field, Field))
@@ -88,6 +91,7 @@ else:
         config: ConfigDict | type[object] | None = None,
         validate_on_init: bool | None = None,
     ) -> type[PydanticDataclass]:
+        """Overload for `dataclass`."""
         ...
 
 
@@ -106,11 +110,46 @@ def dataclass(
     kw_only: bool = False,
 ) -> Callable[[type[_T]], type[PydanticDataclass]] | type[PydanticDataclass]:
     """
-    Like the python standard lib dataclasses but enhanced with validation.
+    Returns a decorator that creates a Pydantic-enhanced dataclass, similar to the standard Python `dataclasses`,
+    but with added validation.
+
+    Args:
+        _cls (type[_T] | None): The target dataclass.
+        init (Literal[False]): If set to `False`, the `dataclass` will not generate an `__init__`,
+            and you will need to provide one. Defaults to `False`.
+        repr (bool): Determines if a `__repr__` should be generated for the class. Defaults to `True`.
+        eq (bool): Determines if a `__eq__` should be generated for the class. Defaults to `True`.
+        order (bool): Determines if comparison magic methods should be generated, such as `__lt__`, but
+            not `__eq__`. Defaults to `False`.
+        unsafe_hash (bool): Determines if an unsafe hashing function should be included in the class.
+        frozen (bool): Determines if the generated class should be a 'frozen' dataclass, which does not allow its
+            attributes to be modified from its constructor. Defaults to `False`.
+        config (ConfigDict | type[object] | None): A configuration for the `dataclass` generation. Defaults to `None`.
+        validate_on_init (bool | None): Determines whether the `dataclass` will be validated upon creation.
+        kw_only (bool): Determines if keyword-only parameters should be used on the `__init__` method. Defaults
+            to `False`.
+
+    Returns:
+        A callable that takes a `type` as its argument, and returns a `type` of `PydanticDataclass`. This can
+        also return a `tyoe` of `PydanticDataclass` directly.
+
+    Raises:
+        AssertionError: Raised if `init` is not `False`.
     """
     assert init is False, 'pydantic.dataclasses.dataclass only supports init=False'
 
     def create_dataclass(cls: type[Any]) -> type[PydanticDataclass]:
+        """Create a Pydantic dataclass from a regular dataclass.
+
+        Args:
+            cls (type[Any]): The class to create the Pydantic dataclass from.
+
+        Returns:
+            type[PydanticDataclass]: Returns a Pydantic dataclass.
+
+        Raises:
+            TypeError: If a non-class value is provided.
+        """
         # Keep track of the original __doc__ so that we can restore it after applying the dataclasses decorator
         # Otherwise, classes with no __doc__ will have their signature added into the JSON schema description,
         # since dataclasses.dataclass will set this as the __doc__


### PR DESCRIPTION
Adds docstrings for dataclasses.py

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @kludex