### PR TITLE
Split `__get_pydantic_core_schema__` into `__modify_pydantic_core_schema__` and `__get_pydantic_core_schema__`

### DIFF
--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -377,7 +377,7 @@ from pydantic import BaseModel, ValidationError
 class RestrictCharacters:
     alphabet: Sequence[str]
 
-    def __get_pydantic_core_schema__(
+    def __modify_pydantic_core_schema__(
         self,
         schema: core_schema.CoreSchema,
     ) -> core_schema.CoreSchema:

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -366,9 +366,10 @@ included.
 
 ```py
 from dataclasses import dataclass
-from typing import Annotated, Sequence
+from typing import Sequence
 
 from pydantic_core import core_schema
+from typing_extensions import Annotated
 
 from pydantic import BaseModel, ValidationError
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1181,7 +1181,7 @@ def apply_single_annotation(  # noqa C901
     if metadata_schema is not None:
         return metadata_schema
 
-    metadata_get_schema = getattr(metadata, '__get_pydantic_core_schema__', None)
+    metadata_get_schema = getattr(metadata, '__modify_pydantic_core_schema__', None)
     if metadata_get_schema is not None:
         return metadata_get_schema(schema)
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1177,10 +1177,6 @@ def apply_single_annotation(  # noqa C901
     if metadata is None:
         return schema
 
-    metadata_schema = getattr(metadata, '__pydantic_core_schema__', None)
-    if metadata_schema is not None:
-        return metadata_schema
-
     metadata_get_schema = getattr(metadata, '__modify_pydantic_core_schema__', None)
     if metadata_get_schema is not None:
         return metadata_get_schema(schema)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -44,7 +44,6 @@ from pydantic.color import Color
 from pydantic.config import ConfigDict
 from pydantic.dataclasses import dataclass
 from pydantic.errors import PydanticInvalidForJsonSchema
-from pydantic.fields import FieldInfo
 from pydantic.json_schema import (
     DEFAULT_REF_TEMPLATE,
     GenerateJsonSchema,
@@ -2599,33 +2598,6 @@ def test_complex_nested_generic():
             },
         },
         'allOf': [{'$ref': '#/$defs/Model'}],
-    }
-
-
-@pytest.mark.xfail(reason='__pydantic_modify_json_schema__ does not receive FieldInfo')
-def test_schema_with_field_parameter():
-    # TODO: Update so that __pydantic_modify_json_schema__ gets called with the FieldInfo when handling fields
-    class RestrictedAlphabetStr(str):
-        @classmethod
-        def __pydantic_modify_json_schema__(cls, field_schema, field: Optional[FieldInfo]):
-            assert isinstance(field, FieldInfo)
-            alphabet = field.json_schema_extra['alphabet']
-            field_schema['examples'] = [c * 3 for c in alphabet]
-            field_schema['title'] = field.title.lower()
-            return field_schema
-
-    class MyModel(BaseModel):
-        value: RestrictedAlphabetStr = Field(title='RESTRICTED_ALPHABET', json_schema_extra={'alphabet': 'ABC'})
-
-        model_config = {'arbitrary_types_allowed': True}
-
-    assert MyModel.model_json_schema() == {
-        'title': 'MyModel',
-        'type': 'object',
-        'properties': {
-            'value': {'title': 'Value', 'alphabet': 'ABC', 'examples': ['AAA', 'BBB', 'CCC'], 'type': 'string'}
-        },
-        'required': ['value'],
     }
 
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -174,7 +174,7 @@ def test_annotated_customisation():
 
     class CommaFriendlyIntLogic:
         @classmethod
-        def __get_pydantic_core_schema__(cls, _schema):
+        def __modify_pydantic_core_schema__(cls, _schema):
             # here we ignore the schema argument (which is just `{'type': 'int'}`) and return our own
             return core_schema.general_before_validator_function(
                 parse_int,


### PR DESCRIPTION
As discussed in meeting today. This should make it a lot clearer what these functions are expected to do.

Selected Reviewer: @kludex