### PR TITLE
Add `BaseConfig` back to the `pydantic.config` module

### DIFF
--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -6,7 +6,9 @@ from warnings import warn
 
 from typing_extensions import Literal, TypedDict
 
-__all__ = 'ConfigDict', 'Extra'
+from .deprecated.config import BaseConfig
+
+__all__ = 'BaseConfig', 'ConfigDict', 'Extra'
 
 
 class _Extra:


### PR DESCRIPTION
## Change Summary

This PR adds the `BaseConfig` back to the namespace where it was located on V1, so people that import from `pydantic.config` will not have a breaking change on V2. Since the class itself is deprecated, we are not going to send a warning about the import location being changed, but just let the user know that they should replace `BaseConfig` by `ConfigDict`. 

There's already a test for the deprecation.

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb