### PR TITLE
Rework `__get_pydantic_core_schema__` APIs

### DIFF
--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -265,7 +265,7 @@ class DayThisYear(date):
     """
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: Type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -251,6 +251,7 @@ Subclasses of common types are automatically encoded like their super-classes:
 
 ```py
 from datetime import date, timedelta
+from typing import Any, Callable, Type
 
 from pydantic_core import core_schema
 
@@ -264,7 +265,9 @@ class DayThisYear(date):
     """
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **kwargs):
+    def __modify_pydantic_core_schema__(
+        cls, source: Type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(
             cls.validate,
             core_schema.int_schema(),

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1198,7 +1198,6 @@ def apply_annotations(
     for metadata in annotations:
         if metadata is None:
             continue
-        # check if this supports
         metadata_get_schema = getattr(metadata, '__get_pydantic_core_schema__', None)
         if metadata_get_schema is not None:
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations as _annotations
 
 import collections.abc
 import dataclasses
+import inspect
 import re
 import sys
 import typing
@@ -16,7 +17,7 @@ from types import FunctionType, LambdaType, MethodType
 from typing import TYPE_CHECKING, Any, Callable, ForwardRef, Iterable, Mapping, TypeVar, Union
 
 from annotated_types import BaseMetadata, GroupedMetadata
-from pydantic_core import SchemaError, SchemaValidator, core_schema
+from pydantic_core import CoreSchema, SchemaError, SchemaValidator, core_schema
 from typing_extensions import Annotated, Final, Literal, TypedDict, get_args, get_origin, is_typeddict
 
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
@@ -71,6 +72,8 @@ AnyFieldDecorator = Union[
     Decorator[FieldValidatorDecoratorInfo],
     Decorator[FieldSerializerDecoratorInfo],
 ]
+
+ModifyCoreSchemaWrapHandler = Callable[[Any], core_schema.CoreSchema]
 
 
 def check_validator_fields_against_field_name(
@@ -165,7 +168,7 @@ class GenerateSchema:
         return self.config_wrapper.arbitrary_types_allowed
 
     def generate_schema(self, obj: Any) -> core_schema.CoreSchema:
-        schema = self._generate_schema(obj)
+        schema = self._generate_schema(obj, from_dunder_get_core_schema=True)
 
         schema = remove_unnecessary_invalid_definitions(schema)
 
@@ -184,9 +187,12 @@ class GenerateSchema:
 
         return schema
 
-    def _model_schema(self, cls: type[BaseModel]) -> core_schema.CoreSchema:
+    def model_schema(self, cls: type[BaseModel]) -> core_schema.CoreSchema:
         """
         Generate schema for a pydantic model.
+
+        Since models generate schemas for themselves this method is public and can be called
+        from within BaseModel's metaclass.
         """
         model_ref, schema = self._get_or_cache_recursive_ref(cls)
         if schema is not None:
@@ -237,16 +243,24 @@ class GenerateSchema:
 
     def _generate_schema_from_property(self, obj: Any, source: Any) -> core_schema.CoreSchema | None:
         """
-        Try to generate schema from either the `__get_pydantic_core_schema__` function or
+        Try to generate schema from either the `__modify_pydantic_core_schema__` function or
         `__pydantic_core_schema__` property.
 
-        Note: `__get_pydantic_core_schema__` takes priority so it can decide whether to use a `__pydantic_core_schema__`
-        attribute, or generate a fresh schema.
+        Note: `__modify_pydantic_core_schema__` takes priority so it can
+        decide whether to use a `__pydantic_core_schema__` attribute, or generate a fresh schema.
         """
-        get_schema = getattr(obj, '__get_pydantic_core_schema__', None)
+        get_schema = getattr(obj, '__modify_pydantic_core_schema__', None)
         if get_schema is not None:
+            # (source) -> CoreSchema
+            if len(inspect.signature(get_schema).parameters) == 1:
+                return get_schema(source)
+
+            # (source, handler) -> CoreSchema
+            def handler(source: Any) -> core_schema.CoreSchema:
+                return self._generate_schema(source, False)
+
             # Can return None to tell pydantic not to override
-            return get_schema(source=source, gen_schema=self)
+            return get_schema(source, handler)
 
         if _typing_extra.is_dataclass(obj):
             # For dataclasses, only use the __pydantic_core_schema__ if it is defined on this exact class, not a parent
@@ -259,7 +273,7 @@ class GenerateSchema:
 
         return None
 
-    def _generate_schema(self, obj: Any) -> core_schema.CoreSchema:  # noqa: C901
+    def _generate_schema(self, obj: Any, from_dunder_get_core_schema: bool) -> core_schema.CoreSchema:  # noqa: C901
         """
         Recursively generate a pydantic-core schema for any supported python type.
         """
@@ -288,14 +302,15 @@ class GenerateSchema:
             if self.typevars_map is not None:
                 obj = replace_types(obj, self.typevars_map)
 
-        from_property = self._generate_schema_from_property(obj, obj)
-        if from_property is not None:
-            return from_property
+        if from_dunder_get_core_schema:
+            from_property = self._generate_schema_from_property(obj, obj)
+            if from_property is not None:
+                return from_property
 
         from pydantic.main import BaseModel
 
         if lenient_issubclass(obj, BaseModel):
-            return self._model_schema(obj)
+            return self.model_schema(obj)
 
         if isinstance(obj, PydanticRecursiveRef):
             return core_schema.definition_reference_schema(schema_ref=obj.type_ref)
@@ -496,11 +511,13 @@ class GenerateSchema:
     def _common_field_schema(self, name: str, field_info: FieldInfo, decorators: DecoratorInfos) -> _CommonField:
         assert field_info.annotation is not None, 'field_info.annotation should not be None when generating a schema'
 
-        schema = self.generate_schema(field_info.annotation)
+        def generate_schema(source: Any) -> CoreSchema:
+            schema = self.generate_schema(source)
+            if field_info.discriminator is not None:
+                schema = _discriminated_union.apply_discriminator(schema, field_info.discriminator, self.definitions)
+            return schema
 
-        if field_info.discriminator is not None:
-            schema = _discriminated_union.apply_discriminator(schema, field_info.discriminator, self.definitions)
-        schema = apply_annotations(schema, field_info.metadata, self.definitions)
+        schema = apply_annotations(generate_schema, field_info.metadata, self.definitions)(field_info.annotation)
 
         # TODO: remove this V1 compatibility shim once it's deprecated
         # push down any `each_item=True` validators
@@ -571,8 +588,7 @@ class GenerateSchema:
         Generate schema for an Annotated type, e.g. `Annotated[int, Field(...)]` or `Annotated[int, Gt(0)]`.
         """
         first_arg, *other_args = get_args(annotated_type)
-        schema = self.generate_schema(first_arg)
-        return apply_annotations(schema, other_args, self.definitions)
+        return apply_annotations(self.generate_schema, other_args, self.definitions)(first_arg)
 
     def _literal_schema(self, literal_type: Any) -> core_schema.LiteralSchema:
         """
@@ -679,8 +695,7 @@ class GenerateSchema:
         else:
             field = FieldInfo.from_annotated_attribute(annotation, default)
         assert field.annotation is not None, 'field.annotation should not be None when generating a schema'
-        schema = self.generate_schema(field.annotation)
-        schema = apply_annotations(schema, field.metadata, self.definitions)
+        schema = apply_annotations(self.generate_schema, field.metadata, self.definitions)(annotation)
 
         if not field.is_required():
             schema = wrap_default(field, schema)
@@ -1173,41 +1188,67 @@ def apply_model_validators(
 
 
 def apply_annotations(
-    schema: core_schema.CoreSchema, annotations: typing.Iterable[Any], definitions: dict[str, core_schema.CoreSchema]
-) -> core_schema.CoreSchema:
+    get_inner_schema: ModifyCoreSchemaWrapHandler,
+    annotations: typing.Iterable[Any],
+    definitions: dict[str, core_schema.CoreSchema],
+) -> ModifyCoreSchemaWrapHandler:
     """
     Apply arguments from `Annotated` or from `FieldInfo` to a schema.
     """
-    handler = CoreMetadataHandler(schema)
     for metadata in annotations:
-        schema = apply_single_annotation(schema, metadata, definitions)
+        if metadata is None:
+            continue
+        # check if this supports
+        metadata_get_schema = getattr(metadata, '__modify_pydantic_core_schema__', None)
+        if metadata_get_schema is not None:
 
-        metadata_js_modify_function = _get_pydantic_modify_json_schema(metadata)
-        handler.compose_js_modify_functions(metadata_js_modify_function)
+            def _new_inner_schema_handler(
+                source: Any,
+                handler: ModifyCoreSchemaWrapHandler = get_inner_schema,
+                metadata: Any = metadata,
+                metadata_get_schema: Callable[
+                    [Any, ModifyCoreSchemaWrapHandler], core_schema.CoreSchema
+                ] = metadata_get_schema,
+            ) -> core_schema.CoreSchema:
+                schema = metadata_get_schema(source, handler)
+                metadata_js_modify_function = _get_pydantic_modify_json_schema(metadata)
+                CoreMetadataHandler(schema).compose_js_modify_functions(metadata_js_modify_function)
+                return schema
 
-    return schema
+            get_inner_schema = _new_inner_schema_handler
+        else:
+
+            def _new_inner_after_handler(
+                source: Any,
+                handler: ModifyCoreSchemaWrapHandler = get_inner_schema,
+                metadata: Any = metadata,
+            ) -> core_schema.CoreSchema:
+                schema = handler(source)
+                schema = apply_single_annotation(schema, metadata, definitions)
+                metadata_js_modify_function = _get_pydantic_modify_json_schema(metadata)
+                CoreMetadataHandler(schema).compose_js_modify_functions(metadata_js_modify_function)
+                return schema
+
+            get_inner_schema = _new_inner_after_handler
+
+    return get_inner_schema
 
 
-def apply_single_annotation(  # C901
+def apply_single_annotation(
     schema: core_schema.CoreSchema, metadata: Any, definitions: dict[str, core_schema.CoreSchema]
 ) -> core_schema.CoreSchema:
-    if metadata is None:
-        return schema
-
-    metadata_get_schema = getattr(metadata, '__modify_pydantic_core_schema__', None)
-    if metadata_get_schema is not None:
-        return metadata_get_schema(schema)
-
     if isinstance(metadata, GroupedMetadata):
-        # GroupedMetadata yields `BaseMetadata`s
-        return apply_annotations(schema, metadata, definitions)
+        for a in metadata:
+            schema = apply_single_annotation(schema, a, definitions)
     elif isinstance(metadata, FieldInfo):
-        schema = apply_annotations(schema, metadata.metadata, definitions)
+        for field_metadata in metadata.metadata:
+            schema = apply_single_annotation(schema, field_metadata, definitions)
         if metadata.discriminator is not None:
             schema = _discriminated_union.apply_discriminator(schema, metadata.discriminator, definitions)
         # TODO setting a default here needs to be tested
         return wrap_default(metadata, schema)
-    elif isinstance(metadata, PydanticGeneralMetadata):
+
+    if isinstance(metadata, PydanticGeneralMetadata):
         metadata_dict = metadata.__dict__
     elif isinstance(metadata, (BaseMetadata, PydanticMetadata)):
         metadata_dict = dataclasses.asdict(metadata)  # type: ignore[call-overload]

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -243,13 +243,13 @@ class GenerateSchema:
 
     def _generate_schema_from_property(self, obj: Any, source: Any) -> core_schema.CoreSchema | None:
         """
-        Try to generate schema from either the `__modify_pydantic_core_schema__` function or
+        Try to generate schema from either the `__get_pydantic_core_schema__` function or
         `__pydantic_core_schema__` property.
 
-        Note: `__modify_pydantic_core_schema__` takes priority so it can
+        Note: `__get_pydantic_core_schema__` takes priority so it can
         decide whether to use a `__pydantic_core_schema__` attribute, or generate a fresh schema.
         """
-        get_schema = getattr(obj, '__modify_pydantic_core_schema__', None)
+        get_schema = getattr(obj, '__get_pydantic_core_schema__', None)
         if get_schema is not None:
             # (source) -> CoreSchema
             if len(inspect.signature(get_schema).parameters) == 1:
@@ -1199,7 +1199,7 @@ def apply_annotations(
         if metadata is None:
             continue
         # check if this supports
-        metadata_get_schema = getattr(metadata, '__modify_pydantic_core_schema__', None)
+        metadata_get_schema = getattr(metadata, '__get_pydantic_core_schema__', None)
         if metadata_get_schema is not None:
 
             def _new_inner_schema_handler(

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -167,7 +167,7 @@ def complete_model_class(
         typevars_map,
     )
     try:
-        schema = cls.__modify_pydantic_core_schema__(cls, gen_schema.generate_schema)
+        schema = cls.__get_pydantic_core_schema__(cls, gen_schema.generate_schema)
     except PydanticUndefinedAnnotation as e:
         if raise_errors:
             raise

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -167,7 +167,7 @@ def complete_model_class(
         typevars_map,
     )
     try:
-        schema = gen_schema.generate_schema(cls)
+        schema = cls.__modify_pydantic_core_schema__(cls, gen_schema.generate_schema)
     except PydanticUndefinedAnnotation as e:
         if raise_errors:
             raise

--- a/pydantic/annotated_arguments.py
+++ b/pydantic/annotated_arguments.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Callable
+
 from pydantic_core import core_schema
 from typing_extensions import Literal
 
@@ -11,7 +13,10 @@ from ._internal._internal_dataclass import slots_dataclass
 class AfterValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.GeneralValidatorFunction
 
-    def __modify_pydantic_core_schema__(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
+    def __modify_pydantic_core_schema__(
+        self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
         info_arg = inspect_validator(self.func, 'after')
         if info_arg:
             return core_schema.general_after_validator_function(self.func, schema=schema)  # type: ignore
@@ -23,7 +28,10 @@ class AfterValidator:
 class BeforeValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.GeneralValidatorFunction
 
-    def __modify_pydantic_core_schema__(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
+    def __modify_pydantic_core_schema__(
+        self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
         info_arg = inspect_validator(self.func, 'before')
         if info_arg:
             return core_schema.general_before_validator_function(self.func, schema=schema)  # type: ignore
@@ -35,7 +43,10 @@ class BeforeValidator:
 class PlainValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.GeneralValidatorFunction
 
-    def __modify_pydantic_core_schema__(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
+    def __modify_pydantic_core_schema__(
+        self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
         info_arg = inspect_validator(self.func, 'plain')
         if info_arg:
             return core_schema.general_plain_validator_function(self.func, schema=schema)  # type: ignore
@@ -47,7 +58,10 @@ class PlainValidator:
 class WrapValidator:
     func: core_schema.GeneralWrapValidatorFunction | core_schema.FieldWrapValidatorFunction
 
-    def __modify_pydantic_core_schema__(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
+    def __modify_pydantic_core_schema__(
+        self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
         info_arg = inspect_validator(self.func, 'wrap')
         if info_arg:
             return core_schema.general_wrap_validator_function(self.func, schema=schema)  # type: ignore
@@ -61,7 +75,10 @@ class PlainSerializer:
     json_return_type: core_schema.JsonReturnTypes | None = None
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
-    def __modify_pydantic_core_schema__(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
+    def __modify_pydantic_core_schema__(
+        self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
         schema['serialization'] = core_schema.plain_serializer_function_ser_schema(
             function=self.func,
             info_arg=inspect_annotated_serializer(self.func, 'plain'),
@@ -77,8 +94,10 @@ class WrapSerializer:
     json_return_type: core_schema.JsonReturnTypes | None = None
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
-    def __modify_pydantic_core_schema__(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
-        schema = schema
+    def __modify_pydantic_core_schema__(
+        self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
         schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
             function=self.func,
             info_arg=inspect_annotated_serializer(self.func, 'wrap'),

--- a/pydantic/annotated_arguments.py
+++ b/pydantic/annotated_arguments.py
@@ -13,7 +13,7 @@ from ._internal._internal_dataclass import slots_dataclass
 class AfterValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.GeneralValidatorFunction
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         schema = handler(source_type)
@@ -28,7 +28,7 @@ class AfterValidator:
 class BeforeValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.GeneralValidatorFunction
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         schema = handler(source_type)
@@ -43,7 +43,7 @@ class BeforeValidator:
 class PlainValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.GeneralValidatorFunction
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         schema = handler(source_type)
@@ -58,7 +58,7 @@ class PlainValidator:
 class WrapValidator:
     func: core_schema.GeneralWrapValidatorFunction | core_schema.FieldWrapValidatorFunction
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         schema = handler(source_type)
@@ -75,7 +75,7 @@ class PlainSerializer:
     json_return_type: core_schema.JsonReturnTypes | None = None
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         schema = handler(source_type)
@@ -94,7 +94,7 @@ class WrapSerializer:
     json_return_type: core_schema.JsonReturnTypes | None = None
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source_type: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         schema = handler(source_type)

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -225,7 +225,7 @@ class Color(_repr.Representation):
         return 1 if self._rgba.alpha is None else self._rgba.alpha
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: Type[Any], handler: Callable[[Any], CoreSchema]
     ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -10,9 +10,9 @@ eg. `Color((0, 255, 255)).as_named() == 'cyan'` because "cyan" comes after "aqua
 import math
 import re
 from colorsys import hls_to_rgb, rgb_to_hls
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union, cast
 
-from pydantic_core import PydanticCustomError, core_schema
+from pydantic_core import CoreSchema, PydanticCustomError, core_schema
 
 from ._internal import _repr, _utils
 
@@ -225,7 +225,9 @@ class Color(_repr.Representation):
         return 1 if self._rgba.alpha is None else self._rgba.alpha
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: Type[Any], handler: Callable[[Any], CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(
             cls._validate, serialization=core_schema.to_string_ser_schema()
         )

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -230,7 +230,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, __source: type[BaseModel], __handler: Callable[[Any], CoreSchema]
     ) -> CoreSchema:
         # Only use the cached value from this _exact_ class; we don't want one from a parent class

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -10,7 +10,7 @@ from copy import copy, deepcopy
 from inspect import getdoc
 from pathlib import Path
 from types import prepare_class, resolve_bases
-from typing import Any, Generic, Mapping, Tuple, cast
+from typing import Any, Callable, Generic, Mapping, Tuple, cast
 
 import pydantic_core
 import typing_extensions
@@ -38,7 +38,6 @@ if typing.TYPE_CHECKING:
 
     from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator
 
-    from ._internal._generate_schema import GenerateSchema
     from ._internal._utils import AbstractSetIntStr, MappingIntStrAny
 
     AnyClassMethod = classmethod[Any, Any, Any]
@@ -231,7 +230,9 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source: type[BaseModel], gen_schema: GenerateSchema) -> CoreSchema | None:
+    def __modify_pydantic_core_schema__(
+        cls, __source: type[BaseModel], __handler: Callable[[Any], CoreSchema]
+    ) -> CoreSchema:
         # Only use the cached value from this _exact_ class; we don't want one from a parent class
         # This is why we check `cls.__dict__` and don't use `cls.__pydantic_core_schema__` or similar.
         if '__pydantic_core_schema__' in cls.__dict__:
@@ -241,7 +242,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
             if not cls.__pydantic_generic_metadata__['origin']:
                 return cls.__pydantic_core_schema__
 
-        return None
+        return __handler(__source)
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import dataclasses as _dataclasses
 import re
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, TypeAlias
@@ -132,15 +132,11 @@ else:
 
     class EmailStr:
         @classmethod
-        def __get_pydantic_core_schema__(
-            cls, schema: core_schema.CoreSchema | None = None, **_kwargs: Any
+        def __modify_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             import_email_validator()
-            if schema is None:
-                return core_schema.general_after_validator_function(cls.validate, core_schema.str_schema())
-            else:
-                assert schema['type'] == 'str', 'EmailStr must be used with string fields'
-                return core_schema.general_after_validator_function(cls.validate, schema)
+            return core_schema.general_after_validator_function(cls.validate, core_schema.str_schema())
 
         @classmethod
         def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
@@ -168,7 +164,9 @@ class NameEmail(_repr.Representation):
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.AfterValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         import_email_validator()
         return core_schema.general_after_validator_function(
             cls._validate,
@@ -208,7 +206,9 @@ class IPvAnyAddress:
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
 
     @classmethod
@@ -236,7 +236,9 @@ class IPvAnyInterface:
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
 
     @classmethod
@@ -266,7 +268,9 @@ class IPvAnyNetwork:
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
 
     @classmethod

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -132,7 +132,7 @@ else:
 
     class EmailStr:
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             import_email_validator()
@@ -164,7 +164,7 @@ class NameEmail(_repr.Representation):
         return field_schema
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         import_email_validator()
@@ -206,7 +206,7 @@ class IPvAnyAddress:
         return field_schema
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
@@ -236,7 +236,7 @@ class IPvAnyInterface:
         return field_schema
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
@@ -268,7 +268,7 @@ class IPvAnyNetwork:
         return field_schema
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
     FrozenSet,
     Generic,
@@ -246,13 +247,16 @@ else:
             return Annotated[item, cls()]
 
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
-            # Treat bare usage of ImportString (`schema is None`) as the same as ImportString[Any]
-            return core_schema.general_plain_validator_function(lambda v, _: _validators.import_string(v))
-
-        @classmethod
-        def __modify_pydantic_core_schema__(cls, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
-            return core_schema.general_before_validator_function(lambda v, _: _validators.import_string(v), schema)
+        def __modify_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
+            if cls is source:
+                # Treat bare usage of ImportString (`schema is None`) as the same as ImportString[Any]
+                return core_schema.general_plain_validator_function(lambda v, _: _validators.import_string(v))
+            else:
+                return core_schema.general_before_validator_function(
+                    lambda v, _: _validators.import_string(v), handler(source)
+                )
 
         def __repr__(self) -> str:
             return 'ImportString'
@@ -296,10 +300,10 @@ class UuidVersion:
         return field_schema
 
     def __modify_pydantic_core_schema__(
-        self, schema: core_schema.CoreSchema, **_kwargs: Any
-    ) -> core_schema.AfterValidatorFunctionSchema:
+        self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(
-            cast(core_schema.GeneralValidatorFunction, self.validate), schema
+            cast(core_schema.GeneralValidatorFunction, self.validate), handler(source)
         )
 
     def validate(self, value: UUID, _: core_schema.ValidationInfo) -> UUID:
@@ -329,8 +333,8 @@ class PathType:
         return field_schema
 
     def __modify_pydantic_core_schema__(
-        self, schema: core_schema.CoreSchema, **_kwargs: Any
-    ) -> core_schema.AfterValidatorFunctionSchema:
+        self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         function_lookup = {
             'file': cast(core_schema.GeneralValidatorFunction, self.validate_file),
             'dir': cast(core_schema.GeneralValidatorFunction, self.validate_directory),
@@ -339,7 +343,7 @@ class PathType:
 
         return core_schema.general_after_validator_function(
             function_lookup[self.path_type],
-            schema,
+            handler(source),
         )
 
     @staticmethod
@@ -387,20 +391,13 @@ else:
             return Annotated[item, cls()]
 
         @classmethod
-        def __get_pydantic_core_schema__(
-            cls,
-            **_kwargs: Any,
-        ) -> core_schema.JsonSchema:
-            return core_schema.json_schema(None)
-
-        @classmethod
-        def __modify_pydantic_core_schema__(cls, schema: core_schema.CoreSchema) -> core_schema.JsonSchema:
-            return core_schema.json_schema(schema)
-
-        @classmethod
-        def __pydantic_modify_json_schema__(cls, field_schema: dict[str, Any]) -> dict[str, Any]:
-            field_schema.update(type='string', format='json-string')
-            return field_schema
+        def __modify_pydantic_core_schema__(
+            cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
+            if cls is source:
+                return core_schema.json_schema(None)
+            else:
+                return core_schema.json_schema(handler(source))
 
         def __repr__(self) -> str:
             return 'Json'
@@ -427,7 +424,9 @@ class SecretField(abc.ABC, Generic[SecretType]):
         return self._secret_value
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.AfterValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         validator = SecretFieldValidator(cls)
         if issubclass(cls, SecretStr):
             # Use a lambda here so that `apply_metadata` can be called on the validator before the override is generated
@@ -595,7 +594,9 @@ class PaymentCardNumber(str):
         self.brand = self.validate_brand(card_number)
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.AfterValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(
             cls.validate,
             core_schema.str_schema(
@@ -697,12 +698,9 @@ byte_string_re = re.compile(r'^\s*(\d*\.?\d+)\s*(\w+)?', re.IGNORECASE)
 
 class ByteSize(int):
     @classmethod
-    def __modify_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
-        # TODO better schema
-        return core_schema.general_plain_validator_function(cls.validate)
-
-    @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __modify_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         # TODO better schema
         return core_schema.general_plain_validator_function(cls.validate)
 
@@ -767,34 +765,34 @@ else:
 
     class PastDate:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
-            # used directly as a type
-            return core_schema.date_schema(now_op='past')
-
-        @classmethod
         def __modify_pydantic_core_schema__(
-            cls, schema: core_schema.CoreSchema, **_kwargs: Any
+            cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
-            assert schema['type'] == 'date'
-            schema['now_op'] = 'past'
-            return schema
+            if cls is source:
+                # used directly as a type
+                return core_schema.date_schema(now_op='past')
+            else:
+                schema = handler(source)
+                assert schema['type'] == 'date'
+                schema['now_op'] = 'past'
+                return schema
 
         def __repr__(self) -> str:
             return 'PastDate'
 
     class FutureDate:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
-            # used directly as a type
-            return core_schema.date_schema(now_op='future')
-
-        @classmethod
         def __modify_pydantic_core_schema__(
-            cls, schema: core_schema.CoreSchema, **_kwargs: Any
+            cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
-            assert schema['type'] == 'date'
-            schema['now_op'] = 'future'
-            return schema
+            if cls is source:
+                # used directly as a type
+                return core_schema.date_schema(now_op='future')
+            else:
+                schema = handler(source)
+                assert schema['type'] == 'date'
+                schema['now_op'] = 'future'
+                return schema
 
         def __repr__(self) -> str:
             return 'FutureDate'
@@ -824,34 +822,34 @@ else:
 
     class AwareDatetime:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
-            # used directly as a type
-            return core_schema.datetime_schema(tz_constraint='aware')
-
-        @classmethod
         def __modify_pydantic_core_schema__(
-            cls, schema: core_schema.CoreSchema, **_kwargs: Any
+            cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
-            assert schema['type'] == 'datetime'
-            schema['tz_constraint'] = 'aware'
-            return schema
+            if cls is source:
+                # used directly as a type
+                return core_schema.datetime_schema(tz_constraint='aware')
+            else:
+                schema = handler(source)
+                assert schema['type'] == 'datetime'
+                schema['tz_constraint'] = 'aware'
+                return schema
 
         def __repr__(self) -> str:
             return 'AwareDatetime'
 
     class NaiveDatetime:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
-            # used directly as a type
-            return core_schema.datetime_schema(tz_constraint='naive')
-
-        @classmethod
         def __modify_pydantic_core_schema__(
-            cls, schema: core_schema.CoreSchema, **_kwargs: Any
+            cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
-            assert schema['type'] == 'datetime'
-            schema['tz_constraint'] = 'naive'
-            return schema
+            if cls is source:
+                # used directly as a type
+                return core_schema.datetime_schema(tz_constraint='naive')
+            else:
+                schema = handler(source)
+                assert schema['type'] == 'datetime'
+                schema['tz_constraint'] = 'naive'
+                return schema
 
         def __repr__(self) -> str:
             return 'NaiveDatetime'

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -247,7 +247,7 @@ else:
             return Annotated[item, cls()]
 
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             if cls is source:
@@ -299,7 +299,7 @@ class UuidVersion:
         field_schema.update(type='string', format=f'uuid{self.uuid_version}')
         return field_schema
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(
@@ -332,7 +332,7 @@ class PathType:
         field_schema.update(format=format_conversion.get(self.path_type, 'path'), type='string')
         return field_schema
 
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         function_lookup = {
@@ -391,7 +391,7 @@ else:
             return Annotated[item, cls()]
 
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             if cls is source:
@@ -424,7 +424,7 @@ class SecretField(abc.ABC, Generic[SecretType]):
         return self._secret_value
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         validator = SecretFieldValidator(cls)
@@ -594,7 +594,7 @@ class PaymentCardNumber(str):
         self.brand = self.validate_brand(card_number)
 
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(
@@ -698,7 +698,7 @@ byte_string_re = re.compile(r'^\s*(\d*\.?\d+)\s*(\w+)?', re.IGNORECASE)
 
 class ByteSize(int):
     @classmethod
-    def __modify_pydantic_core_schema__(
+    def __get_pydantic_core_schema__(
         cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         # TODO better schema
@@ -765,7 +765,7 @@ else:
 
     class PastDate:
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             if cls is source:
@@ -782,7 +782,7 @@ else:
 
     class FutureDate:
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             if cls is source:
@@ -822,7 +822,7 @@ else:
 
     class AwareDatetime:
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             if cls is source:
@@ -839,7 +839,7 @@ else:
 
     class NaiveDatetime:
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: type[Any], handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             if cls is source:

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -206,7 +206,7 @@ def test_modify_get_schema_annotated() -> None:
 
     class CustomType:
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             calls.append('CustomType:before')
@@ -217,7 +217,7 @@ def test_modify_get_schema_annotated() -> None:
             return schema
 
     class PydanticMetadata:
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             calls.append('PydanticMetadata:before')
@@ -263,7 +263,7 @@ def test_get_pydantic_core_schema_source_type() -> None:
     types: Set[Any] = set()
 
     class PydanticMarker:
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             types.add(source)

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,11 +1,13 @@
 import sys
-from typing import List
+from typing import Any, Callable, Generic, Iterator, List, Set, TypeVar
 
 import pytest
-from annotated_types import Gt, Lt
+from annotated_types import BaseMetadata, GroupedMetadata, Gt, Lt
+from pydantic_core import core_schema
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field
+from pydantic.errors import PydanticSchemaGenerationError
 from pydantic.fields import Undefined
 
 NO_VALUE = object()
@@ -197,3 +199,89 @@ def test_annotated_alias() -> None:
         ),
     }
     assert MyModel(b='def', e=['xyz']).model_dump() == dict(a='abc', b='def', c=2, d=2, e=['xyz'])
+
+
+def test_modify_get_schema_annotated() -> None:
+    calls: List[str] = []
+
+    class CustomType:
+        @classmethod
+        def __modify_pydantic_core_schema__(
+            cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
+            calls.append('CustomType:before')
+            with pytest.raises(PydanticSchemaGenerationError):
+                handler(source)
+            schema = core_schema.no_info_plain_validator_function(lambda _: CustomType())
+            calls.append('CustomType:after')
+            return schema
+
+    class PydanticMetadata:
+        def __modify_pydantic_core_schema__(
+            self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
+            calls.append('PydanticMetadata:before')
+            schema = handler(source)
+            calls.append('PydanticMetadata:after')
+            return schema
+
+    class GroupedMetadataMarker(GroupedMetadata):
+        def __iter__(self) -> Iterator[BaseMetadata]:
+            # no way to actually hook into schema building
+            # so just register when our iter is called
+            calls.append('GroupedMetadataMarker:iter')
+            yield from []
+
+    class _(BaseModel):
+        x: Annotated[CustomType, GroupedMetadataMarker(), PydanticMetadata()]
+
+    assert calls == [
+        'PydanticMetadata:before',
+        'CustomType:before',
+        'CustomType:after',
+        'GroupedMetadataMarker:iter',
+        'PydanticMetadata:after',
+    ]
+
+    calls.clear()
+
+    class _(BaseModel):
+        x: Annotated[CustomType, PydanticMetadata(), GroupedMetadataMarker()]
+
+    assert calls == [
+        'PydanticMetadata:before',
+        'CustomType:before',
+        'CustomType:after',
+        'PydanticMetadata:after',
+        'GroupedMetadataMarker:iter',
+    ]
+
+    calls.clear()
+
+
+def test_get_pydantic_core_schema_source_type() -> None:
+    types: Set[Any] = set()
+
+    class PydanticMarker:
+        def __modify_pydantic_core_schema__(
+            self, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
+            types.add(source)
+            return handler(source)
+
+    class _(BaseModel):
+        x: Annotated[Annotated[int, 'foo'], PydanticMarker()]
+
+    assert types == {int}
+    types.clear()
+
+    T = TypeVar('T')
+
+    class GenericModel(Generic[T], BaseModel):
+        y: T
+
+    class _(BaseModel):
+        x: Annotated[GenericModel[int], PydanticMarker()]
+
+    assert types == {GenericModel[int]}
+    types.clear()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import Hashable
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, FrozenSet, Generic, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
 
 import pytest
 from dirty_equals import HasRepr, IsStr
@@ -1861,7 +1861,7 @@ def test_custom_generic_validators():
             self.t2 = t2
 
         @classmethod
-        def __get_pydantic_core_schema__(cls, source, **kwargs):
+        def __modify_pydantic_core_schema__(cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]):
             schema = core_schema.is_instance_schema(cls)
 
             args = get_args(source)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1861,7 +1861,7 @@ def test_custom_generic_validators():
             self.t2 = t2
 
         @classmethod
-        def __modify_pydantic_core_schema__(cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]):
+        def __get_pydantic_core_schema__(cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]):
             schema = core_schema.is_instance_schema(cls)
 
             args = get_args(source)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2275,7 +2275,7 @@ def test_schema_for_generic_field():
             return v
 
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls,
             source: Any,
             handler: Callable[[Any], core_schema.CoreSchema],
@@ -2374,7 +2374,7 @@ def test_advanced_generic_schema():
             return v
 
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
         ) -> core_schema.CoreSchema:
             if hasattr(source, '__args__'):
@@ -2405,7 +2405,7 @@ def test_advanced_generic_schema():
             return cls(*v)
 
         @classmethod
-        def __modify_pydantic_core_schema__(
+        def __get_pydantic_core_schema__(
             cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema], **_kwargs: Any
         ) -> core_schema.CoreSchema:
             if hasattr(source, '__args__'):

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -39,7 +39,6 @@ from pydantic import (
     field_validator,
 )
 from pydantic._internal._core_metadata import build_metadata_dict
-from pydantic._internal._generate_schema import GenerateSchema
 from pydantic.color import Color
 from pydantic.config import ConfigDict
 from pydantic.dataclasses import dataclass
@@ -2276,12 +2275,14 @@ def test_schema_for_generic_field():
             return v
 
         @classmethod
-        def __get_pydantic_core_schema__(
-            cls, source: Any, gen_schema: GenerateSchema, **_kwargs: Any
+        def __modify_pydantic_core_schema__(
+            cls,
+            source: Any,
+            handler: Callable[[Any], core_schema.CoreSchema],
         ) -> core_schema.PlainValidatorFunctionSchema:
             source_args = getattr(source, '__args__', [Any])
             param = source_args[0]
-            metadata = build_metadata_dict(js_cs_override=gen_schema.generate_schema(param))
+            metadata = build_metadata_dict(js_cs_override=handler(param))
             return core_schema.general_plain_validator_function(
                 GenModel,
                 metadata=metadata,
@@ -2373,19 +2374,19 @@ def test_advanced_generic_schema():
             return v
 
         @classmethod
-        def __get_pydantic_core_schema__(
-            cls, source: Any, gen_schema: GenerateSchema, **_kwargs: Any
-        ) -> core_schema.PlainValidatorFunctionSchema:
+        def __modify_pydantic_core_schema__(
+            cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             if hasattr(source, '__args__'):
                 param = source.__args__[0]
-                metadata = build_metadata_dict(js_cs_override=gen_schema.generate_schema(Optional[param]))
+                metadata = build_metadata_dict(js_cs_override=handler(Optional[param]))
                 return core_schema.general_plain_validator_function(
                     Gen,
                     metadata=metadata,
                 )
 
         @classmethod
-        def __pydantic_modify_json_schema__(cls, field_schema):
+        def __pydantic_modify_json_schema__(cls, field_schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
             the_type = field_schema.pop('anyOf', [{'type': 'string'}])[0]
             field_schema.update(title='Gen title', anyOf=[the_type, {'type': 'array', 'items': the_type}])
             return field_schema
@@ -2404,18 +2405,19 @@ def test_advanced_generic_schema():
             return cls(*v)
 
         @classmethod
-        def __get_pydantic_core_schema__(
-            cls, source: Any, gen_schema: GenerateSchema, **_kwargs: Any
-        ) -> core_schema.PlainValidatorFunctionSchema:
+        def __modify_pydantic_core_schema__(
+            cls, source: Any, handler: Callable[[Any], core_schema.CoreSchema], **_kwargs: Any
+        ) -> core_schema.CoreSchema:
             if hasattr(source, '__args__'):
-                metadata = build_metadata_dict(js_cs_override=gen_schema.generate_schema(Tuple[source.__args__]))
+                metadata = build_metadata_dict(js_cs_override=handler(Tuple[source.__args__]))
                 return core_schema.general_plain_validator_function(
                     GenTwoParams,
                     metadata=metadata,
                 )
+            return handler(source)
 
         @classmethod
-        def __pydantic_modify_json_schema__(cls, field_schema):
+        def __pydantic_modify_json_schema__(cls, field_schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
             field_schema.pop('minItems')
             field_schema.pop('maxItems')
             field_schema.update(examples='examples')
@@ -2426,7 +2428,7 @@ def test_advanced_generic_schema():
         B = 'b'
 
         @classmethod
-        def __pydantic_modify_json_schema__(cls, field_schema):
+        def __pydantic_modify_json_schema__(cls, field_schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
             field_schema.update(title='CustomType title', type='string')
             return field_schema
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -174,7 +174,7 @@ def test_annotated_customisation():
 
     class CommaFriendlyIntLogic:
         @classmethod
-        def __modify_pydantic_core_schema__(cls, _schema):
+        def __modify_pydantic_core_schema__(cls, _source, _handler):
             # here we ignore the schema argument (which is just `{'type': 'int'}`) and return our own
             return core_schema.general_before_validator_function(
                 parse_int,

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -174,7 +174,7 @@ def test_annotated_customisation():
 
     class CommaFriendlyIntLogic:
         @classmethod
-        def __modify_pydantic_core_schema__(cls, _source, _handler):
+        def __get_pydantic_core_schema__(cls, _source, _handler):
             # here we ignore the schema argument (which is just `{'type': 'int'}`) and return our own
             return core_schema.general_before_validator_function(
                 parse_int,


### PR DESCRIPTION
Change the signature into (type, handler) -> CoreSchema; this operates similar to wrap validators (if you consider the input to be the type and the output the CoreSchema). The innermost handler is our internal schema generation.

All in all, this resolves several issues:
- Much more flexibility in schema creation, including handling of arbitrary types using Annotated without subclassing.
- Avoids exposing the internal `GenerateSchema` class
- Unifies the signature and usage of what is currently two mostly unrelated functions called `__get_pydantic_core_schema__`

Selected Reviewer: @dmontagu