### PR TITLE
Change signature of __get_pydantic_core_schema__ to hide GenerateSchema

### DIFF
--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -251,6 +251,7 @@ Subclasses of common types are automatically encoded like their super-classes:
 
 ```py
 from datetime import date, timedelta
+from typing import Any, Callable, Type
 
 from pydantic_core import core_schema
 
@@ -264,7 +265,9 @@ class DayThisYear(date):
     """
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **kwargs):
+    def __get_pydantic_core_schema__(
+        cls, source: Type[Any], handler: Callable[[Any], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(
             cls.validate,
             core_schema.int_schema(),

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -363,7 +363,7 @@ All implementation of `__get_pydantic_core_schema__` *must* accept `**_kwargs` a
 
 ```py
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Type
 
 from pydantic_core import core_schema
 
@@ -380,7 +380,7 @@ class CompressedString:
 
     @classmethod
     def __get_pydantic_core_schema__(
-        cls, source: Any, **_kwargs: Any
+        cls, source: Type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
         assert source is CompressedString
         return core_schema.no_info_after_validator_function(

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -167,7 +167,7 @@ def complete_model_class(
         typevars_map,
     )
     try:
-        schema = gen_schema.generate_schema(cls)
+        schema = cls.__get_pydantic_core_schema__(cls, gen_schema.generate_schema)
     except PydanticUndefinedAnnotation as e:
         if raise_errors:
             raise

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -10,9 +10,9 @@ eg. `Color((0, 255, 255)).as_named() == 'cyan'` because "cyan" comes after "aqua
 import math
 import re
 from colorsys import hls_to_rgb, rgb_to_hls
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union, cast
 
-from pydantic_core import PydanticCustomError, core_schema
+from pydantic_core import CoreSchema, PydanticCustomError, core_schema
 
 from ._internal import _repr, _utils
 
@@ -225,7 +225,9 @@ class Color(_repr.Representation):
         return 1 if self._rgba.alpha is None else self._rgba.alpha
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: Type[Any], handler: Callable[[], CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(
             cls._validate, serialization=core_schema.to_string_ser_schema()
         )

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 import dataclasses as _dataclasses
 import re
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, TypeAlias
@@ -132,7 +132,9 @@ else:
 
     class EmailStr:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             import_email_validator()
             return core_schema.general_after_validator_function(cls.validate, core_schema.str_schema())
 
@@ -162,7 +164,9 @@ class NameEmail(_repr.Representation):
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.AfterValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         import_email_validator()
         return core_schema.general_after_validator_function(
             cls._validate,
@@ -202,7 +206,9 @@ class IPvAnyAddress:
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
 
     @classmethod
@@ -230,7 +236,9 @@ class IPvAnyInterface:
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
 
     @classmethod
@@ -260,7 +268,9 @@ class IPvAnyNetwork:
         return field_schema
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_plain_validator_function(cls._validate)
 
     @classmethod

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -247,7 +247,9 @@ else:
             return Annotated[item, cls()]
 
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             # Treat bare usage of ImportString (`schema is None`) as the same as ImportString[Any]
             return core_schema.general_plain_validator_function(lambda v, _: _validators.import_string(v))
 
@@ -391,9 +393,8 @@ else:
 
         @classmethod
         def __get_pydantic_core_schema__(
-            cls,
-            **_kwargs: Any,
-        ) -> core_schema.JsonSchema:
+            cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             return core_schema.json_schema(None)
 
         @classmethod
@@ -432,7 +433,9 @@ class SecretField(abc.ABC, Generic[SecretType]):
         return self._secret_value
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.AfterValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         validator = SecretFieldValidator(cls)
         if issubclass(cls, SecretStr):
             # Use a lambda here so that `apply_metadata` can be called on the validator before the override is generated
@@ -600,7 +603,9 @@ class PaymentCardNumber(str):
         self.brand = self.validate_brand(card_number)
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.AfterValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         return core_schema.general_after_validator_function(
             cls.validate,
             core_schema.str_schema(
@@ -709,7 +714,9 @@ class ByteSize(int):
         return core_schema.general_plain_validator_function(cls.validate)
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.PlainValidatorFunctionSchema:
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+    ) -> core_schema.CoreSchema:
         # TODO better schema
         return core_schema.general_plain_validator_function(cls.validate)
 
@@ -774,7 +781,9 @@ else:
 
     class PastDate:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             # used directly as a type
             return core_schema.date_schema(now_op='past')
 
@@ -792,7 +801,9 @@ else:
 
     class FutureDate:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             # used directly as a type
             return core_schema.date_schema(now_op='future')
 
@@ -833,7 +844,9 @@ else:
 
     class AwareDatetime:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             # used directly as a type
             return core_schema.datetime_schema(tz_constraint='aware')
 
@@ -851,7 +864,9 @@ else:
 
     class NaiveDatetime:
         @classmethod
-        def __get_pydantic_core_schema__(cls, **_kwargs: Any) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(
+            cls, source: type[Any], handler: Callable[[], core_schema.CoreSchema]
+        ) -> core_schema.CoreSchema:
             # used directly as a type
             return core_schema.datetime_schema(tz_constraint='naive')
 


### PR DESCRIPTION
Taking #5490 one step further, we can make the signatures of `__get_pydantic_core_schema__` and `__modify_pydantic_core_schema__` equivalent.

TODO: can we just collapse them into one thing again?
TODO: add tests for stuff like a try/except calling of handler