### PR TITLE
codespell: workflow, config + some typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+# ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,4 @@
 [codespell]
 skip = .git,*.pdf,*.svg
-# ignore-words-list = 
+# GIR - part of a regex in docs/examples/types_custom_type.py
+ignore-words-list = gir

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,5 @@
 [codespell]
 skip = .git,*.pdf,*.svg
 # GIR - part of a regex in docs/examples/types_custom_type.py
-ignore-words-list = gir
+# ser - popular abbreviation for something "ser"ialized, could be a typo for set
+ignore-words-list = gir,ser

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1

--- a/docs/integrations/visual_studio_code.md
+++ b/docs/integrations/visual_studio_code.md
@@ -192,7 +192,7 @@ that way Pylance and mypy will interpret the variable `age_str` as if they didn'
 
 The same idea from the previous example can be put on the same line with the help of `cast()`.
 
-This way, the type declaration of the value is overriden inline, without requiring another variable.
+This way, the type declaration of the value is overridden inline, without requiring another variable.
 
 ```Python hl_lines="1 11"
 from typing import Any, cast

--- a/docs/usage/schema.md
+++ b/docs/usage/schema.md
@@ -549,7 +549,7 @@ class AllowAnySubclass:
     def __get_pydantic_core_schema__(
         self, source: Type[Any], handler: Callable[[Any], core_schema.CoreSchema]
     ) -> core_schema.CoreSchema:
-        # we can't call handler since it will fail for abitrary types
+        # we can't call handler since it will fail for arbitrary types
         def validate(value: Any) -> Any:
             if not isinstance(value, source):
                 raise ValueError(

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -631,7 +631,7 @@ class PydanticModelTransformer:
             # only required if default is Ellipsis (i.e., `field_name: Annotation = Field(...)`) or if default_factory
             # is specified.
             for arg, name in zip(expr.args, expr.arg_names):
-                # If name is None, then this arg is the default because it is the only positonal argument.
+                # If name is None, then this arg is the default because it is the only positional argument.
                 if name is None or name == 'default':
                     return arg.__class__ is EllipsisExpr
                 if name == 'default_factory':

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -625,7 +625,7 @@ def test_serializer_allow_reuse_inheritance_override():
 
     # overriding a serializer with a function / class var
     # of the same name is allowed
-    # to mimick how inheritance works
+    # to mimic how inheritance works
     # the serializer in the child class replaces the parent
     # (without modifying the parent class itself)
     class Child1(Parent):


### PR DESCRIPTION
## Change Summary

Make pydantic typo free from now on

## Checklist

* [N/A] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [N/A] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
