### PR TITLE
Add support for pulsar dsn

### DIFF
--- a/changes/5543-evan6998.md
+++ b/changes/5543-evan6998.md
@@ -1,0 +1,1 @@
+Add support for pulsar dsn: `pulsar` or `pulsar+ssl`

--- a/docs/usage/urls.md
+++ b/docs/usage/urls.md
@@ -37,6 +37,7 @@ For URI/URL validation the following types are available:
 - `RedisDsn`: scheme `redis` or `rediss`, user info not required, tld not required, host not required (CHANGED: user info) (e.g., `rediss://:pass@localhost`)
 - `MongoDsn` : scheme `mongodb`, user info not required, database name not required, port
   not required from **v1.6** onwards), user info may be passed without user part (e.g., `mongodb://mongodb0.example.com:27017`)
+- `PulsarDsn`: schema `pulsar` or `pulsar+ssl`, user info not required, database name not required, port not required
 - `stricturl`: method with the following keyword arguments:
     - `strip_whitespace: bool = True`
     - `min_length: int = 1`

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -82,6 +82,7 @@ __all__ = [
     'KafkaDsn',
     'MySQLDsn',
     'MariaDBDsn',
+    'PulsarDsn',
     'validate_email',
     # tools
     'parse_obj_as',

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -37,6 +37,7 @@ __all__ = [
     'RedisDsn',
     'MongoDsn',
     'KafkaDsn',
+    'PulsarDsn',
     'validate_email',
     'MySQLDsn',
     'MariaDBDsn',
@@ -94,6 +95,9 @@ RedisDsn = Annotated[
 ]
 MongoDsn = Annotated[MultiHostUrl, UrlConstraints(allowed_schemes=['mongodb', 'mongodb+srv'], default_port=27017)]
 KafkaDsn = Annotated[Url, UrlConstraints(allowed_schemes=['kafka'], default_host='localhost', default_port=9092)]
+PulsarDsn = Annotated[
+    MultiHostUrl, UrlConstraints(allowed_schemes=['pulsar', 'pulsar+ssl'], default_host='localhost', default_port=6650)
+]
 MySQLDsn = Annotated[
     Url,
     UrlConstraints(

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -641,7 +641,7 @@ def test_pulsar_dsns(dsn):
         a: PulsarDsn
 
     m = Model(a=dsn)
-    assert m.a.scheme == 'pulsar' or 'pulsar+ssl'
+    assert m.a.scheme in ('pulsar', 'pulsar+ssl')
     assert str(Model(a=dsn).a) == dsn
 
 

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -15,6 +15,7 @@ from pydantic import (
     MySQLDsn,
     NameEmail,
     PostgresDsn,
+    PulsarDsn,
     RedisDsn,
     Strict,
     UrlConstraints,
@@ -625,6 +626,23 @@ def test_kafka_dsns():
     m = Model(a='kafka://kafka3:9093')
     assert m.a.username is None
     assert m.a.password is None
+
+
+@pytest.mark.parametrize(
+    'dsn',
+    [
+        'pulsar://localhost:6650',
+        'pulsar+ssl://pulsar.us-west.example.com:6651',
+        'pulsar+ssl://localhost:6550,localhost:6651,localhost:6652',
+    ],
+)
+def test_pulsar_dsns(dsn):
+    class Model(BaseModel):
+        a: PulsarDsn
+
+    m = Model(a=dsn)
+    assert m.a.scheme == 'pulsar' or 'pulsar+ssl'
+    assert str(Model(a=dsn).a) == dsn
 
 
 def test_custom_schemes():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary
Add support for pulsar dsn: `pulsar` or `pulsar+ssl`
```python
PulsarDsn = Annotated[
    MultiHostUrl, UrlConstraints(allowed_schemes=['pulsar', 'pulsar+ssl'], default_host='localhost', default_port=6650)
]
```
<!-- Please give a short summary of the changes. -->
## Related issue number
implementing #5543 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb