### PR TITLE
Bump typing-extensions minimum version to 4.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 ]
 requires-python = '>=3.7'
 dependencies = [
-    'typing-extensions>=4.2.0',
+    'typing-extensions>=4.5.0',
     'pydantic-core==0.25.0',
     'annotated-types>=0.4.0',
 ]

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -31,7 +31,9 @@ click==8.1.3
     #   black
     #   mkdocs
 colorama==0.4.6
-    # via mkdocs-material
+    # via
+    #   griffe
+    #   mkdocs-material
 coverage==7.2.2
     # via -r requirements/testing.in
 devtools==0.10.0
@@ -52,6 +54,8 @@ ghp-import==2.1.0
     # via mkdocs
 greenlet==2.0.2
     # via sqlalchemy
+griffe==0.27.1
+    # via mkdocstrings-python
 hypothesis==6.70.0
     # via
     #   -r requirements/linting.in
@@ -66,15 +70,20 @@ jinja2==3.1.2
     # via
     #   mkdocs
     #   mkdocs-material
+    #   mkdocstrings
 markdown==3.3.7
     # via
     #   mkdocs
+    #   mkdocs-autorefs
     #   mkdocs-material
+    #   mkdocstrings
     #   pymdown-extensions
 markdown-it-py==2.2.0
     # via rich
 markupsafe==2.1.2
-    # via jinja2
+    # via
+    #   jinja2
+    #   mkdocstrings
 mdurl==0.1.2
     # via markdown-it-py
 mergedeep==1.3.4
@@ -82,10 +91,14 @@ mergedeep==1.3.4
 mkdocs==1.4.2
     # via
     #   -r requirements/docs.in
+    #   mkdocs-autorefs
     #   mkdocs-exclude
     #   mkdocs-material
     #   mkdocs-redirects
     #   mkdocs-simple-hooks
+    #   mkdocstrings
+mkdocs-autorefs==0.4.1
+    # via mkdocstrings
 mkdocs-exclude==1.0.2
     # via -r requirements/docs.in
 mkdocs-material==9.1.4
@@ -95,6 +108,10 @@ mkdocs-material-extensions==1.1.1
 mkdocs-redirects==1.2.0
     # via -r requirements/docs.in
 mkdocs-simple-hooks==0.1.5
+    # via -r requirements/docs.in
+mkdocstrings==0.21.2
+    # via mkdocstrings-python
+mkdocstrings-python==0.9.0
     # via -r requirements/docs.in
 mypy-extensions==1.0.0
     # via black
@@ -126,7 +143,9 @@ pygments==2.14.0
     #   mkdocs-material
     #   rich
 pymdown-extensions==9.10
-    # via mkdocs-material
+    # via
+    #   mkdocs-material
+    #   mkdocstrings
 pytest==7.2.2
     # via
     #   -r requirements/testing.in

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -29,8 +29,10 @@ ghp-import==2.1.0
     # via
     #   -c requirements/all.txt
     #   mkdocs
-griffe==0.26.0
-    # via mkdocstrings-python
+griffe==0.27.1
+    # via
+    #   -c requirements/all.txt
+    #   mkdocstrings-python
 idna==3.4
     # via
     #   -c requirements/all.txt
@@ -69,7 +71,9 @@ mkdocs==1.4.2
     #   mkdocs-simple-hooks
     #   mkdocstrings
 mkdocs-autorefs==0.4.1
-    # via mkdocstrings
+    # via
+    #   -c requirements/all.txt
+    #   mkdocstrings
 mkdocs-exclude==1.0.2
     # via
     #   -c requirements/all.txt
@@ -91,9 +95,13 @@ mkdocs-simple-hooks==0.1.5
     #   -c requirements/all.txt
     #   -r requirements/docs.in
 mkdocstrings==0.21.2
-    # via mkdocstrings-python
+    # via
+    #   -c requirements/all.txt
+    #   mkdocstrings-python
 mkdocstrings-python==0.9.0
-    # via -r requirements/docs.in
+    # via
+    #   -c requirements/all.txt
+    #   -r requirements/docs.in
 packaging==23.0
     # via
     #   -c requirements/all.txt


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

<!-- Please give a short summary of the changes. -->

PEP 702 deprecation by #5480 started to use `typing_extensions.deprecated`.
This function is available only [4.5.0 or later](https://github.com/python/typing_extensions/blob/4.5.0/CHANGELOG.md#release-450-february-14-2023).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb