### PR TITLE
Fix typing_extension version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 ]
 requires-python = '>=3.7'
 dependencies = [
-    'typing-extensions>=4.2.0',
+    'typing-extensions>=4.5.0',
     'pydantic-core==0.25.0',
     'annotated-types>=0.4.0',
 ]


### PR DESCRIPTION
`@deprecated` doesn't exist in older versions:
https://github.com/pydantic/pydantic/blob/main/pydantic/deprecated/config.py#L6