### PR TITLE
Use only relative imports

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -6,9 +6,8 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 from pydantic_core import core_schema
 from typing_extensions import Literal, Self
 
-from pydantic.errors import PydanticUserError
-
 from ..config import ConfigDict, ExtraValues
+from ..errors import PydanticUserError
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
 

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -204,7 +204,7 @@ def collect_model_fields(  # noqa: C901
 
 
 def _is_finalvar_with_default_val(type_: type[Any], val: Any) -> bool:
-    from pydantic.fields import FieldInfo
+    from ..fields import FieldInfo
 
     if not is_finalvar(type_):
         return False

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -199,7 +199,7 @@ class GenerateSchema:
         if schema is not None:
             return schema
 
-        from pydantic.main import BaseModel
+        from ..main import BaseModel
 
         fields = cls.model_fields
         decorators = cls.__pydantic_decorators__
@@ -311,7 +311,7 @@ class GenerateSchema:
             if from_property is not None:
                 return from_property
 
-        from pydantic.main import BaseModel
+        from ..main import BaseModel
 
         if lenient_issubclass(obj, BaseModel):
             return self.model_schema(obj)

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -21,7 +21,7 @@ if sys.version_info >= (3, 10):
     from typing import _UnionGenericAlias  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
-    from pydantic import BaseModel
+    from ..main import BaseModel
 
 GenericTypesCacheKey = Tuple[Any, Any, Tuple[Any, ...]]
 

--- a/pydantic/deprecated/copy_internals.py
+++ b/pydantic/deprecated/copy_internals.py
@@ -15,8 +15,8 @@ from .._internal import (
 from .._internal._fields import Undefined
 
 if typing.TYPE_CHECKING:
-    from pydantic import BaseModel
-    from pydantic._internal._utils import AbstractSetIntStr, MappingIntStrAny
+    from .. import BaseModel
+    from .._internal._utils import AbstractSetIntStr, MappingIntStrAny
 
     AnyClassMethod = classmethod[Any, Any, Any]
     TupleGenerator = typing.Generator[Tuple[str, Any], None, None]
@@ -122,7 +122,7 @@ def _get_value(
     exclude_defaults: bool,
     exclude_none: bool,
 ) -> Any:
-    from pydantic import BaseModel
+    from .. import BaseModel
 
     if isinstance(v, BaseModel):
         if to_dict:


### PR DESCRIPTION
The idea here is mainly to make it easier to create `pydantic-next`, and have a single way to do _importing_.

Selected Reviewer: @samuelcolvin