### PR TITLE
Change bare-enum behavior for strict json

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -107,7 +107,6 @@ def enum_schema(_schema_generator: GenerateSchema, enum_type: type[Enum]) -> cor
         lax = core_schema.chain_schema([core_schema.str_schema(), to_enum_validator])
         strict = core_schema.is_instance_schema(enum_type, json_types={'str'}, json_function=enum_type)
     elif issubclass(enum_type, float):
-        # this handles `StrEnum` (3.11 only), and also `Foobar(str, Enum)`
         updates['type'] = 'numeric'
         lax = core_schema.chain_schema([core_schema.float_schema(), to_enum_validator])
         strict = core_schema.is_instance_schema(enum_type, json_types={'float'}, json_function=enum_type)

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -13,11 +13,11 @@ from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import PurePath
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 from uuid import UUID
 
 from pydantic_core import CoreSchema, MultiHostUrl, PydanticCustomError, Url, core_schema
-from typing_extensions import Literal, get_args
+from typing_extensions import get_args
 
 from ..json_schema import update_json_schema
 from . import _serializers, _validators
@@ -95,24 +95,35 @@ def enum_schema(_schema_generator: GenerateSchema, enum_type: type[Enum]) -> cor
         js_modify_function=lambda s: update_json_schema(s, updates),
     )
 
-    strict_json_types: set[Literal['int', 'float', 'str']]
     to_enum_validator = core_schema.general_plain_validator_function(to_enum)
     if issubclass(enum_type, int):
         # this handles `IntEnum`, and also `Foobar(int, Enum)`
         updates['type'] = 'integer'
-        strict_json_types = {'int'}
-        lax: core_schema.CoreSchema = core_schema.chain_schema([core_schema.int_schema(), to_enum_validator])
+        lax = core_schema.chain_schema([core_schema.int_schema(), to_enum_validator])
+        strict = core_schema.is_instance_schema(enum_type, json_types={'int'}, json_function=enum_type)
     elif issubclass(enum_type, str):
         # this handles `StrEnum` (3.11 only), and also `Foobar(str, Enum)`
         updates['type'] = 'string'
-        strict_json_types = {'str'}
         lax = core_schema.chain_schema([core_schema.str_schema(), to_enum_validator])
+        strict = core_schema.is_instance_schema(enum_type, json_types={'str'}, json_function=enum_type)
+    elif issubclass(enum_type, float):
+        # this handles `StrEnum` (3.11 only), and also `Foobar(str, Enum)`
+        updates['type'] = 'numeric'
+        lax = core_schema.chain_schema([core_schema.float_schema(), to_enum_validator])
+        strict = core_schema.is_instance_schema(enum_type, json_types={'float'}, json_function=enum_type)
     else:
+
+        def unable_to_parse_from_json(_: Any) -> NoReturn:
+            raise ValueError('Could not parse input, it cannot be converted to the target type')
+
         lax = to_enum_validator
-        strict_json_types = {'int', 'float', 'str'}
+        # allow inputs to pass thorough and hit our unable_to_parse_from_json function
+        strict = core_schema.is_instance_schema(
+            enum_type, json_types={'float', 'int', 'str'}, json_function=unable_to_parse_from_json
+        )
     return core_schema.lax_or_strict_schema(
         lax_schema=lax,
-        strict_schema=core_schema.is_instance_schema(enum_type, json_types=strict_json_types, json_function=enum_type),
+        strict_schema=strict,
         ref=enum_ref,
         metadata=metadata,
     )

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -37,13 +37,16 @@ def test_construct_fields_set():
     assert m.model_dump() == {'a': 3, 'b': -1}
 
 
-def test_construct_allow_extra():
-    """model_construct() should allow extra fields"""
+@pytest.mark.parametrize('extra', ['allow', 'ignore', 'forbid'])
+def test_construct_allow_extra(extra: str):
+    """model_construct() should allow extra fields regardless of the config"""
 
-    class Foo(BaseModel, extra='allow'):
+    class Foo(BaseModel, extra=extra):
         x: int
 
-    assert Foo.model_construct(x=1, y=2).model_dump() == {'x': 1, 'y': 2}
+    model = Foo.model_construct(x=1, y=2)
+    assert model.x == 1
+    assert model.y == 2
 
 
 def test_construct_keep_order():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1366,6 +1366,19 @@ def test_plain_enum_validate():
         }
     ]
 
+    assert AnalyzedType(MyEnum).validate_json('1') is MyEnum.a
+    with pytest.raises(ValidationError) as exc_info:
+        AnalyzedType(MyEnum).validate_json('1', strict=True)
+    assert exc_info.value.errors() == [
+        {
+            'type': 'value_error',
+            'loc': (),
+            'msg': 'Value error, Could not parse input, it cannot be converted to the target type',
+            'input': 1,
+            'ctx': {'error': 'Could not parse input, it cannot be converted to the target type'},
+        }
+    ]
+
 
 def test_plain_enum_validate_json():
     class MyEnum(Enum):
@@ -1443,8 +1456,7 @@ def test_int_enum_type():
         Model.model_json_schema()
 
 
-@pytest.mark.parametrize('enum_base', [Enum, IntEnum])
-@pytest.mark.parametrize('strict', [True, False])
+@pytest.mark.parametrize('enum_base,strict', [(Enum, False), (IntEnum, False), (IntEnum, True)])
 def test_enum_from_json(enum_base, strict):
     class MyEnum(enum_base):
         a = 1


### PR DESCRIPTION
Fixes #2257.

This makes the behavior more consistent for strict mode json.

Selected Reviewer: @Kludex