### PR TITLE
Improve consistency of error messages for Enum

### DIFF
--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -2283,7 +2283,13 @@ def test_generic_intenum_bound():
     with pytest.raises(ValidationError) as exc_info:
         Model[MyEnum](x=OtherEnum.b)
     assert exc_info.value.errors() == [
-        {'ctx': {'expected': '1'}, 'input': 2, 'loc': ('x',), 'msg': 'Input should be 1', 'type': 'enum'}
+        {
+            'ctx': {'expected': '1'},
+            'input': 2,
+            'loc': ('x',),
+            'msg': 'Input should be 1',
+            'type': 'enum',
+        }
     ]
 
     assert Model[MyEnum].model_json_schema() == {


### PR DESCRIPTION
This change results in the following change to error messages when attempting to parse enums from JSON:
```python
from enum import IntEnum

from pydantic import BaseModel, ValidationError


class MyEnum(IntEnum):
    x = 1
    y = 2


class DemoModel(BaseModel):
    e: MyEnum

try:
    DemoModel.model_validate_json('{"e":3}')
except ValidationError as e:
    print(e)
    # Without change: > Input should be 1 or 2 [type=enum, input_value=3, input_type=int]
    # With change:    > Input should be 1 or 2 [type=enum, input_value=3, input_type=int]
    # (No effect)

try:
    DemoModel.model_validate_json('{"e":3}', strict=True)
except ValidationError as e:
    print(e)
    # Without change:> Value error, 3 is not a valid MyEnum [type=value_error, input_value=3, input_type=int]
    # With change:   > Input should be 1 or 2 [type=enum, input_value=3, input_type=int]
    # (Same error message as non-strict mode)
```

(I discovered the inconsistency while reviewing some issues related to enum validation)