### PR TITLE
Make it possible to have a plain BaseModel field annotation

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -214,6 +214,8 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         __pydantic_generic_metadata__: typing.ClassVar[_generics.PydanticGenericMetadata]
         __pydantic_parent_namespace__: typing.ClassVar[dict[str, Any] | None]
     else:
+        # `model_fields` and `__pydantic_decorators__` must be set for
+        # pydantic._internal._generate_schema.GenerateSchema.model_schema to work for a plain BaseModel annotation
         model_fields = {}
         __pydantic_decorators__ = _decorators.DecoratorInfos()
         __pydantic_validator__ = _model_construction.MockValidator(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -214,6 +214,8 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         __pydantic_generic_metadata__: typing.ClassVar[_generics.PydanticGenericMetadata]
         __pydantic_parent_namespace__: typing.ClassVar[dict[str, Any] | None]
     else:
+        model_fields = {}
+        __pydantic_decorators__ = _decorators.DecoratorInfos()
         __pydantic_validator__ = _model_construction.MockValidator(
             'Pydantic models should inherit from BaseModel, BaseModel cannot be instantiated directly',
             code='base-model-instantiated',

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2366,3 +2366,18 @@ def test_generic_wrapped_forwardref():
     assert exc_info.value.errors() == [
         {'input': 1, 'loc': ('callbacks', 0), 'msg': 'Input should be a valid dictionary', 'type': 'dict_type'}
     ]
+
+
+def test_plain_basemodel_field():
+    class Model(BaseModel):
+        x: BaseModel
+
+    class Model2(BaseModel):
+        pass
+
+    assert Model(x=Model2()).x == Model2()
+    with pytest.raises(ValidationError) as exc_info:
+        Model(x=1)
+    assert exc_info.value.errors() == [
+        {'input': 1, 'loc': ('x',), 'msg': 'Input should be a valid dictionary', 'type': 'dict_type'}
+    ]


### PR DESCRIPTION
Right now, if you try to use a plain BaseModel as a field, you get:

```python
  File "/Users/davidmontague/Programming/pydantic/pydantic/pydantic/_internal/_generate_schema.py", line 245, in model_schema
    fields = cls.model_fields
             ^^^^^^^^^^^^^^^^
AttributeError: type object 'BaseModel' has no attribute 'model_fields'. Did you mean: 'model_fields_set'?
```

Found an example of this here: https://github.com/gdsfactory/gdsfactory/blob/f3daacc74de6e59ad6b550d7daa5b34f142c0ba9/gdsfactory/technology/layer_views.py#L762

Doesn't seem unreasonable to use `BaseModel` as a field annotation in principle (though obviously the serialization may suffer..), and I just needed to set two of the class attributes to get this to stop erroring.

Selected Reviewer: @Kludex