### PR TITLE
✨ Add `Base64` and a general `Encoded` types

### DIFF
--- a/changes/692-lig.md
+++ b/changes/692-lig.md
@@ -1,0 +1,1 @@
+Add `EncodedBytes` and `EncodedStr` general types and implement `base64` encoding support in  `Base64Bytes` and `Base64Str` types.

--- a/docs/usage/types/encoded.md
+++ b/docs/usage/types/encoded.md
@@ -3,10 +3,10 @@ description: Support for storing data in an encoded form.
 ---
 
 `EncodedBytes`
-: bytes value being encoded into a bytes value upon serialization
+: a bytes value which is decoded from/encoded into a (different) bytes value during validation/serialization
 
 `EncodedStr`
-: string value being encoded into a string value upon serialization
+: a string value which is decoded from/encoded into a (different) string value during validation/serialization
 
 `EncodedBytes` and `EncodedStr` needs an encoder that implements `EncoderProtocol` to operate.
 
@@ -83,7 +83,7 @@ except ValidationError as e:
 
 ## Base64 encoding support
 
-*pydantic* uses `EncodedBytes` and `EncodedStr` types for `base64` implementation in `Base64Bytes` and `Base64Str` respectively.
+Internally, pydantic uses the `pydantic.types.EncodedBytes` and `pydantic.types.EncodedStr` annotations with `pydantic.types.Base64Encoder` to implement base64 encoding/decoding in the `Base64Bytes` and `Base64Str` types, respectively.
 
 ```py
 from typing import Optional

--- a/docs/usage/types/encoded.md
+++ b/docs/usage/types/encoded.md
@@ -1,0 +1,130 @@
+---
+description: Support for storing data in an encoded form.
+---
+
+`EncodedBytes`
+: bytes value being encoded into a bytes value upon serialization
+
+`EncodedStr`
+: string value being encoded into a string value upon serialization
+
+`EncodedBytes` and `EncodedStr` needs an encoder that implements `EncoderProtocol` to operate.
+
+```py
+from typing import Optional
+
+from typing_extensions import Annotated
+
+from pydantic import (
+    BaseModel,
+    EncodedBytes,
+    EncodedStr,
+    EncoderProtocol,
+    ValidationError,
+)
+
+
+class MyEncoder(EncoderProtocol):
+    @classmethod
+    def decode(cls, data: bytes) -> bytes:
+        if data == b'**undecodable**':
+            raise ValueError('Cannot decode data')
+        return data[13:]
+
+    @classmethod
+    def encode(cls, value: bytes) -> bytes:
+        return b'**encoded**: ' + value
+
+    @classmethod
+    def get_json_format(cls) -> str:
+        return 'my-encoder'
+
+
+MyEncodedBytes = Annotated[bytes, EncodedBytes(encoder=MyEncoder)]
+MyEncodedStr = Annotated[str, EncodedStr(encoder=MyEncoder)]
+
+
+class Model(BaseModel):
+    my_encoded_bytes: MyEncodedBytes
+    my_encoded_str: Optional[MyEncodedStr] = None
+
+
+# Initialize the model with encoded data
+m = Model(
+    my_encoded_bytes=b'**encoded**: some bytes', my_encoded_str='**encoded**: some str'
+)
+
+# Access decoded value
+print(m.my_encoded_bytes)
+#> b'some bytes'
+print(m.my_encoded_str)
+#> some str
+
+# Serialize into the encoded form
+print(m.model_dump())
+"""
+{
+    'my_encoded_bytes': b'**encoded**: some bytes',
+    'my_encoded_str': '**encoded**: some str',
+}
+"""
+
+# Validate encoded data
+try:
+    Model(my_encoded_bytes=b'**undecodable**')
+except ValidationError as e:
+    print(e)
+    """
+    1 validation error for Model
+    my_encoded_bytes
+      Value error, Cannot decode data [type=value_error, input_value=b'**undecodable**', input_type=bytes]
+    """
+```
+
+## Base64 encoding support
+
+*pydantic* uses `EncodedBytes` and `EncodedStr` types for `base64` implementation in `Base64Bytes` and `Base64Str` respectively.
+
+```py
+from typing import Optional
+
+from pydantic import Base64Bytes, Base64Str, BaseModel, ValidationError
+
+
+class Model(BaseModel):
+    base64_bytes: Base64Bytes
+    base64_str: Optional[Base64Str] = None
+
+
+# Initialize the model with base64 data
+m = Model(
+    base64_bytes=b'VGhpcyBpcyB0aGUgd2F5',
+    base64_str='VGhlc2UgYXJlbid0IHRoZSBkcm9pZHMgeW91J3JlIGxvb2tpbmcgZm9y',
+)
+
+# Access decoded value
+print(m.base64_bytes)
+#> b'This is the way'
+print(m.base64_str)
+#> These aren't the droids you're looking for
+
+# Serialize into the base64 form
+print(m.model_dump())
+"""
+{
+    'base64_bytes': b'VGhpcyBpcyB0aGUgd2F5\n',
+    'base64_str': 'VGhlc2UgYXJlbid0IHRoZSBkcm9pZHMgeW91J3JlIGxvb2tpbmcgZm9y\n',
+}
+"""
+
+# Validate base64 data
+try:
+    print(Model(base64_bytes=b'undecodable').base64_bytes)
+except ValidationError as e:
+    print(e)
+    """
+    1 validation error for Model
+    base64_bytes
+      Base64 decoding error: 'Incorrect padding' [type=base64_decode, input_value=b'undecodable', input_type=bytes]
+    """
+```

--- a/docs/usage/types/types.md
+++ b/docs/usage/types/types.md
@@ -29,6 +29,6 @@ The following sections describe the types supported by Pydantic.
 * [Unions](unions.md) &mdash; allows a model attribute to accept different types.
 * [URLs](urls.md) &mdash; URI/URL validation types.
 * [UUIDs](uuids.md) &mdash; types that allow you to store UUIDs in your model.
-* [Base64 and other encodings](encoded.md) &mdash; types that allow serializing values into an encoded form, i.e. `base64`.
+* [Base64 and other encodings](encoded.md) &mdash; types that allow serializing values into an encoded form, e.g. `base64`.
 * [Custom Data Types](custom.md) &mdash; create your own custom data types.
 * [Field Type Conversions](../conversion_table.md) &mdash; strict and lax conversion between different field types.

--- a/docs/usage/types/types.md
+++ b/docs/usage/types/types.md
@@ -29,5 +29,6 @@ The following sections describe the types supported by Pydantic.
 * [Unions](unions.md) &mdash; allows a model attribute to accept different types.
 * [URLs](urls.md) &mdash; URI/URL validation types.
 * [UUIDs](uuids.md) &mdash; types that allow you to store UUIDs in your model.
+* [Base64 and other encodings](encoded.md) &mdash; types that allow serializing values into an encoded form, i.e. `base64`.
 * [Custom Data Types](custom.md) &mdash; create your own custom data types.
 * [Field Type Conversions](../conversion_table.md) &mdash; strict and lax conversion between different field types.

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -133,6 +133,12 @@ __all__ = [
     'AwareDatetime',
     'NaiveDatetime',
     'AllowInfNan',
+    'EncoderProtocol',
+    'EncodedBytes',
+    'EncodedStr',
+    'Base64Encoder',
+    'Base64Bytes',
+    'Base64Str',
     # version
     'VERSION',
 ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -43,6 +43,8 @@ from pydantic import (
     UUID5,
     AnalyzedType,
     AwareDatetime,
+    Base64Bytes,
+    Base64Str,
     BaseModel,
     ByteSize,
     ConfigDict,
@@ -4350,4 +4352,83 @@ def test_custom_generic_containers():
             'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
             'type': 'int_parsing',
         }
+    ]
+
+
+@pytest.mark.parametrize(
+    ('field_type', 'input_data', 'expected_value', 'serialized_data'),
+    [
+        pytest.param(Base64Bytes, b'Zm9vIGJhcg==\n', b'foo bar', b'Zm9vIGJhcg==\n', id='Base64Bytes-reversible'),
+        pytest.param(Base64Str, 'Zm9vIGJhcg==\n', 'foo bar', 'Zm9vIGJhcg==\n', id='Base64Str-reversible'),
+        pytest.param(Base64Bytes, b'Zm9vIGJhcg==', b'foo bar', b'Zm9vIGJhcg==\n', id='Base64Bytes-bytes-input'),
+        pytest.param(Base64Bytes, 'Zm9vIGJhcg==', b'foo bar', b'Zm9vIGJhcg==\n', id='Base64Bytes-str-input'),
+        pytest.param(
+            Base64Bytes, bytearray(b'Zm9vIGJhcg=='), b'foo bar', b'Zm9vIGJhcg==\n', id='Base64Bytes-bytearray-input'
+        ),
+        pytest.param(Base64Str, b'Zm9vIGJhcg==', 'foo bar', 'Zm9vIGJhcg==\n', id='Base64Str-bytes-input'),
+        pytest.param(Base64Str, 'Zm9vIGJhcg==', 'foo bar', 'Zm9vIGJhcg==\n', id='Base64Str-str-input'),
+        pytest.param(
+            Base64Str, bytearray(b'Zm9vIGJhcg=='), 'foo bar', 'Zm9vIGJhcg==\n', id='Base64Str-bytearray-input'
+        ),
+    ],
+)
+def test_base64(field_type, input_data, expected_value, serialized_data):
+    class Model(BaseModel):
+        base64_value: field_type
+        base64_value_or_none: Optional[field_type] = None
+
+    m = Model(base64_value=input_data)
+    assert m.base64_value == expected_value
+
+    m = Model.model_construct(base64_value=expected_value)
+    assert m.base64_value == expected_value
+
+    assert m.model_dump() == {
+        'base64_value': serialized_data,
+        'base64_value_or_none': None,
+    }
+
+    assert Model.model_json_schema() == {
+        'properties': {
+            'base64_value': {
+                'format': 'base64',
+                'title': 'Base64 Value',
+                'type': 'string',
+            },
+            'base64_value_or_none': {
+                'anyOf': [{'type': 'string', 'format': 'base64'}, {'type': 'null'}],
+                'default': None,
+                'title': 'Base64 Value Or None',
+            },
+        },
+        'required': ['base64_value'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
+@pytest.mark.parametrize(
+    ('field_type', 'input_data'),
+    [
+        pytest.param(Base64Bytes, b'Zm9vIGJhcg', id='Base64Bytes-invalid-base64-bytes'),
+        pytest.param(Base64Bytes, 'Zm9vIGJhcg', id='Base64Bytes-invalid-base64-str'),
+        pytest.param(Base64Str, b'Zm9vIGJhcg', id='Base64Str-invalid-base64-bytes'),
+        pytest.param(Base64Str, 'Zm9vIGJhcg', id='Base64Str-invalid-base64-str'),
+    ],
+)
+def test_base64_invalid(field_type, input_data):
+    class Model(BaseModel):
+        base64_value: field_type
+
+    with pytest.raises(ValidationError) as e:
+        Model(base64_value=input_data)
+
+    assert e.value.errors() == [
+        {
+            'ctx': {'error': 'Incorrect padding'},
+            'input': input_data,
+            'loc': ('base64_value',),
+            'msg': "Base64 decoding error: 'Incorrect padding'",
+            'type': 'base64_decode',
+        },
     ]


### PR DESCRIPTION
## Change Summary

Add `EncodedBytes` and `EncodedStr` general types and implement `base64` encoding support in  `Base64Bytes` and `Base64Str` types.

## Related issue number

Fix #692 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu