### PR TITLE
Error more eagerly for proper subclasses of generics that we don't know how to validate

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -486,8 +486,13 @@ class GenerateSchema:
 
             return ordered_dict_schema(self, obj)
         elif issubclass(origin, typing.Sequence):
-            # Because typing.Sequence does not have a specified `__init__` signature, we don't validate into subclasses
-            return self._sequence_schema(obj)
+            if origin in {typing.Sequence, collections.abc.Sequence}:
+                return self._sequence_schema(obj)
+            # TODO: similarly handle other generic subclasses (like Iterable, etc.) where there's no standard __init__
+            raise PydanticSchemaGenerationError(
+                'Unable to generate pydantic-core schema for custom subclasses of Sequence.'
+                ' Please define `__get_pydantic_core_schema__`. TODO: Add docs link.'
+            )
         elif issubclass(origin, typing.MutableSet):
             raise PydanticSchemaGenerationError('Unable to generate pydantic-core schema MutableSet TODO.')
         elif issubclass(origin, (typing.Iterable, collections.abc.Iterable)):


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/2264. (As it fixes some confusing behavior.)

We should go further and make similar changes for other subclasses of generics which don't have a "standard" way to call `__init__`.

Users who want to support such classes should implement a `__get_pydantic_core_schema__` classmethod on the type in question, or if they don't control the type, on a pydantic-specific annotation used whenever that type occurs as a pydantic field annotation.

An example of how to do this is included in `tests.test_edge_cases.test_custom_generic_validators`





Selected Reviewer: @samuelcolvin