### PR TITLE
Add make help command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,81 +1,82 @@
 .DEFAULT_GOAL := all
 sources = pydantic tests docs/plugins
 
-.PHONY: .pdm
-.pdm:  ## Check that PDM is isntallced
+.PHONY: .pdm  ## Check that PDM is isntallced
+.pdm:
 	@pdm -V || echo 'Please install PDM: https://pdm.fming.dev/latest/\#installation'
 
-.PHONY: .pre-commit
-.pre-commit:  ## Check that pre-commit is installed
+.PHONY: .pre-commit  ## Check that pre-commit is installed
+.pre-commit:
 	@pre-commit -V || echo 'Please install pre-commit: https://pre-commit.com/'
 
-.PHONY: install
+.PHONY: install  ## Install the package, dependencies, and pre-commit for local development
 install: .pdm .pre-commit
 	pdm install --group :all
 	pre-commit install --install-hooks
 
-.PHONY: refresh-lockfiles
-refresh-lockfiles: .pdm       ## Sync lockfiles with requirements files.
+.PHONY: refresh-lockfiles  ## Sync lockfiles with requirements files.
+refresh-lockfiles: .pdm
 	pdm lock --refresh --dev --group :all
 
-.PHONY: rebuild-lockfiles
-rebuild-lockfiles: .pdm       ## Rebuild lockfiles from scratch, updating all dependencies
+.PHONY: rebuild-lockfiles  ## Rebuild lockfiles from scratch, updating all dependencies
+rebuild-lockfiles: .pdm
 	pdm lock --dev --group :all
 
-.PHONY: format
+.PHONY: format  ## Auto-format python source files
 format: .pdm
 	pdm run black $(sources)
 	pdm run ruff --fix $(sources)
 
-.PHONY: lint
+.PHONY: lint  ## Lint python source files
 lint: .pdm
 	pdm run ruff $(sources)
 	pdm run black $(sources) --check --diff
 
-.PHONY: codespell
+.PHONY: codespell  ## Use Codespell to do spellchecking
 codespell: .pre-commit
 	pre-commit run codespell --all-files
 
-.PHONY: typecheck
+.PHONY: typecheck  ## Perform type-checking
 typecheck: .pre-commit .pdm
 	pre-commit run typecheck --all-files
 
-.PHONY: test-mypy
+.PHONY: test-mypy  ## Run the mypy integration tests
 test-mypy: .pdm
 	pdm run coverage run -m pytest tests/mypy --test-mypy
 
-.PHONY: test-pyright
+.PHONY: test-pyright  ## Run the pyright integration tests
 test-pyright: .pdm
 	pdm run bash -c 'cd tests/pyright && pyright'
 
-.PHONY: test
+.PHONY: test  ## Run all tests, skipping the type-checker integration tests
 test: .pdm
 	pdm run coverage run -m pytest --durations=10
 
-.PHONY: testcov
+.PHONY: testcov  ## Run tests and generate a coverage report, skipping the type-checker integration tests
 testcov: test
 	@echo "building coverage html"
 	@pdm run coverage html
 
-.PHONY: testcov-compile
-testcov-compile: .pdm build-trace test
-	@echo "building coverage html"
-	@pdm run coverage html
+# It looks like this is no longer used; can it be removed?
+#.PHONY: testcov-compile
+#testcov-compile: .pdm build-trace test
+#	@echo "building coverage html"
+#	@pdm run coverage html
 
-.PHONY: test-examples
+.PHONY: test-examples  ## Run only the tests from the documentation
 test-examples: .pdm
 	@echo "running examples"
 	@find docs/examples -type f -name '*.py' | xargs -I'{}' sh -c 'pdm run python {} >/dev/null 2>&1 || (echo "{} failed")'
 
-.PHONY: test-fastapi
+.PHONY: test-fastapi  ## Run the FastAPI tests with this version of pydantic
 test-fastapi: .pdm
 	git clone https://github.com/tiangolo/fastapi.git --single-branch
 	pdm run ./tests/test_fastapi.sh
 
-.PHONY: all
+.PHONY: all  ## Run the standard set of checks performed in CI
 all: lint typecheck codespell testcov
 
-.PHONY: clean
+.PHONY: clean  ## Clear local caches and build artifacts
 clean:
 	rm -rf `find . -name __pycache__`
 	rm -f `find . -type f -name '*.py[co]'`
@@ -96,6 +97,13 @@ clean:
 	rm -rf fastapi/test.db
 	rm -rf coverage.xml
 
-.PHONY: docs
+.PHONY: docs  ## Generate the docs
 docs:
 	pdm run mkdocs build
+
+.PHONY: help  ## Display this message
+help:
+	@grep -E \
+		'^.PHONY: .*?## .*$$' $(MAKEFILE_LIST) | \
+		sort | \
+		awk 'BEGIN {FS = ".PHONY: |## "}; {printf "\033[36m%-19s\033[0m %s\n", $$2, $$3}'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := all
 sources = pydantic tests docs/plugins
 
-.PHONY: .pdm  ## Check that PDM is isntallced
+.PHONY: .pdm  ## Check that PDM is installed
 .pdm:
 	@pdm -V || echo 'Please install PDM: https://pdm.fming.dev/latest/\#installation'
 
@@ -56,12 +56,6 @@ test: .pdm
 testcov: test
 	@echo "building coverage html"
 	@pdm run coverage html
-
-# It looks like this is no longer used; can it be removed?
-#.PHONY: testcov-compile
-#testcov-compile: .pdm build-trace test
-#	@echo "building coverage html"
-#	@pdm run coverage html
 
 .PHONY: test-examples  ## Run only the tests from the documentation
 test-examples: .pdm


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/3786

Adds the ability to run `make help` and get a nice table of available commands displayed:

<img width="866" alt="image" src="https://user-images.githubusercontent.com/35119617/235269773-307cdc73-b9af-47d6-bfa8-596b1f261f93.png">

Feel free to drop this and close it, but it was requested in the linked issue and despite the lack of context provided there, I knew exactly what they meant, as I already had this working in another repo of mine (just needed to add/slightly reposition the comments to get it working). (I did not come up with this myself.) And I do like having this in my other projects when I forget which commands I have available.

(I normally set it so `help` is the `DEFAULT_GOAL`, so if you forget what to run you can just run `make` and you see all the options, happy to keep `DEFAULT_GOAL := all` though if people are used to that.)

