### PR TITLE
remove unused info arguments from validator functions

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -834,7 +834,7 @@ class GenerateSchema:
         from ._validators import mapping_validator
 
         # TODO could do `core_schema.chain_schema(core_schema.is_instance_schema(dict_subclass), ...` in strict mode
-        return core_schema.general_wrap_validator_function(
+        return core_schema.no_info_wrap_validator_function(
             mapping_validator,
             core_schema.dict_schema(
                 keys_schema=self.generate_schema(arg0),
@@ -851,7 +851,7 @@ class GenerateSchema:
         from ._validators import construct_counter
 
         # TODO could do `core_schema.chain_schema(core_schema.is_instance_schema(Counter), ...` in strict mode
-        return core_schema.general_after_validator_function(
+        return core_schema.no_info_after_validator_function(
             construct_counter,
             core_schema.dict_schema(
                 keys_schema=self.generate_schema(arg),
@@ -870,7 +870,7 @@ class GenerateSchema:
         else:
             from ._validators import mapping_validator
 
-            return core_schema.general_wrap_validator_function(
+            return core_schema.no_info_wrap_validator_function(
                 mapping_validator,
                 core_schema.dict_schema(
                     keys_schema=self.generate_schema(arg0),
@@ -918,7 +918,7 @@ class GenerateSchema:
             return core_schema.chain_schema(
                 [
                     core_schema.is_instance_schema(typing.Sequence, cls_repr='Sequence'),
-                    core_schema.general_wrap_validator_function(
+                    core_schema.no_info_wrap_validator_function(
                         sequence_validator,
                         core_schema.list_schema(self.generate_schema(item_type), allow_any_iter=True),
                     ),
@@ -944,17 +944,17 @@ class GenerateSchema:
         )
         if pattern_type == typing.Pattern or pattern_type == re.Pattern:
             # bare type
-            return core_schema.general_plain_validator_function(
+            return core_schema.no_info_plain_validator_function(
                 _validators.pattern_either_validator, serialization=ser, metadata=metadata
             )
 
         param = get_args(pattern_type)[0]
         if param == str:
-            return core_schema.general_plain_validator_function(
+            return core_schema.no_info_plain_validator_function(
                 _validators.pattern_str_validator, serialization=ser, metadata=metadata
             )
         elif param == bytes:
-            return core_schema.general_plain_validator_function(
+            return core_schema.no_info_plain_validator_function(
                 _validators.pattern_bytes_validator, serialization=ser, metadata=metadata
             )
         else:

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -139,7 +139,7 @@ def decimal_schema(_schema_generator: GenerateSchema, _decimal_type: type[Decima
         # Use a lambda here so `apply_metadata` is called on the decimal_validator before the override is generated
         js_functions=[lambda _c, h: h(decimal_validator.json_schema_override_schema())],
     )
-    lax = core_schema.general_after_validator_function(
+    lax = core_schema.no_info_after_validator_function(
         decimal_validator,
         core_schema.union_schema(
             [
@@ -152,7 +152,7 @@ def decimal_schema(_schema_generator: GenerateSchema, _decimal_type: type[Decima
         ),
     )
     strict = core_schema.custom_error_schema(
-        core_schema.general_after_validator_function(
+        core_schema.no_info_after_validator_function(
             decimal_validator,
             core_schema.is_instance_schema(Decimal, json_types={'int', 'float'}),
         ),
@@ -169,7 +169,7 @@ def uuid_schema(_schema_generator: GenerateSchema, uuid_type: type[UUID]) -> cor
     lax = core_schema.union_schema(
         [
             core_schema.is_instance_schema(uuid_type, json_types={'str'}),
-            core_schema.general_after_validator_function(
+            core_schema.no_info_after_validator_function(
                 _validators.uuid_validator,
                 core_schema.union_schema([core_schema.str_schema(), core_schema.bytes_schema()]),
             ),
@@ -191,7 +191,7 @@ def uuid_schema(_schema_generator: GenerateSchema, uuid_type: type[UUID]) -> cor
                         core_schema.chain_schema(
                             [
                                 core_schema.str_schema(),
-                                core_schema.general_plain_validator_function(_validators.uuid_validator),
+                                core_schema.no_info_plain_validator_function(_validators.uuid_validator),
                             ]
                         ),
                     ]
@@ -244,7 +244,7 @@ def _deque_ser_schema(
 def _deque_any_schema() -> core_schema.LaxOrStrictSchema:
     metadata = build_metadata_dict(js_functions=[lambda _c, h: h(core_schema.list_schema(core_schema.any_schema()))])
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_wrap_validator_function(
+        lax_schema=core_schema.no_info_wrap_validator_function(
             _validators.deque_any_validator,
             core_schema.list_schema(),
         ),
@@ -277,7 +277,7 @@ def deque_schema(schema_generator: GenerateSchema, obj: Any) -> core_schema.Core
         inner_schema = schema_generator.generate_schema(arg)
         # Use a lambda here so `apply_metadata` is called on the decimal_validator before the override is generated
         metadata = build_metadata_dict(js_functions=[lambda _c, h: h(core_schema.list_schema(inner_schema))])
-        lax_schema = core_schema.general_wrap_validator_function(
+        lax_schema = core_schema.no_info_wrap_validator_function(
             _validators.deque_typed_validator,
             core_schema.list_schema(inner_schema, strict=False),
         )
@@ -294,7 +294,7 @@ def deque_schema(schema_generator: GenerateSchema, obj: Any) -> core_schema.Core
 
 def _ordered_dict_any_schema() -> core_schema.LaxOrStrictSchema:
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_wrap_validator_function(
+        lax_schema=core_schema.no_info_wrap_validator_function(
             _validators.ordered_dict_any_validator, core_schema.dict_schema()
         ),
         strict_schema=core_schema.general_after_validator_function(
@@ -324,7 +324,7 @@ def ordered_dict_schema(schema_generator: GenerateSchema, obj: Any) -> core_sche
             schema_generator.generate_schema(keys_arg), schema_generator.generate_schema(values_arg)
         )
         return core_schema.lax_or_strict_schema(
-            lax_schema=core_schema.general_after_validator_function(
+            lax_schema=core_schema.no_info_after_validator_function(
                 _validators.ordered_dict_typed_validator,
                 core_schema.dict_schema(
                     schema_generator.generate_schema(keys_arg), schema_generator.generate_schema(values_arg)
@@ -354,7 +354,7 @@ def make_strict_ip_schema(tp: type[Any], metadata: Any) -> CoreSchema:
 def ip_v4_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
     metadata = build_metadata_dict(js_functions=[lambda _c, _h: {'type': 'string', 'format': 'ipv4'}])
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_plain_validator_function(_validators.ip_v4_address_validator, metadata=metadata),
+        lax_schema=core_schema.no_info_plain_validator_function(_validators.ip_v4_address_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv4Address, metadata=metadata),
         serialization=core_schema.to_string_ser_schema(),
     )
@@ -364,7 +364,7 @@ def ip_v4_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_s
 def ip_v4_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
     metadata = build_metadata_dict(js_functions=[lambda _c, _h: {'type': 'string', 'format': 'ipv4interface'}])
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_plain_validator_function(
+        lax_schema=core_schema.no_info_plain_validator_function(
             _validators.ip_v4_interface_validator, metadata=metadata
         ),
         strict_schema=make_strict_ip_schema(IPv4Interface, metadata=metadata),
@@ -376,7 +376,7 @@ def ip_v4_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core
 def ip_v4_network_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
     metadata = build_metadata_dict(js_functions=[lambda _c, _h: {'type': 'string', 'format': 'ipv4network'}])
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_plain_validator_function(_validators.ip_v4_network_validator, metadata=metadata),
+        lax_schema=core_schema.no_info_plain_validator_function(_validators.ip_v4_network_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv4Network, metadata=metadata),
         serialization=core_schema.to_string_ser_schema(),
     )
@@ -386,7 +386,7 @@ def ip_v4_network_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_s
 def ip_v6_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
     metadata = build_metadata_dict(js_functions=[lambda _c, _h: {'type': 'string', 'format': 'ipv6'}])
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_plain_validator_function(_validators.ip_v6_address_validator, metadata=metadata),
+        lax_schema=core_schema.no_info_plain_validator_function(_validators.ip_v6_address_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv6Address, metadata=metadata),
         serialization=core_schema.to_string_ser_schema(),
     )
@@ -396,7 +396,7 @@ def ip_v6_address_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_s
 def ip_v6_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
     metadata = build_metadata_dict(js_functions=[lambda _c, _h: {'type': 'string', 'format': 'ipv6interface'}])
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_plain_validator_function(
+        lax_schema=core_schema.no_info_plain_validator_function(
             _validators.ip_v6_interface_validator, metadata=metadata
         ),
         strict_schema=make_strict_ip_schema(IPv6Interface, metadata=metadata),
@@ -408,7 +408,7 @@ def ip_v6_interface_schema(_schema_generator: GenerateSchema, _obj: Any) -> core
 def ip_v6_network_schema(_schema_generator: GenerateSchema, _obj: Any) -> core_schema.CoreSchema:
     metadata = build_metadata_dict(js_functions=[lambda _c, _h: {'type': 'string', 'format': 'ipv6network'}])
     return core_schema.lax_or_strict_schema(
-        lax_schema=core_schema.general_plain_validator_function(_validators.ip_v6_network_validator, metadata=metadata),
+        lax_schema=core_schema.no_info_plain_validator_function(_validators.ip_v6_network_validator, metadata=metadata),
         strict_schema=make_strict_ip_schema(IPv6Network, metadata=metadata),
         serialization=core_schema.to_string_ser_schema(),
     )

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -22,7 +22,6 @@ from . import _fields
 def mapping_validator(
     __input_value: typing.Mapping[Any, Any],
     validator: core_schema.ValidatorFunctionWrapHandler,
-    info: core_schema.ValidationInfo,
 ) -> typing.Mapping[Any, Any]:
     """
     Validator for `Mapping` types, if required `isinstance(v, Mapping)` has already been called.
@@ -41,7 +40,7 @@ def mapping_validator(
         return value_type(v_dict)  # type: ignore[call-arg]
 
 
-def construct_counter(__input_value: typing.Mapping[Any, Any], _: core_schema.ValidationInfo) -> typing.Counter[Any]:
+def construct_counter(__input_value: typing.Mapping[Any, Any]) -> typing.Counter[Any]:
     """
     Validator for `Counter` types, if required `isinstance(v, Counter)` has already been called.
     """
@@ -51,7 +50,6 @@ def construct_counter(__input_value: typing.Mapping[Any, Any], _: core_schema.Va
 def sequence_validator(
     __input_value: typing.Sequence[Any],
     validator: core_schema.ValidatorFunctionWrapHandler,
-    _: core_schema.ValidationInfo,
 ) -> typing.Sequence[Any]:
     """
     Validator for `Sequence` types, isinstance(v, Sequence) has already been called.
@@ -162,9 +160,7 @@ class DecimalValidator(_fields.CustomValidator):
         if self.check_digits and self.allow_inf_nan:
             raise ValueError('allow_inf_nan=True cannot be used with max_digits or decimal_places')
 
-    def __call__(  # noqa: C901 (ignore complexity)
-        self, __input_value: int | float | str, _: core_schema.ValidationInfo
-    ) -> Decimal:
+    def __call__(self, __input_value: int | float | str) -> Decimal:  # noqa: C901 (ignore complexity)
         if isinstance(__input_value, Decimal):
             value = __input_value
         else:
@@ -256,7 +252,7 @@ class DecimalValidator(_fields.CustomValidator):
         return f'DecimalValidator({s})'
 
 
-def uuid_validator(__input_value: str | bytes, _: core_schema.ValidationInfo) -> UUID:
+def uuid_validator(__input_value: str | bytes) -> UUID:
     try:
         if isinstance(__input_value, str):
             return UUID(__input_value)
@@ -271,7 +267,7 @@ def uuid_validator(__input_value: str | bytes, _: core_schema.ValidationInfo) ->
         raise PydanticCustomError('uuid_parsing', 'Input should be a valid UUID, unable to parse string as an UUID')
 
 
-def pattern_either_validator(__input_value: Any, _: core_schema.ValidationInfo) -> typing.Pattern[Any]:
+def pattern_either_validator(__input_value: Any) -> typing.Pattern[Any]:
     if isinstance(__input_value, typing.Pattern):
         return __input_value  # type: ignore
     elif isinstance(__input_value, (str, bytes)):
@@ -281,7 +277,7 @@ def pattern_either_validator(__input_value: Any, _: core_schema.ValidationInfo) 
         raise PydanticCustomError('pattern_type', 'Input should be a valid pattern')
 
 
-def pattern_str_validator(__input_value: Any, _: core_schema.ValidationInfo) -> typing.Pattern[str]:
+def pattern_str_validator(__input_value: Any) -> typing.Pattern[str]:
     if isinstance(__input_value, typing.Pattern):
         if isinstance(__input_value.pattern, str):  # type: ignore
             return __input_value  # type: ignore
@@ -295,7 +291,7 @@ def pattern_str_validator(__input_value: Any, _: core_schema.ValidationInfo) -> 
         raise PydanticCustomError('pattern_type', 'Input should be a valid pattern')
 
 
-def pattern_bytes_validator(__input_value: Any, _: core_schema.ValidationInfo) -> Any:
+def pattern_bytes_validator(__input_value: Any) -> Any:
     if isinstance(__input_value, typing.Pattern):
         if isinstance(__input_value.pattern, bytes):
             return __input_value
@@ -319,18 +315,14 @@ def compile_pattern(pattern: PatternType) -> typing.Pattern[PatternType]:
         raise PydanticCustomError('pattern_regex', 'Input should be a valid regular expression')
 
 
-def deque_any_validator(
-    __input_value: Any, validator: core_schema.ValidatorFunctionWrapHandler, _: core_schema.ValidationInfo
-) -> deque[Any]:
+def deque_any_validator(__input_value: Any, validator: core_schema.ValidatorFunctionWrapHandler) -> deque[Any]:
     if isinstance(__input_value, deque):
         return __input_value
     else:
         return deque(validator(__input_value))
 
 
-def deque_typed_validator(
-    __input_value: Any, validator: core_schema.ValidatorFunctionWrapHandler, _: core_schema.ValidationInfo
-) -> deque[Any]:
+def deque_typed_validator(__input_value: Any, validator: core_schema.ValidatorFunctionWrapHandler) -> deque[Any]:
     if isinstance(__input_value, deque):
         return deque(validator(__input_value), maxlen=__input_value.maxlen)
     else:
@@ -338,7 +330,7 @@ def deque_typed_validator(
 
 
 def ordered_dict_any_validator(
-    __input_value: Any, validator: core_schema.ValidatorFunctionWrapHandler, _: core_schema.ValidationInfo
+    __input_value: Any, validator: core_schema.ValidatorFunctionWrapHandler
 ) -> OrderedDict[Any, Any]:
     if isinstance(__input_value, OrderedDict):
         return __input_value
@@ -346,11 +338,11 @@ def ordered_dict_any_validator(
         return OrderedDict(validator(__input_value))
 
 
-def ordered_dict_typed_validator(__input_value: list[Any], _: core_schema.ValidationInfo) -> OrderedDict[Any, Any]:
+def ordered_dict_typed_validator(__input_value: list[Any]) -> OrderedDict[Any, Any]:
     return OrderedDict(__input_value)
 
 
-def ip_v4_address_validator(__input_value: Any, _: core_schema.ValidationInfo) -> IPv4Address:
+def ip_v4_address_validator(__input_value: Any) -> IPv4Address:
     if isinstance(__input_value, IPv4Address):
         return __input_value
 
@@ -360,7 +352,7 @@ def ip_v4_address_validator(__input_value: Any, _: core_schema.ValidationInfo) -
         raise PydanticCustomError('ip_v4_address', 'Input is not a valid IPv4 address')
 
 
-def ip_v6_address_validator(__input_value: Any, _: core_schema.ValidationInfo) -> IPv6Address:
+def ip_v6_address_validator(__input_value: Any) -> IPv6Address:
     if isinstance(__input_value, IPv6Address):
         return __input_value
 
@@ -370,7 +362,7 @@ def ip_v6_address_validator(__input_value: Any, _: core_schema.ValidationInfo) -
         raise PydanticCustomError('ip_v6_address', 'Input is not a valid IPv6 address')
 
 
-def ip_v4_network_validator(__input_value: Any, _: core_schema.ValidationInfo) -> IPv4Network:
+def ip_v4_network_validator(__input_value: Any) -> IPv4Network:
     """
     Assume IPv4Network initialised with a default `strict` argument
 
@@ -386,7 +378,7 @@ def ip_v4_network_validator(__input_value: Any, _: core_schema.ValidationInfo) -
         raise PydanticCustomError('ip_v4_network', 'Input is not a valid IPv4 network')
 
 
-def ip_v6_network_validator(__input_value: Any, _: core_schema.ValidationInfo) -> IPv6Network:
+def ip_v6_network_validator(__input_value: Any) -> IPv6Network:
     """
     Assume IPv6Network initialised with a default `strict` argument
 
@@ -402,7 +394,7 @@ def ip_v6_network_validator(__input_value: Any, _: core_schema.ValidationInfo) -
         raise PydanticCustomError('ip_v6_network', 'Input is not a valid IPv6 network')
 
 
-def ip_v4_interface_validator(__input_value: Any, _: core_schema.ValidationInfo) -> IPv4Interface:
+def ip_v4_interface_validator(__input_value: Any) -> IPv4Interface:
     if isinstance(__input_value, IPv4Interface):
         return __input_value
 
@@ -412,7 +404,7 @@ def ip_v4_interface_validator(__input_value: Any, _: core_schema.ValidationInfo)
         raise PydanticCustomError('ip_v4_interface', 'Input is not a valid IPv4 interface')
 
 
-def ip_v6_interface_validator(__input_value: Any, _: core_schema.ValidationInfo) -> IPv6Interface:
+def ip_v6_interface_validator(__input_value: Any) -> IPv6Interface:
     if isinstance(__input_value, IPv6Interface):
         return __input_value
 


### PR DESCRIPTION
We had a bunch of function validators which still took the `info` argument from before we made it optional.

Updating them to not take the argument, should be a little faster.

selected reviewer: @adriangb - I guess these could conflict with your work on how some of these validators work, happy to defer this if that's easier, hence assigning you.

Selected Reviewer: @adriangb