### PR TITLE
set URL for errors

### DIFF
--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -8,6 +8,7 @@ import re
 from typing_extensions import Literal
 
 from ._migration import getattr_migration
+from .version import VERSION
 
 __all__ = (
     'PydanticUserError',
@@ -21,8 +22,7 @@ __all__ = (
 # We use this URL to allow for future flexibility about how we host the docs, while allowing for Pydantic
 # code in the while with "old" URLs to still work.
 # 'u' refers to "user errors" - e.g. errors caused by developers using pydantic, as opposed to validation errors.
-# DEV_ERROR_DOCS_URL = f'https://errors.pydantic.dev/{VERSION}/u/'
-DEV_ERROR_DOCS_URL = '<TODO: Set up the errors URLs>/'
+DEV_ERROR_DOCS_URL = f'https://errors.pydantic.dev/{VERSION}/u/'
 PydanticErrorCodes = Literal[
     'decorator-missing-field',
     'dataclass-not-fully-defined',

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pydantic import BaseModel, PydanticUserError
+from pydantic.version import VERSION
 
 
 def test_user_error_url():
@@ -8,12 +9,7 @@ def test_user_error_url():
         BaseModel()
 
     # insert_assert(str(exc_info.value))
-    # assert str(exc_info.value) == (
-    #     'Pydantic models should inherit from BaseModel, BaseModel cannot be instantiated directly\n\n'
-    #     f'For further information visit https://errors.pydantic.dev/{VERSION}/u/base-model-instantiated'
-    # )
-    # TODO: Replace the below with the above once the errors URLs are set up.
     assert str(exc_info.value) == (
         'Pydantic models should inherit from BaseModel, BaseModel cannot be instantiated directly\n\n'
-        'For further information visit <TODO: Set up the errors URLs>/base-model-instantiated'
+        f'For further information visit https://errors.pydantic.dev/{VERSION}/u/base-model-instantiated'
     )


### PR DESCRIPTION
Now we have https://github.com/pydantic/pydantic-errors-redirect up and running, and docs versions working, see #5626