### PR TITLE
Delegate equality checks for BaseModel

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2203,3 +2203,14 @@ def test_model_validate_with_context():
     assert OuterModel.model_validate({'inner': {'x': 2}}, context={'multiplier': 1}).inner.x == 2
     assert OuterModel.model_validate({'inner': {'x': 2}}, context={'multiplier': 2}).inner.x == 4
     assert OuterModel.model_validate({'inner': {'x': 2}}, context={'multiplier': 3}).inner.x == 6
+
+
+def test_equality_delegation():
+    from unittest.mock import ANY
+
+    from pydantic import BaseModel
+
+    class MyModel(BaseModel):
+        foo: str
+
+    assert MyModel(foo='bar') == ANY


### PR DESCRIPTION
Closes #5622 

Changes from returning `False` in `BaseModel` equality checks to telling python to look at the implementation from the other side of the `==`. I did some investigation in https://github.com/pydantic/pydantic/issues/5622 which I will copy below:

-----
_Quoting [this comment](https://github.com/pydantic/pydantic/issues/5622#issuecomment-1526721788)_

I did a little benchmarking of this:
```python
import time
from dataclasses import dataclass

from pydantic import BaseModel

class MyModel(BaseModel):
    a: int

@dataclass
class MyDataclass:
    a: int

m1 = MyModel(a=1)
m2 = MyDataclass(a=1)
t0 = time.time()
for _ in range(10_000_000):
    m1 == m2
t1 = time.time()

print(f"elapsed: {t1-t0:.3f}s")
# with return False:          elapsed: 1.793s
# with return NotImplemented: elapsed: 2.581s, 43% slower
```
As you can see, it runs _significantly_ slower with `return NotImplemented` vs. `return False`. However, I think there are several good arguments for us making this change:
* It does improve testability of various things and allows custom comparisons, as you've noted
* It's only slower in the case that you are doing an `==` comparison against something that isn't even a BaseModel; this seems pretty unlikely to be happening in "hot" code
* Even though it's noticeably slower, it's still pretty fast, at approximately 4M comparisons/second on my local machine.
* This is what `dataclasses` does: https://github.com/python/cpython/blob/d2e2e53f733f8c8098035bbbc452bd1892796cb3/Lib/dataclasses.py#L669-L671

Given all the above points, I'll open a PR making this change.

Selected Reviewer: @samuelcolvin