### PR TITLE
Add `__prepare_pydantic_annotations__` for custom types

### DIFF
--- a/pydantic/_internal/_core_metadata.py
+++ b/pydantic/_internal/_core_metadata.py
@@ -18,10 +18,6 @@ if typing.TYPE_CHECKING:
 
 
 class CoreMetadata(typing_extensions.TypedDict, total=False):
-    # `pydantic_cs_update_function Retrieves the function that will be used to update the CoreSchema.
-    # This is generally obtained from a `__pydantic_update_schema__` function
-    pydantic_cs_update_function: UpdateCoreSchemaCallable | None
-
     pydantic_js_functions: list[GetJsonSchemaFunction]
 
     # If `pydantic_js_prefer_positional_arguments` is True, the JSON schema generator will
@@ -79,7 +75,6 @@ class CoreMetadataHandler:
 
 def build_metadata_dict(
     *,  # force keyword arguments to make it easier to modify this signature in a backwards-compatible way
-    cs_update_function: UpdateCoreSchemaCallable | None = None,
     js_functions: list[GetJsonSchemaFunction] | None = None,
     js_prefer_positional_arguments: bool | None = None,
     initial_metadata: Any | None = None,
@@ -92,7 +87,6 @@ def build_metadata_dict(
         raise TypeError(f'CoreSchema metadata should be a dict; got {initial_metadata!r}.')
 
     metadata = CoreMetadata(
-        pydantic_cs_update_function=cs_update_function,
         pydantic_js_functions=js_functions or [],
         pydantic_js_prefer_positional_arguments=js_prefer_positional_arguments,
     )

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -5,11 +5,8 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import sys
-from abc import ABC, abstractmethod
 from copy import copy
 from typing import TYPE_CHECKING, Any
-
-from pydantic_core import core_schema
 
 from . import _typing_extra
 from ._forward_ref import PydanticForwardRef
@@ -69,46 +66,6 @@ class PydanticMetadata(Representation):
 class PydanticGeneralMetadata(PydanticMetadata):
     def __init__(self, **metadata: Any):
         self.__dict__ = metadata
-
-
-class SchemaRef(Representation):
-    """
-    Holds a reference to another schema.
-    """
-
-    __slots__ = ('__pydantic_core_schema__',)
-
-    def __init__(self, schema: core_schema.CoreSchema):
-        self.__pydantic_core_schema__ = schema
-
-
-class CustomValidator(ABC):
-    """
-    Used to define functional validators which can be updated with constraints.
-    """
-
-    @abstractmethod
-    def __pydantic_update_schema__(self, schema: core_schema.CoreSchema, **constraints: Any) -> None:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def __call__(self, __input_value: Any, __info: core_schema.ValidationInfo) -> Any:
-        raise NotImplementedError()
-
-    def _update_attrs(self, constraints: dict[str, Any], attrs: set[str] | None = None) -> None:
-        """
-        Utility for updating attributes/slots and raising an error if they don't exist, to be used by
-        implementations of `CustomValidator`.
-        """
-        attrs = attrs or set(self.__slots__)  # type: ignore[attr-defined]
-        for k, v in constraints.items():
-            if k not in attrs:
-                raise TypeError(f'{k!r} is not a valid constraint for {self.__class__.__name__}')
-            setattr(self, k, v)
-
-
-# KW_ONLY is only available in Python 3.10+
-DC_KW_ONLY = getattr(dataclasses, 'KW_ONLY', None)
 
 
 def collect_model_fields(  # noqa: C901

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1142,6 +1142,7 @@ class GenerateSchema:
         if prepare is None:
             # check if this is one of our "known" types
             prepare = self._get_prepare_pydantic_annotations_for_known_type(source_type)
+
         if prepare is not None:
             # make annotations a tuple to error if it gets mutated
             # make the return type a list to support generators or returning a sequence

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -306,9 +306,18 @@ class GenerateSchema:
         if prepare is not None:
             # make annotations a tuple to error if it gets mutated
             # make the return type a list to support generators or returning a sequence
-            new_annotations = list(prepare(obj, tuple(annotations)))
+            res = list(prepare(obj, tuple(annotations)))
+            if not res:
+                raise PydanticSchemaGenerationError(
+                    f'The type {obj} that implements `__prepare_pydantic_annotations__`'
+                    ' returned no new annotations when called.'
+                    ' You must return at least 1 item since the first item is the replacement source type.'
+                )
+            obj, *new_annotations = list(prepare(obj, tuple(annotations)))
             if new_annotations:
                 return self._annotated_args_schema(obj, new_annotations)
+            else:
+                return self.generate_schema(obj)
 
         return None
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1139,7 +1139,6 @@ class GenerateSchema:
         `Annotated[source_type, *annotations]` -> `Annotated[new_source_type, *new_annotations]`
         """
         prepare = getattr(source_type, '__prepare_pydantic_annotations__', None)
-        annotations = list(annotations)
         if prepare is None:
             # check if this is one of our "known" types
             prepare = self._get_prepare_pydantic_annotations_for_known_type(source_type)
@@ -1154,7 +1153,7 @@ class GenerateSchema:
                     ' Custom types must return at least 1 item since the first item is the replacement source type.'
                 )
             source_type, *annotations = res
-        return (source_type, annotations)
+        return (source_type, list(annotations))
 
     def _apply_annotations(
         self,

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -20,7 +20,7 @@ from typing_extensions import Annotated, Final, Literal, TypedDict, get_args, ge
 
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import FieldInfo
-from . import _discriminated_union, _metadata, _typing_extra
+from . import _discriminated_union, _known_annotated_metadata, _typing_extra
 from ._config import ConfigWrapper
 from ._core_metadata import (
     CoreMetadataHandler,
@@ -1366,7 +1366,7 @@ def apply_single_annotation(
     # PEP 593: "If a library (or tool) encounters a typehint Annotated[T, x] and has no
     # special logic for metadata x, it should ignore it and simply treat the type as T."
     # Allow, but ignore, any unknown metadata.
-    metadata_dict, _ = _metadata.collect_known_metadata([metadata])
+    metadata_dict, _ = _known_annotated_metadata.collect_known_metadata([metadata])
 
     if not metadata_dict:
         return schema

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -313,7 +313,7 @@ class GenerateSchema:
                     ' returned no new annotations when called.'
                     ' You must return at least 1 item since the first item is the replacement source type.'
                 )
-            obj, *new_annotations = list(prepare(obj, tuple(annotations)))
+            obj, *new_annotations = res
             if new_annotations:
                 return self._annotated_args_schema(obj, new_annotations)
             else:

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -7,24 +7,34 @@ import annotated_types as at
 
 from ._fields import PydanticGeneralMetadata, PydanticMetadata
 
+STRICT = {'strict'}
 SEQUENCE_CONSTRAINTS = {'min_length', 'max_length'}
-COMPARISON_CONSTRAINTS = {'le', 'ge', 'lt', 'gt'}
-NUMERIC_CONSTRAINTS = {'multiple_of', 'allow_inf_nan', *COMPARISON_CONSTRAINTS}
+INEQUALITY = {'le', 'ge', 'lt', 'gt'}
+NUMERIC_CONSTRAINTS = {'multiple_of', 'allow_inf_nan', *INEQUALITY}
 
-CORE_SCHEMA_CONSTRAINTS = {
-    'float': NUMERIC_CONSTRAINTS,
-    'int': NUMERIC_CONSTRAINTS,
-    'str': {*SEQUENCE_CONSTRAINTS, 'strip_whitespace', 'to_lower', 'to_upper', 'strict'},
-    'list': SEQUENCE_CONSTRAINTS,
-    'bytes': SEQUENCE_CONSTRAINTS,
-    'date': NUMERIC_CONSTRAINTS,
-    'time': NUMERIC_CONSTRAINTS,
-    'datetime': NUMERIC_CONSTRAINTS,
-    'timedelta': NUMERIC_CONSTRAINTS,
-}
+STR_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT, 'strip_whitespace', 'to_lower', 'to_upper'}
+BYTES_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
+
+LIST_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
+TUPLE_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
+SET_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
+DICT_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
+GENERATOR_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
+
+FLOAT_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
+INT_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
+
+DATE_TIME_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
+TIMEDELTA_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
+TIME_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
 
 
 def collect_known_metadata(annotations: Iterable[Any]) -> tuple[dict[str, Any], list[Any]]:
+    """
+    Split `annotations` into known metadata and unknown annotations.
+
+    For example `[Gt(1), Len(42), Unknown()]` -> `({'gt': 1, 'min_length': 42}, [Unknown()])`.
+    """
     from pydantic.fields import FieldInfo  # circular import
 
     res: dict[str, Any] = {}

--- a/pydantic/_internal/_metadata.py
+++ b/pydantic/_internal/_metadata.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Iterable
+
+import annotated_types as at
+
+from ._fields import PydanticGeneralMetadata, PydanticMetadata
+
+SEQUENCE_CONSTRAINTS = {'min_length', 'max_length'}
+COMPARISON_CONSTRAINTS = {'le', 'ge', 'lt', 'gt'}
+NUMERIC_CONSTRAINTS = {'multiple_of', 'allow_inf_nan', *COMPARISON_CONSTRAINTS}
+
+CORE_SCHEMA_CONSTRAINTS = {
+    'float': NUMERIC_CONSTRAINTS,
+    'int': NUMERIC_CONSTRAINTS,
+    'str': {*SEQUENCE_CONSTRAINTS, 'strip_whitespace', 'to_lower', 'to_upper', 'strict'},
+    'list': SEQUENCE_CONSTRAINTS,
+    'bytes': SEQUENCE_CONSTRAINTS,
+    'date': NUMERIC_CONSTRAINTS,
+    'time': NUMERIC_CONSTRAINTS,
+    'datetime': NUMERIC_CONSTRAINTS,
+    'timedelta': NUMERIC_CONSTRAINTS,
+}
+
+
+def collect_known_metadata(annotations: Iterable[Any]) -> tuple[dict[str, Any], list[Any]]:
+    from pydantic.fields import FieldInfo  # circular import
+
+    res: dict[str, Any] = {}
+    remaining: list[Any] = []
+    for annotation in annotations:
+        if isinstance(annotation, at.GroupedMetadata):
+            m, r = collect_known_metadata(list(annotation))
+            res.update(m)
+            remaining.extend(r)
+        elif isinstance(annotation, FieldInfo):
+            for sub in annotation.metadata:
+                m, r = collect_known_metadata([sub])
+                res.update(m)
+                remaining.extend(r)
+        # Do we really want to consume any `BaseMetadata`?
+        # It does let us give a better error when there is an annotation that doesn't apply
+        # But it seems dangerous!
+        elif isinstance(annotation, PydanticGeneralMetadata):
+            res.update(annotation.__dict__)
+        elif isinstance(annotation, (at.BaseMetadata, PydanticMetadata)):
+            res.update(dataclasses.asdict(annotation))  # type: ignore[call-overload]
+        elif isinstance(annotation, type) and issubclass(annotation, PydanticMetadata):
+            # also support PydanticMetadata classes being used without initialisation,
+            # e.g. `Annotated[int, Strict]` as well as `Annotated[int, Strict()]`
+            res.update({k: v for k, v in vars(annotation).items() if not k.startswith('_')})
+        else:
+            remaining.append(annotation)
+    # Nones can sneak in but pydantic-core will reject them
+    # it'd be nice to clean things up so we don't put in None (we probably don't _need_ to, it was just easier)
+    # but this is simple enough to kick that can down the road
+    res = {k: v for k, v in res.items() if v is not None}
+    return res, remaining
+
+
+def check_metadata(metadata: dict[str, Any], allowed: Iterable[str], source_type: Any) -> None:
+    """
+    A small utility function to validate that the given metadata can be applied to the target.
+    More than saving lines of code, this gives us a consistent error message for all of our internal implementations.
+    """
+    unknown = metadata.keys() - set(allowed)
+    if unknown:
+        raise TypeError(
+            f'The following constraints cannot be applied to {source_type!r}: {", ".join([f"{k!r}" for k in unknown])}'
+        )

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -21,11 +21,10 @@ from pydantic_core import CoreSchema, MultiHostUrl, PydanticCustomError, Pydanti
 from typing_extensions import get_args
 
 from ..json_schema import JsonSchemaValue, update_json_schema
-from . import _serializers, _validators
+from . import _known_annotated_metadata, _serializers, _validators
 from ._core_metadata import build_metadata_dict
 from ._core_utils import get_type_ref
 from ._internal_dataclass import slots_dataclass
-from ._metadata import CORE_SCHEMA_CONSTRAINTS, check_metadata, collect_known_metadata
 from ._schema_generation_shared import GetCoreSchemaHandler, GetJsonSchemaHandler
 
 if typing.TYPE_CHECKING:
@@ -285,8 +284,10 @@ class DecimalValidator:
 
 
 def decimal_prepare_pydantic_annotations(_source: Any, annotations: Iterable[Any]) -> Iterable[Any]:
-    metadata, remaining_annotations = collect_known_metadata(annotations)
-    check_metadata(metadata, {*CORE_SCHEMA_CONSTRAINTS['float'], 'max_digits', 'decimal_places'}, Decimal)
+    metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
+    _known_annotated_metadata.check_metadata(
+        metadata, {*_known_annotated_metadata.FLOAT_CONSTRAINTS, 'max_digits', 'decimal_places'}, Decimal
+    )
     yield Decimal
     yield DecimalValidator(**metadata)
     yield from remaining_annotations

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -32,9 +32,8 @@ from ._internal import _fields, _internal_dataclass, _validators
 from pydantic_core import CoreSchema, PydanticCustomError, PydanticKnownError, core_schema
 from typing_extensions import Annotated, Literal
 
-from ._internal import _fields, _validators
+from ._internal import _fields, _known_annotated_metadata, _validators
 from ._internal._internal_dataclass import slots_dataclass
-from ._internal._metadata import CORE_SCHEMA_CONSTRAINTS, check_metadata, collect_known_metadata
 from ._migration import getattr_migration
 from .annotated import GetCoreSchemaHandler
 from .errors import PydanticUserError
@@ -468,8 +467,8 @@ class SecretField(Generic[SecretType]):
 
     @classmethod
     def __prepare_pydantic_annotations__(cls, source: type[Any], annotations: Iterator[Any]) -> Iterator[Any]:
-        metadata, remaining_annotations = collect_known_metadata(annotations)
-        check_metadata(metadata, CORE_SCHEMA_CONSTRAINTS['str'], cls)
+        metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
+        _known_annotated_metadata.check_metadata(metadata, {'min_length', 'max_length'}, cls)
         yield cls
         yield _SecretFieldValidator(source, **metadata)
         yield from remaining_annotations

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-import abc
 import base64
 import dataclasses as _dataclasses
 import re
@@ -25,14 +24,10 @@ from typing import (
 from uuid import UUID
 
 import annotated_types
-from pydantic_core import PydanticCustomError, PydanticKnownError, core_schema
+from pydantic_core import CoreSchema, PydanticCustomError, PydanticKnownError, core_schema
 from typing_extensions import Annotated, Literal, Protocol
 
-from ._internal import _fields, _internal_dataclass, _validators
-from pydantic_core import CoreSchema, PydanticCustomError, PydanticKnownError, core_schema
-from typing_extensions import Annotated, Literal
-
-from ._internal import _fields, _known_annotated_metadata, _validators
+from ._internal import _fields, _internal_dataclass, _known_annotated_metadata, _validators
 from ._internal._internal_dataclass import slots_dataclass
 from ._migration import getattr_migration
 from .annotated import GetCoreSchemaHandler

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -16,7 +16,7 @@ from typing import (
     FrozenSet,
     Generic,
     Hashable,
-    Iterator,
+    Iterable,
     List,
     Set,
     TypeVar,
@@ -466,7 +466,7 @@ class SecretField(Generic[SecretType]):
         return self._secret_value
 
     @classmethod
-    def __prepare_pydantic_annotations__(cls, source: type[Any], annotations: Iterator[Any]) -> Iterator[Any]:
+    def __prepare_pydantic_annotations__(cls, source: type[Any], annotations: Iterable[Any]) -> Iterable[Any]:
         metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
         _known_annotated_metadata.check_metadata(metadata, {'min_length', 'max_length'}, cls)
         yield cls

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -16,6 +16,7 @@ from typing import (
     FrozenSet,
     Generic,
     Hashable,
+    Iterator,
     List,
     Set,
     TypeVar,
@@ -28,6 +29,12 @@ from pydantic_core import PydanticCustomError, PydanticKnownError, core_schema
 from typing_extensions import Annotated, Literal, Protocol
 
 from ._internal import _fields, _internal_dataclass, _validators
+from pydantic_core import CoreSchema, PydanticCustomError, PydanticKnownError, core_schema
+from typing_extensions import Annotated, Literal
+
+from ._internal import _fields, _validators
+from ._internal._internal_dataclass import slots_dataclass
+from ._internal._metadata import CORE_SCHEMA_CONSTRAINTS, check_metadata, collect_known_metadata
 from ._migration import getattr_migration
 from .annotated import GetCoreSchemaHandler
 from .errors import PydanticUserError
@@ -84,7 +91,6 @@ __all__ = [
     'Base64Str',
 ]
 
-from ._internal._core_metadata import build_metadata_dict
 from ._internal._schema_generation_shared import GetJsonSchemaHandler
 from ._internal._utils import update_not_none
 from .json_schema import JsonSchemaValue
@@ -453,9 +459,7 @@ else:
 SecretType = TypeVar('SecretType', str, bytes)
 
 
-class SecretField(abc.ABC, Generic[SecretType]):
-    _error_kind: str
-
+class SecretField(Generic[SecretType]):
     def __init__(self, secret_value: SecretType) -> None:
         self._secret_value: SecretType = secret_value
 
@@ -463,67 +467,12 @@ class SecretField(abc.ABC, Generic[SecretType]):
         return self._secret_value
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
-        validator = SecretFieldValidator(cls)
-        js_modify_functions: list[Any] = []
-        if issubclass(cls, SecretStr):
-            # Use a lambda here so that `apply_metadata` can be called on the validator before the override is generated
-            def js_cs_override1(_c: Any, h: Any) -> Any:
-                return h(core_schema.str_schema(min_length=validator.min_length, max_length=validator.max_length))
-
-            js_modify_functions.append(js_cs_override1)
-
-        elif issubclass(cls, SecretBytes):
-
-            def js_cs_override2(_c: Any, h: Any) -> Any:
-                return h(core_schema.bytes_schema(min_length=validator.min_length, max_length=validator.max_length))
-
-            js_modify_functions.append(js_cs_override2)
-
-        metadata = build_metadata_dict(
-            cs_update_function=validator.__pydantic_update_schema__, js_functions=js_modify_functions
-        )
-        return core_schema.general_after_validator_function(
-            validator,
-            core_schema.union_schema(
-                [core_schema.is_instance_schema(cls), cls._pre_core_schema()],
-                strict=True,
-                custom_error_type=cls._error_kind,
-            ),
-            metadata=metadata,
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                cls._serialize, info_arg=True, json_return_type='str'
-            ),
-        )
-
-    @classmethod
-    def _serialize(
-        cls, value: SecretField[SecretType], info: core_schema.SerializationInfo
-    ) -> str | SecretField[SecretType]:
-        if info.mode == 'json':
-            # we want the output to always be string without the `b'` prefix for byties,
-            # hence we just use `secret_display`
-            return secret_display(value)
-        else:
-            return value
-
-    @classmethod
-    @abc.abstractmethod
-    def _pre_core_schema(cls) -> core_schema.CoreSchema:
-        ...
-
-    @classmethod
-    def __get_pydantic_json_schema__(
-        cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
-    ) -> JsonSchemaValue:
-        field_schema = handler(core_schema)
-        update_not_none(
-            field_schema,
-            type='string',
-            writeOnly=True,
-            format='password',
-        )
-        return field_schema
+    def __prepare_pydantic_annotations__(cls, source: type[Any], annotations: Iterator[Any]) -> Iterator[Any]:
+        metadata, remaining_annotations = collect_known_metadata(annotations)
+        check_metadata(metadata, CORE_SCHEMA_CONSTRAINTS['str'], cls)
+        yield cls
+        yield _SecretFieldValidator(source, **metadata)
+        yield from remaining_annotations
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, self.__class__) and self.get_secret_value() == other.get_secret_value()
@@ -534,69 +483,94 @@ class SecretField(abc.ABC, Generic[SecretType]):
     def __len__(self) -> int:
         return len(self._secret_value)
 
-    @abc.abstractmethod
-    def _display(self) -> SecretType:
-        ...
-
     def __str__(self) -> str:
         return str(self._display())
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}({self._display()!r})'
 
+    def _display(self) -> SecretType:
+        raise NotImplementedError
 
-def secret_display(secret_field: SecretField[Any]) -> str:
-    return '**********' if secret_field.get_secret_value() else ''
+
+def _secret_display(value: str | bytes) -> str:
+    if isinstance(value, bytes):
+        value = value.decode()
+    return '**********' if value else ''
 
 
-class SecretFieldValidator(_fields.CustomValidator, Generic[SecretType]):
-    __slots__ = 'field_type', 'min_length', 'max_length', 'error_prefix'
+@slots_dataclass
+class _SecretFieldValidator:
+    field_type: type[SecretField[Any]]
+    min_length: int | None = None
+    max_length: int | None = None
+    inner_schema: CoreSchema = _dataclasses.field(init=False)
 
-    def __init__(
-        self, field_type: type[SecretField[SecretType]], min_length: int | None = None, max_length: int | None = None
-    ) -> None:
-        self.field_type: type[SecretField[SecretType]] = field_type
-        self.min_length = min_length
-        self.max_length = max_length
-        self.error_prefix: Literal['string', 'bytes'] = 'string' if field_type is SecretStr else 'bytes'
-
-    def __call__(self, __value: SecretField[SecretType] | SecretType, _: core_schema.ValidationInfo) -> Any:
-        if self.min_length is not None and len(__value) < self.min_length:
-            short_kind: core_schema.ErrorType = f'{self.error_prefix}_too_short'  # type: ignore[assignment]
+    def validate(self, value: SecretField[SecretType] | SecretType, _: core_schema.ValidationInfo) -> Any:
+        error_prefix: Literal['string', 'bytes'] = 'string' if self.field_type is SecretStr else 'bytes'
+        if self.min_length is not None and len(value) < self.min_length:
+            short_kind: core_schema.ErrorType = f'{error_prefix}_too_short'  # type: ignore[assignment]
             raise PydanticKnownError(short_kind, {'min_length': self.min_length})
-        if self.max_length is not None and len(__value) > self.max_length:
-            long_kind: core_schema.ErrorType = f'{self.error_prefix}_too_long'  # type: ignore[assignment]
+        if self.max_length is not None and len(value) > self.max_length:
+            long_kind: core_schema.ErrorType = f'{error_prefix}_too_long'  # type: ignore[assignment]
             raise PydanticKnownError(long_kind, {'max_length': self.max_length})
 
-        if isinstance(__value, self.field_type):
-            return __value
+        if isinstance(value, self.field_type):
+            return value
         else:
-            return self.field_type(__value)  # type: ignore[arg-type]
+            return self.field_type(value)  # type: ignore[arg-type]
 
-    def __pydantic_update_schema__(self, schema: core_schema.CoreSchema, **constraints: Any) -> None:
-        self._update_attrs(constraints, {'min_length', 'max_length'})
+    def serialize(
+        self, value: SecretField[SecretType], info: core_schema.SerializationInfo
+    ) -> str | SecretField[SecretType]:
+        if info.mode == 'json':
+            # we want the output to always be string without the `b'` prefix for bytes,
+            # hence we just use `secret_display`
+            return _secret_display(value.get_secret_value())
+        else:
+            return value
+
+    def __get_pydantic_json_schema__(
+        self, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        schema = self.inner_schema.copy()
+        if self.min_length is not None:
+            schema['min_length'] = self.min_length  # type: ignore
+        if self.max_length is not None:
+            schema['max_length'] = self.max_length  # type: ignore
+        json_schema = handler(schema)
+        update_not_none(
+            json_schema,
+            type='string',
+            writeOnly=True,
+            format='password',
+        )
+        return json_schema
+
+    def __get_pydantic_core_schema__(self, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        self.inner_schema = handler(str if self.field_type is SecretStr else bytes)
+        error_kind = 'string_type' if self.field_type is SecretStr else 'bytes_type'
+        return core_schema.general_after_validator_function(
+            self.validate,
+            core_schema.union_schema(
+                [core_schema.is_instance_schema(self.field_type), self.inner_schema],
+                strict=True,
+                custom_error_type=error_kind,
+            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                self.serialize, info_arg=True, json_return_type='str'
+            ),
+        )
 
 
 class SecretStr(SecretField[str]):
-    _error_kind = 'string_type'
-
-    @classmethod
-    def _pre_core_schema(cls) -> core_schema.CoreSchema:
-        return core_schema.str_schema()
-
     def _display(self) -> str:
-        return secret_display(self)
+        return _secret_display(self.get_secret_value())
 
 
 class SecretBytes(SecretField[bytes]):
-    _error_kind = 'bytes_type'
-
-    @classmethod
-    def _pre_core_schema(cls) -> core_schema.CoreSchema:
-        return core_schema.bytes_schema()
-
     def _display(self) -> bytes:
-        return secret_display(self).encode()
+        return _secret_display(self.get_secret_value()).encode()
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PAYMENT CARD TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1235,10 +1235,7 @@ def test_multiple_errors():
             'type': 'decimal_parsing',
             'loc': (
                 'a',
-                (
-                    'lax-or-strict[lax=function-after[validate(), union[is-instance[Decimal],int,float,constrained-str'
-                    ']],strict=custom-error[function-after[validate(), is-instance[Decimal]]]]',
-                ),
+                'lax-or-strict[lax=function-after[validate(), union[is-instance[Decimal],int,float,constrained-str]],strict=custom-error[function-after[validate(), is-instance[Decimal]]]]',  # noqa: E501
             ),
             'msg': 'Input should be a valid decimal',
             'input': 'foobar',

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1235,7 +1235,10 @@ def test_multiple_errors():
             'type': 'decimal_parsing',
             'loc': (
                 'a',
-                'lax-or-strict[lax=function-after[DecimalValidator(allow_inf_nan=False, check_digits=False, strict=False)(), union[is-instance[Decimal],int,float,constrained-str]],strict=custom-error[function-after[DecimalValidator(allow_inf_nan=False, check_digits=False, strict=False)(), is-instance[Decimal]]]]',  # noqa: E501
+                (
+                    'lax-or-strict[lax=function-after[validate(), union[is-instance[Decimal],int,float,constrained-str'
+                    ']],strict=custom-error[function-after[validate(), is-instance[Decimal]]]]',
+                ),
             ),
             'msg': 'Input should be a valid decimal',
             'input': 'foobar',

--- a/tests/test_prepare_annotations.py
+++ b/tests/test_prepare_annotations.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
-from typing import Annotated, Any, Iterator, List, Sequence
+from typing import Any, Iterator, List, Sequence
 
 import dirty_equals as de
 import pytest
 from annotated_types import Gt, Lt
 from pydantic_core import CoreSchema, core_schema
+from typing_extensions import Annotated
 
 from pydantic.analyzed_type import AnalyzedType
 from pydantic.annotated import GetCoreSchemaHandler

--- a/tests/test_prepare_annotations.py
+++ b/tests/test_prepare_annotations.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Annotated, Any, List, Sequence
 
+import dirty_equals as de
 from annotated_types import Gt
 from pydantic_core import CoreSchema, core_schema
 
@@ -10,44 +11,71 @@ from pydantic.annotated_arguments import AfterValidator
 from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
 
 
-def test_prepare_annotations_decimal_like() -> None:
-    @dataclass
-    class MetadataApplier:
-        inner_core_schema: CoreSchema
-        outer_core_schema: CoreSchema
+@dataclass
+class MetadataApplier:
+    inner_core_schema: CoreSchema
+    outer_core_schema: CoreSchema
 
-        def __get_pydantic_core_schema__(self, _source_type: Any, _handler: GetCoreSchemaHandler) -> CoreSchema:
-            return self.outer_core_schema
+    def __get_pydantic_core_schema__(self, _source_type: Any, _handler: GetCoreSchemaHandler) -> CoreSchema:
+        return self.outer_core_schema
 
-        def __get_pydantic_json_schema__(self, _schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            return handler(self.inner_core_schema)
+    def __get_pydantic_json_schema__(self, _schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        return handler(self.inner_core_schema)
 
-    class MyDecimal(float):
-        @classmethod
-        def __prepare_pydantic_annotations__(cls, source_type: Any, annotations: Sequence[Any]) -> Sequence[Any]:
-            assert source_type is MyDecimal
-            metadata: dict[str, Any] = {}
-            remaining_annotations: list[Any] = []
-            for annotation in annotations:
-                if isinstance(annotation, Gt):
-                    metadata['gt'] = annotation.gt
-                else:
-                    remaining_annotations.append(annotation)
-            inner_schema = core_schema.float_schema(**metadata)
-            outer_schema = core_schema.no_info_after_validator_function(MyDecimal, inner_schema)
-            new_annotations = [
-                MetadataApplier(inner_core_schema=inner_schema, outer_core_schema=outer_schema),
-                *remaining_annotations,
-            ]
-            return new_annotations
 
+class MyDecimal(float):
+    @classmethod
+    def __prepare_pydantic_annotations__(cls, source_type: Any, annotations: Sequence[Any]) -> Sequence[Any]:
+        assert source_type is MyDecimal
+        metadata: dict[str, Any] = {}
+        remaining_annotations: list[Any] = []
+        for annotation in annotations:
+            if isinstance(annotation, Gt):
+                metadata['gt'] = annotation.gt
+            else:
+                remaining_annotations.append(annotation)
+        inner_schema = core_schema.float_schema(**metadata)
+        outer_schema = core_schema.no_info_after_validator_function(MyDecimal, inner_schema)
+        new_annotations = [
+            MetadataApplier(inner_core_schema=inner_schema, outer_core_schema=outer_schema),
+            *remaining_annotations,
+        ]
+        return new_annotations
+
+
+def test_decimal_like_in_annotated() -> None:
     def no_op_val(x: Any) -> Any:
         return x
 
     a = AnalyzedType(List[Annotated[MyDecimal, Gt(10), AfterValidator(no_op_val)]])
 
-    assert a.core_schema == core_schema.list_schema(
-        core_schema.no_info_after_validator_function(
-            no_op_val, core_schema.no_info_after_validator_function(MyDecimal, core_schema.float_schema(gt=10))
+    expected = de.IsPartialDict(
+        core_schema.list_schema(
+            de.IsPartialDict(
+                core_schema.no_info_after_validator_function(
+                    no_op_val,
+                    de.IsPartialDict(
+                        core_schema.no_info_after_validator_function(
+                            MyDecimal, de.IsPartialDict(core_schema.float_schema(gt=10))
+                        )
+                    ),
+                )
+            )
         )
     )
+
+    assert a.core_schema == expected
+
+
+def test_decimal_like_outside_of_annotated() -> None:
+    a = AnalyzedType(List[MyDecimal])
+
+    expected = de.IsPartialDict(
+        core_schema.list_schema(
+            de.IsPartialDict(
+                core_schema.no_info_after_validator_function(MyDecimal, de.IsPartialDict(core_schema.float_schema()))
+            )
+        )
+    )
+
+    assert a.core_schema == expected

--- a/tests/test_prepare_annotations.py
+++ b/tests/test_prepare_annotations.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from typing import Annotated, Any, List, Sequence
+
+from annotated_types import Gt
+from pydantic_core import CoreSchema, core_schema
+
+from pydantic.analyzed_type import AnalyzedType
+from pydantic.annotated import GetCoreSchemaHandler
+from pydantic.annotated_arguments import AfterValidator
+from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
+
+
+def test_prepare_annotations_decimal_like() -> None:
+    @dataclass
+    class MetadataApplier:
+        inner_core_schema: CoreSchema
+        outer_core_schema: CoreSchema
+
+        def __get_pydantic_core_schema__(self, _source_type: Any, _handler: GetCoreSchemaHandler) -> CoreSchema:
+            return self.outer_core_schema
+
+        def __get_pydantic_json_schema__(self, _schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+            return handler(self.inner_core_schema)
+
+    class Decimal:
+        @classmethod
+        def __prepare_pydantic_annotations__(cls, source_type: Any, annotations: Sequence[Any]) -> Sequence[Any]:
+            metadata: dict[str, Any] = {}
+            remaining_annotations: list[Any] = []
+            for annotation in annotations:
+                if isinstance(annotation, Gt):
+                    metadata['gt'] = annotation.gt
+                else:
+                    remaining_annotations.append(annotation)
+            inner_schema = core_schema.float_schema(**metadata)
+            outer_schema = core_schema.no_info_after_validator_function(Decimal, inner_schema)
+            new_annotations = [
+                MetadataApplier(inner_core_schema=inner_schema, outer_core_schema=outer_schema),
+                *remaining_annotations,
+            ]
+            return new_annotations
+
+    def no_op_val(x: Any) -> Any:
+        return x
+
+    a = AnalyzedType(List[Annotated[Decimal, Gt(10), AfterValidator(no_op_val)]])
+
+    assert a.core_schema == core_schema.list_schema(
+        core_schema.no_info_after_validator_function(
+            no_op_val, core_schema.no_info_after_validator_function(Decimal, core_schema.float_schema(gt=10))
+        )
+    )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1539,7 +1539,9 @@ def test_invalid_schema_constraints(kwargs, type_):
 
 
 def test_invalid_decimal_constraint():
-    with pytest.raises(TypeError, match="'max_length' is not a valid constraint for DecimalValidator"):
+    with pytest.raises(
+        TypeError, match="The following constraints cannot be applied to <class 'decimal.Decimal'>: 'max_length'"
+    ):
 
         class Foo(BaseModel):
             a: Decimal = Field('foo', title='A title', description='A description', max_length=5)


### PR DESCRIPTION
This covers two important use cases, both of which we use in `Decimal`:
- "Consuming" constraints when the core schema you return from `__get_pydantic_core_schema__` is not the one that the metadata should be applied to.
- Persisting state between `__get_pydantic_core_schema__` and `__get_pydantic_json_schema__` (e.g. if you want to generate the json schema on something other than the actual core schema but need info from within that core schema or the source type).

Both of these are _impossible_ to do as a user currently and even within our implementation require a lot of hacking around.

I'm doing this as standalone thing in this PR, a followup PR will refactor our current `Decimal` and everything else using `CustomValidator` stuff to be like this.

Selected Reviewer: @samuelcolvin