### PR TITLE
Re-add schema_extra functionality removed from config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,8 +369,8 @@ jobs:
   send-tweet:
     name: Send tweet
     runs-on: ubuntu-latest
-    needs: [deploy]
-    if: ${{ needs.deploy.status == 'OK' }}
+    needs: [release]
+    if: ${{ needs.release.status == 'OK' }}
 
     steps:
       - uses: actions/setup-python@v4
@@ -394,9 +394,9 @@ jobs:
           client.create_tweet(text=tweet)
         env:
           TWEET: |
-            Pydantic version ${{needs.deploy.outputs.pydantic-version}} is out! 🎉
+            Pydantic version ${{needs.release.outputs.pydantic-version}} is out! 🎉
 
-            https://github.com/pydantic/pydantic-settings/releases/tag/v${{needs.deploy.outputs.pydantic-version}}
+            https://github.com/pydantic/pydantic-settings/releases/tag/v${{needs.release.outputs.pydantic-version}}
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 from pydantic_core import core_schema
 from typing_extensions import Literal, Self
 
-from ..config import ConfigDict, ExtraValues
+from ..config import ConfigDict, ExtraValues, JsonSchemaExtraCallable
 from ..errors import PydanticUserError
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
@@ -43,6 +43,7 @@ class ConfigWrapper:
     alias_generator: Callable[[str], str] | None
     ignored_types: tuple[type, ...]
     allow_inf_nan: bool
+    json_schema_extra: dict[str, Any] | JsonSchemaExtraCallable | None
 
     # new in V2
     strict: bool
@@ -162,6 +163,7 @@ config_defaults = ConfigDict(
     alias_generator=None,
     ignored_types=(),
     allow_inf_nan=True,
+    json_schema_extra=None,
     strict=False,
     revalidate_instances='never',
     ser_json_timedelta='iso8601',
@@ -195,7 +197,6 @@ V2_REMOVED_KEYS = {
     'error_msg_templates',
     'fields',
     'getter_dict',
-    'schema_extra',
     'smart_union',
     'underscore_attrs_are_private',
     'json_loads',
@@ -213,13 +214,14 @@ V2_RENAMED_KEYS = {
     'max_anystr_length': 'str_max_length',
     'min_anystr_length': 'str_min_length',
     'orm_mode': 'from_attributes',
+    'schema_extra': 'json_schema_extra',
     'validate_all': 'validate_default',
 }
 
 
 def check_deprecated(config_dict: ConfigDict) -> None:
     """
-    Check for depreciated config keys and warn the user.
+    Check for deprecated config keys and warn the user.
     """
     deprecated_removed_keys = V2_REMOVED_KEYS & config_dict.keys()
     deprecated_renamed_keys = V2_RENAMED_KEYS.keys() & config_dict.keys()

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -43,7 +43,7 @@ class ConfigWrapper:
     alias_generator: Callable[[str], str] | None
     ignored_types: tuple[type, ...]
     allow_inf_nan: bool
-    json_schema_extra: dict[str, Any] | JsonSchemaExtraCallable | None
+    json_schema_extra: dict[str, object] | JsonSchemaExtraCallable | None
 
     # new in V2
     strict: bool

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -92,7 +92,7 @@ class ConfigDict(TypedDict, total=False):
     alias_generator: Callable[[str], str] | None
     ignored_types: tuple[type, ...]
     allow_inf_nan: bool
-    json_schema_extra: dict[str, Any] | JsonSchemaExtraCallable | None
+    json_schema_extra: dict[str, object] | JsonSchemaExtraCallable | None
 
     # new in V2
     strict: bool

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -12,6 +12,26 @@ from .deprecated.config import BaseConfig
 __all__ = 'BaseConfig', 'ConfigDict', 'Extra'
 
 
+# if TYPE_CHECKING:
+from typing import overload
+
+from typing_extensions import Protocol
+
+
+class JsonSchemaExtraCallable(Protocol):
+    @overload
+    def __call__(self, schema: dict[str, Any]) -> None:
+        pass
+
+    @overload
+    def __call__(self, schema: dict[str, Any], model_class: type[Any]) -> None:
+        pass
+
+
+# else:
+#     JsonSchemaExtraCallable = Callable[..., None]
+
+
 class _Extra:
     allow: Literal['allow'] = 'allow'
     ignore: Literal['ignore'] = 'ignore'
@@ -82,6 +102,7 @@ class ConfigDict(TypedDict, total=False):
     alias_generator: Callable[[str], str] | None
     ignored_types: tuple[type, ...]
     allow_inf_nan: bool
+    json_schema_extra: dict[str, Any] | JsonSchemaExtraCallable | None
 
     # new in V2
     strict: bool

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,21 +1,15 @@
 """Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, overload
 from warnings import warn
 
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal, Protocol, TypedDict
 
 from ._migration import getattr_migration
 from .deprecated.config import BaseConfig
 
 __all__ = 'BaseConfig', 'ConfigDict', 'Extra'
-
-
-# if TYPE_CHECKING:
-from typing import overload
-
-from typing_extensions import Protocol
 
 
 class JsonSchemaExtraCallable(Protocol):
@@ -26,10 +20,6 @@ class JsonSchemaExtraCallable(Protocol):
     @overload
     def __call__(self, schema: dict[str, Any], model_class: type[Any]) -> None:
         pass
-
-
-# else:
-#     JsonSchemaExtraCallable = Callable[..., None]
 
 
 class _Extra:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -586,7 +586,7 @@ class GenerateJsonSchema:
         # We do not use schema['model'].model_json_schema() because it could lead to inconsistent refs handling, etc.
         json_schema = self.generate_inner(schema['schema'])
 
-        cls = cast(type[BaseModel], schema['cls'])
+        cls = cast('type[BaseModel]', schema['cls'])
         config = cls.model_config
         title = config.get('title')
         forbid_additional_properties = config.get('extra') == 'forbid'

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -159,9 +159,8 @@ class GenerateJsonSchema:
         json_ref_counts = self.get_json_ref_counts(json_schema)
 
         # Remove the top-level $ref if present; note that the _generate method already ensures there are no sibling keys
-        ref = json_schema.get('$ref')
+        ref = cast(JsonRef, json_schema.get('$ref'))
         while ref is not None:  # may need to unpack multiple levels
-            ref = JsonRef(ref)
             ref_json_schema = self.get_schema_from_definitions(ref)
             if json_ref_counts[ref] > 1 or ref_json_schema is None:
                 # Keep the ref, but use an allOf to remove the top level $ref
@@ -170,7 +169,7 @@ class GenerateJsonSchema:
                 # "Unpack" the ref since this is the only reference
                 json_schema = ref_json_schema.copy()  # copy to prevent recursive dict reference
                 json_ref_counts[ref] -= 1
-            ref = json_schema.get('$ref')
+            ref = cast(JsonRef, json_schema.get('$ref'))
 
         # Remove any definitions that, thanks to $ref-substitution, are no longer present.
         # I think this should only _possibly_ apply to the root model, though I'm not 100% sure.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -430,12 +430,12 @@ Valid config keys have changed in V2:
 * 'max_anystr_length' has been renamed to 'str_max_length'
 * 'min_anystr_length' has been renamed to 'str_min_length'
 * 'orm_mode' has been renamed to 'from_attributes'
+* 'schema_extra' has been renamed to 'json_schema_extra'
 * 'validate_all' has been renamed to 'validate_default'
 * 'allow_mutation' has been removed
 * 'error_msg_templates' has been removed
 * 'fields' has been removed
 * 'getter_dict' has been removed
-* 'schema_extra' has been removed
 * 'smart_union' has been removed
 * 'underscore_attrs_are_private' has been removed
     """.strip()


### PR DESCRIPTION
Re-adds the `schema_extra` config key (though renames it to `json_schema_extra`), with the same types/function signatures accepted as in v1.

This was one of the bigger pain points for me updating the FastAPI tests, as the migration path wasn't super straightforward.

At PyCon I think we came to the conclusion that this was a reasonable thing to re-add.

