### PR TITLE
Fix refs consolidation for union models

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -620,6 +620,7 @@ class GenerateSchema:
             s = choices[0]
         else:
             s = core_schema.union_schema(choices)
+            s = consolidate_refs(s)
 
         if nullable:
             s = core_schema.nullable_schema(s)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2493,3 +2493,26 @@ def test_sequences_str(sequence_type, input_data, expected_error_type, expected_
         Model(str_sequence=input_data)
 
     assert e.value.errors() == [expected_error]
+
+
+def test_union_without_duplicate_ref():
+    """
+    This test checks that a union of models with same nested model consolidates refs.
+
+    Related issue: https://github.com/pydantic/pydantic/issues/5660
+    """
+
+    class Nested(BaseModel):
+        pass
+
+    class SomeData(BaseModel):
+        nested1: Nested
+
+    class FirstModel(BaseModel):
+        nested2: Nested
+        data: SomeData
+
+    class SecondModel(BaseModel):
+        nested3: Nested
+
+    AnalyzedType(Union[FirstModel, SecondModel])


### PR DESCRIPTION
Fixes #5660
## Summary
Consolidating refs after a union schema was created

## Explanation
I get approximately the next call chart
```mermaid
flowchart TD
    A["self._union_schema()"] -->B["self.generate_schema()"]
    B --> C["self._generate_schema_from_property()"]
    C --> D["BaseModel.__get_pydantic_core_schema__()"]
``` 

https://github.com/pydantic/pydantic/blob/9c1b9804ef4db1a7c22532ee9a6d9168961db1f5/pydantic/_internal/_generate_schema.py#L606-L618
https://github.com/pydantic/pydantic/blob/9c1b9804ef4db1a7c22532ee9a6d9168961db1f5/pydantic/main.py#L264-L265

`self.generate_schema(arg)` returns already prepared schema from `cls.__pydantic_core_schema__` and this is the problem. The schema of `SecondModel` doesn't know anything about `FirstModel`.


## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb