### PR TITLE
Adds basic docs for pydantic-settings

### DIFF
--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -1,6 +1,7 @@
 Below are details on common errors developers can see when working with pydantic, together
 with some suggestions on how to fix them.
 
+{% raw %}
 ## Decorator on missing field {#decorator-missing-field}
 
 TODO
@@ -172,3 +173,4 @@ TODO
 ## Multiple field serializers {#multiple-field-serializers}
 
 TODO
+{% endraw %}

--- a/docs/usage/pydantic-settings.md
+++ b/docs/usage/pydantic-settings.md
@@ -6,5 +6,4 @@ description: Support for loading a settings or config class from environment var
 
 [Pydantic Settings](https://github.com/pydantic/pydantic-settings) provides optional Pydantic features for loading a settings or config class from environment variables or secrets files.
 
-<!-- {{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/main/docs/index.md', '') }} -->
-{{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/ecc6779e0a034ff53737b8bc9fb6d6ce12c1bffb/docs/index.md', '') }}
+{{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/main/docs/index.md', '') }}

--- a/docs/usage/pydantic-settings.md
+++ b/docs/usage/pydantic-settings.md
@@ -1,0 +1,10 @@
+---
+description: Support for loading a settings or config class from environment variables or secrets files.
+---
+
+# Pydantic Settings
+
+[Pydantic Settings](https://github.com/pydantic/pydantic-settings) provides optional Pydantic features for loading a settings or config class from environment variables or secrets files.
+
+<!-- {{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/main/docs/index.md', '') }} -->
+{{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/ecc6779e0a034ff53737b8bc9fb6d6ce12c1bffb/docs/index.md', '') }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,7 +151,7 @@ plugins:
 - mkdocstrings:
     handlers:
       python:
-        paths: .
+        paths: [.]
         options:
           separate_signature: true
 - mkdocs-simple-hooks:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,7 +151,9 @@ plugins:
 - mkdocstrings:
     handlers:
       python:
-        path: .
+        paths: .
+        options:
+          separate_signature: true
 - mkdocs-simple-hooks:
     hooks:
       on_pre_build: 'docs.plugins.main:on_pre_build'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,10 +83,11 @@ nav:
   - usage/dataclasses.md
   - usage/validation_decorator.md
   - usage/postponed_annotations.md
+  - usage/pydantic-settings.md
+  - usage/conversion_table.md
   - Errors:
     - Usage Errors: usage/errors.md
     - Validation Errors: usage/validation_errors.md
-  - usage/conversion_table.md
 - Integrations:
   - 'Mypy': integrations/mypy.md
   - 'PyCharm': integrations/pycharm.md
@@ -169,3 +170,4 @@ plugins:
       'pycharm_plugin.md': 'integrations/pycharm.md'
       'usage/devtools.md': 'integrations/devtools.md'
       'usage/rich.md': 'integrations/rich.md'
+- external-markdown:

--- a/pdm.lock
+++ b/pdm.lock
@@ -328,6 +328,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mkdocs-embed-external-markdown"
+version = "2.3.0"
+requires_python = ">=3.6.2,<4.0.0"
+summary = "Mkdocs plugin that allow to inject external markdown or markdown section from given url"
+dependencies = [
+    "Jinja2<4.0.0,>=3.0.3",
+    "requests<3.0.0,>=2.27.1",
+]
+
+[[package]]
 name = "mkdocs-exclude"
 version = "1.0.2"
 summary = "A mkdocs plugin that lets you exclude files or trees."
@@ -678,7 +688,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 [metadata]
 lock_version = "4.2"
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
-content_hash = "sha256:9ebdeaedcbb164eedbf015178cc9e587e8721d276099c6077dde1c72022f5c3a"
+content_hash = "sha256:90804d733449c98b09d120d3fc4a43917f5f1b261c2eda892437af297ca14d84"
 
 [metadata.files]
 "annotated-types 0.4.0" = [
@@ -1088,6 +1098,10 @@ content_hash = "sha256:9ebdeaedcbb164eedbf015178cc9e587e8721d276099c6077dde1c720
 "mkdocs-autorefs 0.4.1" = [
     {url = "https://files.pythonhosted.org/packages/3b/3f/9531888bc92bafb1bffddca5d9240a7bae9a479d465528883b61808ef9d6/mkdocs-autorefs-0.4.1.tar.gz", hash = "sha256:70748a7bd025f9ecd6d6feeba8ba63f8e891a1af55f48e366d6d6e78493aba84"},
     {url = "https://files.pythonhosted.org/packages/fb/5c/6594400290df38f99bf8d9ef249387b56f4ad962667836266f6fe7da8597/mkdocs_autorefs-0.4.1-py3-none-any.whl", hash = "sha256:a2248a9501b29dc0cc8ba4c09f4f47ff121945f6ce33d760f145d6f89d313f5b"},
+]
+"mkdocs-embed-external-markdown 2.3.0" = [
+    {url = "https://files.pythonhosted.org/packages/77/0d/72119c7e9075e193daae6e02ed4e8212b23a91877df773802e5b90233868/mkdocs_embed_external_markdown-2.3.0-py3-none-any.whl", hash = "sha256:a14918a2beacf50ba215670e802fee75de3013bb9db8d8e8d23dd6978004b5bc"},
+    {url = "https://files.pythonhosted.org/packages/b7/d6/45813b061306de85c758150b53a9132381568344d40f8953dceac7cc91c1/mkdocs-embed-external-markdown-2.3.0.tar.gz", hash = "sha256:543ecbaf1d1b62bb6b557714d20ac76b7c24b2b76adc5243a406e636964a8d45"},
 ]
 "mkdocs-exclude 1.0.2" = [
     {url = "https://files.pythonhosted.org/packages/54/b5/3a8e289282c9e8d7003f8a2f53d673d4fdaa81d493dc6966092d9985b6fc/mkdocs-exclude-1.0.2.tar.gz", hash = "sha256:ba6fab3c80ddbe3fd31d3e579861fd3124513708271180a5f81846da8c7e2a51"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ docs = [
     "tomli",
     "pyupgrade",
     "mike @ git+https://github.com/jimporter/mike.git",
+    "mkdocs-embed-external-markdown>=2.3.0",
 ]
 linting = [
     "black",


### PR DESCRIPTION
Adds a docs page for pydantic-settings. The docs are imported from index.md in the pydantic-settings repository.

Documentation will render correctly when https://github.com/pydantic/pydantic-settings/pull/48 is merged, due to a limitation in the mkdocs plugin. 

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
