### PR TITLE
⚡ Speedup `ModelPrivateAttr`

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -680,14 +680,13 @@ class ModelPrivateAttr(_repr.Representation):
         """
         preserve `__set_name__` protocol defined in https://peps.python.org/pep-0487
         """
-        if self.default is not Undefined:
-            try:
-                set_name = getattr(self.default, '__set_name__')
-            except AttributeError:
-                pass
-            else:
-                if callable(set_name):
-                    set_name(cls, name)
+        if self.default is Undefined:
+            return
+        if not hasattr(self.default, '__set_name__'):
+            return
+        set_name = self.default.__set_name__
+        if callable(set_name):
+            set_name(cls, name)
 
     def get_default(self) -> Any:
         """Returns the default value for the object.


### PR DESCRIPTION
## Change Summary

This should speedup using private model attributes as using `hasattr` is significantly faster than `getattr` in case of an attribute doesn't not exist. It seems likely that `ModelPrivateAttr` would be used without a custom `__set_name__` more often.

```py
>>> import timeit
>>> timeit.timeit("hasattr(a, 'foo')", setup="a = type('A', (), {})")
0.17332394601544365
>>> timeit.timeit("try: getattr(a, 'foo')\nexcept AttributeError: pass", setup="a = type('A', (), {})")
0.38944376300787553
```

## Related issue number

None

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu