### PR TITLE
Replace deprecated `validator` usage

### DIFF
--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -1,4 +1,4 @@
-Custom validation and complex relationships between objects can be achieved using the `field_validator` decorator.
+Custom validation and complex relationships between objects can be achieved using the `validator` decorator.
 
 ```py
 from pydantic_core.core_schema import FieldValidationInfo
@@ -204,13 +204,13 @@ to set a dynamic default value.
 ```py test="xfail - we need default value validation"
 from datetime import datetime
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, validator
 
 
 class DemoModel(BaseModel):
     ts: datetime = None
 
-    @field_validator('ts', pre=True, always=True)
+    @validator('ts', pre=True, always=True)
     def set_ts_now(cls, v):
         return v or datetime.now()
 

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -1,4 +1,4 @@
-Custom validation and complex relationships between objects can be achieved using the `validator` decorator.
+Custom validation and complex relationships between objects can be achieved using the `field_validator` decorator.
 
 ```py
 from pydantic_core.core_schema import FieldValidationInfo
@@ -204,13 +204,13 @@ to set a dynamic default value.
 ```py test="xfail - we need default value validation"
 from datetime import datetime
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 
 class DemoModel(BaseModel):
     ts: datetime = None
 
-    @validator('ts', pre=True, always=True)
+    @field_validator('ts', pre=True, always=True)
     def set_ts_now(cls, v):
         return v or datetime.now()
 

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -36,7 +36,7 @@ if typing.TYPE_CHECKING:
         __pydantic_validator__: typing.ClassVar[SchemaValidator]
         __pydantic_serializer__: typing.ClassVar[SchemaSerializer]
         __pydantic_decorators__: typing.ClassVar[_decorators.DecoratorInfos]
-        """metadata for `@validator`, `@root_validator` and `@serializer` decorators"""
+        """metadata for `@field_validator`, `@root_validator` and `@serializer` decorators"""
         __pydantic_fields__: typing.ClassVar[dict[str, FieldInfo]]
         __pydantic_config__: typing.ClassVar[ConfigDict]
 

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -1,5 +1,5 @@
 """
-Logic related to validators applied to models etc. via the `@validator` and `@root_validator` decorators.
+Logic related to validators applied to models etc. via the `@field_validator` and `@root_validator` decorators.
 """
 from __future__ import annotations as _annotations
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -209,7 +209,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         __pydantic_core_schema__: typing.ClassVar[CoreSchema]
         __pydantic_serializer__: typing.ClassVar[SchemaSerializer]
         __pydantic_decorators__: typing.ClassVar[_decorators.DecoratorInfos]
-        """metadata for `@validator`, `@root_validator` and `@serializer` decorators"""
+        """metadata for `@field_validator`, `@root_validator` and `@serializer` decorators"""
         model_fields: typing.ClassVar[dict[str, FieldInfo]] = {}
         __signature__: typing.ClassVar[Signature]
         __private_attributes__: typing.ClassVar[dict[str, ModelPrivateAttr]]
@@ -1076,7 +1076,7 @@ def create_model(
     :param __config__: config dict/class to use for the new model
     :param __base__: base class for the new model to inherit from
     :param __module__: module of the created model
-    :param __validators__: a dict of method names and @validator class methods
+    :param __validators__: a dict of method names and @field_validator class methods
     :param __cls_kwargs__: a dict for class creation
     :param __slots__: Deprecated, `__slots__` should not be passed to `create_model`
     :param field_definitions: fields of the model (or extra fields if a base is supplied)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

There might be other places where this needs to be replaced, but I think I've covered all the ones. Let me know if this requires a new file in `changes`. 

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani