### PR TITLE
Use `typing.Self` for `@classmethod` constructors

### DIFF
--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -5,7 +5,7 @@ from __future__ import annotations as _annotations
 
 import re
 
-from typing_extensions import Literal
+from typing_extensions import Literal, Self
 
 from ._migration import getattr_migration
 from .version import VERSION
@@ -97,7 +97,7 @@ class PydanticUndefinedAnnotation(PydanticErrorMixin, NameError):
         super().__init__(message=message, code='undefined-annotation')
 
     @classmethod
-    def from_name_error(cls, name_error: NameError) -> PydanticUndefinedAnnotation:
+    def from_name_error(cls, name_error: NameError) -> Self:
         """
         Convert a `NameError` to a `PydanticUndefinedAnnotation` error.
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -136,7 +136,7 @@ class FieldInfo(_repr.Representation):
         self.kw_only = kwargs.get('kw_only', None)
 
     @classmethod
-    def from_field(cls, default: Any = Undefined, **kwargs: Any) -> FieldInfo:
+    def from_field(cls, default: Any = Undefined, **kwargs: Any) -> typing_extensions.Self:
         """
         Create a new `FieldInfo` object with the `Field` function.
 
@@ -166,7 +166,7 @@ class FieldInfo(_repr.Representation):
         return cls(default=default, **kwargs)
 
     @classmethod
-    def from_annotation(cls, annotation: type[Any] | _forward_ref.PydanticForwardRef) -> FieldInfo:
+    def from_annotation(cls, annotation: type[Any] | _forward_ref.PydanticForwardRef) -> typing_extensions.Self:
         """
         Creates a `FieldInfo` instance from a bare annotation.
 
@@ -218,7 +218,7 @@ class FieldInfo(_repr.Representation):
         return cls(annotation=annotation, final=final)
 
     @classmethod
-    def from_annotated_attribute(cls, annotation: type[Any], default: Any) -> FieldInfo:
+    def from_annotated_attribute(cls, annotation: type[Any], default: Any) -> typing_extensions.Self:
         """
         Create `FieldInfo` from an annotation with a default value.
 
@@ -284,7 +284,7 @@ class FieldInfo(_repr.Representation):
             return cls(annotation=annotation, default=default, final=final)
 
     @classmethod
-    def _from_dataclass_field(cls, dc_field: DataclassField[Any]) -> FieldInfo:
+    def _from_dataclass_field(cls, dc_field: DataclassField[Any]) -> typing_extensions.Self:
         """
         Return a new `FieldInfo` instance from a `dataclasses.Field` instance.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

See https://peps.python.org/pep-0673/#use-in-classmethod-signatures

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin