### PR TITLE
Replace TypeError with ValidationError in forzen model

### DIFF
--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -1147,7 +1147,7 @@ except ValidationError as e:
     print(e)
     """
     1 validation error for FooBarModel
-    __root__
+    a
       Instance is frozen [type=frozen_instance, input_value='different', input_type=str]
     """
 

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -1130,7 +1130,7 @@ values of instance attributes will raise errors. See [model config](model_config
     modify a so-called "immutable" object.
 
 ```py
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 
 class FooBarModel(BaseModel):
@@ -1143,9 +1143,13 @@ foobar = FooBarModel(a='hello', b={'apple': 'pear'})
 
 try:
     foobar.a = 'different'
-except TypeError as e:
+except ValidationError as e:
     print(e)
-    #> "FooBarModel" is frozen and does not support item assignment
+    """
+    1 validation error for FooBarModel
+    __root__
+      Instance is frozen [type=frozen_instance, input_value='different', input_type=str]
+    """
 
 print(foobar.a)
 #> hello

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -369,7 +369,12 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
             _object_setattr(self, name, value)
             return
         elif self.model_config.get('frozen', None):
-            raise TypeError(f'"{self.__class__.__name__}" is frozen and does not support item assignment')
+            error: pydantic_core.InitErrorDetails = {
+                'type': 'frozen_instance',
+                'loc': ('__root__',),
+                'input': value,
+            }
+            raise pydantic_core.ValidationError(self.__class__.__name__, [error])
 
         attr = getattr(self.__class__, name, None)
         if isinstance(attr, property):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -371,7 +371,7 @@ class BaseModel(_repr.Representation, metaclass=ModelMetaclass):
         elif self.model_config.get('frozen', None):
             error: pydantic_core.InitErrorDetails = {
                 'type': 'frozen_instance',
-                'loc': ('__root__',),
+                'loc': (name,),
                 'input': value,
             }
             raise pydantic_core.ValidationError(self.__class__.__name__, [error])

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -408,8 +408,11 @@ def test_frozen():
     assert m.area == 16.0
     assert m.model_dump() == {'side': 4.0, 'area': 16.0}
 
-    with pytest.raises(TypeError, match='"Square" is frozen and does not support item assignment'):
+    with pytest.raises(ValidationError) as exc_info:
         m.area = 4
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'frozen_instance', 'loc': ('__root__',), 'msg': 'Instance is frozen', 'input': 4}
+    ]
 
 
 def test_validate_assignment():

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -411,7 +411,7 @@ def test_frozen():
     with pytest.raises(ValidationError) as exc_info:
         m.area = 4
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'frozen_instance', 'loc': ('__root__',), 'msg': 'Instance is frozen', 'input': 4}
+        {'type': 'frozen_instance', 'loc': ('area',), 'msg': 'Instance is frozen', 'input': 4}
     ]
 
 

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -2,6 +2,7 @@ import pickle
 from typing import Any, List, Optional
 
 import pytest
+from pydantic_core import ValidationError
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from pydantic.fields import Undefined
@@ -361,7 +362,7 @@ def test_immutable_copy_with_frozen(copy_method):
 
     m2 = copy_method(m, update={'b': 12})
     assert repr(m2) == 'Model(a=40, b=12)'
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         m2.b = 13
 
 

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -92,7 +92,7 @@ def test_custom_config():
     m = model(**{'foo': '987'})
     assert m.foo == 987
     assert model.model_config == expected_config
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         m.foo = 654
 
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -178,7 +178,7 @@ def test_config_is_inherited():
     with pytest.raises(ValidationError) as exc_info:
         instance.data = 2
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'frozen_instance', 'loc': ('__root__',), 'msg': 'Instance is frozen', 'input': 2}
+        {'type': 'frozen_instance', 'loc': ('data',), 'msg': 'Instance is frozen', 'input': 2}
     ]
 
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -175,10 +175,11 @@ def test_config_is_inherited():
 
     instance = Model[int](data=1)
 
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(ValidationError) as exc_info:
         instance.data = 2
-
-    assert str(exc_info.value) == '"Model[int]" is frozen and does not support item assignment'
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'frozen_instance', 'loc': ('__root__',), 'msg': 'Instance is frozen', 'input': 2}
+    ]
 
 
 def test_default_argument():
@@ -444,7 +445,7 @@ def test_generic_config():
 
     result = Result[int](data=1)
     assert result.data == 1
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         result.data = 2
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -446,7 +446,7 @@ def test_frozen_model():
     with pytest.raises(ValidationError) as exc_info:
         m.a = 11
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'frozen_instance', 'loc': ('__root__',), 'msg': 'Instance is frozen', 'input': 11}
+        {'type': 'frozen_instance', 'loc': ('a',), 'msg': 'Instance is frozen', 'input': 11}
     ]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -443,9 +443,11 @@ def test_frozen_model():
     m = FrozenModel()
 
     assert m.a == 10
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(ValidationError) as exc_info:
         m.a = 11
-    assert '"FrozenModel" is frozen and does not support item assignment' in exc_info.value.args[0]
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'frozen_instance', 'loc': ('__root__',), 'msg': 'Instance is frozen', 'input': 11}
+    ]
 
 
 def test_not_frozen_are_not_hashable():


### PR DESCRIPTION
As discussed with @samuelcolvin the frozen model error is better to be a `ValidationError` instead of `TypeError`.
Error documentation will come later with the validation error docs PR

Selected Reviewer: @dmontagu