### PR TITLE
Fixes discriminated unions not working on aliased literal fields. Issue #3849.

### DIFF
--- a/changes/5736-benwah.md
+++ b/changes/5736-benwah.md
@@ -1,0 +1,1 @@
+This solves the (closed) issue #3849 where aliased fields that use discriminated union fail to validate when the data contains the non-aliased field name.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1107,7 +1107,10 @@ class ModelField(Representation):
         assert self.discriminator_alias is not None
 
         try:
-            discriminator_value = v[self.discriminator_alias]
+            try:
+                discriminator_value = v[self.discriminator_alias]
+            except KeyError:
+                discriminator_value = v[self.discriminator_key]
         except KeyError:
             return v, ErrorWrapper(MissingDiscriminator(discriminator_key=self.discriminator_key), loc)
         except TypeError:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1110,7 +1110,10 @@ class ModelField(Representation):
             try:
                 discriminator_value = v[self.discriminator_alias]
             except KeyError:
-                discriminator_value = v[self.discriminator_key]
+                if self.model_config.allow_population_by_field_name:
+                    discriminator_value = v[self.discriminator_key]
+                else:
+                    raise
         except KeyError:
             return v, ErrorWrapper(MissingDiscriminator(discriminator_key=self.discriminator_key), loc)
         except TypeError:

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -285,6 +285,64 @@ def test_discriminated_union_basemodel_instance_value_with_alias():
     assert Top(sub=B(literal='b')).sub.literal == 'b'
 
 
+def test_discriminated_union_model_with_alias():
+    class A(BaseModel):
+        literal: Literal['a'] = Field(alias='lit')
+
+    class B(BaseModel):
+        literal: Literal['b'] = Field(alias='lit')
+
+        class Config:
+            allow_population_by_field_name = True
+
+    class TopDisallow(BaseModel):
+        sub: Union[A, B] = Field(..., discriminator='literal', alias='s')
+
+    class TopAllow(BaseModel):
+        sub: Union[A, B] = Field(..., discriminator='literal', alias='s')
+
+        class Config:
+            allow_population_by_field_name = True
+
+    assert TopDisallow.parse_obj({'s': {'lit': 'a'}}).sub.literal == 'a'
+    assert TopDisallow.parse_obj({'s': {'literal': 'b'}}).sub.literal == 'b'
+
+    with pytest.raises(ValidationError) as exc_info:
+        TopDisallow.parse_obj({'s': {'literal': 'a'}})
+
+    assert exc_info.value.errors() == [
+        {'loc': ('s', 'A', 'lit'), 'msg': 'field required', 'type': 'value_error.missing'},
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        TopDisallow.parse_obj({'sub': {'lit': 'a'}})
+
+    assert exc_info.value.errors() == [
+        {'loc': ('s',), 'msg': 'field required', 'type': 'value_error.missing'},
+    ]
+
+    assert TopAllow.parse_obj({'s': {'lit': 'a'}}).sub.literal == 'a'
+    assert TopAllow.parse_obj({'s': {'lit': 'b'}}).sub.literal == 'b'
+    assert TopAllow.parse_obj({'s': {'literal': 'b'}}).sub.literal == 'b'
+    assert TopAllow.parse_obj({'sub': {'lit': 'a'}}).sub.literal == 'a'
+    assert TopAllow.parse_obj({'sub': {'lit': 'b'}}).sub.literal == 'b'
+    assert TopAllow.parse_obj({'sub': {'literal': 'b'}}).sub.literal == 'b'
+
+    with pytest.raises(ValidationError) as exc_info:
+        TopAllow.parse_obj({'s': {'literal': 'a'}})
+
+    assert exc_info.value.errors() == [
+        {'loc': ('s', 'A', 'lit'), 'msg': 'field required', 'type': 'value_error.missing'},
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        TopAllow.parse_obj({'sub': {'literal': 'a'}})
+
+    assert exc_info.value.errors() == [
+        {'loc': ('s', 'A', 'lit'), 'msg': 'field required', 'type': 'value_error.missing'},
+    ]
+
+
 def test_discriminated_union_int():
     class A(BaseModel):
         l: Literal[1]

--- a/tests/test_discrimated_union.py
+++ b/tests/test_discrimated_union.py
@@ -305,13 +305,29 @@ def test_discriminated_union_model_with_alias():
             allow_population_by_field_name = True
 
     assert TopDisallow.parse_obj({'s': {'lit': 'a'}}).sub.literal == 'a'
-    assert TopDisallow.parse_obj({'s': {'literal': 'b'}}).sub.literal == 'b'
+
+    with pytest.raises(ValidationError) as exc_info:
+        TopDisallow.parse_obj({'s': {'literal': 'b'}})
+
+    assert exc_info.value.errors() == [
+        {
+            'ctx': {'discriminator_key': 'literal'},
+            'loc': ('s',),
+            'msg': "Discriminator 'literal' is missing in value",
+            'type': 'value_error.discriminated_union.missing_discriminator',
+        },
+    ]
 
     with pytest.raises(ValidationError) as exc_info:
         TopDisallow.parse_obj({'s': {'literal': 'a'}})
 
     assert exc_info.value.errors() == [
-        {'loc': ('s', 'A', 'lit'), 'msg': 'field required', 'type': 'value_error.missing'},
+        {
+            'ctx': {'discriminator_key': 'literal'},
+            'loc': ('s',),
+            'msg': "Discriminator 'literal' is missing in value",
+            'type': 'value_error.discriminated_union.missing_discriminator',
+        }
     ]
 
     with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
## Change Summary

The issue is described here: https://github.com/pydantic/pydantic/issues/3849

TL;DR:

When you have an aliased field, and it uses a discriminated union; you can no longer use the un-aliased field name to instantiate the model.

According to the discussion, this is not going to be a problem once Pydantic 2.x releases, but it's definitly problematic for 1.10.x which I'm currently using.

Here's the test failure without this change:

```
============================================================== FAILURES ==============================================================
_________________________________________ test_discriminated_union_validation_aliased_field __________________________________________

    def test_discriminated_union_validation_aliased_field():
        def to_upper(field_name: str) -> str:
            return field_name.upper()
    
    
        class PyBase(BaseModel):
            class Config:
                allow_population_by_field_name = True
                alias_generator = to_upper
    
    
        class Dog(PyBase):
            pet_type: Literal["dog"]
            first_name: str
    
    
        class Cat(PyBase):
            pet_type: Literal["cat"]
            first_name: str
    
    
        Pet = Annotated[Cat | Dog, Field(discriminator="pet_type")]
    
    
        class Model(PyBase):
            pet: Pet
    
    
>       m = Model.parse_obj({'pet': {'pet_type': 'cat', "first_name": "Benoit"}})

tests/test_discrimated_union.py:116: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pydantic/main.py:526: in parse_obj
    return cls(**obj)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

__pydantic_self__ = Model(), data = {'pet': {'first_name': 'Benoit', 'pet_type': 'cat'}}, values = {}, fields_set = {'pet'}
validation_error = ValidationError(model='Model', errors=[{'loc': ('PET',), 'msg': "Discriminator 'pet_type' is missing in value", 'type': 'value_error.discriminated_union.missing_discriminator', 'ctx': {'discriminator_key': 'pet_type'}}])

    def __init__(__pydantic_self__, **data: Any) -> None:
        """
        Create a new model by parsing and validating input data from keyword arguments.
    
        Raises ValidationError if the input data cannot be parsed to form a valid model.
        """
        # Uses something other than `self` the first arg to allow "self" as a settable attribute
        values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)
        if validation_error:
>           raise validation_error
E           pydantic.error_wrappers.ValidationError: 1 validation error for Model
E           PET
E             Discriminator 'pet_type' is missing in value (type=value_error.discriminated_union.missing_discriminator; discriminator_key=pet_type)

pydantic/main.py:341: ValidationError
====================================================== short test summary info =======================================================
FAILED tests/test_discrimated_union.py::test_discriminated_union_validation_aliased_field - pydantic.error_wrappers.ValidationError...
========================================================= 1 failed in 0.17s ==========================================================
```

## Related issue number

Fix #3849

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @PrettyWood