### PR TITLE
Do not try to automatically handle subclasses of mappings

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -31,7 +31,7 @@ from pydantic.errors import PydanticSchemaGenerationError
 from pydantic.fields import FieldInfo
 
 from ..json_schema import JsonSchemaValue, update_json_schema
-from . import _known_annotated_metadata, _validators
+from . import _known_annotated_metadata, _typing_extra, _validators
 from ._core_metadata import build_metadata_dict
 from ._core_utils import get_type_ref
 from ._internal_dataclass import slots_dataclass
@@ -673,7 +673,10 @@ def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable
         return allowed_default_types[values_type_origin]
 
     # Assume Annotated[..., Field(...)]
-    field_info = next((v for v in get_args(values_source_type) if isinstance(v, FieldInfo)), None)
+    if _typing_extra.is_annotated(values_source_type):
+        field_info = next((v for v in get_args(values_source_type) if isinstance(v, FieldInfo)), None)
+    else:
+        field_info = None
     if field_info and field_info.default_factory:
         default_default_factory = field_info.default_factory
     else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,6 +1,7 @@
 import json
 import math
 import re
+import typing
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
@@ -3982,4 +3983,23 @@ def test_serialization_schema_with_exclude():
         'required': ['x'],
         'title': 'Model',
         'type': 'object',
+    }
+
+
+@pytest.mark.parametrize('mapping_type', [typing.Dict, typing.Mapping])
+def test_mappings_str_int_json_schema(mapping_type: Any):
+    class Model(BaseModel):
+        str_int_map: mapping_type[str, int]
+
+    assert Model.model_json_schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {
+            'str_int_map': {
+                'title': 'Str Int Map',
+                'type': 'object',
+                'additionalProperties': {'type': 'integer'},
+            }
+        },
+        'required': ['str_int_map'],
     }


### PR DESCRIPTION
- Better handling of constraints for mappings
- Better handling of DefaultDict
    - only infer a default factory for obvious cases (int, float, bool, list, set and dict basically) and fail for other cases
    - allow specifying a default factory via `OrderedDict[int, Annotated[list, Field(default_factory=...)]]`
- Better handling of OrderedDict

Fixes #3417, #4687

Selected Reviewer: @dmontagu