### PR TITLE
🔥 Remove `_base_class_defined` hack in favor of an empty bases check

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -102,7 +102,7 @@ class ModelMetaclass(ABCMeta):
             type: the new class created by the metaclass
         """
         # Note `ModelMetaclass` refers to `BaseModel`, but is also used to *create* `BaseModel`, so we rely on the fact
-        # that `BaseModel` itself won't have any bases, but any subclass of it will, to determine that the `__new__`
+        # that `BaseModel` itself won't have any bases, but any subclass of it will, to determine whether the `__new__`
         # call we're in the middle of is for the `BaseModel` class.
         if bases:
             base_field_names, class_vars, base_private_attributes = _collect_bases_data(bases)


### PR DESCRIPTION
## Change Summary

Remove `_base_class_defined` hack and check for empty `bases` as an indicator for detecting `BaseModel` in `ModelMetaclass`. These classes are no longer tied to their places in the module.

## Related issue number

None 

## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb