### PR TITLE
Add SimpleIsInstance type

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -28,6 +28,7 @@ from pydantic_core import CoreSchema, PydanticCustomError, PydanticKnownError, c
 from typing_extensions import Annotated, Literal, Protocol
 
 from ._internal import _fields, _internal_dataclass, _known_annotated_metadata, _validators
+from ._internal._generics import get_origin
 from ._internal._internal_dataclass import slots_dataclass
 from ._migration import getattr_migration
 from .annotated import GetCoreSchemaHandler
@@ -988,5 +989,25 @@ class EncodedStr(EncodedBytes):
 
 Base64Bytes = Annotated[bytes, EncodedBytes(encoder=Base64Encoder)]
 Base64Str = Annotated[str, EncodedStr(encoder=Base64Encoder)]
+
+
+if TYPE_CHECKING:
+    SimpleIsInstance = Annotated[AnyType, ...]  # Json[list[str]] will be recognized by type checkers as list[str]
+
+else:
+
+    @_internal_dataclass.slots_dataclass
+    class SimpleIsInstance:
+        @classmethod
+        def __class_getitem__(cls, item: AnyType) -> AnyType:
+            return Annotated[item, cls()]
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+            # use the generic _origin_ as the second argument to isinstance when appropriate
+            python_schema = core_schema.is_instance_schema(get_origin(source) or source)
+            json_schema = handler(source)
+            return core_schema.json_or_python_schema(python_schema=python_schema, json_schema=json_schema)
+
 
 __getattr__ = getattr_migration(__name__)


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/5773

Looking for feedback on the implementation here before doing documentation/etc.

I've set it up so it has the standard behavior for JSON and JSON schema by default, just uses `isinstance` for python. We could make this configurable but I wanted to hash out the desired configuration choices first.

---

Unfortunately, due to the way JSON gets parsed on the Rust side, it seems that we don't get perfect preservation of big-ints, which was one of the things I was hoping to address with this change:

```python
import json

from pydantic import BaseModel
from pydantic.types import SimpleIsInstance


class Model(BaseModel):
    x: SimpleIsInstance[int]


value = dict(x=10000000000000000000000000000000000000000)
print(Model.model_validate(value))
#> x=10000000000000000000000000000000000000000


json_value = json.dumps(value)
print(json_value)
#> {"x": 10000000000000000000000000000000000000000}

print(Model.model_validate_json(json_value))
#> x=9223372036854775807
```

Not sure if it makes sense to worry about this, but I at least wanted to point it out.