### PR TITLE
Add a convenience type to override JSON schema

### DIFF
--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -150,14 +150,4 @@ class PydanticInvalidForJsonSchema(PydanticUserError):
         super().__init__(message, code='invalid-for-json-schema')
 
 
-class OmitJsonSchemaField(Exception):
-    """
-    An exception raised during generation of the JSON schema that is intended
-    specifically to indicate to the schema generator that the field should be excluded from
-    the JSON schema.
-
-    This exception should generally not be propagated outside of method calls on the GenerateJsonSchema class.
-    """
-
-
 __getattr__ = getattr_migration(__name__)

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -150,4 +150,14 @@ class PydanticInvalidForJsonSchema(PydanticUserError):
         super().__init__(message, code='invalid-for-json-schema')
 
 
+class OmitJsonSchemaField(Exception):
+    """
+    An exception raised during generation of the JSON schema that is intended
+    specifically to indicate to the schema generator that the field should be excluded from
+    the JSON schema.
+
+    This exception should generally not be propagated outside of method calls on the GenerateJsonSchema class.
+    """
+
+
 __getattr__ = getattr_migration(__name__)

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -24,7 +24,7 @@ from typing import (
 )
 
 import pydantic_core
-from pydantic_core import CoreSchema, core_schema
+from pydantic_core import CoreSchema, PydanticOmit, core_schema
 from pydantic_core.core_schema import ComputedField
 from typing_extensions import Literal, assert_never
 
@@ -33,7 +33,7 @@ from pydantic._internal._schema_generation_shared import GenerateJsonSchemaHandl
 from ._internal import _core_metadata, _core_utils, _schema_generation_shared, _typing_extra
 from ._internal._core_utils import CoreSchemaField, CoreSchemaOrField, is_core_schema, is_core_schema_field
 from .config import JsonSchemaExtraCallable
-from .errors import OmitJsonSchemaField, PydanticInvalidForJsonSchema, PydanticUserError
+from .errors import PydanticInvalidForJsonSchema, PydanticUserError
 
 if TYPE_CHECKING:
     from . import ConfigDict
@@ -923,7 +923,7 @@ class GenerateJsonSchema:
                 name = self._get_alias_name(field, name)
             try:
                 field_json_schema = self.generate_inner(field).copy()
-            except OmitJsonSchemaField:
+            except PydanticOmit:
                 continue
             if 'title' not in field_json_schema and self.field_title_should_be_set(field):
                 title = self.get_title_from_name(name)

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -33,7 +33,7 @@ from pydantic._internal._schema_generation_shared import GenerateJsonSchemaHandl
 from ._internal import _core_metadata, _core_utils, _schema_generation_shared, _typing_extra
 from ._internal._core_utils import CoreSchemaField, CoreSchemaOrField, is_core_schema, is_core_schema_field
 from .config import JsonSchemaExtraCallable
-from .errors import PydanticInvalidForJsonSchema, PydanticUserError
+from .errors import OmitJsonSchemaField, PydanticInvalidForJsonSchema, PydanticUserError
 
 if TYPE_CHECKING:
     from . import ConfigDict
@@ -921,7 +921,10 @@ class GenerateJsonSchema:
         for name, required, field in named_required_fields:
             if self.by_alias:
                 name = self._get_alias_name(field, name)
-            field_json_schema = self.generate_inner(field).copy()
+            try:
+                field_json_schema = self.generate_inner(field).copy()
+            except OmitJsonSchemaField:
+                continue
             if 'title' not in field_json_schema and self.field_title_should_be_set(field):
                 title = self.get_title_from_name(name)
                 field_json_schema['title'] = title

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -993,7 +993,7 @@ __getattr__ = getattr_migration(__name__)
 
 
 @_internal_dataclass.slots_dataclass
-class JsonSchema:
+class WithJsonSchema:
     """
     Add this as an annotation on a field to override the (base) JSON schema that would be generated for that field.
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -24,14 +24,14 @@ from typing import (
 from uuid import UUID
 
 import annotated_types
-from pydantic_core import CoreSchema, PydanticCustomError, PydanticKnownError, core_schema
+from pydantic_core import CoreSchema, PydanticCustomError, PydanticKnownError, PydanticOmit, core_schema
 from typing_extensions import Annotated, Literal, Protocol
 
 from ._internal import _fields, _internal_dataclass, _known_annotated_metadata, _validators
 from ._internal._internal_dataclass import slots_dataclass
 from ._migration import getattr_migration
 from .annotated import GetCoreSchemaHandler
-from .errors import OmitJsonSchemaField, PydanticUserError
+from .errors import PydanticUserError
 
 __all__ = [
     'Strict',
@@ -1011,6 +1011,7 @@ class JsonSchema:
         self, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
         if self.json_schema is None:
-            raise OmitJsonSchemaField
+            # This exception is handled in pydantic.json_schema.GenerateJsonSchema._named_required_fields_schema
+            raise PydanticOmit
         else:
             return self.json_schema

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -66,6 +66,7 @@ from pydantic.types import (
     DirectoryPath,
     FilePath,
     Json,
+    JsonSchema,
     NegativeFloat,
     NegativeInt,
     NewPath,
@@ -1183,24 +1184,46 @@ def test_ipvanynetwork_type():
         (Callable[[int], int], lambda x: x),
     ),
 )
-def test_callable_type(type_, default_value):
-    # TODO: Is this still how we want to handle this?
-    #   With my current changes, it raises
-    #       InvalidForJsonSchema('Cannot generate a JsonSchema for core_schema.CallableSchema')
-    #   We could continue the practice of just not creating such fields,
-    #   but producing a UserWarning when a field is ignored
-    # TODO: If the default value is not JSON encodable, should we just not include it in the schema?
-    #   This seems preferable to me over erroring, but maybe we should also produce a UserWarning for that?
-
-    # Decision: Different user warning depending on if there's a default or not
-
+@pytest.mark.parametrize(
+    'base_json_schema,properties',
+    [
+        (
+            {'a': 'b'},
+            {
+                'callback': {'title': 'Callback', 'a': 'b'},
+                'foo': {'title': 'Foo', 'type': 'integer'},
+            },
+        ),
+        (
+            None,
+            {
+                'foo': {'title': 'Foo', 'type': 'integer'},
+            },
+        ),
+    ],
+)
+def test_callable_type(type_, default_value, base_json_schema, properties):
     class Model(BaseModel):
         callback: type_ = default_value
         foo: int
 
     with pytest.raises(PydanticInvalidForJsonSchema):
-        model_schema = Model.model_json_schema()
-        assert 'callback' not in model_schema['properties']
+        Model.model_json_schema()
+
+    class ModelWithOverride(BaseModel):
+        callback: Annotated[type_, JsonSchema(base_json_schema)] = default_value
+        foo: int
+
+    if default_value is Ellipsis or base_json_schema is None:
+        model_schema = ModelWithOverride.model_json_schema()
+    else:
+        with pytest.warns(
+            PydanticJsonSchemaWarning,
+            match='Default value .* is not JSON serializable; excluding'
+            r' default from JSON schema \[non-serializable-default]',
+        ):
+            model_schema = ModelWithOverride.model_json_schema()
+    assert model_schema['properties'] == properties
 
 
 @pytest.mark.parametrize(
@@ -4039,3 +4062,25 @@ def test_sequences_int_json_schema(sequence_type):
         'required': ['int_seq'],
     }
     assert Model.model_validate_json('{"int_seq": [1, 2, 3]}')
+
+
+@pytest.mark.parametrize(
+    'field_schema,model_schema',
+    [
+        (None, {'properties': {}, 'title': 'Model', 'type': 'object'}),
+        (
+            {'a': 'b'},
+            {'properties': {'x': {'a': 'b', 'title': 'X'}}, 'required': ['x'], 'title': 'Model', 'type': 'object'},
+        ),
+    ],
+)
+def test_arbitrary_type_json_schema(field_schema, model_schema):
+    class ArbitraryClass:
+        pass
+
+    class Model(BaseModel):
+        model_config = dict(arbitrary_types_allowed=True)
+
+        x: Annotated[ArbitraryClass, JsonSchema(field_schema)]
+
+    assert Model.model_json_schema() == model_schema

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -66,7 +66,6 @@ from pydantic.types import (
     DirectoryPath,
     FilePath,
     Json,
-    JsonSchema,
     NegativeFloat,
     NegativeInt,
     NewPath,
@@ -80,6 +79,7 @@ from pydantic.types import (
     SecretStr,
     StrictBool,
     StrictStr,
+    WithJsonSchema,
     conbytes,
     condate,
     condecimal,
@@ -1211,7 +1211,7 @@ def test_callable_type(type_, default_value, base_json_schema, properties):
         Model.model_json_schema()
 
     class ModelWithOverride(BaseModel):
-        callback: Annotated[type_, JsonSchema(base_json_schema)] = default_value
+        callback: Annotated[type_, WithJsonSchema(base_json_schema)] = default_value
         foo: int
 
     if default_value is Ellipsis or base_json_schema is None:
@@ -4081,6 +4081,6 @@ def test_arbitrary_type_json_schema(field_schema, model_schema):
     class Model(BaseModel):
         model_config = dict(arbitrary_types_allowed=True)
 
-        x: Annotated[ArbitraryClass, JsonSchema(field_schema)]
+        x: Annotated[ArbitraryClass, WithJsonSchema(field_schema)]
 
     assert Model.model_json_schema() == model_schema


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/5096
Closes https://github.com/pydantic/pydantic/issues/4079

Introduces an annotation `WithJsonSchema` that you can use to override the JSON schema for a type.

Also makes it so that if you raise `pydantic_core.PydanticOmit` while generating the JSON schema for a _field_ of any type that has fields (i.e., model, dataclass, typeddict), that field is omitted from the generated JSON schema.

The tests added to this PR demonstrate how to use this functionality to address:
* Callable, related to https://github.com/pydantic/pydantic/issues/5096
* Arbitrary types, related to https://github.com/pydantic/pydantic/issues/4079

Selected Reviewer: @samuelcolvin