### PR TITLE
Do not inherit config in model fields that are themselves of type model

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -109,17 +109,18 @@ class ConfigWrapper:
                 except KeyError:
                     raise AttributeError(f'Config has no attribute {name!r}') from None
 
-    def core_config(self, obj: Any = None) -> core_schema.CoreConfig:
+    def core_config(self, obj: Any) -> core_schema.CoreConfig:
         """
         Create a pydantic-core config, `obj` is just used to populate `title` if not set in config.
 
+        Pass `obj=None` if you do not want to attempt to infer the `title`.
+
         We don't use getattr here since we don't want to populate with defaults.
         """
-        extra = self.config_dict.get('extra')
         core_config = core_schema.CoreConfig(
             **core_schema.dict_not_none(
                 title=self.config_dict.get('title') or (obj and obj.__name__),
-                extra_fields_behavior=extra,
+                extra_fields_behavior=self.config_dict.get('extra'),
                 allow_inf_nan=self.config_dict.get('allow_inf_nan'),
                 populate_by_name=self.config_dict.get('populate_by_name'),
                 str_strip_whitespace=self.config_dict.get('str_strip_whitespace'),

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -272,7 +272,7 @@ class GenerateSchema:
 
         inner_schema = define_expected_missing_refs(inner_schema, recursively_defined_type_refs())
 
-        core_config = config_wrapper.core_config()
+        core_config = config_wrapper.core_config(cls)
         model_post_init = None if cls.model_post_init is BaseModel.model_post_init else 'model_post_init'
 
         metadata = build_metadata_dict(js_functions=[partial(modify_model_json_schema, cls=cls)])

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -114,7 +114,7 @@ class TypeAdapter(Generic[T]):
         core_schema = flatten_schema_defs(core_schema)
         simplified_core_schema = inline_schema_defs(core_schema)
 
-        core_config = config_wrapper.core_config()
+        core_config = config_wrapper.core_config(None)
         validator: SchemaValidator
         if hasattr(__type, '__pydantic_validator__') and config is None:
             validator = __type.__pydantic_validator__

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -802,3 +802,18 @@ def test_invalid_field():
             @field_serializer('b')
             def customise_b_serialisation(v):
                 return v
+
+
+@pytest.mark.xfail(reason='requires changes to pydantic-core')
+def test_serialize_with_extra():
+    class Inner(BaseModel):
+        a: str = 'a'
+
+    class Outer(BaseModel):
+        # this cause the inner model incorrectly dumpped:
+        model_config = ConfigDict(extra='allow')
+        inner: Inner = Field(default_factory=Inner)
+
+    m = Outer.model_validate({})
+
+    assert m.model_dump() == {'inner': {'a': 'a'}}


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/5784

This is the pydantic-side companion to https://github.com/pydantic/pydantic-core/pull/612. Currently, pydantic doesn't work with the `main` branch of `pydantic-core`, but if I rebase the change from that PR onto the `v0.31.0` commit (which pydantic is currently using), the xfailing tests I've added to this PR start passing.

The PR body from https://github.com/pydantic/pydantic-core/pull/612 goes into great detail about the problems this solves, but I'll also add a bit of detail here demonstrating that this actually reverts to the v1 behavior. (The following code is basically the same as one of the tests I added in here, just has been modified to be simultaneously compatible with v1 and v2, with deprecation warnings in v2):

```python
from typing import List

from pydantic import BaseModel, ConfigDict


class Inner(BaseModel):
    a: str


class Outer(BaseModel):
    # this cause the inner model incorrectly dumpped:
    class Config:
        str_to_lower = True
        anystr_lower = True

    x: List[str]  # should be converted to lower
    inner: Inner  # should not have fields converted to lower



m = Outer.parse_obj(dict(x=['Abc'], inner=dict(a='Def')))
print(m.dict())
# Current v2:
#> {'x': ['abc'], 'inner': {'a': 'def'}}

# Preferred in v2 (and current in v1):
#> {'x': ['abc'], 'inner': {'a': 'Def'}}
```