### PR TITLE
Fix some issues with pydantic extra

### DIFF
--- a/pydantic/deprecated/copy_internals.py
+++ b/pydantic/deprecated/copy_internals.py
@@ -107,6 +107,7 @@ def _copy_and_set_values(
     if deep:
         # chances of having empty dict here are quite low for using smart_deepcopy
         values = deepcopy(values)
+        extra = deepcopy(extra)
 
     cls = self.__class__
     m = cls.__new__(cls)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -494,6 +494,7 @@ class BaseModel(metaclass=ModelMetaclass):
         private_attrs = ((k, getattr(self, k, Undefined)) for k in self.__private_attributes__)
         return {
             '__dict__': self.__dict__,
+            '__pydantic_extra__': self.__pydantic_extra__,
             '__pydantic_fields_set__': self.__pydantic_fields_set__,
             '__private_attribute_values__': {k: v for k, v in private_attrs if v is not Undefined},
         }
@@ -501,6 +502,7 @@ class BaseModel(metaclass=ModelMetaclass):
     def __setstate__(self, state: dict[Any, Any]) -> None:
         _object_setattr(self, '__dict__', state['__dict__'])
         _object_setattr(self, '__pydantic_fields_set__', state['__pydantic_fields_set__'])
+        _object_setattr(self, '__pydantic_extra__', state['__pydantic_extra__'])
         for name, value in state.get('__private_attribute_values__', {}).items():
             _object_setattr(self, name, value)
 
@@ -756,6 +758,9 @@ class BaseModel(metaclass=ModelMetaclass):
                 return False
 
             if self.__dict__ != other.__dict__:
+                return False
+
+            if self.__pydantic_extra__ != other.__pydantic_extra__:
                 return False
 
             # If the types and field values match, check for equality of private attributes

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -266,6 +266,20 @@ def test_copy_update_unset(copy_method):
     )
 
 
+class ExtraModel(BaseModel, extra='allow'):
+    pass
+
+
+def test_copy_deep_extra(copy_method):
+    class Foo(BaseModel, extra='allow'):
+        pass
+
+    m = Foo(extra=[])
+    assert copy_method(m).extra is m.extra
+    assert copy_method(m, deep=True).extra == m.extra
+    assert copy_method(m, deep=True).extra is not m.extra
+
+
 def test_copy_set_fields(ModelTwo, copy_method):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = copy_method(m)
@@ -371,6 +385,13 @@ def test_pickle_fields_set():
     assert m.model_dump(exclude_unset=True) == {'a': 24}
     m2 = pickle.loads(pickle.dumps(m))
     assert m2.model_dump(exclude_unset=True) == {'a': 24}
+
+
+def test_pickle_preserves_extra():
+    m = ExtraModel(a=24)
+    assert m.model_extra == {'a': 24}
+    m2 = pickle.loads(pickle.dumps(m))
+    assert m2.model_extra == {'a': 24}
 
 
 def test_copy_update_exclude():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -359,7 +359,7 @@ def test_extra_broken_via_pydantic_extra_interference():
     class BrokenExtraBaseModel(BaseModel):
         def model_post_init(self, __context: Any) -> None:
             super().model_post_init(__context)
-            self.__pydantic_extra__ = None
+            object.__setattr__(self, '__pydantic_extra__', None)
 
     class Model(BrokenExtraBaseModel):
         model_config = ConfigDict(extra='allow')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2165,10 +2165,15 @@ def test_model_validate_with_context():
     assert OuterModel.model_validate({'inner': {'x': 2}}, context={'multiplier': 3}).inner.x == 6
 
 
+def test_extra_equality():
+    class MyModel(BaseModel, extra='allow'):
+        pass
+
+    assert MyModel(x=1) != MyModel()
+
+
 def test_equality_delegation():
     from unittest.mock import ANY
-
-    from pydantic import BaseModel
 
     class MyModel(BaseModel):
         foo: str


### PR DESCRIPTION
I discovered some issues while attempting to make `__pydantic_private__`, so will fix them here.

* We weren't properly deepcopying `__pydantic_extra__` in the deprecated copy method
* We weren't checking `__pydantic_extra__` during equality checks
* We weren't including `__pydantic_extra__` when pickling models

Selected Reviewer: @samuelcolvin