### PR TITLE
Add a convenience type for transforming a core schema via annotation

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1048,3 +1048,15 @@ else:
             original_schema = handler.generate_schema(source)
             metadata = build_metadata_dict(js_functions=[lambda _c, h: h(original_schema)])
             return core_schema.any_schema(metadata=metadata, serialization=original_schema)
+
+
+@_internal_dataclass.slots_dataclass
+class TransformSchema:
+    """
+    An annotation that can be used to apply a transform to a core schema.
+    """
+
+    transform: Callable[[CoreSchema], CoreSchema]
+
+    def __get_pydantic_core_schema__(self, source_type: type[Any], handler: GetCoreSchemaHandler) -> CoreSchema:
+        return self.transform(handler(source_type))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -99,7 +99,7 @@ from pydantic import (
 from pydantic.annotated import GetCoreSchemaHandler
 from pydantic.errors import PydanticSchemaGenerationError
 from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
-from pydantic.types import AllowInfNan, ImportString, SecretField, SkipValidation, Strict
+from pydantic.types import AllowInfNan, ImportString, SecretField, SkipValidation, Strict, TransformSchema
 
 try:
     import email_validator
@@ -5073,3 +5073,80 @@ def test_skip_validation_json_schema():
         'title': 'A',
         'type': 'object',
     }
+
+
+def test_transform_schema_for_first_party_class():
+    # Here, first party means you can define the `__prepare_pydantic_annotations__` method on the class directly.
+    class LowercaseStr(str):
+        @classmethod
+        def __prepare_pydantic_annotations__(
+            cls, _source: type[Any], annotations: Iterable[Any]
+        ) -> tuple[Any, list[Any]]:
+            def transform_schema(schema: CoreSchema) -> CoreSchema:
+                return core_schema.no_info_after_validator_function(lambda v: v.lower(), schema)
+
+            return str, list(annotations) + [TransformSchema(transform_schema)]
+
+    class Model(BaseModel):
+        lower: LowercaseStr = Field(min_length=1)
+
+    assert Model(lower='ABC').lower == 'abc'
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(lower='')
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'min_length': 1},
+            'input': '',
+            'loc': ('lower',),
+            'msg': 'String should have at least 1 characters',
+            'type': 'string_too_short',
+        }
+    ]
+
+
+def test_transform_schema_for_third_party_class():
+    # Here, third party means you can't define methods on the class directly, so have to use annotations.
+
+    class DatetimeWrapper:
+        # This is pretending to be a third-party class. This example is specifically inspired by pandas.Timestamp,
+        # which can receive an item of type `datetime` as an input to its `__init__`.
+        # The important thing here is we are not defining any custom methods on this type directly.
+        def __init__(self, t: datetime):
+            self.t = t
+
+    class _DatetimeWrapperAnnotation:
+        # This is an auxiliary class that, when used as the first annotation for DatetimeWrapper,
+        # ensures pydantic can produce a valid schema.
+        @classmethod
+        def __prepare_pydantic_annotations__(
+            cls, _source: type[Any], annotations: Iterable[Any]
+        ) -> tuple[Any, list[Any]]:
+            def transform(schema: CoreSchema) -> CoreSchema:
+                return core_schema.no_info_after_validator_function(lambda v: DatetimeWrapper(v), schema)
+
+            return datetime, list(annotations) + [TransformSchema(transform)]
+
+    # Giving a name to Annotated[DatetimeWrapper, _DatetimeWrapperAnnotation] makes it easier to use in code
+    # where I want a field of type `DatetimeWrapper` that works as desired with pydantic.
+    PydanticDatetimeWrapper = Annotated[DatetimeWrapper, _DatetimeWrapperAnnotation]
+
+    class Model(BaseModel):
+        # The reason all of the above is necessary is specifically so that we get good behavior
+        timestamp: Annotated[PydanticDatetimeWrapper, annotated_types.Gt(datetime.fromisoformat('2020-01-01 00:00:00'))]
+
+    m = Model(timestamp='2021-01-01 00:00:00')
+    assert isinstance(m.timestamp, DatetimeWrapper)
+    assert repr(m.timestamp.t) == 'datetime.datetime(2021, 1, 1, 0, 0)'
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(timestamp='2019-01-01 00:00:00')
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'gt': '2020-01-01T00:00:00'},
+            'input': '2019-01-01 00:00:00',
+            'loc': ('timestamp',),
+            'msg': 'Input should be greater than 2020-01-01T00:00:00',
+            'type': 'greater_than',
+        }
+    ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -28,6 +28,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -5080,8 +5081,8 @@ def test_transform_schema_for_first_party_class():
     class LowercaseStr(str):
         @classmethod
         def __prepare_pydantic_annotations__(
-            cls, _source: type[Any], annotations: Iterable[Any]
-        ) -> tuple[Any, list[Any]]:
+            cls, _source: Type[Any], annotations: Iterable[Any]
+        ) -> Tuple[Any, List[Any]]:
             def transform_schema(schema: CoreSchema) -> CoreSchema:
                 return core_schema.no_info_after_validator_function(lambda v: v.lower(), schema)
 
@@ -5120,8 +5121,8 @@ def test_transform_schema_for_third_party_class():
         # ensures pydantic can produce a valid schema.
         @classmethod
         def __prepare_pydantic_annotations__(
-            cls, _source: type[Any], annotations: Iterable[Any]
-        ) -> tuple[Any, list[Any]]:
+            cls, _source: Type[Any], annotations: Iterable[Any]
+        ) -> Tuple[Any, List[Any]]:
             def transform(schema: CoreSchema) -> CoreSchema:
                 return core_schema.no_info_after_validator_function(lambda v: DatetimeWrapper(v), schema)
 


### PR DESCRIPTION
The added tests show how this can be used to transform both first- and third-party defined custom types that are basically minor extensions of non-custom types, and make them compatible with `FieldInfo`- and `annotated_types`-style constraints.

Note: these tests were specifically inspired by:
* https://github.com/pydantic/pydantic/discussions/5798 in the case of first-party types
* https://github.com/pydantic/pydantic/issues/5053 in the case of third-party types