### PR TITLE
📌 Use Cython < v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
         CIBW_BUILD: 'cp3${{ matrix.python-version }}-*'
         CIBW_SKIP: '*-win32'
         CIBW_PLATFORM: '${{ matrix.platform || matrix.os }}'
-        CIBW_BEFORE_BUILD: 'pip install -U cython'
+        CIBW_BEFORE_BUILD: 'pip install -U "cython<3"'
         CIBW_TEST_REQUIRES: 'pytest==6.2.5 pytest-mock==3.6.1'
         CIBW_TEST_COMMAND: 'pytest {project}/tests'
         CIBW_MANYLINUX_X86_64_IMAGE: 'manylinux2014'

--- a/changes/5845-lig.md
+++ b/changes/5845-lig.md
@@ -1,0 +1,1 @@
+Discourage usage of Cython 3 with Pydantic 1.x.

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ conda install pydantic -c conda-forge
 By default `pip install` provides optimized binaries via [PyPI](https://pypi.org/project/pydantic/#files) for Linux, MacOS and 64bit Windows.
 
 
-If you're installing manually, install `cython` before installing *pydantic* and compilation should happen automatically.
+If you're installing manually, install `cython<3` (Pydantic 1.x is incompatible with Cython v3 and above) before installing *pydantic* and compilation should happen automatically.
 
 To test if *pydantic* is compiled run:
 

--- a/pydantic/_hypothesis_plugin.py
+++ b/pydantic/_hypothesis_plugin.py
@@ -46,7 +46,7 @@ from pydantic.utils import lenient_issubclass
 #
 # conlist() and conset() are unsupported for now, because the workarounds for
 # Cython and Hypothesis to handle parametrized generic types are incompatible.
-# Once Cython can support 'normal' generics we'll revisit this.
+# We are rethinking Hypothesis compatibility in Pydantic v2.
 
 # Emails
 try:

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -38,7 +38,8 @@ class Extra(str, Enum):
 
 
 # https://github.com/cython/cython/issues/4003
-# Will be fixed with Cython 3 but still in alpha right now
+# Fixed in Cython 3 and Pydantic v1 won't support Cython 3.
+# Pydantic v2 doesn't depend on Cython at all.
 if not compiled:
     from typing_extensions import TypedDict
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -252,15 +252,7 @@ else:
     WithArgsTypes = (typing._GenericAlias, types.GenericAlias, types.UnionType)
 
 
-if sys.version_info < (3, 9):
-    StrPath = Union[str, PathLike]
-else:
-    StrPath = Union[str, PathLike]
-    # TODO: Once we switch to Cython 3 to handle generics properly
-    #  (https://github.com/cython/cython/issues/2753), use following lines instead
-    #  of the one above
-    # # os.PathLike only becomes subscriptable from Python 3.9 onwards
-    # StrPath = Union[str, PathLike[str]]
+StrPath = Union[str, PathLike]
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Change Summary

Discourage usage of Cython 3 with Pydantic 1.x.

This fix prevents Pydantic 1.x CI crashing after Cython 3 is released.

## Related issue number

Fix #5842

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin