### PR TITLE
Ignore pytest warnings on 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,8 @@ xfail_strict = true
 filterwarnings = [
     'error',
     'ignore:path is deprecated.*:DeprecationWarning:',
+    # Work around https://github.com/pytest-dev/pytest/issues/10977 for Python 3.12
+    'ignore:(ast\.Str|ast\.NameConstant|ast\.Num|Attribute s) is deprecated and will be removed.*:DeprecationWarning:',
 ]
 
 # configuring https://github.com/pydantic/hooky


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

<!-- Please give a short summary of the changes. -->
I decided to try to run the pydantic test suite against current Python 3.12 to look for issues in typing. I had to ignore these warnings (already tracked in pytest-dev/pytest#10977) first to get the tests to run at all.

Now a lot of tests fail for me locally with errors like

```
E               pytest.PytestUnraisableExceptionWarning: Exception ignored in: None
E               
E               Traceback (most recent call last):
E                 File "/Users/jelle/py/pydantic/pydantic/_internal/_core_utils.py", line 247, in walk
E                   return f(schema.copy(), self._walk)
E                            ^^^^^^^^^^^^^
E               ResourceWarning: Object of type pydantic_core._pydantic_core.SchemaValidator is not untracked before destruction
```

That might be a bug in `pydantic_core` but I haven't investigated further. Still, this PR at least enables running the test suite.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
