### PR TITLE
Add future and past date hypothesis strategies

### DIFF
--- a/changes/5850-bschoenmaeckers.md
+++ b/changes/5850-bschoenmaeckers.md
@@ -1,0 +1,1 @@
+Add future and past date hypothesis strategies.

--- a/pydantic/_hypothesis_plugin.py
+++ b/pydantic/_hypothesis_plugin.py
@@ -168,6 +168,11 @@ st.register_type_strategy(pydantic.StrictBool, st.booleans())
 st.register_type_strategy(pydantic.StrictStr, st.text())
 
 
+# FutureDate, PastDate
+st.register_type_strategy(pydantic.FutureDate, st.dates(min_value=datetime.date.today() + datetime.timedelta(days=1)))
+st.register_type_strategy(pydantic.PastDate, st.dates(max_value=datetime.date.today() - datetime.timedelta(days=1)))
+
+
 # Constrained-type resolver functions
 #
 # For these ones, we actually want to inspect the type in order to work out a

--- a/tests/test_hypothesis_plugin.py
+++ b/tests/test_hypothesis_plugin.py
@@ -86,6 +86,8 @@ def gen_models():
     class ConstrainedDateModel(pydantic.BaseModel):
         condatet: pydantic.condate(gt=date(1980, 1, 1), lt=date(2180, 12, 31))
         condatee: pydantic.condate(ge=date(1980, 1, 1), le=date(2180, 12, 31))
+        future: pydantic.FutureDate
+        past: pydantic.PastDate
 
     yield from (
         MiscModel,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

<!-- Please give a short summary of the changes. -->
The Hypothesis plugin couldn't generate FutureDate and/or PastDate fields initially. So I tweaked the plugin to support those fields too.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani