### PR TITLE
Add a test demonstrating initvar works with inheritance

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -211,3 +211,8 @@ def dataclass(
 
 
 __getattr__ = getattr_migration(__name__)
+
+if sys.version_info <= (3, 10):
+    # Monkeypatch dataclasses.InitVar so that typing doesn't error if it occurs as a type when evaluating type hints
+    # This is not necessary in 3.11
+    dataclasses.InitVar.__call__ = lambda: None

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -6,7 +6,7 @@ from __future__ import annotations as _annotations
 import dataclasses
 import sys
 import types
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, Generic, NoReturn, TypeVar, overload
 
 from typing_extensions import Literal, dataclass_transform
 
@@ -214,5 +214,14 @@ __getattr__ = getattr_migration(__name__)
 
 if (3, 8) <= sys.version_info < (3, 11):
     # Monkeypatch dataclasses.InitVar so that typing doesn't error if it occurs as a type when evaluating type hints
-    # This is not necessary in 3.11, and we don't support InitVar in python < 3.8.
-    dataclasses.InitVar.__call__ = lambda: None  # type: ignore
+    # Starting in 3.11, typing.get_type_hints will not raise an error if the retrieved type hints are not callable.
+
+    def _call_initvar(*args: Any, **kwargs: Any) -> NoReturn:
+        """
+        This function does nothing but raise an error that is as similar as possible to what you'd get
+        if you were to try calling `InitVar[int]()` without this monkeypatch. The whole purpose is just
+        to ensure typing._type_check does not error if the type hint evaluates to `InitVar[<parameter>]`.
+        """
+        raise TypeError("'InitVar' object is not callable")
+
+    dataclasses.InitVar.__call__ = _call_initvar  # type: ignore

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -212,7 +212,7 @@ def dataclass(
 
 __getattr__ = getattr_migration(__name__)
 
-if sys.version_info <= (3, 10):
+if (3, 8) <= sys.version_info <= (3, 10):
     # Monkeypatch dataclasses.InitVar so that typing doesn't error if it occurs as a type when evaluating type hints
-    # This is not necessary in 3.11
+    # This is not necessary in 3.11, and we don't support InitVar in python < 3.8.
     dataclasses.InitVar.__call__ = lambda: None  # type: ignore

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -212,7 +212,7 @@ def dataclass(
 
 __getattr__ = getattr_migration(__name__)
 
-if (3, 8) <= sys.version_info <= (3, 10):
+if (3, 8) <= sys.version_info < (3, 11):
     # Monkeypatch dataclasses.InitVar so that typing doesn't error if it occurs as a type when evaluating type hints
     # This is not necessary in 3.11, and we don't support InitVar in python < 3.8.
     dataclasses.InitVar.__call__ = lambda: None  # type: ignore

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -215,4 +215,4 @@ __getattr__ = getattr_migration(__name__)
 if sys.version_info <= (3, 10):
     # Monkeypatch dataclasses.InitVar so that typing doesn't error if it occurs as a type when evaluating type hints
     # This is not necessary in 3.11
-    dataclasses.InitVar.__call__ = lambda: None
+    dataclasses.InitVar.__call__ = lambda: None  # type: ignore

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -3,6 +3,7 @@ import pickle
 import re
 import sys
 from collections.abc import Hashable
+from dataclasses import InitVar
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, List, Optional, Set, TypeVar, Union
@@ -2004,3 +2005,22 @@ def test_dataclass_alias_generator():
             'input': ArgsKwargs((), {'name': 'test name', 'score': 2}),
         },
     ]
+
+
+def test_init_vars_inheritance():
+    init_vars = []
+
+    @pydantic.dataclasses.dataclass
+    class Foo:
+        init: 'InitVar[int]'
+
+    @pydantic.dataclasses.dataclass
+    class Bar(Foo):
+        arg: int
+
+        def __post_init__(self, init: int) -> None:
+            init_vars.append(init)
+
+    bar = Bar(init=1, arg=2)
+    assert TypeAdapter(Bar).dump_python(bar) == {'arg': 2}
+    assert init_vars == [1]

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2036,3 +2036,16 @@ def test_init_vars_inheritance():
             'type': 'int_parsing',
         }
     ]
+
+
+def test_init_vars_call_monkeypatch():
+    initvar_monkeypatched = hasattr(pydantic.dataclasses, '_call_initvar')
+
+    if not (3, 8) <= sys.version_info < (3, 11):
+        assert not initvar_monkeypatched
+    else:
+        assert initvar_monkeypatched
+        InitVar(int)  # this is what is produced by InitVar[int]; note monkeypatching __call__ doesn't break this
+
+        with pytest.raises(TypeError, match="'InitVar' object is not callable"):
+            InitVar[int]()

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2025,3 +2025,14 @@ def test_init_vars_inheritance():
     bar = Bar(init=1, arg=2)
     assert TypeAdapter(Bar).dump_python(bar) == {'arg': 2}
     assert init_vars == [1]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Bar(init='a', arg=2)
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'input': 'a',
+            'loc': ('init',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'type': 'int_parsing',
+        }
+    ]

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2053,5 +2053,5 @@ def test_init_vars_call_monkeypatch(remove_monkeypatch, monkeypatch):
         InitVar[int]()
 
     # Check that the custom __call__ was called precisely if the monkeypatch was not removed
-    stack_depth = len(traceback.format_exception(exc.value))
-    assert stack_depth == 3 if remove_monkeypatch else 4
+    stack_depth = len(traceback.extract_tb(exc.value.__traceback__))
+    assert stack_depth == 1 if remove_monkeypatch else 2

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2007,6 +2007,7 @@ def test_dataclass_alias_generator():
     ]
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='InitVar not supported in python 3.7')
 def test_init_vars_inheritance():
     init_vars = []
 


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/5496.

~It seems that at some point since the 2.0a4 release, this got fixed, but I've added a test written from the code in the issue. (This test fails in 2.0a4.)~

This got fixed for python 3.11 after #5760, but not for other python versions..

Selected Reviewer: @adriangb