### PR TITLE
Use `duration` instead of `time-delta` type for `timedelta` on JSON schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -532,10 +532,7 @@ class GenerateJsonSchema:
         Returns:
             JsonSchemaValue: The generated JSON schema.
         """
-        # It's weird that this schema has 'type': 'number' but also specifies a 'format'.
-        # TODO: Probably should just change this to str (look at readme intro for speeddate)
-        #   Issue: https://github.com/pydantic/pydantic/issues/5034
-        return {'type': 'number', 'format': 'time-delta'}
+        return {'type': 'string', 'format': 'duration'}
 
     def literal_schema(self, schema: core_schema.LiteralSchema) -> JsonSchemaValue:
         """

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -757,7 +757,7 @@ def test_list_union_dict(field_type, expected_schema):
         (datetime, {'type': 'string', 'format': 'date-time'}),
         (date, {'type': 'string', 'format': 'date'}),
         (time, {'type': 'string', 'format': 'time'}),
-        (timedelta, {'type': 'number', 'format': 'time-delta'}),
+        (timedelta, {'type': 'string', 'format': 'duration'}),
     ],
 )
 def test_date_types(field_type, expected_schema):


### PR DESCRIPTION
## Change Summary

Replaces `{"type": "time-delta"}` by `{"type": "duration"}` for `timedelta` objects, as described on the [spec](https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times).

## Related issue number

- Closes https://github.com/pydantic/pydantic/issues/5034

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

selected review: @dmontagu

Selected Reviewer: @lig