### PR TITLE
Fix dataclass stuff

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -174,7 +174,7 @@ def is_builtin_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
 
 
 def is_pydantic_dataclass(_cls: type[Any]) -> TypeGuard[type[PydanticDataclass]]:
-    return dataclasses.is_dataclass(_cls) and hasattr(_cls, '__pydantic_validator__')
+    return dataclasses.is_dataclass(_cls) and '__pydantic_validator__' in _cls.__dict__
 
 
 def rebuild_dataclass(

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -240,7 +240,7 @@ class DecoratorInfos:
         # reminder: dicts are ordered and replacement does not alter the order
         res = DecoratorInfos()
         for base in model_dc.__bases__[::-1]:
-            existing = cast(Union[DecoratorInfos, None], getattr(base, '__pydantic_decorators__', None))
+            existing = cast(Union[DecoratorInfos, None], base.__dict__.get('__pydantic_decorators__'))
             if existing is None:
                 existing = DecoratorInfos.build(base)
             res.validators.update({k: v.bind_to_cls(model_dc) for k, v in existing.validators.items()})

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -946,7 +946,7 @@ class GenerateSchema:
                 self.types_namespace,
                 typevars_map=typevars_map,
             )
-        decorators = getattr(dataclass, '__pydantic_decorators__', None) or DecoratorInfos.build(dataclass)
+        decorators = dataclass.__dict__.get('__pydantic_decorators__') or DecoratorInfos.build(dataclass)
         args = [self._generate_dc_field_schema(k, v, decorators) for k, v in fields.items()]
         has_post_init = hasattr(dataclass, '__post_init__')
 

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -31,8 +31,9 @@ class ValidateCallWrapper:
         'raw_function',
         '_config',
         '_validate_return',
-        '__pydantic_core_schema__',
-        '__pydantic_validator__',
+        # Removing these from slots ensures that self.__dict__['__pydantic_core_schema__'] works
+        # '__pydantic_core_schema__',
+        # '__pydantic_validator__',
         '__signature__',
         '__name__',
         '__qualname__',

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -31,9 +31,8 @@ class ValidateCallWrapper:
         'raw_function',
         '_config',
         '_validate_return',
-        # Removing these from slots ensures that self.__dict__['__pydantic_core_schema__'] works
-        # '__pydantic_core_schema__',
-        # '__pydantic_validator__',
+        '__pydantic_core_schema__',
+        '__pydantic_validator__',
         '__signature__',
         '__name__',
         '__qualname__',

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -107,8 +107,9 @@ class TypeAdapter(Generic[T]):
 
         core_schema: CoreSchema
         try:
-            core_schema = __type.__pydantic_core_schema__
-        except AttributeError:
+            # look in __type.__dict__ to make sure we don't get the core schema of a parent class
+            core_schema = __type.__dict__['__pydantic_core_schema__']
+        except KeyError:
             core_schema = _get_schema(__type, config_wrapper, parent_depth=_parent_depth + 1)
 
         core_schema = flatten_schema_defs(core_schema)
@@ -116,16 +117,18 @@ class TypeAdapter(Generic[T]):
 
         core_config = config_wrapper.core_config(None)
         validator: SchemaValidator
-        if hasattr(__type, '__pydantic_validator__') and config is None:
-            validator = __type.__pydantic_validator__
-        else:
-            validator = SchemaValidator(simplified_core_schema, core_config)
+        # If we were to keep this logic, we'd need to make sure we look in __type.__dict__, not use getattr
+        # if hasattr(__type, '__pydantic_validator__') and config is None:
+        #     validator = __type.__pydantic_validator__
+        # else:
+        validator = SchemaValidator(simplified_core_schema, core_config)
 
         serializer: SchemaSerializer
-        if hasattr(__type, '__pydantic_serializer__') and config is None:
-            serializer = __type.__pydantic_serializer__
-        else:
-            serializer = SchemaSerializer(simplified_core_schema, core_config)
+        # If we were to keep this logic, we'd need to make sure we look in __type.__dict__, not use getattr
+        # if hasattr(_type, '__pydantic_serializer__') and config is None:
+        #     serializer = _type.__pydantic_serializer__
+        # else:
+        serializer = SchemaSerializer(simplified_core_schema, core_config)
 
         self.core_schema = core_schema
         self.validator = validator

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -78,7 +78,7 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
 
 def _getattr_no_parents(obj: Any, attribute: str) -> Any:
     """
-    Returns the attribute value without looking at class attributes or parent types
+    Returns the attribute value without attempting to look up attributes from parent types
     """
     if hasattr(obj, '__dict__'):
         try:

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -108,8 +108,11 @@ class TypeAdapter(Generic[T]):
         core_schema: CoreSchema
         try:
             # look in __type.__dict__ to make sure we don't get the core schema of a parent class
-            core_schema = __type.__dict__['__pydantic_core_schema__']
-        except KeyError:
+            if hasattr(__type, '__dict__'):
+                core_schema = __type.__dict__['__pydantic_core_schema__']
+            else:
+                core_schema = __type.__pydantic_core_schema__
+        except (KeyError, AttributeError):
             core_schema = _get_schema(__type, config_wrapper, parent_depth=_parent_depth + 1)
 
         core_schema = flatten_schema_defs(core_schema)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1479,8 +1479,7 @@ def test_cyclic_reference_dataclass(create_module):
     assert isinstance(D1.__pydantic_validator__, SchemaValidator)
     assert isinstance(D2.__pydantic_validator__, SchemaValidator)
 
-    adapter = TypeAdapter(D1)
-    assert adapter.dump_python(instance) == {'d2': {'d1': {'d2': {'d1': {'d2': None}}}}}
+    assert TypeAdapter(D1).dump_python(instance) == {'d2': {'d1': {'d2': {'d1': {'d2': None}}}}}
 
     with pytest.raises(ValidationError) as exc_info:
         D2(d1=D2())
@@ -1495,8 +1494,7 @@ def test_cyclic_reference_dataclass(create_module):
     ]
 
     with pytest.raises(ValidationError) as exc_info:
-        m = adapter.validate_python(dict(d2=dict(d1=dict(d2=dict(d2=dict())))))
-        print(m)
+        TypeAdapter(D1).validate_python(dict(d2=dict(d1=dict(d2=dict(d2=dict())))))
     assert exc_info.value.errors(include_url=False) == [
         {
             'input': {},

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1479,7 +1479,8 @@ def test_cyclic_reference_dataclass(create_module):
     assert isinstance(D1.__pydantic_validator__, SchemaValidator)
     assert isinstance(D2.__pydantic_validator__, SchemaValidator)
 
-    assert TypeAdapter(D1).dump_python(instance) == {'d2': {'d1': {'d2': {'d1': {'d2': None}}}}}
+    adapter = TypeAdapter(D1)
+    assert adapter.dump_python(instance) == {'d2': {'d1': {'d2': {'d1': {'d2': None}}}}}
 
     with pytest.raises(ValidationError) as exc_info:
         D2(d1=D2())
@@ -1494,7 +1495,8 @@ def test_cyclic_reference_dataclass(create_module):
     ]
 
     with pytest.raises(ValidationError) as exc_info:
-        TypeAdapter(D1).validate_python(dict(d2=dict(d1=dict(d2=dict(d2=dict())))))
+        m = adapter.validate_python(dict(d2=dict(d1=dict(d2=dict(d2=dict())))))
+        print(m)
     assert exc_info.value.errors(include_url=False) == [
         {
             'input': {},

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -22,6 +22,7 @@ from pydantic import (
     PydanticUserError,
     TypeAdapter,
     ValidationError,
+    field_serializer,
     field_validator,
 )
 from pydantic._internal._model_construction import MockValidator
@@ -2057,8 +2058,10 @@ def test_init_vars_call_monkeypatch(remove_monkeypatch, monkeypatch):
     assert stack_depth == 1 if remove_monkeypatch else 2
 
 
-def test_vanilla_dataclass_validators_in_model_field():
-    @dataclasses.dataclass
+@pytest.mark.parametrize('decorator1', **dataclass_decorators())
+@pytest.mark.parametrize('decorator2', **dataclass_decorators())
+def test_decorators_in_model_field(decorator1, decorator2):
+    @decorator1
     class Demo1:
         int1: int
 
@@ -2066,22 +2069,36 @@ def test_vanilla_dataclass_validators_in_model_field():
         def set_int_1(cls, v):
             return v + 100
 
-    @dataclasses.dataclass
+        @field_serializer('int1')
+        def serialize_int_1(self, v):
+            return v + 10
+
+    @decorator2
     class Demo2(Demo1):
         int2: int
 
         @field_validator('int2', mode='before')
         def set_int_2(cls, v):
             return v + 200
+
+        @field_serializer('int2')
+        def serialize_int_2(self, v):
+            return v + 20
 
     class Model(BaseModel):
         x: Demo2
 
-    assert Model.model_validate(dict(x=dict(int1=1, int2=2))).model_dump() == {'x': {'int1': 101, 'int2': 202}}
+    m = Model.model_validate(dict(x=dict(int1=1, int2=2)))
+    assert m.x.int1 == 101
+    assert m.x.int2 == 202
+
+    assert m.model_dump() == {'x': {'int1': 111, 'int2': 222}}
 
 
-def test_vanilla_dataclass_validators_in_type_adapter():
-    @dataclasses.dataclass
+@pytest.mark.parametrize('decorator1', **dataclass_decorators())
+@pytest.mark.parametrize('decorator2', **dataclass_decorators())
+def test_vanilla_dataclass_decorators_in_type_adapter(decorator1, decorator2):
+    @decorator1
     class Demo1:
         int1: int
 
@@ -2089,7 +2106,11 @@ def test_vanilla_dataclass_validators_in_type_adapter():
         def set_int_1(cls, v):
             return v + 100
 
-    @dataclasses.dataclass
+        @field_serializer('int1')
+        def serialize_int_1(self, v):
+            return v + 10
+
+    @decorator2
     class Demo2(Demo1):
         int2: int
 
@@ -2097,7 +2118,14 @@ def test_vanilla_dataclass_validators_in_type_adapter():
         def set_int_2(cls, v):
             return v + 200
 
+        @field_serializer('int2')
+        def serialize_int_2(self, v):
+            return v + 20
+
     adapter = TypeAdapter(Demo2)
 
     m = adapter.validate_python(dict(int1=1, int2=2))
-    assert adapter.dump_python(m) == {'int1': 101, 'int2': 202}
+    assert m.int1 == 101
+    assert m.int2 == 202
+
+    assert adapter.dump_python(m) == {'int1': 111, 'int2': 222}


### PR DESCRIPTION
Closes #5271 

Without this change, we get some misbehavior due to looking up the schema from a parent class.

In particular, on the current main branch:
```python
import dataclasses

import pydantic
from pydantic import BaseModel


@pydantic.dataclasses.dataclass
class MyDataclass:
    x: int


@dataclasses.dataclass
class MySubDataclass(MyDataclass):
    y: int


class Model(BaseModel):
    dc: MySubDataclass


print(Model.parse_obj({'dc': {'x': 1, 'y': 2}}))
"""
  File "<string>", line 3, in __repr__
AttributeError: 'MySubDataclass' object has no attribute 'y'
"""
```
This error happens because the `__pydantic_validator__` (or maybe `__pydantic_core_schema__`..) from `MyDataclass` is finding its way into the schema used by `Model` thanks to `MySubDataclass.__pydantic_validator__ is MyDataclass.__pydantic_validator__` (since `MySubDataclass` isn't a pydantic dataclass, it doesn't get an updated validator). And therefore the validator isn't setting the `y` attribute on the validated instance the way it should.

I've written this using v1-style method names, since I confirmed that v1 does not have this bug.

(I discovered this while trying to test serialization worked for arbitrary combinations of pydantic/non-pydantic dataclasses.)

-----

The solution is to be careful not to read any of `__pydantic_core_schema__`, `__pydantic_validator__`, `__pydantic_serializer__` from proper parent classes when building schemas.

----

I think whether we merge this change or not, we are in the slightly precarious situation that we need to remember to be careful not to use attribute access on unknown types to retrieve the `__pydantic_serializer__` or similar when there is any chance that that could be associated to a different parent type (the most obvious way this can happen today is if you subclass a pydantic dataclass with a non-pydantic dataclass, you'll run into this problem, but in general you can imagine this happening for other types).

I think our current approach of storing these things as class attributes might be kind of unfortunate, since really I think, conceptually, it would be better if we had a cache whose keys were the model/dataclass/etc. types, and whose values were the schemas/validators/serializers, rather than retrieving them from (possibly strict parent) class attributes.

-----

This same issue may also currently be causing misbehavior in pydantic-core with `to_jsonable_python` for instances of a non-pydantic-dataclass that is a subclass of a pydantic-dataclass, since we do look for the presence of a `__pydantic_serializer__` when serializing, and that may not be for the right class.

I'm not sure what the best way to resolve that is, and I suspect it will eventually make sense to resolve it, but I believe that's a smaller issue than what is addressed here for `TypeAdapter` etc. (In particular, it's generally safe to use a parent class serializer to serialize instances of a subclass, though you might not get the representation you'd expect; however, it's generally _unsafe_ to do the same for validation, which is why this PR is more important.)