### PR TITLE
Allow `__prepare_pydantic_annotations__` to exist without `__get_pydantic_core_schema__`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -311,11 +311,11 @@ class GenerateSchema:
         Note: `__get_pydantic_core_schema__` takes priority so it can
         decide whether to use a `__pydantic_core_schema__` attribute, or generate a fresh schema.
         """
-        obj, new_annotations = self._prepare_annotations(obj, [])
-        if new_annotations:
+        new_obj, new_annotations = self._prepare_annotations(obj, [])
+        if new_obj is not obj or new_annotations:
             return self._apply_annotations(
                 lambda x: x,
-                obj,
+                new_obj,
                 new_annotations,
             )
         return None

--- a/tests/test_prepare_annotations.py
+++ b/tests/test_prepare_annotations.py
@@ -12,6 +12,16 @@ from pydantic.functional_validators import AfterValidator
 from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
 
 
+def test_prepare_annotations_without_get_core_schema() -> None:
+    class Foo:
+        @classmethod
+        def __prepare_pydantic_annotations__(cls, src_type: Any, annotations: List[Any]) -> Tuple[Any, List[Any]]:
+            return int, annotations
+
+    ta = TypeAdapter(Foo)
+    assert ta.validate_json('1') == 1
+
+
 @dataclass
 class MetadataApplier:
     inner_core_schema: CoreSchema


### PR DESCRIPTION


Selected Reviewer: @dmontagu