### PR TITLE
🐛 Fix `AttributeError` on deleting a field of a Model having a `PrivateAttr` defined

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -551,5 +551,7 @@ def model_private_delattr(self: BaseModel, item: str) -> Any:
             del self.__pydantic_private__[item]  # type: ignore
         except KeyError as exc:
             raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
+    elif item in self.model_fields:
+        super(self.__class__, self).__delattr__(item)
     else:
         raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -1,3 +1,4 @@
+import platform
 from typing import Optional, Tuple
 
 import pytest
@@ -358,6 +359,72 @@ def test_private_attr_set_name_do_not_crash_if_not_callable():
     # Checks below are just to ensure that everything is the same as in `test_private_attr_set_name`
     # The main check is that model class definition above doesn't crash
     assert Model()._private_attr == 2
+
+
+def test_del_model_attr():
+    class Model(BaseModel):
+        some_field: str
+
+    m = Model(some_field='value')
+    assert hasattr(m, 'some_field')
+
+    del m.some_field
+
+    assert not hasattr(m, 'some_field')
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() == 'PyPy' and platform.python_version_tuple() < ('3', '8'),
+    reason='In this single case `del` behaves weird on pypy 3.7',
+)
+def test_del_model_attr_error():
+    class Model(BaseModel):
+        some_field: str
+
+    m = Model(some_field='value')
+    assert not hasattr(m, 'other_field')
+
+    with pytest.raises(AttributeError, match='other_field'):
+        del m.other_field
+
+
+def test_del_model_attr_with_privat_attrs():
+    class Model(BaseModel):
+        _private_attr: int = PrivateAttr(default=1)
+        some_field: str
+
+    m = Model(some_field='value')
+    assert hasattr(m, 'some_field')
+
+    del m.some_field
+
+    assert not hasattr(m, 'some_field')
+
+
+def test_del_model_attr_with_privat_attrs_error():
+    class Model(BaseModel):
+        _private_attr: int = PrivateAttr(default=1)
+        some_field: str
+
+    m = Model(some_field='value')
+    assert not hasattr(m, 'other_field')
+
+    with pytest.raises(AttributeError, match="'Model' object has no attribute 'other_field'"):
+        del m.other_field
+
+
+def test_del_model_attr_with_privat_attrs_twice_error():
+    class Model(BaseModel):
+        _private_attr: int = 1
+        some_field: str
+
+    m = Model(some_field='value')
+    assert hasattr(m, '_private_attr')
+
+    del m._private_attr
+
+    with pytest.raises(AttributeError, match="'Model' object has no attribute '_private_attr'"):
+        del m._private_attr
 
 
 def test_create_model_with_slots():


### PR DESCRIPTION
## Change Summary

Fix `AttributeError` on deleting a field of a Model having a `PrivateAttr` defined

## Related issue number

Fix #5896

## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin