### PR TITLE
Move model before validators

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -262,11 +262,15 @@ class GenerateSchema:
         core_config = config_wrapper.core_config(cls)
         metadata = build_metadata_dict(js_functions=[partial(modify_model_json_schema, cls=cls)])
 
+        model_validators = decorators.model_validators.values()
+
         if cls.__pydantic_root_model__:
             root_field = self._common_field_schema('root', fields['root'], decorators)
+            inner_schema = root_field['schema']
+            inner_schema = apply_before_model_validators(inner_schema, model_validators)
             model_schema = core_schema.model_schema(
                 cls,
-                root_field['schema'],
+                inner_schema,
                 custom_init=getattr(cls, '__pydantic_custom_init__', None),
                 root_model=True,
                 post_init=getattr(cls, '__pydantic_post_init__', None),
@@ -286,6 +290,7 @@ class GenerateSchema:
 
             inner_schema = apply_validators(fields_schema, decorators.root_validators.values())
             inner_schema = define_expected_missing_refs(inner_schema, recursively_defined_type_refs())
+            inner_schema = apply_before_model_validators(inner_schema, model_validators)
 
             model_schema = core_schema.model_schema(
                 cls,
@@ -300,7 +305,7 @@ class GenerateSchema:
 
         model_schema = consolidate_refs(model_schema)
         schema = apply_model_serializers(model_schema, decorators.model_serializers.values())
-        return apply_model_validators(schema, decorators.model_validators.values())
+        return apply_other_model_validators(schema, model_validators)
 
     def _generate_schema_from_prepare_annotations(self, obj: Any) -> core_schema.CoreSchema | None:
         """
@@ -947,6 +952,10 @@ class GenerateSchema:
                 self._config_wrapper_stack.pop()
 
         inner_schema = apply_validators(args_schema, decorators.root_validators.values())
+
+        model_validators = decorators.model_validators.values()
+        inner_schema = apply_before_model_validators(inner_schema, model_validators)
+
         dc_schema = core_schema.dataclass_schema(
             dataclass,
             inner_schema,
@@ -956,7 +965,7 @@ class GenerateSchema:
             slots=has_slots,
         )
         schema = apply_model_serializers(dc_schema, decorators.model_serializers.values())
-        return apply_model_validators(schema, decorators.model_validators.values())
+        return apply_other_model_validators(schema, model_validators)
 
     def _callable_schema(self, function: Callable[..., Any]) -> core_schema.CallSchema:
         """
@@ -1297,6 +1306,24 @@ def apply_model_serializers(
     if ref:
         schema['ref'] = ref  # type: ignore
     return schema
+
+
+def apply_before_model_validators(
+    inner_schema: core_schema.CoreSchema, validators: Iterable[Decorator[ModelValidatorDecoratorInfo]]
+) -> core_schema.CoreSchema:
+    """
+    `before` model validators are applied to the inner schema
+    """
+    return apply_model_validators(inner_schema, [x for x in validators if x.info.mode == 'before'])
+
+
+def apply_other_model_validators(
+    model_schema: core_schema.CoreSchema, validators: Iterable[Decorator[ModelValidatorDecoratorInfo]]
+) -> core_schema.CoreSchema:
+    """
+    model validators other than `before` are applied to the outer model_schema
+    """
+    return apply_model_validators(model_schema, [x for x in validators if x.info.mode != 'before'])
 
 
 def apply_model_validators(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1115,6 +1115,8 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType]):
 
     def __init__(__pydantic_self__, root: RootModelRootType) -> None:  # type: ignore
         __tracebackhide__ = True
+        # this is required set setattr works on RootModels, should be moved to rust
+        _object_setattr(__pydantic_self__, '__pydantic_fields_set__', {'root'})
         __pydantic_self__.__pydantic_validator__.validate_python(root, self_instance=__pydantic_self__)
 
     __init__.__pydantic_base_init__ = True  # type: ignore

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1762,7 +1762,6 @@ def test_validating_assignment_pre_root_validator_fail():
     ]
 
 
-@pytest.mark.xfail(reason='Something weird going on with model_validator and assignment')
 def test_validating_assignment_model_validator_before_fail():
     class Model(BaseModel):
         current_value: float = Field(..., alias='current')
@@ -1772,7 +1771,7 @@ def test_validating_assignment_model_validator_before_fail():
 
         @model_validator(mode='before')
         def values_are_not_string(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-            print(values)
+            assert isinstance(values, dict)
             if any(isinstance(x, str) for x in values.values()):
                 raise ValueError('values cannot be a string')
             return values


### PR DESCRIPTION
As discussed yesterday with @dmontagu.

I know this changes the behaviour of `test_model_validator_before`, but I think it's actually more correct.

Previously `before` model validators were called when the input is a model, even when validation wasn't being run. Now before validators are called in the same scenarios as the rest of model validation is run:
* on both instances of the model type and instances of subclasses if `revalidate_instances='always'`
* only on instances of subclasses if `revalidate_instances='subclass-instances'`
* on neither instances of the model type nor instances of subclasses if `revalidate_instances='never'`

As previously, `before` model validators are always called when the input does not pass `isinstance(input, Model)`.

This change does mean the logic for when before validators are called differs from `wrap` and `after` model validators - but honestly I think `wrap` and `after` model validators are wrong, although I'm not sure that's worth changing.

We should probably add tests for:
* `model_validator(mode='before')` on `RootModel`
* `model_validator(mode='before')` on `dataclass`

Selected Reviewer: @adriangb