### PR TITLE
Add `lenient_issubclass` and `lenient_isinstance` to `DEPRECATED_MOVED_IN_V2`

### DIFF
--- a/pydantic/_migration.py
+++ b/pydantic/_migration.py
@@ -22,6 +22,8 @@ DEPRECATED_MOVED_IN_V2 = {
     'pydantic.decorator:validate_arguments': 'pydantic.deprecated.decorator:validate_arguments',
     'pydantic.class_validators:validator': 'pydantic.deprecated.class_validators:validator',
     'pydantic.class_validators:root_validator': 'pydantic.deprecated.class_validators:root_validator',
+    'pydantic.utils:lenient_isinstance': 'pydantic._internal._utils:lenient_isinstance',
+    'pydantic.utils:lenient_issubclass': 'pydantic._internal._utils:lenient_issubclass',
 }
 
 REMOVED_IN_V2 = {
@@ -227,8 +229,6 @@ REMOVED_IN_V2 = {
     'pydantic.utils:in_ipython',
     'pydantic.utils:is_valid_field',
     'pydantic.utils:is_valid_identifier',
-    'pydantic.utils:lenient_isinstance',
-    'pydantic.utils:lenient_issubclass',
     'pydantic.utils:path_type',
     'pydantic.utils:sequence_like',
     'pydantic.utils:smart_deepcopy',


### PR DESCRIPTION
This PR moves `lenient_is*` functions from "removed" to "deprecated" on the `migration` module.

Packages like `FastAPI` depends on those methods (actually only the `lenient_issubclass`), see:
```bash
❯ grep -r 'lenient_'                          
./fastapi/dependencies/utils.py:from pydantic.utils import lenient_issubclass
./fastapi/dependencies/utils.py:        and not lenient_issubclass(field.type_, BaseModel)
./fastapi/dependencies/utils.py:        and not lenient_issubclass(field.type_, sequence_types + (dict,))
./fastapi/dependencies/utils.py:    if (field.shape in sequence_shapes) and not lenient_issubclass(
./fastapi/dependencies/utils.py:    if lenient_issubclass(field.type_, sequence_types):
./fastapi/dependencies/utils.py:    if lenient_issubclass(type_annotation, Request):
./fastapi/dependencies/utils.py:    elif lenient_issubclass(type_annotation, WebSocket):
./fastapi/dependencies/utils.py:    elif lenient_issubclass(type_annotation, HTTPConnection):
./fastapi/dependencies/utils.py:    elif lenient_issubclass(type_annotation, Response):
./fastapi/dependencies/utils.py:    elif lenient_issubclass(type_annotation, BackgroundTasks):
./fastapi/dependencies/utils.py:    elif lenient_issubclass(type_annotation, SecurityScopes):
./fastapi/dependencies/utils.py:    if lenient_issubclass(
./fastapi/dependencies/utils.py:            if lenient_issubclass(field.type_, UploadFile):
./fastapi/dependencies/utils.py:                and lenient_issubclass(field.type_, bytes)
./fastapi/dependencies/utils.py:                and lenient_issubclass(field.type_, bytes)
./fastapi/openapi/utils.py:from pydantic.utils import lenient_issubclass
./fastapi/openapi/utils.py:                if lenient_issubclass(current_response_class, JSONResponse):
./fastapi/utils.py:from pydantic.utils import lenient_issubclass
./fastapi/utils.py:    if lenient_issubclass(original_type, BaseModel):
./fastapi/routing.py:from pydantic.utils import lenient_issubclass
./fastapi/routing.py:            if lenient_issubclass(return_annotation, Response):
```

## Questions
- Should I move `lenient_isinstance` to the `deprecated` subpackge?