### PR TITLE
Fix mypy plugin for 1.4.0

### DIFF
--- a/changes/5927-cdce8p.md
+++ b/changes/5927-cdce8p.md
@@ -1,0 +1,1 @@
+Fix mypy plugin for v1.4.0

--- a/changes/5927-cdce8p.md
+++ b/changes/5927-cdce8p.md
@@ -1,1 +1,0 @@
-Fix mypy plugin for v1.4.0

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -541,8 +541,16 @@ class PydanticModelTransformer:
         self_tvar_name = '_PydanticBaseModel'  # Make sure it does not conflict with other names in the class
         tvar_fullname = ctx.cls.fullname + '.' + self_tvar_name
         # requires mypy>0.910
-        self_type = TypeVarDef(self_tvar_name, tvar_fullname, -1, [], obj_type)
-        self_tvar_expr = TypeVarExpr(self_tvar_name, tvar_fullname, [], obj_type)
+        if MYPY_VERSION_TUPLE >= (1, 4):
+            self_type = TypeVarType(
+                self_tvar_name, tvar_fullname, -1, [], obj_type, AnyType(TypeOfAny.from_omitted_generics)
+            )
+            self_tvar_expr = TypeVarExpr(
+                self_tvar_name, tvar_fullname, [], obj_type, AnyType(TypeOfAny.from_omitted_generics)
+            )
+        else:
+            self_type = TypeVarDef(self_tvar_name, tvar_fullname, -1, [], obj_type)
+            self_tvar_expr = TypeVarExpr(self_tvar_name, tvar_fullname, [], obj_type)
         ctx.cls.info.names[self_tvar_name] = SymbolTableNode(MDEF, self_tvar_expr)
 
         add_method(


### PR DESCRIPTION
## Change Summary
The next mypy release (1.4.0) will add a new required argument `default` for `TypeVarType` and `TypeVarExpr` (in preparation for PEP 696 support).

I'll open a custom cherry-pick PR next as this won't backport cleanly.

https://github.com/python/mypy/pull/14872

## Related issue number
--

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani