### PR TITLE
Disallow passing config to TypeAdapter for models and implement config for TypedDict

### DIFF
--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -784,12 +784,12 @@ from typing_extensions import TypedDict
 from pydantic import ConfigDict, PydanticUserError, TypeAdapter
 
 
-class Model(TypedDict):
-    pass
+class MyTypedDict(TypedDict):
+    x: int
 
 
 try:
-    TypeAdapter(Model, config=ConfigDict(strict=True))
+    TypeAdapter(MyTypedDict, config=ConfigDict(strict=True))
 except PydanticUserError as e:
     print(e)
     """
@@ -807,14 +807,14 @@ from typing_extensions import TypedDict
 from pydantic import ConfigDict, TypeAdapter
 
 
-class Model(TypedDict):
+class MyTypedDict(TypedDict):
+    x: int
+
     # or `model_config = ...` for BaseModel
-    __pydantic_config__ = ConfigDict(
-        strict=True
-    )
+    __pydantic_config__ = ConfigDict(strict=True)
 
 
-TypeAdapter(Model)  # ok
+TypeAdapter(MyTypedDict)  # ok
 ```
 
 {% endraw %}

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -776,7 +776,7 @@ except PydanticUserError as exc_info:
 
 ## `config` is unused with TypeAdapter {#type-adapter-config-unused}
 
-You will get this error if you try to pass `config` to `TypeAdapter` when the type is a type that has it's own config that cannot be overridden (currently this is only `BaseModel`, `TypedDict` and dataclasses):
+You will get this error if you try to pass `config` to `TypeAdapter` when the type is a type that has it's own config that cannot be overridden (currently this is only `BaseModel`, `TypedDict` and `dataclass`):
 
 ```py
 from typing_extensions import TypedDict

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -773,4 +773,48 @@ try:
 except PydanticUserError as exc_info:
     assert exc_info.code == 'invalid_annotated_type'
 ```
+
+## `config` is unused with TypeAdapter {#type-adapter-config-unused}
+
+You will get this error if you try to pass `config` to `TypeAdapter` when the type is a type that has it's own config that cannot be overridden (currently this is only `BaseModel`, `TypedDict` and dataclasses):
+
+```py
+from typing_extensions import TypedDict
+
+from pydantic import ConfigDict, PydanticUserError, TypeAdapter
+
+
+class Model(TypedDict):
+    pass
+
+
+try:
+    TypeAdapter(Model, config=ConfigDict(strict=True))
+except PydanticUserError as e:
+    print(e)
+    """
+    Cannot use `config` when the type is a BaseModel, dataclass or TypedDict. These types can have their own config and setting the config via the `config` parameter to TypeAdapter will not override it, thus the `config` you passed to TypeAdapter becomes meaningless, which is probably not what you want.
+
+    For further information visit https://errors.pydantic.dev/2/u/type-adapter-config-unused
+    """
+```
+
+Instead you'll need to subclass the type and override or set the config on it:
+
+```py
+from typing_extensions import TypedDict
+
+from pydantic import ConfigDict, TypeAdapter
+
+
+class Model(TypedDict):
+    # or `model_config = ...` for BaseModel
+    __pydantic_config__ = ConfigDict(
+        strict=True
+    )
+
+
+TypeAdapter(Model)  # ok
+```
+
 {% endraw %}

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, ForwardRef, Iterable, Mapping, 
 from pydantic_core import CoreSchema, core_schema
 from typing_extensions import Annotated, Final, Literal, TypeAliasType, TypedDict, get_args, get_origin, is_typeddict
 
-from pydantic.config import ConfigDict
+from ..config import ConfigDict
 
 from ..annotated import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any, Callable, ForwardRef, Iterable, Mapping, 
 from pydantic_core import CoreSchema, core_schema
 from typing_extensions import Annotated, Final, Literal, TypeAliasType, TypedDict, get_args, get_origin, is_typeddict
 
+from pydantic.config import ConfigDict
+
 from ..annotated import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import AliasChoices, AliasPath, FieldInfo
@@ -730,6 +732,10 @@ class GenerateSchema:
                 code='typed-dict-version',
             )
 
+        config: ConfigDict | None = getattr(typed_dict_cls, '__pydantic_config__', None)
+        config_wrapper = ConfigWrapper(config)
+        core_config = config_wrapper.core_config(None)
+
         required_keys: frozenset[str] = typed_dict_cls.__required_keys__
 
         fields: dict[str, core_schema.TypedDictField] = {}
@@ -759,6 +765,7 @@ class GenerateSchema:
             extra_behavior='forbid',
             ref=typed_dict_ref,
             metadata=metadata,
+            config=core_config,
         )
 
         schema = self._apply_model_serializers(td_schema, decorators.model_serializers.values())

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -54,6 +54,7 @@ PydanticErrorCodes = Literal[
     'model-serializer-signature',
     'multiple-field-serializers',
     'invalid_annotated_type',
+    'type-adapter-config-unused',
 ]
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -101,8 +101,11 @@ def test_validate_python_strict() -> None:
     class Model(TypedDict):
         x: int
 
-    lax_validator = TypeAdapter(Model, config=ConfigDict(strict=False))
-    strict_validator = TypeAdapter(Model, config=ConfigDict(strict=True))
+    class ModelStrict(Model):
+        __pydantic_config__ = ConfigDict(strict=True)  # type: ignore
+
+    lax_validator = TypeAdapter(Model)
+    strict_validator = TypeAdapter(ModelStrict)
 
     assert lax_validator.validate_python({'x': '1'}, strict=None) == Model(x=1)
     assert lax_validator.validate_python({'x': '1'}, strict=False) == Model(x=1)
@@ -129,8 +132,11 @@ def test_validate_json_strict() -> None:
     class Model(TypedDict):
         x: int
 
+    class ModelStrict(Model):
+        __pydantic_config__ = ConfigDict(strict=True)  # type: ignore
+
     lax_validator = TypeAdapter(Model, config=ConfigDict(strict=False))
-    strict_validator = TypeAdapter(Model, config=ConfigDict(strict=True))
+    strict_validator = TypeAdapter(ModelStrict)
 
     assert lax_validator.validate_json(json.dumps({'x': '1'}), strict=None) == Model(x=1)
     assert lax_validator.validate_json(json.dumps({'x': '1'}), strict=False) == Model(x=1)


### PR DESCRIPTION
Requires pydantic-core update.

cc @samuelcolvin 

Selected Reviewer: @Kludex