### PR TITLE
Pushdown config

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -80,7 +80,7 @@ def complete_dataclass(
 
     typevars_map = get_standard_typevars_map(cls)
     gen_schema = GenerateSchema(
-        config_wrapper,
+        config_wrapper.config_dict,
         types_namespace,
         typevars_map,
     )

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -368,7 +368,7 @@ def complete_model_class(
     """
     typevars_map = get_model_typevars_map(cls)
     gen_schema = GenerateSchema(
-        config_wrapper,
+        config_wrapper.config_dict,
         types_namespace,
         typevars_map,
     )

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -61,7 +61,7 @@ class ValidateCallWrapper:
 
         namespace = _typing_extra.add_module_globals(function, None)
         config_wrapper = ConfigWrapper(config)
-        gen_schema = _generate_schema.GenerateSchema(config_wrapper, namespace)
+        gen_schema = _generate_schema.GenerateSchema(config_wrapper.config_dict, namespace)
         self.__pydantic_core_schema__ = schema = gen_schema.generate_schema(function)
         core_config = config_wrapper.core_config(self)
         schema = flatten_schema_defs(schema)

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -159,10 +159,11 @@ def dataclass(
         Raises:
             TypeError: If a non-class value is provided.
         """
-
         original_cls = cls
 
-        config_wrapper = _config.ConfigWrapper(config)
+        config_ = config if config is not None else getattr(original_cls, '__pydantic_config__', None)
+
+        config_wrapper = _config.ConfigWrapper(config_)
         decorators = _decorators.DecoratorInfos.build(cls)
 
         # Keep track of the original __doc__ so that we can restore it after applying the dataclasses decorator

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -138,6 +138,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     __init__.__pydantic_base_init__ = True  # type: ignore
 
     @classmethod
+    @property
+    def __pydantic_config__(cls) -> ConfigDict:
+        return cls.model_config
+
+    @classmethod
     def __get_pydantic_core_schema__(cls, __source: type[BaseModel], __handler: GetCoreSchemaHandler) -> CoreSchema:
         """Hook into generating the model's CoreSchema.
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -807,7 +807,6 @@ def test_override_builtin_dataclass_2():
     assert f.seen_count == 7
 
 
-@pytest.mark.xfail(reason='Meta() is not being revalidated')
 def test_override_builtin_dataclass_nested():
     @dataclasses.dataclass
     class Meta:
@@ -819,7 +818,9 @@ def test_override_builtin_dataclass_nested():
         filename: str
         meta: Meta
 
-    FileChecked = pydantic.dataclasses.dataclass(File, config=ConfigDict(revalidate_instances='always'))
+        __pydantic_config__ = ConfigDict(revalidate_instances='always')
+
+    FileChecked = pydantic.dataclasses.dataclass(File)
     f = FileChecked(filename=b'thefilename', meta=Meta(modified_date='2020-01-01T00:00', seen_count='7'))
     assert f.filename == 'thefilename'
     assert f.meta.modified_date == datetime(2020, 1, 1, 0, 0)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -79,7 +79,7 @@ class MyModel(BaseModel):
 )
 def test_json_serialization(ser_type, gen_value, json_output):
     config_wrapper = ConfigWrapper({'arbitrary_types_allowed': False})
-    gen = GenerateSchema(config_wrapper, None)
+    gen = GenerateSchema(config_wrapper.config_dict, None)
     schema = gen.generate_schema(ser_type)
     serializer = SchemaSerializer(schema)
     assert serializer.to_json(gen_value()) == json_output
@@ -88,7 +88,7 @@ def test_json_serialization(ser_type, gen_value, json_output):
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 def test_json_serialization_email():
     config_wrapper = ConfigWrapper({'arbitrary_types_allowed': False})
-    gen = GenerateSchema(config_wrapper, None)
+    gen = GenerateSchema(config_wrapper.config_dict, None)
     schema = gen.generate_schema(NameEmail)
     serializer = SchemaSerializer(schema)
     assert serializer.to_json(NameEmail('foo bar', 'foobaR@example.com')) == b'"foo bar <foobaR@example.com>"'

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -627,7 +627,6 @@ def test_recursive_generic_typeddict_in_function_3():
     ]
 
 
-@pytest.mark.xfail(reason='Needs https://github.com/pydantic/pydantic/pull/5944')
 def test_typeddict_alias_generator(TypedDict):
     def alias_generator(name: str) -> str:
         return 'alias_' + name

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -128,7 +128,6 @@ def test_validate_python_strict() -> None:
     ]
 
 
-@pytest.mark.xfail(reason='Need to fix this in https://github.com/pydantic/pydantic/pull/5944')
 def test_validate_json_strict() -> None:
     class Model(TypedDict):
         x: int


### PR DESCRIPTION
This changes the config `model_config = ConfigDict()` on BaseModel and `__pydantic_config__ = ConfigDict()` on dataclasses and TypedDict) to "push down". This means that configs set on an outer model in the case of nested models get recursively pushed onto their children models as long as the child does not explicitly set the config param.