### PR TITLE
Make instanceof schema work with arbitrary types

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -153,6 +153,8 @@ __all__ = [
     'Base64Bytes',
     'Base64Str',
     'SkipValidation',
+    'InstanceOf',
+    'WithJsonSchema',
     # type_adapter
     'TypeAdapter',
     # version

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -66,6 +66,7 @@ from pydantic.types import (
     UUID5,
     DirectoryPath,
     FilePath,
+    InstanceOf,
     Json,
     NegativeFloat,
     NegativeInt,
@@ -4063,14 +4064,22 @@ def test_sequences_int_json_schema(sequence_type):
         ),
     ],
 )
-def test_arbitrary_type_json_schema(field_schema, model_schema):
+@pytest.mark.parametrize('instance_of', [True, False])
+def test_arbitrary_type_json_schema(field_schema, model_schema, instance_of):
     class ArbitraryClass:
         pass
 
-    class Model(BaseModel):
-        model_config = dict(arbitrary_types_allowed=True)
+    if instance_of:
 
-        x: Annotated[ArbitraryClass, WithJsonSchema(field_schema)]
+        class Model(BaseModel):
+            x: Annotated[InstanceOf[ArbitraryClass], WithJsonSchema(field_schema)]
+
+    else:
+
+        class Model(BaseModel):
+            model_config = dict(arbitrary_types_allowed=True)
+
+            x: Annotated[ArbitraryClass, WithJsonSchema(field_schema)]
 
     assert Model.model_json_schema() == model_schema
 


### PR DESCRIPTION
Inspired by https://github.com/pydantic/pydantic/discussions/5581#discussioncomment-6023981.

One of the original motivations (and I'm pretty sure requested in an issue I closed because I thought it was addressed..) of `InstanceOf` was to be able to remove the need for `arbitrary_types_allowed=True` in the config by using this annotation, and only needing to use it on the actual arbitrary types. However as @adriangb noted, this doesn't currently work because it tries to generate the schema for loading from JSON.

This change allows that to fail, in which case a standard is_instance_schema is used. This keeps some of the functionality behaving nicely (namely, `InstanceOf[Sequence[str]]` remains compatible with JSON loading, etc.), but resolves one of the actual reasons this `InstanceOf` type was introduced.

I've also added it to the exports; I'm assuming its lack of inclusion was an oversight, but if we purposely weren't exporting it for the sake of not making it a "public API", then I guess we can remove it again, but I think these types merit inclusion in the public API.

Selected Reviewer: @adriangb