### PR TITLE
📦 Import `RootModel` dynamically when accessed directly only

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -176,7 +176,7 @@ __all__ = [
 # A mapping of {<member name>: <module name>} defining dynamic imports
 _dynamic_imports = {'RootModel': '.root_model'}
 if typing.TYPE_CHECKING:
-    from .root_model import *
+    from .root_model import RootModel
 
 _getattr_migration = getattr_migration(__name__)
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,3 +1,5 @@
+import typing
+
 import pydantic_core
 from pydantic_core.core_schema import (
     FieldSerializationInfo,
@@ -80,7 +82,6 @@ __all__ = [
     # main
     'BaseModel',
     'create_model',
-    'RootModel',
     # network
     'AnyUrl',
     'AnyHttpUrl',
@@ -101,6 +102,8 @@ __all__ = [
     'MySQLDsn',
     'MariaDBDsn',
     'validate_email',
+    # root_model
+    'RootModel',
     # tools
     'parse_obj_as',
     'schema_of',
@@ -170,5 +173,18 @@ __all__ = [
     'GetJsonSchemaHandler',
 ]
 
+# A mapping of {<member name>: <module name>} defining dynamic imports
+__all_dynamic__ = {'RootModel': '.root_model'}
+if typing.TYPE_CHECKING:
+    from .root_model import *
 
-__getattr__ = getattr_migration(__name__)
+__getattr_migration__ = getattr_migration(__name__)
+
+
+def __getattr__(attr_name: str) -> object:
+    if attr_name in __all_dynamic__:
+        from importlib import import_module
+
+        module = import_module(__all_dynamic__[attr_name], package=__package__)
+        return getattr(module, attr_name)
+    return __getattr_migration__(attr_name)

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -174,17 +174,19 @@ __all__ = [
 ]
 
 # A mapping of {<member name>: <module name>} defining dynamic imports
-__all_dynamic__ = {'RootModel': '.root_model'}
+_dynamic_imports = {'RootModel': '.root_model'}
 if typing.TYPE_CHECKING:
     from .root_model import *
 
-__getattr_migration__ = getattr_migration(__name__)
+_getattr_migration = getattr_migration(__name__)
 
 
 def __getattr__(attr_name: str) -> object:
-    if attr_name in __all_dynamic__:
-        from importlib import import_module
+    dynamic_attr = _dynamic_imports.get(attr_name)
+    if dynamic_attr is None:
+        return _getattr_migration(attr_name)
 
-        module = import_module(__all_dynamic__[attr_name], package=__package__)
-        return getattr(module, attr_name)
-    return __getattr_migration__(attr_name)
+    from importlib import import_module
+
+    module = import_module(_dynamic_imports[attr_name], package=__package__)
+    return getattr(module, attr_name)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -54,7 +54,7 @@ if typing.TYPE_CHECKING:
     # should be `set[int] | set[str] | dict[int, IncEx] | dict[str, IncEx] | None`, but mypy can't cope
     IncEx: typing_extensions.TypeAlias = 'set[int] | set[str] | dict[int, Any] | dict[str, Any] | None'
 
-__all__ = 'BaseModel', 'RootModel', 'create_model'
+__all__ = 'BaseModel', 'create_model'
 
 _object_setattr = _model_construction.object_setattr
 _Undefined = _fields.Undefined
@@ -1116,58 +1116,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             'The private method `_calculate_keys` will be removed and should no longer be used.', DeprecationWarning
         )
         return _deprecated_copy_internals._calculate_keys(self, *args, **kwargs)  # type: ignore
-
-
-RootModelRootType = typing.TypeVar('RootModelRootType')
-
-
-class RootModel(BaseModel, typing.Generic[RootModelRootType]):
-    """
-    A Pydantic `BaseModel` for the root object of the model.
-
-    Attributes:
-        root (RootModelRootType): The root object of the model.
-    """
-
-    __pydantic_root_model__ = True
-    # TODO: Make `__pydantic_fields_set__` logic consistent with `BaseModel`, i.e. it should be `set()` if default value
-    # was used
-    __pydantic_fields_set__ = {'root'}  # It's fine having a set here as it will never change
-    __pydantic_private__ = None
-    __pydantic_extra__ = None
-
-    root: RootModelRootType
-
-    def __init__(__pydantic_self__, root: RootModelRootType) -> None:  # type: ignore
-        __tracebackhide__ = True
-        __pydantic_self__.__pydantic_validator__.validate_python(root, self_instance=__pydantic_self__)
-
-    __init__.__pydantic_base_init__ = True  # type: ignore
-
-    @classmethod
-    def model_construct(cls: type[Model], root: RootModelRootType, _fields_set: set[str] | None = None) -> Model:
-        """
-        Create a new model using the provided root object and update fields set.
-
-        Args:
-            root: The root object of the model.
-            _fields_set: The set of fields to be updated.
-
-        Returns:
-            The new model.
-
-        Raises:
-            NotImplemented: If the model is not a subclass of `RootModel`.
-        """
-        return super().model_construct(root=root, _fields_set=_fields_set)
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, RootModel):
-            return NotImplemented
-        return self.model_fields['root'].annotation == other.model_fields['root'].annotation and super().__eq__(other)
-
-    def __repr_args__(self) -> _repr.ReprArgs:
-        yield 'root', self.root
 
 
 @typing.overload

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -1,0 +1,66 @@
+from __future__ import annotations as _annotations
+
+import typing
+
+from ._internal import _repr
+from .main import BaseModel
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+
+    Model = typing.TypeVar('Model', bound='BaseModel')
+
+
+__all__ = ['RootModel']
+
+
+RootModelRootType = typing.TypeVar('RootModelRootType')
+
+
+class RootModel(BaseModel, typing.Generic[RootModelRootType]):
+    """
+    A Pydantic `BaseModel` for the root object of the model.
+
+    Attributes:
+        root (RootModelRootType): The root object of the model.
+    """
+
+    __pydantic_root_model__ = True
+    # TODO: Make `__pydantic_fields_set__` logic consistent with `BaseModel`, i.e. it should be `set()` if default value
+    # was used
+    __pydantic_fields_set__ = {'root'}  # It's fine having a set here as it will never change
+    __pydantic_private__ = None
+    __pydantic_extra__ = None
+
+    root: RootModelRootType
+
+    def __init__(__pydantic_self__, root: RootModelRootType) -> None:  # type: ignore
+        __tracebackhide__ = True
+        __pydantic_self__.__pydantic_validator__.validate_python(root, self_instance=__pydantic_self__)
+
+    __init__.__pydantic_base_init__ = True  # type: ignore
+
+    @classmethod
+    def model_construct(cls: type[Model], root: RootModelRootType, _fields_set: set[str] | None = None) -> Model:
+        """
+        Create a new model using the provided root object and update fields set.
+
+        Args:
+            root: The root object of the model.
+            _fields_set: The set of fields to be updated.
+
+        Returns:
+            The new model.
+
+        Raises:
+            NotImplemented: If the model is not a subclass of `RootModel`.
+        """
+        return super().model_construct(root=root, _fields_set=_fields_set)
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, RootModel):
+            return NotImplemented
+        return self.model_fields['root'].annotation == other.model_fields['root'].annotation and super().__eq__(other)
+
+    def __repr_args__(self) -> _repr.ReprArgs:
+        yield 'root', self.root

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -11,7 +11,7 @@ if typing.TYPE_CHECKING:
     Model = typing.TypeVar('Model', bound='BaseModel')
 
 
-__all__ = ['RootModel']
+__all__ = ('RootModel',)
 
 
 RootModelRootType = typing.TypeVar('RootModelRootType')

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -24,12 +24,12 @@ def test_init_export():
             continue
         exported.add(name)
 
-    exported.update(pydantic.__all_dynamic__)
+    exported.update(pydantic._dynamic_imports)
 
     assert pydantic_all == exported, "pydantic.__all__ doesn't match actual exports"
 
 
-@pytest.mark.parametrize(('attr_name', 'module_name'), list(pydantic.__all_dynamic__.items()))
+@pytest.mark.parametrize(('attr_name', 'module_name'), list(pydantic._dynamic_imports.items()))
 def test_public_api_dynamic_imports(attr_name, module_name):
     imported_object = getattr(importlib.import_module(module_name, package='pydantic'), attr_name)
     assert isinstance(imported_object, object)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,4 +1,6 @@
+import importlib
 import importlib.util
+import platform
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -22,9 +24,21 @@ def test_init_export():
             continue
         exported.add(name)
 
+    exported.update(pydantic.__all_dynamic__)
+
     assert pydantic_all == exported, "pydantic.__all__ doesn't match actual exports"
 
 
+@pytest.mark.parametrize(('attr_name', 'module_name'), list(pydantic.__all_dynamic__.items()))
+def test_public_api_dynamic_imports(attr_name, module_name):
+    imported_object = getattr(importlib.import_module(module_name, package='pydantic'), attr_name)
+    assert isinstance(imported_object, object)
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() == 'PyPy' and platform.python_version_tuple() < ('3', '8'),
+    reason='Produces a weird error on pypy<3.8',
+)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_public_internal():
     """


### PR DESCRIPTION
## Change Summary

Implement mechanics for dynamic imports of public api exports and use it for `RootModel`.

## Related issue number

None

## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb