### PR TITLE
Feat basesetting dev

### DIFF
--- a/changes/5908-oslijw.md
+++ b/changes/5908-oslijw.md
@@ -1,0 +1,5 @@
+The loading of the configuration needs to add additional debug-level logging to facilitate the user to debug. 
+
+For this reason, I specifically added the configuration loading source to the deep_update function in utils.py. 
+
+At the same time, in order to be able to pass the instantiated Settings class, additional Added a variable, set it to None where it is not necessary to perform such an operation, and modified it in function-related positions

--- a/pydantic/v1/env_settings.py
+++ b/pydantic/v1/env_settings.py
@@ -72,7 +72,7 @@ class BaseSettings(BaseModel):
             init_settings=init_settings, env_settings=env_settings, file_secret_settings=file_secret_settings
         )
         if sources:
-            return deep_update(*reversed([source(self) for source in sources]))
+            return deep_update(self, *reversed([source(self) for source in sources]))
         else:
             # no one should mean to do this, but I think returning an empty dict is marginally preferable
             # to an informative error and much better than a confusing error
@@ -200,7 +200,7 @@ class EnvSettingsSource:
                             raise SettingsError(f'error parsing env var "{env_name}"') from e
 
                     if isinstance(env_val, dict):
-                        d[field.alias] = deep_update(env_val, self.explode_env_vars(field, env_vars))
+                        d[field.alias] = deep_update(None, env_val, self.explode_env_vars(field, env_vars))
                     else:
                         d[field.alias] = env_val
             elif env_val is not None:


### PR DESCRIPTION
Increase the number of data sources loaded from which variables in the setting are recorded through the log debug level
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

I think that the loading of the configuration needs to add additional debug-level logging to facilitate the user to debug. For this reason, I specifically added the configuration loading source to the deep_update function in utils.py. At the same time, in order to be able to pass the instantiated Settings class, additional Added a variable, set it to None where it is not necessary to perform such an operation, and modified it in function-related positions

## Scope
pydantic/v1/utils->deep_update
pydantic/v1/env_settings/BaseSettings->_build_values
pydantic/v1/env_settings/EnvSettingsSource->__call__

## Related issue number
fix#5908 

## Checklist

* [ Y] Unit tests for the changes exist
* [ Y] Tests pass on CI and coverage remains at 100%
* [ Y] Documentation reflects the changes where applicable
* [ Y] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ Y] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
