### PR TITLE
Increase coverage for `_generate_schema.py`

### DIFF
--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -71,6 +71,47 @@ foo = Foo(a={'b': {'a': None}})
 
 In other cases, the error message should indicate how to rebuild the class with the appropriate type defined.
 
+## Custom JSON Schema {#custom-json-schema}
+
+The `__modify_schema__` method is not supported in V2. You should use the `__get_pydantic_json_schema__` method instead.
+
+The `__modify_schema__` used to receive a single argument representing the JSON schema. See the example below:
+
+```py title="Old way"
+from pydantic import BaseModel, PydanticUserError
+
+try:
+
+    class Model(BaseModel):
+        @classmethod
+        def __modify_schema__(cls, field_schema):
+            field_schema.update(examples='examples')
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'custom-json-schema'
+```
+
+The new method `__get_pydantic_json_schema__` receives two arguments: the first is a dictionary denoted as `CoreSchema`,
+and the second a callable `handler` that receives a `CoreSchema` as parameter, and returns a JSON schema. See the example
+below:
+
+```py title="New way"
+from pydantic_core import CoreSchema
+
+from pydantic import BaseModel
+from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
+
+
+class Model(BaseModel):
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        json_schema = handler(schema)
+        json_schema.update(examples='examples')
+        return json_schema
+```
+
 ## Decorator on missing field {#decorator-missing-field}
 
 This error is raised when you define a decorator with a field that is not valid.

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -96,17 +96,18 @@ and the second a callable `handler` that receives a `CoreSchema` as parameter, a
 below:
 
 ```py title="New way"
+from typing import Any, Dict
+
 from pydantic_core import CoreSchema
 
-from pydantic import BaseModel
-from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
+from pydantic import BaseModel, GetJsonSchemaHandler
 
 
 class Model(BaseModel):
     @classmethod
     def __get_pydantic_json_schema__(
         cls, schema: CoreSchema, handler: GetJsonSchemaHandler
-    ) -> JsonSchemaValue:
+    ) -> Dict[str, Any]:
         json_schema = handler(schema)
         json_schema.update(examples='examples')
         return json_schema

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -73,7 +73,7 @@ In other cases, the error message should indicate how to rebuild the class with 
 
 ## Custom JSON Schema {#custom-json-schema}
 
-The `__modify_schema__` method is not supported in V2. You should use the `__get_pydantic_json_schema__` method instead.
+The `__modify_schema__` method is no longer supported in V2. You should use the `__get_pydantic_json_schema__` method instead.
 
 The `__modify_schema__` used to receive a single argument representing the JSON schema. See the example below:
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -612,11 +612,7 @@ class GenerateSchema:
         json_schema_updates.update(field_info.json_schema_extra or {})
 
         def json_schema_update_func(schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            json_schema = handler(schema)
-            # NOTE: We check if it's None in case we are using the older `__modify_schema__`.
-            if json_schema is None:
-                return {**schema, **json_schema_updates}
-            return {**json_schema, **json_schema_updates}
+            return {**handler(schema), **json_schema_updates}
 
         metadata = build_metadata_dict(js_functions=[json_schema_update_func])
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -24,6 +24,7 @@ __all__ = (
 DEV_ERROR_DOCS_URL = f'https://errors.pydantic.dev/{VERSION}/u/'
 PydanticErrorCodes = Literal[
     'class-not-fully-defined',
+    'custom-json-schema',
     'decorator-missing-field',
     'discriminator-no-field',
     'discriminator-alias-type',

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -825,8 +825,6 @@ class GenerateJsonSchema:
         Extract a compatible OpenAPI discriminator from the schema and one_of choices that end up in the final schema.
         """
         openapi_discriminator: str | None = None
-        if 'discriminator' not in schema:
-            return None
 
         if isinstance(schema['discriminator'], str):
             return schema['discriminator']
@@ -863,6 +861,7 @@ class GenerateJsonSchema:
 
     def chain_schema(self, schema: core_schema.ChainSchema) -> JsonSchemaValue:
         # Note: If we wanted to generate a schema for the _serialization_, would want to use the _last_ step:
+        # There are always more than zero steps, since the ChainSchema is validated on the pydantic-core side.
         return self.generate_inner(schema['steps'][0])
 
     def lax_or_strict_schema(self, schema: core_schema.LaxOrStrictSchema) -> JsonSchemaValue:

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -456,6 +456,20 @@ def test_field_regex():
             x: str = Field('test', regex=r'^test$')
 
 
+def test_modify_schema_error():
+    with pytest.raises(
+        PydanticUserError,
+        match='The `__modify_schema__` method is not supported in Pydantic v2. '
+        'Use `__get_pydantic_json_schema__` instead.',
+    ):
+
+        class Model(BaseModel):
+            def __modify_schema__(self, field_schema: Dict[str, Any]) -> None:
+                pass
+
+        Model()
+
+
 def test_field_extra_arguments():
     m = 'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead'
     with pytest.warns(DeprecationWarning, match=m):


### PR DESCRIPTION
This PR adds more coverage to the `_generate_schema.py` file.

It also adds a new error code to notify the user when they are using the old `__modify_schema__`.

Selected Reviewer: @dmontagu