### PR TITLE
Increase coverage for `_generate_schema.py`

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 from . import _typing_extra
 from ._config import ConfigWrapper
-from ._forward_ref import PydanticForwardRef
 from ._repr import Representation
 from ._typing_extra import get_cls_type_hints_lenient, get_type_hints, is_classvar, is_finalvar
 
@@ -136,8 +135,6 @@ def collect_model_fields(  # noqa: C901
         except AttributeError:
             if ann_name in annotations:
                 field_info = FieldInfo.from_annotation(ann_type)
-            elif isinstance(ann_type, PydanticForwardRef):
-                field_info = FieldInfo.from_annotation(annotation=ann_type)  # type: ignore
             else:
                 # if field has no default value and is not in __annotations__ this means that it is
                 # defined in a base class and we can take it from there

--- a/pydantic/_internal/_forward_ref.py
+++ b/pydantic/_internal/_forward_ref.py
@@ -1,9 +1,8 @@
 from __future__ import annotations as _annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Union
 
-from pydantic_core import core_schema
 from typing_extensions import Literal, TypedDict
 
 from ._typing_extra import TypeVarType
@@ -34,46 +33,3 @@ class PydanticRecursiveRef:
         Defining __call__ is necessary for the `typing` module to let you use an instance of
         this class as the result of resolving a standard ForwardRef
         """
-
-
-@dataclass
-class PydanticForwardRef:
-    """
-    No-op marker class for (recursive) type references.
-
-    Most of the logic here exists to handle recursive generics.
-    """
-
-    schema: core_schema.CoreSchema
-    model: type[Any]
-    deferred_actions: tuple[DeferredAction, ...] = ()
-
-    __name__ = 'PydanticForwardRef'
-    __hash__ = object.__hash__
-
-    def __call__(self) -> None:
-        """
-        Defining __call__ is necessary for the `typing` module to let you use an instance of
-        this class as the result of resolving a standard ForwardRef
-        """
-
-    def __getitem__(self, item: Any) -> PydanticForwardRef:
-        updated_actions = self.deferred_actions + ({'kind': 'class_getitem', 'item': item},)
-        return replace(self, deferred_actions=updated_actions)
-
-    def replace_types(self, typevars_map: Any) -> PydanticForwardRef:
-        updated_actions = self.deferred_actions + ({'kind': 'replace_types', 'typevars_map': typevars_map},)
-        return replace(self, deferred_actions=updated_actions)
-
-    def resolve_model(self) -> type[Any] | PydanticForwardRef:
-        from ._generics import replace_types
-
-        model: type[Any] | PydanticForwardRef = self.model
-        for action in self.deferred_actions:
-            if action['kind'] == 'replace_types':
-                model = replace_types(model, action['typevars_map'])
-            elif action['kind'] == 'class_getitem':
-                model = model[action['item']]  # type: ignore[index]
-            else:
-                raise ValueError(f'Unexpected action: {action}')
-        return model

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -612,11 +612,7 @@ class GenerateSchema:
         json_schema_updates.update(field_info.json_schema_extra or {})
 
         def json_schema_update_func(schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            json_schema = handler(schema)
-            # NOTE: We check if it's None in case we are using the older `__modify_schema__`.
-            if json_schema is None:
-                return {**schema, **json_schema_updates}
-            return {**json_schema, **json_schema_updates}
+            return {**handler(schema), **json_schema_updates}
 
         metadata = build_metadata_dict(js_functions=[json_schema_update_func])
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -612,7 +612,11 @@ class GenerateSchema:
         json_schema_updates.update(field_info.json_schema_extra or {})
 
         def json_schema_update_func(schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            return {**handler(schema), **json_schema_updates}
+            json_schema = handler(schema)
+            # NOTE: We check if it's None in case we are using the older `__modify_schema__`.
+            if json_schema is None:
+                return {**schema, **json_schema_updates}
+            return {**json_schema, **json_schema_updates}
 
         metadata = build_metadata_dict(js_functions=[json_schema_update_func])
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -812,6 +812,7 @@ class GenerateSchema:
         """
         params = get_args(tuple_type)
         # NOTE: subtle difference: `tuple[()]` gives `params=()`, whereas `typing.Tuple[()]` gives `params=((),)`
+        # This is only true for <3.11, on Python 3.11+ `typing.Tuple[()]` gives `params=()`
         if not params:
             if tuple_type == typing.Tuple:
                 return core_schema.tuple_variable_schema()
@@ -829,6 +830,10 @@ class GenerateSchema:
             return core_schema.tuple_positional_schema(  # pragma: no cover
                 [self.generate_schema(p) for p in items_schema], extra_schema=self.generate_schema(extra_schema)
             )
+        elif len(params) == 1 and params[0] == ():
+            # special case for `Tuple[()]` which means `Tuple[]` - an empty tuple
+            # NOTE: This conditional can be removed when we drop support for Python 3.10.
+            return core_schema.tuple_positional_schema([])
         else:
             return core_schema.tuple_positional_schema([self.generate_schema(p) for p in params])
 

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -13,7 +13,7 @@ from weakref import WeakValueDictionary
 import typing_extensions
 
 from ._core_utils import get_type_ref
-from ._forward_ref import PydanticForwardRef, PydanticRecursiveRef
+from ._forward_ref import PydanticRecursiveRef
 from ._typing_extra import TypeVarType, typing_base
 from ._utils import all_identical, is_basemodel
 
@@ -316,10 +316,6 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
             return type_
         return resolved_list
 
-    if isinstance(type_, PydanticForwardRef):
-        # queue the replacement as a deferred action
-        return type_.replace_types(type_map)
-
     # If all else fails, we try to resolve the type directly and otherwise just
     # return the input with no modifications.
     return type_map.get(type_, type_)
@@ -339,7 +335,7 @@ _generic_recursion_cache: ContextVar[set[str] | None] = ContextVar('_generic_rec
 @contextmanager
 def generic_recursion_self_type(
     origin: type[BaseModel], args: tuple[Any, ...]
-) -> Iterator[PydanticForwardRef | PydanticRecursiveRef | None]:
+) -> Iterator[PydanticRecursiveRef | None]:
     """
     This contextmanager should be placed around the recursive calls used to build a generic type,
     and accept as arguments the generic origin type and the type arguments being passed to it.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -697,7 +697,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     def __class_getitem__(
         cls, typevar_values: type[Any] | tuple[type[Any], ...]
-    ) -> type[BaseModel] | _forward_ref.PydanticForwardRef | _forward_ref.PydanticRecursiveRef:
+    ) -> type[BaseModel] | _forward_ref.PydanticRecursiveRef:
         cached = _generics.get_cached_generic_type_early(cls, typevar_values)
         if cached is not None:
             return cached

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1441,6 +1441,37 @@ def test_generic_with_referenced_generic_type_1():
     ReferenceModel[int]
 
 
+def test_generic_with_referenced_generic_type_bound():
+    T = TypeVar('T', bound=int)
+
+    class ModelWithType(BaseModel, Generic[T]):
+        # Type resolves to type origin of "type" which is non-subscriptible for
+        # python < 3.9 so we want to make sure it works for other versions
+        some_type: Type[T]
+
+    class ReferenceModel(BaseModel, Generic[T]):
+        abstract_base_with_type: ModelWithType[T]
+
+    class MyInt(int):
+        ...
+
+    ReferenceModel[MyInt]
+
+
+def test_generic_with_referenced_generic_type_constraints():
+    T = TypeVar('T', int, str)
+
+    class ModelWithType(BaseModel, Generic[T]):
+        # Type resolves to type origin of "type" which is non-subscriptible for
+        # python < 3.9 so we want to make sure it works for other versions
+        some_type: Type[T]
+
+    class ReferenceModel(BaseModel, Generic[T]):
+        abstract_base_with_type: ModelWithType[T]
+
+    ReferenceModel[int]
+
+
 def test_generic_with_referenced_nested_typevar():
     T = TypeVar('T')
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3748,12 +3748,22 @@ def test_pattern(pattern_type, pattern_value, matching_value, non_matching_value
     f2 = Foobar(pattern=p)
     assert f2.pattern is p
 
-    # assert Foobar.model_json_schema() == {
-    #     'type': 'object',
-    #     'title': 'Foobar',
-    #     'properties': {'pattern': {'type': 'string', 'format': 'regex', 'title': 'Pattern'}},
-    #     'required': ['pattern'],
-    # }
+    assert Foobar.model_json_schema() == {
+        'type': 'object',
+        'title': 'Foobar',
+        'properties': {'pattern': {'type': 'string', 'format': 'regex', 'title': 'Pattern'}},
+        'required': ['pattern'],
+    }
+
+
+def test_pattern_with_invalid_param():
+    with pytest.raises(
+        PydanticSchemaGenerationError,
+        match=re.escape('Unable to generate pydantic-core schema for typing.Pattern[int].'),
+    ):
+
+        class Foo(BaseModel):
+            pattern: Pattern[int]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -552,6 +552,14 @@ def test_populate_by_name():
     assert foo(a=10, c=1) == 11
 
 
+def test_validate_return():
+    @validate_call(config=dict(validate_return=True))
+    def foo(a: int, b: int) -> int:
+        return a + b
+
+    assert foo(1, 2) == 3
+
+
 def test_validate_all():
     @validate_call(config=dict(validate_default=True))
     def foo(dt: datetime = Field(default_factory=lambda: 946684800)):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1012,6 +1012,21 @@ def test_validation_each_item():
     assert Model(foobar={1: 1}).foobar == {1: 2}
 
 
+def test_validation_each_item_invalid_type():
+    with pytest.raises(
+        TypeError, match=re.escape('@validator(..., each_item=True)` cannot be applied to fields with a schema of int')
+    ):
+        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+
+            class Model(BaseModel):
+                foobar: int
+
+                @validator('foobar', each_item=True)
+                @classmethod
+                def check_foobar(cls, v: Any):
+                    ...
+
+
 def test_validation_each_item_nullable():
     with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
 


### PR DESCRIPTION
Waiting for 5966 to be merged.

## Changes

- Removes `PydanticForwardRef` since it was not being used at all.
- Adds coverage to `_generate_schema.py`.

Selected Reviewer: @dmontagu