### PR TITLE
Fix test_extra_used_as_enum to use pytest.warns()

### DIFF
--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -319,7 +319,7 @@ def test_extra_used_as_enum(
     attribute: str,
     value: str,
 ) -> None:
-    with pytest.raises(
+    with pytest.warns(
         DeprecationWarning,
         match=re.escape("`pydantic.config.Extra` is deprecated, use literal values instead (e.g. `extra='allow'`)"),
     ):


### PR DESCRIPTION
## Change Summary

Fix `tests/test_deprecated.py::test_extra_used_as_enum` to use `pytest.warns()` rather than incorrect `pytest.raises()`.  The latter works only if the test suite is run in `-Werror` mode.  This is problematic for Gentoo that runs test suites with `-Wignore` in order to prevent test regressions from deprecation warnings added in dependent libraries and new Python versions.

## Related issue number

n/a

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani