### PR TITLE
Allow `__pydantic_config__`  to be used on vanilla dataclasses

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -178,7 +178,12 @@ def dataclass(
 
         original_cls = cls
 
-        config_wrapper = _config.ConfigWrapper(config or getattr(cls, '__pydantic_config__', None) or None)
+        cls_config = getattr(cls, '__pydantic_config__', None)
+        config_dict = config
+        if config_dict is None:
+            if cls_config is not None:
+                config_dict = cls_config
+        config_wrapper = _config.ConfigWrapper(config_dict)
         decorators = _decorators.DecoratorInfos.build(cls)
 
         # Keep track of the original __doc__ so that we can restore it after applying the dataclasses decorator

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -178,10 +178,12 @@ def dataclass(
 
         original_cls = cls
 
-        cls_config = getattr(cls, '__pydantic_config__', None)
         config_dict = config
-        if config_dict is None and cls_config is not None:
-            config_dict = cls_config
+        if config_dict is None:
+            # if not explicitly provided, read from the type
+            cls_config = getattr(cls, '__pydantic_config__', None)
+            if cls_config is not None:
+                config_dict = cls_config
         config_wrapper = _config.ConfigWrapper(config_dict)
         decorators = _decorators.DecoratorInfos.build(cls)
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -180,9 +180,8 @@ def dataclass(
 
         cls_config = getattr(cls, '__pydantic_config__', None)
         config_dict = config
-        if config_dict is None:
-            if cls_config is not None:
-                config_dict = cls_config
+        if config_dict is None and cls_config is not None:
+            config_dict = cls_config
         config_wrapper = _config.ConfigWrapper(config_dict)
         decorators = _decorators.DecoratorInfos.build(cls)
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -178,7 +178,7 @@ def dataclass(
 
         original_cls = cls
 
-        config_wrapper = _config.ConfigWrapper(config)
+        config_wrapper = _config.ConfigWrapper(config or getattr(cls, '__pydantic_config__', None) or None)
         decorators = _decorators.DecoratorInfos.build(cls)
 
         # Keep track of the original __doc__ so that we can restore it after applying the dataclasses decorator

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2337,4 +2337,4 @@ def test_model_config_override_in_decorator() -> None:
         __pydantic_config__ = ConfigDict(str_to_lower=True)
 
     ta = TypeAdapter(Model)
-    assert ta.validate_python({'x': 'ABC'}).x == 'ABC'
+    assert ta.validate_python({'x': 'ABC '}).x == 'ABC'

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2328,3 +2328,13 @@ def test_model_config(dataclass_decorator: Any) -> None:
 
     ta = TypeAdapter(Model)
     assert ta.validate_python({'x': 'ABC'}).x == 'abc'
+
+
+def test_model_config_override_in_decorator() -> None:
+    @pydantic.dataclasses.dataclass(config=ConfigDict(str_to_lower=False, str_strip_whitespace=True))
+    class Model:
+        x: str
+        __pydantic_config__ = ConfigDict(str_to_lower=True)
+
+    ta = TypeAdapter(Model)
+    assert ta.validate_python({'x': 'ABC'}).x == 'ABC'

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2310,3 +2310,21 @@ def test_rebuild_dataclass():
 
     with pytest.raises(PydanticUndefinedAnnotation, match="name 'Foo' is not defined"):
         rebuild_dataclass(MyDataClass1, _parent_namespace_depth=0)
+
+
+@pytest.mark.parametrize(
+    'dataclass_decorator',
+    [
+        pydantic.dataclasses.dataclass,
+        dataclasses.dataclass,
+    ],
+    ids=['pydantic', 'stdlib'],
+)
+def test_model_config(dataclass_decorator: Any) -> None:
+    @dataclass_decorator
+    class Model:
+        x: str
+        __pydantic_config__ = ConfigDict(str_to_lower=True)
+
+    ta = TypeAdapter(Model)
+    assert ta.validate_python({'x': 'ABC'}).x == 'abc'

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2338,3 +2338,13 @@ def test_model_config_override_in_decorator() -> None:
 
     ta = TypeAdapter(Model)
     assert ta.validate_python({'x': 'ABC '}).x == 'ABC'
+
+
+def test_model_config_override_in_decorator_empty_config() -> None:
+    @pydantic.dataclasses.dataclass(config=ConfigDict())
+    class Model:
+        x: str
+        __pydantic_config__ = ConfigDict(str_to_lower=True)
+
+    ta = TypeAdapter(Model)
+    assert ta.validate_python({'x': 'ABC '}).x == 'ABC '

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -829,3 +829,13 @@ def test_typeddict_model_serializer(TypedDict) -> None:
     ta = TypeAdapter(Model)
 
     assert ta.dump_python(Model({'x': 1, 'y': 2.5})) == {'x': 2, 'y': 7.5}
+
+
+def test_model_config() -> None:
+    class Model(TypedDict):
+        x: str
+        __pydantic_config__ = ConfigDict(str_to_lower=True)  # type: ignore
+
+    ta = TypeAdapter(Model)
+
+    assert ta.validate_python({'x': 'ABC'}) == {'x': 'abc'}


### PR DESCRIPTION
cc @dmontagu 

Selected Reviewer: @samuelcolvin