### PR TITLE
Give nicer error when using a bare root_validator

### DIFF
--- a/pydantic/deprecated/class_validators.py
+++ b/pydantic/deprecated/class_validators.py
@@ -188,7 +188,7 @@ def root_validator(
 
 
 def root_validator(
-    *,
+    *__args,
     pre: bool = False,
     skip_on_failure: bool = False,
     allow_reuse: bool = False,
@@ -198,7 +198,7 @@ def root_validator(
     modify) data either before or after standard model parsing/validation is performed.
 
     Args:
-        pre (bool, optional): Whether or not this validator should be called before the standard
+        pre (bool, optional): Whether this validator should be called before the standard
             validators (else after). Defaults to False.
         skip_on_failure (bool, optional): Whether to stop validation and return as soon as a
             failure is encountered. Defaults to False.
@@ -215,12 +215,18 @@ def root_validator(
         DeprecationWarning,
         stacklevel=2,
     )
+
+    if __args:
+        # Ensure a nice error is raised if someone attempts to use the bare decorator
+        return root_validator()(*__args)  # type: ignore
+
     if allow_reuse is True:  # pragma: no cover
         warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
     if pre is False and skip_on_failure is not True:
         raise PydanticUserError(
-            'If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`.',
+            'If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`.'
+            ' Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.',
             code='root-validator-pre-skip',
         )
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -17,6 +17,7 @@ from pydantic import (
     ConfigDict,
     Field,
     FieldValidationInfo,
+    PydanticUserError,
     ValidationError,
     ValidationInfo,
     ValidatorFunctionWrapHandler,
@@ -2524,6 +2525,23 @@ def test_root_validator_allow_reuse_inheritance():
 
     assert Parent(x=1).model_dump() == {'x': 2}
     assert Child(x=1).model_dump() == {'x': 4}
+
+
+def test_bare_root_validator():
+    with pytest.raises(
+        PydanticUserError,
+        match=re.escape(
+            'If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`.'
+            ' Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.'
+        ),
+    ):
+        with pytest.warns(DeprecationWarning, match='Pydantic V1 style `@root_validator` validators are deprecated.'):
+
+            class Model(BaseModel):
+                @root_validator
+                @classmethod
+                def validate_values(cls, values):
+                    return values
 
 
 def test_validator_with_underscore_name() -> None:


### PR DESCRIPTION
Without this change, the following code snippet
```python
class Model(BaseModel):
    @root_validator
    @classmethod
    def validate_values(cls, values):
        return values
```
raises:
```
TypeError: root_validator() takes 0 positional arguments but 1 was given
```
Because this was valid code in v1, I think this is kind of problematic as the error message gives minimal insight into what needs to be changed to resolve the issue.

----

*With* the change in this PR, you instead get:
```
PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST
specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should
be replaced with `@model_validator`.
```
(The error message is not actually multiline, I just formatted it that way here for readability.)

Selected Reviewer: @adriangb