### PR TITLE
check for email-validator version >= 2.0

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -5,6 +5,7 @@ import dataclasses as _dataclasses
 import re
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import TYPE_CHECKING, Any
+from importlib.metadata import version
 
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, TypeAlias

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -363,13 +363,8 @@ def import_email_validator() -> None:
         import email_validator
     except ImportError as e:
         raise ImportError('email-validator is not installed, run `pip install pydantic[email]`') from e
-    if getattr(email_validator, '__version__', '').partition('.')[0] == '2':
-        return
-    else:
-        input_email = 'testaddr@example.tld'
-        valid_email = email_validator.validate_email(input_email, check_deliverability=False)
-        if not hasattr(valid_email, 'normalized'):
-            raise ImportError('email-validator version >= 2.0 required')
+    if not version("email-validator").partition('.')[0] == '2':
+        raise ImportError('email-validator version >= 2.0 required, run pip install -U email-validator')
 
 
 if TYPE_CHECKING:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -363,7 +363,7 @@ def import_email_validator() -> None:
         import email_validator
     except ImportError as e:
         raise ImportError('email-validator is not installed, run `pip install pydantic[email]`') from e
-    if hasattr(email_validator, '__version__') and getattr(email_validator, '__version__', '').partition('.')[0] == '2':
+    if getattr(email_validator, '__version__', '').partition('.')[0] == '2':
         return
     else:
         input_email = 'testaddr@example.tld'

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -363,12 +363,12 @@ def import_email_validator() -> None:
         import email_validator
     except ImportError as e:
         raise ImportError('email-validator is not installed, run `pip install pydantic[email]`') from e
-    if hasattr(email_validator, "__version__") and email_validator.__version__.partition(".")[0] == "2":
+    if hasattr(email_validator, '__version__') and getattr(email_validator, '__version__', '').partition('.')[0] == '2':
         return
     else:
-        input_email = b"testaddr@example.tld"
-        valid_email = validate_email(input_email, check_deliverability=False)
-        if not hasattr(valid_email, "normalized"):
+        input_email = 'testaddr@example.tld'
+        valid_email = email_validator.validate_email(input_email, check_deliverability=False)
+        if not hasattr(valid_email, 'normalized'):
             raise ImportError('email-validator version >= 2.0 required')
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -363,6 +363,13 @@ def import_email_validator() -> None:
         import email_validator
     except ImportError as e:
         raise ImportError('email-validator is not installed, run `pip install pydantic[email]`') from e
+    if hasattr(email_validator, "__version__") and email_validator.__version__.partition(".")[0] == "2":
+        return
+    else:
+        input_email = b"testaddr@example.tld"
+        valid_email = validate_email(input_email, check_deliverability=False)
+        if not hasattr(valid_email, "normalized"):
+            raise ImportError('email-validator version >= 2.0 required')
 
 
 if TYPE_CHECKING:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -3,9 +3,9 @@ from __future__ import annotations as _annotations
 
 import dataclasses as _dataclasses
 import re
+from importlib.metadata import version
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import TYPE_CHECKING, Any
-from importlib.metadata import version
 
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, TypeAlias
@@ -364,7 +364,7 @@ def import_email_validator() -> None:
         import email_validator
     except ImportError as e:
         raise ImportError('email-validator is not installed, run `pip install pydantic[email]`') from e
-    if not version("email-validator").partition('.')[0] == '2':
+    if not version('email-validator').partition('.')[0] == '2':
         raise ImportError('email-validator version >= 2.0 required, run pip install -U email-validator')
 
 


### PR DESCRIPTION
## Change Summary

check for email-validator version >= 2.0
will use `email_validator.__version__` if available (https://github.com/JoshData/python-email-validator/commit/68b9d1892dc6007844a80acf5677cf6166bf5533)

## Related issue number

fix #5739 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

