### PR TITLE
Specify members to appear in documentation for pydantic_core

### DIFF
--- a/docs/api/pydantic_core_init.md
+++ b/docs/api/pydantic_core_init.md
@@ -1,1 +1,10 @@
 ::: pydantic_core
+    options:
+        members:
+        - PydanticCustomError
+        - PydanticKnownError
+        - PydanticOmit
+        - PydanticSerializationError
+        - PydanticSerializationUnexpectedValue
+        - SchemaError
+        - ValidationError

--- a/docs/api/pydantic_core_init.md
+++ b/docs/api/pydantic_core_init.md
@@ -1,10 +1,20 @@
 ::: pydantic_core
     options:
         members:
+        - ArgsKwargs
+        - MultiHostUrl
         - PydanticCustomError
         - PydanticKnownError
         - PydanticOmit
         - PydanticSerializationError
         - PydanticSerializationUnexpectedValue
         - SchemaError
+        - SchemaError
+        - SchemaSerializer
+        - SchemaValidator
+        - Some
+        - Url
         - ValidationError
+        - list_all_errors
+        - to_json
+        - to_jsonable_python


### PR DESCRIPTION
Sets the mkdocstrings handler options in /docs/api/pydantic_core_init.md to include only specified members.

It's also possible to take the opposite approach -- use filter to exclude members that should not appear in the documentation -- but I think the positive `members:` option approach is more clear.

Will need docstrings in pydantic_core/_pydantic_core.pyi 

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin