### PR TITLE
Add feedback form on documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,9 +33,25 @@ repo_name: pydantic/pydantic
 repo_url: https://github.com/pydantic/pydantic
 edit_uri: edit/main/docs/
 extra:
+  version:
+    provider: mike
   analytics:
     provider: google
     property: UA-62733018-4
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback!
+
 
 extra_css:
 - 'extra/terminal.css'
@@ -155,10 +171,6 @@ markdown_extensions:
 
 watch:
 - pydantic
-
-extra:
-  version:
-    provider: mike
 
 plugins:
 - mike:


### PR DESCRIPTION
This PR adds this at the end of each doc page:

<img width="224" alt="image" src="https://github.com/pydantic/pydantic/assets/7353520/3f6bd941-757c-4d62-9d4a-35107f93d5f3">
