### PR TITLE
Fix broken and incorrectly formatting internal links

### DIFF
--- a/docs/integrations/mypy.md
+++ b/docs/integrations/mypy.md
@@ -1,4 +1,4 @@
-Pydantic works well with [mypy](http://mypy-lang.org/) right out of the box.
+Pydantic works well with [mypy](http://mypy-lang.org.md) right out of the box.
 
 However, Pydantic also ships with a mypy plugin that adds a number of important pydantic-specific
 features to mypy that improve its ability to type-check your code.
@@ -71,7 +71,7 @@ If these aren't sufficient you can of course define your own.
 
 ### Other Pydantic interfaces
 
-Pydantic [dataclasses](/usage/dataclasses/) and the [`validate_arguments` decorator](/usage/validation_decorator/)
+Pydantic [dataclasses](../usage/dataclasses.md) and the [`validate_arguments` decorator](../usage/validation_decorator.md)
 should also work well with mypy.
 
 ## Mypy Plugin Capabilities
@@ -83,27 +83,27 @@ should also work well with mypy.
   rather than aliases.
 * If `Config.extra="forbid"` and you don't make use of dynamically-determined aliases, the generated signature
   will not allow unexpected inputs.
-* **Optional:** If the [`init_forbid_extra` **plugin setting**](#plugin-settings) is set to `True`, unexpected inputs to
+* **Optional:** If the [`init_forbid_extra` **plugin setting**](#configuring-the-plugin) is set to `True`, unexpected inputs to
   `__init__` will raise errors even if `Config.extra` is not `"forbid"`.
-* **Optional:** If the [`init_typed` **plugin setting**](#plugin-settings) is set to `True`, the generated signature
+* **Optional:** If the [`init_typed` **plugin setting**](#configuring-the-plugin) is set to `True`, the generated signature
   will use the types of the model fields (otherwise they will be annotated as `Any` to allow parsing).
 
 ### Generate a typed signature for `Model.model_construct`
-* The [`model_construct`](/usage/models/#creating-models-without-validation) method is a faster alternative to `__init__`
+* The [`model_construct`](../usage/models.md#creating-models-without-validation) method is a faster alternative to `__init__`
   when input data is known to be valid and does not need to be parsed. But because this method performs no runtime
   validation, static checking is important to detect errors.
 
 ### Respect `Config.allow_mutation`
 * If `Config.allow_mutation` is `False`, you'll get a mypy error if you try to change
-  the value of a model field; cf. [faux immutability](/usage/models/#faux-immutability).
+  the value of a model field; cf. [faux immutability](../usage/models.md#faux-immutability).
 
 ### Respect `Config.from_attributes`
 * If `Config.from_attributes` is `False`, you'll get a mypy error if you try to call `.from_orm()`;
-  cf. [ORM mode](/usage/models/#orm-mode-aka-arbitrary-class-instances)
+  cf. [ORM mode](../usage/models.md#orm-mode-aka-arbitrary-class-instances)
 
 ### Generate a signature for `dataclasses`
-* classes decorated with [`@pydantic.dataclasses.dataclass`](/usage/dataclasses/) are type checked the same as standard Python dataclasses
-* The `@pydantic.dataclasses.dataclass` decorator accepts a `config` keyword argument which has the same meaning as [the `Config` sub-class](/usage/model_config/).
+* classes decorated with [`@pydantic.dataclasses.dataclass`](../usage/dataclasses.md) are type checked the same as standard Python dataclasses
+* The `@pydantic.dataclasses.dataclass` decorator accepts a `config` keyword argument which has the same meaning as [the `Config` sub-class](../usage/model_config.md).
 
 ### Respect the type of the `Field`'s `default` and `default_factory`
 * Field with both a `default` and a `default_factory` will result in an error during static checking.
@@ -116,7 +116,7 @@ should also work well with mypy.
 ## Optional Capabilities:
 ### Prevent the use of required dynamic aliases
 
-* If the [`warn_required_dynamic_aliases` **plugin setting**](#plugin-settings) is set to `True`, you'll get a mypy
+* If the [`warn_required_dynamic_aliases` **plugin setting**](#configuring-the-plugin) is set to `True`, you'll get a mypy
   error any time you use a dynamically-determined alias or alias generator on a model with
   `Config.populate_by_name=False`.
 * This is important because if such aliases are present, mypy cannot properly type check calls to `__init__`.

--- a/docs/integrations/visual_studio_code.md
+++ b/docs/integrations/visual_studio_code.md
@@ -1,6 +1,6 @@
 *pydantic* works well with any editor or IDE out of the box because it's made on top of standard Python type annotations.
 
-When using [Visual Studio Code (VS Code)](https://code.visualstudio.com/), there are some **additional editor features** supported, comparable to the ones provided by the [PyCharm plugin](/integrations/pycharm_plugin/).
+When using [Visual Studio Code (VS Code)](https://code.visualstudio.com/), there are some **additional editor features** supported, comparable to the ones provided by the [PyCharm plugin](../integrations/pycharm.md).
 
 This means that you will have **autocompletion** (or "IntelliSense") and **error checks** for types and required arguments even while creating new *pydantic* model instances.
 
@@ -54,7 +54,7 @@ And you will also get error checks for **invalid data types**.
 
 You might also want to configure mypy in VS Code to get mypy error checks inline in your editor (alternatively/additionally to Pylance).
 
-This would include the errors detected by the [*pydantic* mypy plugin](/integrations/mypy/), if you configured it.
+This would include the errors detected by the [*pydantic* mypy plugin](../integrations/mypy.md), if you configured it.
 
 To enable mypy in VS Code, do the following:
 
@@ -219,7 +219,7 @@ So, this is the equivalent of the previous example, without the additional varia
 
 ### Config in class arguments
 
-*pydantic* has a rich set of [Model Configurations](/usage/model_config/) available.
+*pydantic* has a rich set of [Model Configurations](../usage/model_config.md) available.
 
 These configurations can be set in an internal `class Config` on each model:
 

--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -92,7 +92,7 @@ print(TypeAdapter(User).json_schema())
 keyword argument `config` which has the same meaning as [model_config](model_config.md).
 
 !!! warning
-    After v1.2, [The Mypy plugin](/mypy/) must be installed to type check _pydantic_ dataclasses.
+    After v1.2, [The Mypy plugin](../integrations/mypy.md) must be installed to type check _pydantic_ dataclasses.
 
 For more information about combining validators with dataclasses, see
 [dataclass validators](validators.md#dataclass-validators).

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -5,7 +5,7 @@ and exported in a number of ways:
 
 This is the primary way of converting a model to a dictionary. Sub-models will be recursively converted to dictionaries.
 
-See [arguments](/api/main/#pydantic.main.BaseModel.model_dump) for more information.
+See [arguments](../api/main.md#pydantic.main.BaseModel.model_dump) for more information.
 
 Example:
 
@@ -100,7 +100,7 @@ for name, value in m:
 ## `model_copy(...)`
 
 `model_copy()` allows models to be duplicated, which is particularly useful for immutable models.
-See [arguments](/api/main/#pydantic.main.BaseModel.model_copy) for more information.
+See [arguments](../api/main.md#pydantic.main.BaseModel.model_copy) for more information.
 
 Example:
 
@@ -135,7 +135,7 @@ print(id(m.bar) == id(m.model_copy(deep=True).bar))
 The `.model_dump_json()` method will serialise a model to JSON. (For `RootModel` [custom root type](models.md#custom-root-types),
 only the values are serialised)
 
-See [arguments](/api/main/#pydantic.main.BaseModel.model_dump_json) for more information.
+See [arguments](../api/main.md#pydantic.main.BaseModel.model_dump_json) for more information.
 
 *pydantic* can serialise many commonly used types to JSON (e.g. `datetime`, `date` or `UUID`) which would normally
 fail with a simple `json.dumps(foobar)`.

--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -93,7 +93,7 @@ except ValidationError as e:
 
 ## Options
 
-See the [`ConfigDict` API documentation](/api/config/#pydantic.config.ConfigDict) for the full list of settings.
+See the [`ConfigDict` API documentation](../api/config.md#pydantic.config.ConfigDict) for the full list of settings.
 
 ## Change behaviour globally
 

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -158,7 +158,7 @@ to the model field names. One common application of this functionality is integr
 (ORMs).
 
 To do this, use the `model_config` property on the model with `from_attributes` set to `True`. See
-[Model Config](model_config.md) and [ConfigDict](/api/config/#pydantic.config.ConfigDict) for more information.
+[Model Config](model_config.md) and [ConfigDict](../api/config.md#pydantic.config.ConfigDict) for more information.
 
 The example here uses [SQLAlchemy](https://www.sqlalchemy.org/), but the same approach should work for any ORM.
 
@@ -1009,7 +1009,7 @@ class Model(BaseModel):
 Where `Field` refers to the [field function](schema.md#field-customization).
 
 Here `a`, `b` and `c` are all required. However, use of the ellipses in `b` will not work well
-with [mypy](/mypy_plugin/), and as of **v1.0** should be avoided in most cases.
+with [mypy](../integrations/mypy.md), and as of **v1.0** should be avoided in most cases.
 
 ### Required Optional fields
 
@@ -1247,4 +1247,4 @@ print('id(c1.arr) == id(c2.arr)  ', id(c1.arr) == id(c2.arr))
 ```
 
 !!! note
-    There are some situations where Pydantic does not copy attributes, such as when passing models &mdash; we use the model as is. You can override this behaviour by setting [`config.revalidate_instances='always'`](/api/config/#pydantic.config.ConfigDict) in your model.
+    There are some situations where Pydantic does not copy attributes, such as when passing models &mdash; we use the model as is. You can override this behaviour by setting [`config.revalidate_instances='always'`](../api/config.md#pydantic.config.ConfigDict) in your model.

--- a/docs/usage/types/standard_types.md
+++ b/docs/usage/types/standard_types.md
@@ -3,14 +3,14 @@ description: Support for common types from the Python standard library.
 ---
 
 Pydantic supports many common types from the Python standard library. If you need stricter processing see
-[Strict Types](/usage/strict/). If you need to constrain the values allowed (e.g. to require a positive `int`) see
-[Constrained Types](/usage/constrained/).
+[Strict types](#strict-types). If you need to constrain the values allowed (e.g. to require a positive `int`) see
+[Constrained types](#constrained-types).
 
 | Type | Description |
 | ---- | ----------- |
 | `None`, `type(None)`, or `Literal[None]` | Equivalent according to [PEP 484](https://www.python.org/dev/peps/pep-0484/#using-none). Allows only `None` value. |
-| `bool` | See [Booleans](/usage/booleans/) for details on how bools are validated and what values are permitted. |
-| `int` | Pydantic uses `int(v)` to coerce types to an `int`. See the [Data Conversion](/usage/models/#data-conversion) warning on loss of information during data conversion. |
+| `bool` | See [Booleans](booleans.md) for details on how bools are validated and what values are permitted. |
+| `int` | Pydantic uses `int(v)` to coerce types to an `int`. See the [Data Conversion](../models.md#data-conversion) warning on loss of information during data conversion. |
 | `float` | `float(v)` is used to coerce values to floats. |
 | `str` | Strings are accepted as-is. `int` `float` and `Decimal` are coerced using `str(v)`. `bytes` and `bytearray` are converted using `v.decode()`. `Enum`s inheriting from `str` are converted using `v.value`. All other types cause an error. |
 | `bytes` | `bytes` are accepted as-is. `bytearray` is converted using `bytes(v)`. `str` are converted using `v.encode()`. `int`, `float`, and `Decimal` are coerced using `str(v).encode()`. |
@@ -20,42 +20,42 @@ Pydantic supports many common types from the Python standard library. If you nee
 | `set` | Allows `list`, `tuple`, `set`, `frozenset`, `deque`, or generators and casts to a set. See `typing.Set` below for sub-type constraints. |
 | `frozenset` | Allows `list`, `tuple`, `set`, `frozenset`, `deque`, or generators and casts to a frozen set. See `typing.FrozenSet` below for sub-type constraints. |
 | `deque` | Allows `list`, `tuple`, `set`, `frozenset`, `deque`, or generators and casts to a deque. See `typing.Deque` below for sub-type constraints. |
-| `datetime.date` | See [Datetime Types](/usage/datetime/) below for more detail on parsing and validation. |
-| `datetime.time` | See [Datetime Types](/usage/datetime/) below for more detail on parsing and validation. |
-| `datetime.datetime` | See [Datetime Types](/usage/datetime/) below for more detail on parsing and validation. |
-| `datetime.timedelta` | See [Datetime Types](/usage/datetime/) below for more detail on parsing and validation. |
+| `datetime.date` | See [Datetime Types](datetime.md)  for more detail on parsing and validation. |
+| `datetime.time` | See [Datetime Types](datetime.md)  for more detail on parsing and validation. |
+| `datetime.datetime` | See [Datetime Types](datetime.md)  for more detail on parsing and validation. |
+| `datetime.timedelta` | See [Datetime Types](datetime.md)  for more detail on parsing and validation. |
 | `typing.Any` | Allows any value including `None`, thus an `Any` field is optional. |
-| `typing.Annotated` | Allows wrapping another type with arbitrary metadata, as per [PEP-593](https://www.python.org/dev/peps/pep-0593/). The `Annotated` hint may contain a single call to the [`Field` function](/usage/schema/#typingannotated-fields), but otherwise the additional metadata is ignored and the root type is used. |
-| `typing.TypeVar` | Constrains the values allowed based on `constraints` or `bound`, see [TypeVar](/usage/typevars/). |
-| `typing.Union` | See [Unions](/usage/unions/) below for more detail on parsing and validation. |
-| `typing.Optional` | `Optional[x]` is simply short hand for `Union[x, None]`. See [Unions](/usage/unions/) below for more detail on parsing and validation and [Required Fields](/usage/models/#required-fields) for details about required fields that can receive `None` as a value. |
-| `typing.List` | See [Typing Iterables](/usage/typing_iterables/) below for more detail on parsing and validation. |
-| `typing.Tuple` | See [Typing Iterables](/usage/typing_iterables/) below for more detail on parsing and validation. |
-| Subclass of `typing.NamedTuple` | Same as `tuple`, but instantiates with the given namedtuple and validates fields since they are annotated. See [Annotated Types](/usage/annotated_types/) below for more detail on parsing and validation. |
+| `typing.Annotated` | Allows wrapping another type with arbitrary metadata, as per [PEP-593](https://www.python.org/dev/peps/pep-0593/). The `Annotated` hint may contain a single call to the [`Field` function]../schema.md#typingannotated-fields), but otherwise the additional metadata is ignored and the root type is used. |
+| `typing.TypeVar` | Constrains the values allowed based on `constraints` or `bound`, see [TypeVar](typevars.md). |
+| `typing.Union` | See [Unions](unions.md) for more detail on parsing and validation. |
+| `typing.Optional` | `Optional[x]` is simply short hand for `Union[x, None]`. See [Unions](unions.md) below for more detail on parsing and validation and [Required Fields](../models.md#required-fields) for details about required fields that can receive `None` as a value. |
+| `typing.List` | See [Lists and Tuples](list_types.md) for more detail on parsing and validation. |
+| `typing.Tuple` | See [Lists and Tuples](list_types.md) for more detail on parsing and validation. |
+| Subclass of `typing.NamedTuple` | Same as `tuple`, but instantiates with the given namedtuple and validates fields since they are annotated.  |
 | Subclass of `collections.namedtuple` | Same as subclass of `typing.NamedTuple`, but all fields will have type `Any` since they are not annotated. |
-| `typing.Dict` | See [Typing Iterables](/usage/typing_iterables/) below for more detail on parsing and validation. |
-| Subclass of `typing.TypedDict` | Same as `dict`, but Pydantic will validate the dictionary since keys are annotated. See [Annotated Types](/usage/annotated_types/) below for more detail on parsing and validation. |
-| `typing.Set` | See [Typing Iterables](/usage/typing_iterables/) below for more detail on parsing and validation. |
-| `typing.FrozenSet` | See [Typing Iterables](/usage/typing_iterables/) below for more detail on parsing and validation. |
-| `typing.Deque` | See [Typing Iterables](/usage/typing_iterables/) below for more detail on parsing and validation. |
-| `typing.Sequence` | See [Typing Iterables](/usage/typing_iterables/) below for more detail on parsing and validation. |
-| `typing.Iterable` | This is reserved for iterables that shouldn't be consumed. See [Infinite Generators](/usage/typing_iterables/#infinite-generators) below for more detail on parsing and validation. |
-| `typing.Type` | See [Type](/usage/typevars/#type) below for more detail on parsing and validation. |
-| `typing.Callable` | See [Callables](/usage/callables/) below for more detail on parsing and validation. |
+| `typing.Dict` | See [Dicts and mapping](dicts_mapping.md) for more detail on parsing and validation. |
+| Subclass of `typing.TypedDict` | Same as `dict`, but Pydantic will validate the dictionary since keys are annotated. |
+| `typing.Set` | See [Sets and frozenset](set_types.md) for more detail on parsing and validation. |
+| `typing.FrozenSet` | See [Sets and frozenset](set_types.md) for more detail on parsing and validation. |
+| `typing.Deque` | See [Sequence, Iterable & Iterator](sequence_iterable.md) for more detail on parsing and validation. |
+| `typing.Sequence` | See [Sequence, Iterable & Iterator](sequence_iterable.md) for more detail on parsing and validation. |
+| `typing.Iterable` | This is reserved for iterables that shouldn't be consumed. See [Sequence, Iterable & Iterator](sequence_iterable.md) for more detail on parsing and validation. |
+| `typing.Type` | See [Type and Typevars](typevars.md) for more detail on parsing and validation. |
+| `typing.Callable` | See [Callables](callables.md) below for more detail on parsing and validation. |
 | `typing.Pattern` | Will cause the input value to be passed to `re.compile(v)` to create a regex pattern. |
-| `ipaddress.IPv4Address` | Simply uses the type itself for validation by passing the value to `IPv4Address(v)`. See [Pydantic Types](/usage/pydantic_types/) for other custom IP address types. |
-| <nobr>`ipaddress.IPv4Interface`</nobr> | Simply uses the type itself for validation by passing the value to `IPv4Address(v)`. See [Pydantic Types](/usage/pydantic_types/) for other custom IP address types. |
-| `ipaddress.IPv4Network` | Simply uses the type itself for validation by passing the value to `IPv4Network(v)`. See [Pydantic Types](/usage/pydantic_types/) for other custom IP address types. |
-| `ipaddress.IPv6Address` | Simply uses the type itself for validation by passing the value to `IPv6Address(v)`. See [Pydantic Types](/usage/pydantic_types/) for other custom IP address types. |
-| `ipaddress.IPv6Interface` | Simply uses the type itself for validation by passing the value to `IPv6Interface(v)`. See [Pydantic Types](/usage/pydantic_types/) for other custom IP address types. |
-| `ipaddress.IPv6Network` | Simply uses the type itself for validation by passing the value to `IPv6Network(v)`. See [Pydantic Types](/usage/pydantic_types/) for other custom IP address types. |
+| `ipaddress.IPv4Address` | Simply uses the type itself for validation by passing the value to `IPv4Address(v)`. See [URLs](urls.md) for other custom IP address types. |
+| <nobr>`ipaddress.IPv4Interface`</nobr> | Simply uses the type itself for validation by passing the value to `IPv4Address(v)`. See [URLs](urls.md) for other custom IP address types. |
+| `ipaddress.IPv4Network` | Simply uses the type itself for validation by passing the value to `IPv4Network(v)`. See [URLs](urls.md) for other custom IP address types. |
+| `ipaddress.IPv6Address` | Simply uses the type itself for validation by passing the value to `IPv6Address(v)`. See [URLs](urls.md) for other custom IP address types. |
+| `ipaddress.IPv6Interface` | Simply uses the type itself for validation by passing the value to `IPv6Interface(v)`. See [URLs](urls.md) for other custom IP address types. |
+| `ipaddress.IPv6Network` | Simply uses the type itself for validation by passing the value to `IPv6Network(v)`. See [URLs](urls.md) for other custom IP address types. |
 | `enum.Enum` | Checks that the value is a valid `Enum` instance. |
-| Subclass of `enum.Enum` | Checks that the value is a valid member of the `enum`. See [Enums and Choices](/usage/enums/) for more details. |
+| Subclass of `enum.Enum` | Checks that the value is a valid member of the `enum`. See [Enums and Choices](enums.md) for more details. |
 | `enum.IntEnum` | Checks that the value is a valid `IntEnum` instance. |
-| Subclass of `enum.IntEnum` | Checks that the value is a valid member of the integer `enum`. See [Enums and Choices](/usage/enums/) for more details. |
+| Subclass of `enum.IntEnum` | Checks that the value is a valid member of the integer `enum`. See [Enums and Choices](enums.md) for more details. |
 | `decimal.Decimal` | Pydantic attempts to convert the value to a string, then passes the string to `Decimal(v)`. |
-| `pathlib.Path` | Simply uses the type itself for validation by passing the value to `Path(v)`. See [Pydantic Types](/usage/pydantic_types/) for other more strict path types. |
-| `uuid.UUID` | Strings and bytes (converted to strings) are passed to `UUID(v)`, with a fallback to `UUID(bytes=v)` for `bytes` and `bytearray`. See [Pydantic Types](/usage/pydantic_types/) for other stricter UUID types. |
+| `pathlib.Path` | Simply uses the type itself for validation by passing the value to `Path(v)`. See [File Types](file_types.md) for other more strict path types. |
+| `uuid.UUID` | Strings and bytes (converted to strings) are passed to `UUID(v)`, with a fallback to `UUID(bytes=v)` for `bytes` and `bytearray`. See [UUIDs](uuids.md) for other stricter UUID types. |
 | `ByteSize` | Converts a bytes string with units to bytes. |
 
 ## Literal Type

--- a/docs/usage/types/types_fields.md
+++ b/docs/usage/types/types_fields.md
@@ -4,8 +4,8 @@ description: Support for types with fields including NamedTuple and TypedDict.
 
 Pydantic supports four types with fields:
 
-* [`BaseModel`](/usage/models/)
-* [dataclasses](/usage/dataclasses/)
+* [`BaseModel`](../models.md)
+* [dataclasses](../dataclasses.md)
 * [`NamedTuple`](#namedtuple)
 * [`TypedDict`](#typeddict)
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -77,7 +77,7 @@ class ConfigDict(TypedDict, total=False):
             checking if the value is an instance of the type). If `False`, `RuntimeError` will be raised on model
             declaration. Defaults to `False`.
 
-            See an example in [Field Types](/api/types/custom.md#arbitrary-types-allowed).
+            See an example in [Field Types](../usage/types/custom.md#arbitrary-types-allowed).
         from_attributes: Whether to allow model creation from object attributes. Defaults to `False`.
 
             !!! note


### PR DESCRIPTION
Mkdocs accepts several different internal link formats. However, to maintain valid links for versioned docs, we must use relative links to the markdown file.

This PR reviewed internal links across the docs and edited where necessary to use relative links.

Also tested and fixed broken or outdated links.

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

Closes DOC-119

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani