### PR TITLE
Replace *pydantic* with Pydantic in docs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -329,7 +329,7 @@ for their kind support.
 * Add support for autocomplete in VS Code via `__dataclass_transform__`, #2721 by @tiangolo
 * add missing type annotations in `BaseConfig` and handle `max_length = 0`, #2719 by @PrettyWood
 * Change `orm_mode` checking to allow recursive ORM mode parsing with dicts, #2718 by @nuno-andre
-* Add episode 313 of the *Talk Python To Me* podcast, where Michael Kennedy and Samuel Colvin discuss *pydantic*, to the docs, #2712 by @RatulMaharaj
+* Add episode 313 of the *Talk Python To Me* podcast, where Michael Kennedy and Samuel Colvin discuss Pydantic, to the docs, #2712 by @RatulMaharaj
 * fix JSON schema generation when a field is of type `NamedTuple` and has a default value, #2707 by @PrettyWood
 * `Enum` fields now properly support extra kwargs in schema generation, #2697 by @sammchardy
 * **Breaking Change, see #3780**: Make serialization of referenced pydantic models possible, #2650 by @PrettyWood
@@ -580,7 +580,7 @@ for their kind support.
 * Support `ref_template` when creating schema `$ref`s, #1479 by @kilo59
 * Add a `__call__` stub to `PyObject` so that mypy will know that it is callable, #1352 by @brianmaissy
 * `pydantic.dataclasses.dataclass` decorator now supports built-in `dataclasses.dataclass`.
-  It is hence possible to convert an existing `dataclass` easily to add *pydantic* validation.
+  It is hence possible to convert an existing `dataclass` easily to add Pydantic validation.
   Moreover nested dataclasses are also supported, #744 by @PrettyWood
 
 ## v1.6.2 (2021-05-11)
@@ -604,7 +604,7 @@ Thank you to pydantic's sponsors: @matin, @tiangolo, @chdsbd, @jorgecarleitao, a
   Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never
   stored as a huge list. This can save on both runtime and memory space, #1642 by @cool-RR
 * Add `conset()`, analogous to `conlist()`, #1623 by @patrickkwang
-* make *pydantic* errors (un)pickable, #1616 by @PrettyWood
+* make Pydantic errors (un)pickable, #1616 by @PrettyWood
 * Allow custom encoding for `dotenv` files, #1615 by @PrettyWood
 * Ensure `SchemaExtraCallable` is always defined to get type hints on BaseConfig, #1614 by @PrettyWood
 * Update datetime parser to support negative timestamps, #1600 by @mlbiche

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 Data validation using Python type hints.
 
-Fast and extensible, *pydantic* plays nicely with your linters/IDE/brain.
-Define how data should be in pure, canonical Python 3.7+; validate it with *pydantic*.
+Fast and extensible, Pydantic plays nicely with your linters/IDE/brain.
+Define how data should be in pure, canonical Python 3.7+; validate it with Pydantic.
 
 ## Pydantic Company :rocket:
 
@@ -33,7 +33,7 @@ See [documentation](https://docs.pydantic.dev/) for more details.
 ## Installation
 
 Install using `pip install -U pydantic` or `conda install pydantic -c conda-forge`.
-For more installation options to make *pydantic* even faster,
+For more installation options to make Pydantic even faster,
 see the [Install](https://docs.pydantic.dev/install/) section in the documentation.
 
 ## A Simple Example
@@ -60,7 +60,7 @@ print(user.id)
 ## Contributing
 
 For guidance on setting up a development environment and how to make a
-contribution to *pydantic*, see
+contribution to Pydantic, see
 [Contributing to Pydantic](https://docs.pydantic.dev/contributing/).
 
 ## Reporting a Security Vulnerability

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@ Installation is as simple as:
 pip install pydantic
 ```
 
-*pydantic* has a few dependencies:
+Pydantic has a few dependencies:
 
 * [`pydantic-core`](https://pypi.org/project/pydantic-core/): Core validation logic for _pydantic_ written in rust.
 * [`typing-extensions`](https://pypi.org/project/typing-extensions/): Backport of the standard library `typing` module.
@@ -21,11 +21,11 @@ conda install pydantic -c conda-forge
 
 ## Optional dependencies
 
-*pydantic* has the following optional dependencies:
+Pydantic has the following optional dependencies:
 
 * If you require email validation, you can add [email-validator](https://github.com/JoshData/python-email-validator).
 
-To install optional dependencies along with *pydantic*:
+To install optional dependencies along with Pydantic:
 
 ```bash
 pip install pydantic[email]
@@ -35,7 +35,7 @@ Of course, you can also install requirements manually with `pip install email-va
 
 ## Install from repository
 
-And if you prefer to install *pydantic* directly from the repository:
+And if you prefer to install Pydantic directly from the repository:
 
 ```bash
 pip install git+https://github.com/pydantic/pydantic@main#egg=pydantic

--- a/docs/integrations/devtools.md
+++ b/docs/integrations/devtools.md
@@ -1,12 +1,12 @@
 !!! note
-    **Admission:** I (the primary developer of *pydantic*) also develop python-devtools.
+    **Admission:** I (the primary developer of Pydantic) also develop python-devtools.
 
 [python-devtools](https://python-devtools.helpmanual.io/) (`pip install devtools`) provides a number of tools which
 are useful during Python development, including `debug()` an alternative to `print()` which formats output in a way
 which should be easier to read than `print` as well as giving information about which file/line the print statement
 is on and what value was printed.
 
-*pydantic* integrates with *devtools* by implementing the `__pretty__` method on most public classes.
+Pydantic integrates with *devtools* by implementing the `__pretty__` method on most public classes.
 
 In particular `debug()` is useful when inspecting models:
 

--- a/docs/integrations/visual_studio_code.md
+++ b/docs/integrations/visual_studio_code.md
@@ -1,8 +1,8 @@
-*pydantic* works well with any editor or IDE out of the box because it's made on top of standard Python type annotations.
+Pydantic works well with any editor or IDE out of the box because it's made on top of standard Python type annotations.
 
 When using [Visual Studio Code (VS Code)](https://code.visualstudio.com/), there are some **additional editor features** supported, comparable to the ones provided by the [PyCharm plugin](../integrations/pycharm.md).
 
-This means that you will have **autocompletion** (or "IntelliSense") and **error checks** for types and required arguments even while creating new *pydantic* model instances.
+This means that you will have **autocompletion** (or "IntelliSense") and **error checks** for types and required arguments even while creating new Pydantic model instances.
 
 ![pydantic autocompletion in VS Code](../img/vs_code_01.png)
 
@@ -22,7 +22,7 @@ Pylance is installed as part of the [Python Extension for VS Code](https://marke
 
 Then you need to make sure your editor knows the [Python environment](https://code.visualstudio.com/docs/python/python-tutorial#_install-and-use-packages) (probably a virtual environment) for your Python project.
 
-This would be the environment in where you installed *pydantic*.
+This would be the environment in where you installed Pydantic.
 
 ### Configure Pylance
 
@@ -37,7 +37,7 @@ You can enable type error checks from Pylance with these steps:
 
 ![Type Checking Mode set to strict in VS Code](../img/vs_code_02.png)
 
-Now you will not only get autocompletion when creating new *pydantic* model instances but also error checks for **required arguments**.
+Now you will not only get autocompletion when creating new Pydantic model instances but also error checks for **required arguments**.
 
 ![Required arguments error checks in VS Code](../img/vs_code_03.png)
 
@@ -54,7 +54,7 @@ And you will also get error checks for **invalid data types**.
 
 You might also want to configure mypy in VS Code to get mypy error checks inline in your editor (alternatively/additionally to Pylance).
 
-This would include the errors detected by the [*pydantic* mypy plugin](../integrations/mypy.md), if you configured it.
+This would include the errors detected by the [Pydantic mypy plugin](../integrations/mypy.md), if you configured it.
 
 To enable mypy in VS Code, do the following:
 
@@ -67,13 +67,13 @@ To enable mypy in VS Code, do the following:
 
 ## Tips and tricks
 
-Here are some additional tips and tricks to improve your developer experience when using VS Code with *pydantic*.
+Here are some additional tips and tricks to improve your developer experience when using VS Code with Pydantic.
 
 ### Strict errors
 
-The way this additional editor support works is that Pylance will treat your *pydantic* models as if they were Python's pure `dataclasses`.
+The way this additional editor support works is that Pylance will treat your Pydantic models as if they were Python's pure `dataclasses`.
 
-And it will show **strict type error checks** about the data types passed in arguments when creating a new *pydantic* model instance.
+And it will show **strict type error checks** about the data types passed in arguments when creating a new Pydantic model instance.
 
 In this example you can see that it shows that a `str` of `'23'` is not a valid `int` for the argument `age`.
 
@@ -81,7 +81,7 @@ In this example you can see that it shows that a `str` of `'23'` is not a valid 
 
 It would expect `age=23` instead of `age='23'`.
 
-Nevertheless, the design, and one of the main features of *pydantic*, is that it is very **lenient with data types**.
+Nevertheless, the design, and one of the main features of Pydantic, is that it is very **lenient with data types**.
 
 It will actually accept the `str` with value `'23'` and will convert it to an `int` with value `23`.
 
@@ -91,9 +91,9 @@ These strict error checks are **very useful** most of the time and can help you 
 
 This example above with `age='23'` is intentionally simple, to show the error and the differences in types.
 
-But more common cases where these strict errors would be inconvenient would be when using more sophisticated data types, like `int` values for `datetime` fields, or `dict` values for *pydantic* sub-models.
+But more common cases where these strict errors would be inconvenient would be when using more sophisticated data types, like `int` values for `datetime` fields, or `dict` values for Pydantic sub-models.
 
-For example, this is valid for *pydantic*:
+For example, this is valid for Pydantic:
 
 ```Python hl_lines="12 17"
 from pydantic import BaseModel
@@ -115,7 +115,7 @@ quest = Quest(
 )
 ```
 
-The type of the field `knight` is declared with the class `Knight` (a *pydantic* model) and the code is passing a literal `dict` instead. This is still valid for *pydantic*, and the `dict` would be automatically converted to a `Knight` instance.
+The type of the field `knight` is declared with the class `Knight` (a Pydantic model) and the code is passing a literal `dict` instead. This is still valid for Pydantic, and the `dict` would be automatically converted to a `Knight` instance.
 
 Nevertheless, it would be detected as a type error:
 
@@ -219,7 +219,7 @@ So, this is the equivalent of the previous example, without the additional varia
 
 ### Config in class arguments
 
-*pydantic* has a rich set of [Model Configurations](../usage/model_config.md) available.
+Pydantic has a rich set of [Model Configurations](../usage/model_config.md) available.
 
 These configurations can be set in an internal `class Config` on each model:
 
@@ -279,7 +279,7 @@ This is a limitation of dataclass transforms and cannot be fixed in pydantic.
 ## Technical Details
 
 !!! warning
-    As a *pydantic* user, you don't need the details below. Feel free to skip the rest of this section.
+    As a Pydantic user, you don't need the details below. Feel free to skip the rest of this section.
 
     These details are only useful for other library authors, etc.
 
@@ -287,12 +287,12 @@ This additional editor support works by implementing the proposed draft standard
 
 The proposed draft standard is written by Eric Traut, from the Microsoft team, the same author of the open source package Pyright (used by Pylance to provide Python support in VS Code).
 
-The intention of the standard is to provide a way for libraries like *pydantic* and others to tell editors and tools that they (the editors) should treat these libraries (e.g. *pydantic*) as if they were `dataclasses`, providing autocompletion, type checks, etc.
+The intention of the standard is to provide a way for libraries like Pydantic and others to tell editors and tools that they (the editors) should treat these libraries (e.g. Pydantic) as if they were `dataclasses`, providing autocompletion, type checks, etc.
 
-The draft standard also includes an [Alternate Form](https://github.com/microsoft/pyright/blob/master/specs/dataclass_transforms.md#alternate-form) for early adopters, like *pydantic*, to add support for it right away, even before the new draft standard is finished and approved.
+The draft standard also includes an [Alternate Form](https://github.com/microsoft/pyright/blob/master/specs/dataclass_transforms.md#alternate-form) for early adopters, like Pydantic, to add support for it right away, even before the new draft standard is finished and approved.
 
 This new draft standard, with the Alternate Form, is already supported by Pyright, so it can be used via Pylance in VS Code.
 
 As it is being proposed as an official standard for Python, other editors can also easily add support for it.
 
-And authors of other libraries similar to *pydantic* can also easily adopt the standard right away (using the "Alternate Form") and get the benefits of these additional editor features.
+And authors of other libraries similar to Pydantic can also easily adopt the standard right away (using the "Alternate Form") and get the benefits of these additional editor features.

--- a/docs/usage/exporting_models.md
+++ b/docs/usage/exporting_models.md
@@ -66,7 +66,7 @@ print(Model(x=['{"a": 1}', '[1, 2]']).model_dump(round_trip=True))
 
 ## `dict(model)` and iteration
 
-*pydantic* models can also be converted to dictionaries using `dict(model)`, and you can also
+Pydantic models can also be converted to dictionaries using `dict(model)`, and you can also
 iterate over a model's field using `for field_name, value in model:`. With this approach the raw field values are
 returned, so sub-models will not be converted to dictionaries.
 
@@ -137,7 +137,7 @@ only the values are serialised)
 
 See [arguments](../api/main.md#pydantic.main.BaseModel.model_dump_json) for more information.
 
-*pydantic* can serialise many commonly used types to JSON (e.g. `datetime`, `date` or `UUID`) which would normally
+Pydantic can serialise many commonly used types to JSON (e.g. `datetime`, `date` or `UUID`) which would normally
 fail with a simple `json.dumps(foobar)`.
 
 ```py
@@ -304,7 +304,7 @@ print(m.model_dump_json())
 
 ## `pickle.dumps(model)`
 
-Using the same plumbing as `model_copy()`, *pydantic* models support efficient pickling and unpickling.
+Using the same plumbing as `model_copy()`, Pydantic models support efficient pickling and unpickling.
 
 ```py test="skip"
 # TODO need to get pickling to work

--- a/docs/usage/json_schema.md
+++ b/docs/usage/json_schema.md
@@ -281,7 +281,7 @@ It has the following arguments:
 * `**` any other keyword arguments (e.g. `examples`) will be added verbatim to the field's schema
 
 !!! note
-    *pydantic* validates strings using `re.match`,
+    Pydantic validates strings using `re.match`,
     which treats regular expressions as implicitly anchored at the beginning.
     On the contrary,
     JSON Schema validators treat the `pattern` keyword as implicitly unanchored,
@@ -294,14 +294,14 @@ It has the following arguments:
     (e.g. `.*?foo` to match any string containing the substring `foo`).
 
     See [#1631](https://github.com/pydantic/pydantic/issues/1631)
-    for a discussion of possible changes to *pydantic* behavior in **v2**.
+    for a discussion of possible changes to Pydantic behavior in **v2**.
 
 Instead of using `Field`, the `fields` property of [the Config class](model_config.md) can be used
 to set all of the arguments above except `default`.
 
 ### Unenforced Field constraints
 
-If *pydantic* finds constraints which are not being enforced, an error will be raised. If you want to force the
+If Pydantic finds constraints which are not being enforced, an error will be raised. If you want to force the
 constraint to appear in the schema, even though it's not being checked upon parsing, you can use variadic arguments
 to `Field()` with the raw schema attribute name:
 
@@ -609,9 +609,9 @@ following priority order (when there is an equivalent available):
 1. [JSON Schema Core](http://json-schema.org/latest/json-schema-core.html#rfc.section.4.3.1)
 2. [JSON Schema Validation](http://json-schema.org/latest/json-schema-validation.html)
 3. [OpenAPI Data Types](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#data-types)
-4. The standard `format` JSON field is used to define *pydantic* extensions for more complex `string` sub-types.
+4. The standard `format` JSON field is used to define Pydantic extensions for more complex `string` sub-types.
 
-The field schema mapping from Python / *pydantic* to JSON Schema is done as follows:
+The field schema mapping from Python / Pydantic to JSON Schema is done as follows:
 
 {{ schema_mappings_table }}
 

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -398,7 +398,7 @@ except ValidationError as e:
 
 ### Creating models without validation
 
-*pydantic* also provides the `model_construct()` method which allows models to be created **without validation** this
+Pydantic also provides the `model_construct()` method which allows models to be created **without validation** this
 can be useful when data has already been validated or comes from a trusted source and you want to create a model
 as efficiently as possible (`model_construct()` is generally around 30x faster than creating a model with full validation).
 
@@ -679,7 +679,7 @@ print(concrete_model(a=1, b=1))
 
 ## Dynamic model creation
 
-There are some occasions where the shape of a model is not known until runtime. For this *pydantic* provides
+There are some occasions where the shape of a model is not known until runtime. For this Pydantic provides
 the `create_model` method to allow models to be created on the fly.
 
 ```py
@@ -1112,7 +1112,7 @@ are supported.
 
 ## Data conversion
 
-*pydantic* may cast input data to force it to conform to model field types,
+Pydantic may cast input data to force it to conform to model field types,
 and in some cases this may result in a loss of information.
 For example:
 
@@ -1130,14 +1130,14 @@ print(Model(a=3.000, b='2.72', c=b'binary data').model_dump())
 #> {'a': 3, 'b': 2.72, 'c': 'binary data'}
 ```
 
-This is a deliberate decision of *pydantic*, and in general it's the most useful approach. See
+This is a deliberate decision of Pydantic, and in general it's the most useful approach. See
 [here](https://github.com/pydantic/pydantic/issues/578) for a longer discussion on the subject.
 
 Nevertheless, [strict type checking](types/types.md#strict-types) is partially supported.
 
 ## Model signature
 
-All *pydantic* models will have their signature generated based on their fields:
+All Pydantic models will have their signature generated based on their fields:
 
 ```py
 import inspect
@@ -1180,14 +1180,14 @@ print(inspect.signature(MyModel))
 ```
 
 To be included in the signature, a field's alias or name must be a valid Python identifier.
-*pydantic* prefers aliases over names, but may use field names if the alias is not a valid Python identifier.
+Pydantic prefers aliases over names, but may use field names if the alias is not a valid Python identifier.
 
 If a field's alias and name are both invalid identifiers, a `**data` argument will be added.
 In addition, the `**data` argument will always be present in the signature if `Config.extra` is `Extra.allow`.
 
 ## Structural pattern matching
 
-*pydantic* supports structural pattern matching for models, as introduced by [PEP 636](https://peps.python.org/pep-0636/) in Python 3.10.
+Pydantic supports structural pattern matching for models, as introduced by [PEP 636](https://peps.python.org/pep-0636/) in Python 3.10.
 
 ```py requires="3.10" lint="skip"
 from pydantic import BaseModel

--- a/docs/usage/postponed_annotations.md
+++ b/docs/usage/postponed_annotations.md
@@ -21,7 +21,7 @@ print(Model(a=('1', 2, 3), b='ok'))
 #> a=[1, 2, 3] b='ok'
 ```
 
-Internally, *pydantic*  will call a method similar to `typing.get_type_hints` to resolve annotations.
+Internally, Pydantic  will call a method similar to `typing.get_type_hints` to resolve annotations.
 
 In cases where the referenced type is not yet defined, `ForwardRef` can be used (although referencing the
 type directly or by its string is a simpler solution in the case of
@@ -71,7 +71,7 @@ print(Foo(sibling={'a': '321'}))
 
 Since Python 3.7, you can also refer it by its type, provided you import `annotations` (see
 [above](postponed_annotations.md) for support depending on Python
-and *pydantic* versions).
+and Pydantic versions).
 
 ```py
 from __future__ import annotations

--- a/docs/usage/types/custom.md
+++ b/docs/usage/types/custom.md
@@ -179,7 +179,7 @@ print(type(model2.pet))
 
 !!! warning
     This is an advanced technique that you might not need in the beginning. In most of
-    the cases you will probably be fine with standard *pydantic* models.
+    the cases you will probably be fine with standard Pydantic models.
 
 You can use
 [Generic Classes](https://docs.python.org/3/library/typing.html#typing.Generic) as

--- a/docs/usage/types/enums.md
+++ b/docs/usage/types/enums.md
@@ -2,7 +2,7 @@
 description: Support for Enum types and choices.
 ---
 
-*pydantic* uses Python's standard `enum` classes to define choices.
+Pydantic uses Python's standard `enum` classes to define choices.
 
 `enum.Enum`
 : checks that the value is a valid Enum instance

--- a/docs/usage/types/extra_types/extra_types.md
+++ b/docs/usage/types/extra_types/extra_types.md
@@ -1,4 +1,4 @@
-For types that are more complex, or don't need to be on *pydantic* itself, we have the [Pydantic Extra Types] project.
+For types that are more complex, or don't need to be on Pydantic itself, we have the [Pydantic Extra Types] project.
 
 The following types are supported by [Pydantic Extra Types]:
 

--- a/docs/usage/types/json.md
+++ b/docs/usage/types/json.md
@@ -1,7 +1,7 @@
 `Json`
 : a special type wrapper which loads JSON before parsing
 
-You can use `Json` data type to make *pydantic* first load a raw JSON string.
+You can use `Json` data type to make Pydantic first load a raw JSON string.
 It can also optionally be used to parse the loaded object into another type base on
 the type `Json` is parameterised with:
 

--- a/docs/usage/types/list_types.md
+++ b/docs/usage/types/list_types.md
@@ -21,7 +21,7 @@
 
 ### Typing Iterables
 
-*pydantic* uses standard library `typing` types as defined in PEP 484 to define complex objects.
+Pydantic uses standard library `typing` types as defined in PEP 484 to define complex objects.
 
 ```py
 from typing import Deque, Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union

--- a/docs/usage/types/number_types.md
+++ b/docs/usage/types/number_types.md
@@ -1,5 +1,5 @@
 `int`
-: *pydantic* uses `int(v)` to coerce types to an `int`;
+: Pydantic uses `int(v)` to coerce types to an `int`;
   see [this](../models.md#data-conversion) warning on loss of information during data conversion
 
 `float`
@@ -13,7 +13,7 @@
   see [Enums and Choices](#enums-and-choices) for more details
 
 `decimal.Decimal`
-: *pydantic* attempts to convert the value to a string, then passes the string to `Decimal(v)`
+: Pydantic attempts to convert the value to a string, then passes the string to `Decimal(v)`
 
 `NegativeFloat`
 : allows a float which is negative; uses standard `float` parsing then checks the value is less than 0;

--- a/docs/usage/types/sequence_iterable.md
+++ b/docs/usage/types/sequence_iterable.md
@@ -8,7 +8,7 @@ description: Support for iterable types.
 `typing.Iterable`
 : this is reserved for iterables that shouldn't be consumed. See [Infinite Generators](#infinite-generators) below for more detail on parsing and validation
 
-*pydantic* uses standard library `typing` types as defined in PEP 484 to define complex objects.
+Pydantic uses standard library `typing` types as defined in PEP 484 to define complex objects.
 
 ```py
 from typing import Deque, Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union
@@ -67,7 +67,7 @@ print(Model(deque=[1, 2, 3]).deque)
 ### Strings aren't Sequences
 
 
-*pydantic* doesn't treat strings, i.e. `str` and `bytes` subclasses, as sequences:
+Pydantic doesn't treat strings, i.e. `str` and `bytes` subclasses, as sequences:
 
 ```py
 from typing import Optional, Sequence

--- a/docs/usage/types/standard_types.md
+++ b/docs/usage/types/standard_types.md
@@ -64,7 +64,7 @@ Pydantic supports many common types from the Python standard library. If you nee
     This is a new feature of the Python standard library as of Python 3.8;
     prior to Python 3.8, it requires the [typing-extensions](https://pypi.org/project/typing-extensions/) package.
 
-*pydantic* supports the use of `typing.Literal` (or `typing_extensions.Literal` prior to Python 3.8)
+Pydantic supports the use of `typing.Literal` (or `typing_extensions.Literal` prior to Python 3.8)
 as a lightweight way to specify that a field may accept only specific literal values:
 
 ```py requires="3.8"

--- a/docs/usage/types/typevars.md
+++ b/docs/usage/types/typevars.md
@@ -4,7 +4,7 @@ description: Support for Type[T] and TypeVar.
 
 ## Type
 
-*pydantic* supports the use of `Type[T]` to specify that a field may only accept classes (not instances)
+Pydantic supports the use of `Type[T]` to specify that a field may only accept classes (not instances)
 that are subclasses of `T`.
 
 ```py

--- a/docs/usage/types/unions.md
+++ b/docs/usage/types/unions.md
@@ -40,7 +40,7 @@ print(user_03_uuid.int)
 #> 275603287559914445491632874575877060712
 ```
 
-However, as can be seen above, *pydantic* will attempt to 'match' any of the types defined under `Union` and will use
+However, as can be seen above, Pydantic will attempt to 'match' any of the types defined under `Union` and will use
 the first one that matches. In the above example the `id` of `user_03` was defined as a `uuid.UUID` class (which
 is defined under the attribute's `Union` annotation) but as the `uuid.UUID` can be marshalled into an `int` it
 chose to match against the `int` type and disregarded the other types.

--- a/docs/usage/types/urls.md
+++ b/docs/usage/types/urls.md
@@ -183,7 +183,7 @@ print(m3.url)
 
 
 !!! warning "Underscores in Hostnames"
-    In *pydantic* underscores are allowed in all parts of a domain except the tld.
+    In Pydantic underscores are allowed in all parts of a domain except the tld.
     Technically this might be wrong - in theory the hostname cannot have underscores, but subdomains can.
 
     To explain this; consider the following two cases:

--- a/docs/usage/validation_decorator.md
+++ b/docs/usage/validation_decorator.md
@@ -4,7 +4,7 @@ creation and initialisation; it provides an extremely easy way to apply validati
 boilerplate.
 
 !!! info "In Beta"
-    The `validate_call` decorator is in **beta**, it has been added to *pydantic* in **v1.5** on a
+    The `validate_call` decorator is in **beta**, it has been added to Pydantic in **v1.5** on a
     **provisional basis**. It may change significantly in future releases and its interface will not be concrete
     until **v2**. Feedback from the community while it's still provisional would be extremely useful; either comment
     on [#1205](https://github.com/pydantic/pydantic/issues/1205) or create a new issue.
@@ -43,9 +43,9 @@ except ValidationError as exc:
 ## Argument Types
 
 Argument types are inferred from type annotations on the function, arguments without a type decorator are considered
-as `Any`. All types listed in [types](types/types.md) can be validated, including *pydantic* models and
+as `Any`. All types listed in [types](types/types.md) can be validated, including Pydantic models and
 [custom types](types/types.md#custom-data-types).
-As with the rest of *pydantic*, types can be coerced by the decorator before they're passed to the actual function:
+As with the rest of Pydantic, types can be coerced by the decorator before they're passed to the actual function:
 
 ```py test="no-print-intercept"
 # TODO replace find_file with something that isn't affected the filesystem
@@ -377,7 +377,7 @@ In particular:
 
 ### Validation Exception
 
-Currently upon validation failure, a standard *pydantic* `ValidationError` is raised,
+Currently upon validation failure, a standard Pydantic `ValidationError` is raised,
 see [model error handling](models.md#error-handling).
 
 This is helpful since it's `str()` method provides useful details of the error which occurred and methods like
@@ -388,16 +388,16 @@ exception by default, or both.
 
 ### Coercion and Strictness
 
-*pydantic* currently leans on the side of trying to coerce types rather than raise an error if a type is wrong,
+Pydantic currently leans on the side of trying to coerce types rather than raise an error if a type is wrong,
 see [model data conversion](models.md#data-conversion) and `validate_call` is no different.
 
 See [#1098](https://github.com/pydantic/pydantic/issues/1098) and other issues with the "strictness" label
-for a discussion of this. If *pydantic* gets a "strict" mode in future, `validate_call` will have an option
+for a discussion of this. If Pydantic gets a "strict" mode in future, `validate_call` will have an option
 to use this, it may even become the default for the decorator.
 
 ### Performance
 
-We've made a big effort to make *pydantic* as performant as possible
+We've made a big effort to make Pydantic as performant as possible
 and argument inspect and model creation is only performed once when the function is defined, however
 there will still be a performance impact to using the `validate_call` decorator compared to
 calling the raw function.
@@ -427,7 +427,7 @@ the function's signature:
 * `v__positional_only`
 
 These names (together with `"args"` and `"kwargs"`) may or may not (depending on the function's signature) appear as
-fields on the internal *pydantic* model accessible via `.model` thus this model isn't especially useful
+fields on the internal Pydantic model accessible via `.model` thus this model isn't especially useful
 (e.g. for generating a schema) at the moment.
 
 This should be fixable in future as the way error are raised is changed.

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -224,7 +224,7 @@ print(DemoModel(ts='2017-11-08T14:00'))
 ```
 
 You'll often want to use this together with `pre`, since otherwise with `always=True`
-*pydantic* would try to validate the default `None` which would cause an error.
+Pydantic would try to validate the default `None` which would cause an error.
 
 ## Reuse validators
 
@@ -343,7 +343,7 @@ In this case you should set `check_fields=False` on the validator.
 
 ## Dataclass Validators
 
-Validators also work with *pydantic* dataclasses.
+Validators also work with Pydantic dataclasses.
 
 **TODO: Change this example so that it *should* use a validator; right now it would be better off with default_factory..**
 


### PR DESCRIPTION
Changes remaining instances of `*pydantic*` to `Pydantic` throughout the documentation.

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
