### PR TITLE
Fix racy doctests

### DIFF
--- a/docs/build/exec_examples.py
+++ b/docs/build/exec_examples.py
@@ -353,6 +353,9 @@ def exec_examples() -> int:  # noqa: C901 (I really don't want to decompose it a
         if upgrade:
             versions.extend(populate_upgraded_versions(file, file_text, lowest_version))
 
+        # flush importlib caches to ensure the code we just generated is discovered
+        importlib.invalidate_caches()
+
         json_outputs: set[str | None] = set()
         should_run_as_is = not requirements
         final_content: list[str] = []


### PR DESCRIPTION
On very fast machines (in my case, a 7950X3D with gen4 storage) it's possible that the script will start running the tests before importlib figures out the files are there, and get a spurious `ModuleNotFoundError` instead. Explicitly flushing the cache before importing things seems to help it work consistently, at the cost of an extra 0.1s or so of runtime.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @PrettyWood

skip change file check