### PR TITLE
Replace `deprecated-kwargs` with `removed-kwargs`

### DIFF
--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -381,7 +381,7 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'config-both'
 ```
 
-## Keyword arguments deprecated {#deprecated-kwargs}
+## Keyword arguments removed {#removed-kwargs}
 
 This error is raised when the keyword arguments are not available in Pydantic V2.
 
@@ -396,7 +396,7 @@ try:
         x: str = Field(regex='test')
 
 except PydanticUserError as exc_info:
-    assert exc_info.code == 'deprecated-kwargs'
+    assert exc_info.code == 'removed-kwargs'
 ```
 
 ## JSON schema invalid type {#invalid-for-json-schema}

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -32,7 +32,7 @@ PydanticErrorCodes = Literal[
     'model-field-overridden',
     'model-field-missing-annotation',
     'config-both',
-    'deprecated-kwargs',
+    'removed-kwargs',
     'invalid-for-json-schema',
     'json-schema-already-used',
     'base-model-instantiated',

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -665,7 +665,7 @@ def Field(  # C901
     # Check deprecated and removed params from V1. This logic should eventually be removed.
     const = extra.pop('const', None)  # type: ignore
     if const is not None:
-        raise PydanticUserError('`const` is removed, use `Literal` instead', code='deprecated-kwargs')
+        raise PydanticUserError('`const` is removed, use `Literal` instead', code='removed-kwargs')
 
     min_items = extra.pop('min_items', None)  # type: ignore
     if min_items is not None:
@@ -686,7 +686,7 @@ def Field(  # C901
                 '`unique_items` is removed, use `Set` instead'
                 '(this feature is discussed in https://github.com/pydantic/pydantic-core/issues/296)'
             ),
-            code='deprecated-kwargs',
+            code='removed-kwargs',
         )
 
     allow_mutation = extra.pop('allow_mutation', None)  # type: ignore
@@ -697,7 +697,7 @@ def Field(  # C901
 
     regex = extra.pop('regex', None)  # type: ignore
     if regex is not None:
-        raise PydanticUserError('`regex` is removed. use `pattern` instead', code='deprecated-kwargs')
+        raise PydanticUserError('`regex` is removed. use `pattern` instead', code='removed-kwargs')
 
     if extra:
         warn(

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -362,7 +362,7 @@ def conlist(
                 '`unique_items` is removed, use `Set` instead'
                 '(this feature is discussed in https://github.com/pydantic/pydantic-core/issues/296)'
             ),
-            code='deprecated-kwargs',
+            code='removed-kwargs',
         )
     return Annotated[  # type: ignore[return-value]
         List[item_type],  # type: ignore[valid-type]


### PR DESCRIPTION
W‍‍e use `deprecated-kwargs` error code for removed kwargs. So, it's better to replace it with `removed-kwargs`.
Right now, there is no usecase for `deprecated-kwargs` error code but we can add it again in the future if we need it.

Selected Reviewer: @samuelcolvin`