### PR TITLE
Make unannotated private attrs into private attrs

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -101,7 +101,7 @@ def collect_model_fields(  # noqa: C901
         if _is_finalvar_with_default_val(ann_type, getattr(cls, ann_name, Undefined)):
             class_vars.add(ann_name)
             continue
-        if ann_name.startswith('_'):
+        if not is_valid_field_name(ann_name):
             continue
         if cls.__pydantic_root_model__ and ann_name != 'root':
             raise NameError(
@@ -209,3 +209,11 @@ def collect_dataclass_fields(
             field.apply_typevars_map(typevars_map, types_namespace)
 
     return fields
+
+
+def is_valid_field_name(name: str) -> bool:
+    return not name.startswith('_')
+
+
+def is_valid_privateattr_name(name: str) -> bool:
+    return name.startswith('_') and not name.startswith('__')

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -288,7 +288,7 @@ def inspect_namespace(  # noqa C901
         elif var_name.startswith('__'):
             continue
         elif var_name.startswith('_'):
-            if var_name in raw_annotations and not is_classvar(raw_annotations[var_name]):
+            if var_name not in raw_annotations or not is_classvar(raw_annotations[var_name]):
                 private_attributes[var_name] = PrivateAttr(default=value)
                 del namespace[var_name]
         elif var_name in base_class_vars:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -16,7 +16,7 @@ from ..fields import Field, FieldInfo, ModelPrivateAttr, PrivateAttr
 from ._config import ConfigWrapper
 from ._core_utils import flatten_schema_defs, inline_schema_defs
 from ._decorators import ComputedFieldInfo, DecoratorInfos, PydanticDescriptorProxy
-from ._fields import Undefined, collect_model_fields
+from ._fields import Undefined, collect_model_fields, is_valid_field_name, is_valid_privateattr_name
 from ._generate_schema import GenerateSchema
 from ._generics import PydanticGenericMetadata, get_model_typevars_map
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
@@ -278,7 +278,7 @@ def inspect_namespace(  # noqa C901
                     f'Private attributes "{var_name}" must not have dunder names; '
                     'use a single underscore prefix instead.'
                 )
-            elif not single_underscore(var_name):
+            elif is_valid_field_name(var_name):
                 raise NameError(
                     f'Private attributes "{var_name}" must not be a valid field name; '
                     f'use sunder names, e.g. "_{var_name}"'
@@ -287,7 +287,7 @@ def inspect_namespace(  # noqa C901
             del namespace[var_name]
         elif var_name.startswith('__'):
             continue
-        elif var_name.startswith('_'):
+        elif is_valid_privateattr_name(var_name):
             if var_name not in raw_annotations or not is_classvar(raw_annotations[var_name]):
                 private_attributes[var_name] = PrivateAttr(default=value)
                 del namespace[var_name]
@@ -314,7 +314,7 @@ def inspect_namespace(  # noqa C901
 
     for ann_name, ann_type in raw_annotations.items():
         if (
-            single_underscore(ann_name)
+            is_valid_privateattr_name(ann_name)
             and ann_name not in private_attributes
             and ann_name not in ignored_names
             and not is_classvar(ann_type)
@@ -324,10 +324,6 @@ def inspect_namespace(  # noqa C901
             private_attributes[ann_name] = PrivateAttr()
 
     return private_attributes
-
-
-def single_underscore(name: str) -> bool:
-    return name.startswith('_') and not name.startswith('__')
 
 
 def set_model_fields(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -319,7 +319,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 f'"{name}" is a ClassVar of `{self.__class__.__name__}` and cannot be set on an instance. '
                 f'If you want to set a value on the class, use `{self.__class__.__name__}.{name} = value`.'
             )
-        elif name.startswith('_'):
+        elif not _fields.is_valid_field_name(name):
             if self.__pydantic_private__ is None or name not in self.__private_attributes__:
                 _object_setattr(self, name, value)
             else:
@@ -660,11 +660,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return m
 
     def __repr_args__(self) -> _repr.ReprArgs:
-        yield from (
-            (k, v)
-            for k, v in self.__dict__.items()
-            if not k.startswith('_') and (k not in self.model_fields or self.model_fields[k].repr)
-        )
+        for k, v in self.__dict__.items():
+            field = self.model_fields.get(k)
+            if field and field.repr:
+                yield k, v
         pydantic_extra = self.__pydantic_extra__
         if pydantic_extra is not None:
             yield from ((k, v) for k, v in pydantic_extra.items())
@@ -1174,7 +1173,7 @@ def create_model(
     annotations = {}
 
     for f_name, f_def in field_definitions.items():
-        if f_name.startswith('_'):
+        if not _fields.is_valid_field_name(f_name):
             warnings.warn(f'fields may not start with an underscore, ignoring "{f_name}"', RuntimeWarning)
         if isinstance(f_def, tuple):
             f_def = typing.cast('tuple[str, Any]', f_def)

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -68,6 +68,8 @@ from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 from mypy.version import __version__ as mypy_version
 
+from pydantic._internal import _fields
+
 try:
     from mypy.types import TypeVarDef  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover
@@ -440,7 +442,7 @@ class PydanticModelTransformer:
             return None
 
         lhs = stmt.lvalues[0]
-        if not isinstance(lhs, NameExpr) or lhs.name.startswith('_') or lhs.name == 'model_config':
+        if not isinstance(lhs, NameExpr) or not _fields.is_valid_field_name(lhs.name) or lhs.name == 'model_config':
             return None
 
         if not stmt.new_syntax:

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -310,11 +310,7 @@ def test_private_descriptors(base, use_annotation):
         def _double_x(self):
             return self.x * 2
 
-    if use_annotation or base is ModelPrivateAttr:
-        assert set(A.__private_attributes__) == {'_some_func'}
-    else:
-        assert set(A.__private_attributes__) == set()
-
+    assert set(A.__private_attributes__) == {'_some_func'}
     assert set_name_calls == [(A, '_some_func')]
 
     a = A(x=2)

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -339,3 +339,17 @@ def test_layout_compatible_multiple_private_parents():
     assert m.__pydantic_private__ == {'_mixin_private': 1, '_private': 2}
     assert m._mixin_private == 1
     assert m._private == 2
+
+
+def test_unannotated_private_attr():
+    from pydantic import BaseModel, PrivateAttr
+
+    class A(BaseModel):
+        _x = PrivateAttr()
+        _y = 52
+
+    a = A()
+    assert a._y == 52
+    assert a.__pydantic_private__ == {'_y': 52}
+    a._x = 1
+    assert a.__pydantic_private__ == {'_x': 1, '_y': 52}

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -285,13 +285,13 @@ def test_ignored_types_are_ignored() -> None:
         _c: IgnoredType
         _d: IgnoredType = IgnoredType()
 
-        # The following are included to document existing behavior, and can be updated
-        # if the current behavior does not match the desired behavior
+        # The following are included to document existing behavior, which is to make them into PrivateAttrs
+        # this can be updated if the current behavior is not the desired behavior
         _e: int
         _f: int = 1
-        _g = 1  # Note: this is completely ignored, in keeping with v1
+        _g = 1
 
-    assert sorted(MyModel.__private_attributes__.keys()) == ['_e', '_f']
+    assert sorted(MyModel.__private_attributes__.keys()) == ['_e', '_f', '_g']
 
 
 @pytest.mark.skipif(not hasattr(functools, 'cached_property'), reason='cached_property is not available')


### PR DESCRIPTION
Closes #5972 

I see three reasonable alternative choices for the behavior for leading-`_` attributes on BaseModel classes:

* `ClassVar`
* `PrivateAttr`
* raise an error, same as we would for public attributes

As this PR stands, I've made it so that they become a `PrivateAttr`. Mostly because it was super easy to do. But that can be changed easily.

However, in v1, these leading-underscore fields were _always_ classvars, even when they had an annotation, which perhaps should be the preferred implementation to reduce backwards compatibility issues? I'm not sure why we changed to defaulting to setting as a PrivateAttr in v2; this has led to some confusion as noted in this comment https://github.com/pydantic/pydantic/issues/5972#issuecomment-1573705778

I'll also note there has been a feature request to be able to use leading-`_` attributes as fields (e.g., for `_id` for use with mongodb), which is another angle to the problem not yet resolved.

@samuelcolvin do you remember the motivation behind making `_`-attributes private automatically?