### PR TITLE
Improve the regex used for NameEmail validation

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -376,7 +376,15 @@ class IPvAnyNetwork:
         return cls(__input_value)  # type: ignore[return-value]
 
 
-pretty_email_regex = re.compile(r' *([\w ]*?) *<(.+?)> *')
+def _build_pretty_email_regex() -> re.Pattern:
+    name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'
+    unquoted_name_group = fr'((?:{name_chars}+\s+)*{name_chars}+)'
+    quoted_name_group = r'"((?:[^"]|\")+)"'
+    email_group = r'<\s*(.+)\s*>'
+    return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
+
+
+pretty_email_regex = _build_pretty_email_regex()
 
 
 def validate_email(value: str) -> tuple[str, str]:
@@ -395,7 +403,8 @@ def validate_email(value: str) -> tuple[str, str]:
     m = pretty_email_regex.fullmatch(value)
     name: str | None = None
     if m:
-        name, value = m.groups()
+        unquoted_name, quoted_name, value = m.groups()
+        name = unquoted_name or quoted_name
 
     email = value.strip()
 

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -751,6 +751,8 @@ def test_json():
         ('аррӏе@example.com', 'аррӏе', 'аррӏе@example.com'),
         ('xn--80ak6aa92e@example.com', 'xn--80ak6aa92e', 'xn--80ak6aa92e@example.com'),
         ('葉士豪@臺網中心.tw', '葉士豪', '葉士豪@臺網中心.tw'),
+        ('"first.last" <first.last@example.com>', 'first.last', 'first.last@example.com'),
+        ("Shaquille O'Neal <shaq@example.com>", "Shaquille O'Neal", 'shaq@example.com'),
     ],
 )
 def test_address_valid(value, name, email):
@@ -785,6 +787,7 @@ def test_address_valid(value, name, email):
         ('foobar <foobar@example.com>>', None),
         ('foobar <<foobar<@example.com>', None),
         ('foobar <>', None),
+        ('first.last <first.last@example.com>', None),
     ],
 )
 def test_address_invalid(value, reason):


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/2955

While I agree it would be better to move the logic to rust as suggested in https://github.com/pydantic/pydantic/issues/2955#issuecomment-1414339014, in the interest of fixing this for users, I would suggest we just make this change now.

Happy to add more test cases, special callout to @henrybetts for doing the research and putting together an improved regex ages ago. I took an approach inspired by https://github.com/pydantic/pydantic/issues/2955#issuecomment-1147734780, and just cleaned up the regex a bit (and used a function to build it to get a bit better implicit documentation), and the tests all seem to be passing now as desired.

If anyone wants more tests cases let me know, but I think this covers the ones called out explicitly in the issue.

Selected Reviewer: @Kludex