### PR TITLE
Skip test `test_del_model_attr_error` to run on PyPy < 3.9

### DIFF
--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -406,8 +406,8 @@ def test_del_model_attr():
 
 
 @pytest.mark.skipif(
-    platform.python_implementation() == 'PyPy' and platform.python_version_tuple() < ('3', '8'),
-    reason='In this single case `del` behaves weird on pypy 3.7',
+    platform.python_implementation() == 'PyPy' and platform.python_version_tuple() < ('3', '9'),
+    reason='In this single case `del` behaves weird on pypy < 3.9',
 )
 def test_del_model_attr_error():
     class Model(BaseModel):


### PR DESCRIPTION
Fixes [CI failure on pypy3.8](https://github.com/pydantic/pydantic/actions/runs/5265602879/jobs/9518455018?pr=6128)

Selected Reviewer: @dmontagu