### PR TITLE
Revert "Skip test `test_del_model_attr_error` to run on PyPy < 3.9 (#6131)"

### DIFF
--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -406,8 +406,8 @@ def test_del_model_attr():
 
 
 @pytest.mark.skipif(
-    platform.python_implementation() == 'PyPy' and platform.python_version_tuple() < ('3', '9'),
-    reason='In this single case `del` behaves weird on pypy < 3.9',
+    platform.python_implementation() == 'PyPy' and platform.python_version_tuple() < ('3', '8'),
+    reason='In this single case `del` behaves weird on pypy 3.7',
 )
 def test_del_model_attr_error():
     class Model(BaseModel):


### PR DESCRIPTION
This reverts commit 22591e165fc5cb682168fa6ae75e26ea68a834e7.

