### PR TITLE
🐛 Remove dataclass field with `init_var` from `__pydantic__fields__`

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -200,6 +200,9 @@ def collect_dataclass_fields(
             continue
 
         if isinstance(dataclass_field.default, FieldInfo):
+            if dataclass_field.default.init_var:
+                # TODO: same note as above
+                continue
             field_info = FieldInfo.from_annotated_attribute(ann_type, dataclass_field.default)
         else:
             field_info = FieldInfo.from_annotated_attribute(ann_type, dataclass_field)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -31,6 +31,20 @@ def test_init_var_does_not_work():
     assert e.value.args == ('InitVar is not supported in Python 3.7 as type information is lost',)
 
 
+def test_init_var_field():
+    @pydantic.dataclasses.dataclass
+    class Foo:
+        bar: str
+        baz: str = Field(init_var=True)
+
+    class Model(BaseModel):
+        foo: Foo
+
+    model = Model(foo=Foo('bar', baz='baz'))
+    assert 'bar' in model.foo.__pydantic_fields__
+    assert 'baz' not in model.foo.__pydantic_fields__
+
+
 def test_root_model_arbitrary_field_name_error():
     with pytest.raises(
         NameError, match="Unexpected field with name 'a_field'; only 'root' is allowed as a field of a `RootModel`"


### PR DESCRIPTION


Selected Reviewer: @hramezani