### PR TITLE
Bug fix for forward refs in generics

### DIFF
--- a/changes/6130-mark-todd.md
+++ b/changes/6130-mark-todd.md
@@ -1,0 +1,1 @@
+Fixed bug with generics receiving forward refs

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -267,7 +267,8 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
     if origin_type is Annotated:
         annotated_type, *annotations = type_args
         return Annotated[replace_types(annotated_type, type_map), tuple(annotations)]
-
+    if origin_type is typing.Literal:
+        return type_map.get(type_, type_)
     # Having type args is a good indicator that this is a typing module
     # class instantiation or a generic alias of some sort.
     if type_args:

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -31,6 +31,8 @@ from .utils import all_identical, lenient_issubclass
 
 if sys.version_info >= (3, 10):
     from typing import _UnionGenericAlias
+if sys.version_info >= (3, 8):
+    from typing import Literal
 
 GenericModelT = TypeVar('GenericModelT', bound='GenericModel')
 TypeVarType = Any  # since mypy doesn't allow the use of TypeVar as a type
@@ -267,7 +269,8 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
     if origin_type is Annotated:
         annotated_type, *annotations = type_args
         return Annotated[replace_types(annotated_type, type_map), tuple(annotations)]
-    if origin_type is typing.Literal or origin_type is ExtLiteral:
+
+    if (origin_type is ExtLiteral) or (sys.version_info >= (3, 8) and origin_type is Literal):
         return type_map.get(type_, type_)
     # Having type args is a good indicator that this is a typing module
     # class instantiation or a generic alias of some sort.

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -20,7 +20,7 @@ from typing import (
 )
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
-from typing_extensions import Annotated
+from typing_extensions import Annotated, Literal as ExtLiteral
 
 from .class_validators import gather_all_validators
 from .fields import DeferredType
@@ -267,7 +267,7 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
     if origin_type is Annotated:
         annotated_type, *annotations = type_args
         return Annotated[replace_types(annotated_type, type_map), tuple(annotations)]
-    if origin_type is typing.Literal:
+    if origin_type is typing.Literal or origin_type is ExtLiteral:
         return type_map.get(type_, type_)
     # Having type args is a good indicator that this is a typing module
     # class instantiation or a generic alias of some sort.

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    ForwardRef,
     Generic,
     Iterator,
     List,
@@ -317,7 +318,12 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any]) -> Any:
 
     # If all else fails, we try to resolve the type directly and otherwise just
     # return the input with no modifications.
-    return type_map.get(type_, type_)
+    new_type = type_map.get(type_, type_)
+    # Convert string to ForwardRef
+    if isinstance(new_type, str):
+        return ForwardRef(new_type)
+    else:
+        return new_type
 
 
 def check_parameters_count(cls: Type[GenericModel], parameters: Tuple[Any, ...]) -> None:


### PR DESCRIPTION
## Change Summary


Converts string to Forward Refs to allow for generic case
Also to fix discriminated unions allows Literals to pass through replace types unchanged.

## Related issue number

fix #6130


Selected Reviewer: @dmontagu 