### PR TITLE
Another solution to custom getattr/delattr

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -529,7 +529,7 @@ class ModelAttrBase:
                 return self.__pydantic_private__[item]  # type: ignore
             except KeyError as exc:
                 raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
-        if self.__pydantic_extra__ is not None:
+        elif self.__pydantic_extra__ is not None:
             try:
                 return self.__pydantic_extra__[item]
             except KeyError as exc:
@@ -551,5 +551,10 @@ class ModelAttrBase:
                 raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
         elif item in self.model_fields:
             object.__delattr__(self, item)
+        elif self.__pydantic_extra__ is not None:
+            try:
+                del self.__pydantic_extra__[item]
+            except KeyError as exc:
+                raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
         else:
             raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -314,6 +314,28 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
         pass
 
+    def __getattr__(self, item: str) -> Any:
+        private_attributes = object.__getattribute__(self, '__private_attributes__')
+        if item in private_attributes:
+            attribute = private_attributes[item]
+            if hasattr(attribute, '__get__'):
+                return attribute.__get__(self, type(self))  # type: ignore
+
+            try:
+                # Note: self.__pydantic_private__ is guaranteed to not be None if self.__private_attributes__ has items
+                return self.__pydantic_private__[item]  # type: ignore
+            except KeyError as exc:
+                raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
+        else:
+            pydantic_extra = object.__getattribute__(self, '__pydantic_extra__')
+            if pydantic_extra is not None:
+                try:
+                    return pydantic_extra[item]
+                except KeyError as exc:
+                    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
+            else:
+                raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
+
     def __setattr__(self, name: str, value: Any) -> None:
         if name in self.__class_vars__:
             raise AttributeError(
@@ -349,6 +371,28 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         else:
             self.__dict__[name] = value
             self.__pydantic_fields_set__.add(name)
+
+    def __delattr__(self, item: str) -> Any:
+        if item in self.__private_attributes__:
+            attribute = self.__private_attributes__[item]
+            if hasattr(attribute, '__delete__'):
+                attribute.__delete__(self)  # type: ignore
+                return
+
+            try:
+                # Note: self.__pydantic_private__ is guaranteed to not be None if self.__private_attributes__ has items
+                del self.__pydantic_private__[item]  # type: ignore
+            except KeyError as exc:
+                raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
+        elif item in self.model_fields:
+            object.__delattr__(self, item)
+        elif self.__pydantic_extra__ is not None and item in self.__pydantic_extra__:
+            del self.__pydantic_extra__[item]
+        else:
+            try:
+                object.__delattr__(self, item)
+            except AttributeError:
+                raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
 
     def __getstate__(self) -> dict[Any, Any]:
         private = self.__pydantic_private__

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -429,6 +429,10 @@ def test_del_model_attr_with_privat_attrs():
     assert not hasattr(m, 'some_field')
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == 'PyPy',
+    reason='In this single case `del` behaves weird on pypy',
+)
 def test_del_model_attr_with_privat_attrs_error():
     class Model(BaseModel):
         _private_attr: int = PrivateAttr(default=1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2467,3 +2467,60 @@ def test_resolve_def_schema_from_core_schema() -> None:
         inner: Annotated[Inner, Marker()]
 
     assert Outer.model_validate({'inner': {'x': 1}}).inner.x == 2
+
+
+def test_super_getattr_extra():
+    class Model(BaseModel):
+        model_config = {'extra': 'allow'}
+
+        def __getattr__(self, item):
+            if item == 'test':
+                return 'success'
+            return super().__getattr__(item)
+
+    m = Model(x=1)
+    assert m.x == 1
+    with pytest.raises(AttributeError):
+        m.y
+    assert m.test == 'success'
+
+
+def test_super_getattr_private():
+    class Model(BaseModel):
+        _x: int = PrivateAttr()
+
+        def __getattr__(self, item):
+            if item == 'test':
+                return 'success'
+            else:
+                return super().__getattr__(item)
+
+    m = Model()
+    m._x = 1
+    assert m._x == 1
+    with pytest.raises(AttributeError):
+        m._y
+    assert m.test == 'success'
+
+
+def test_super_delattr_private():
+    test_calls = []
+
+    class Model(BaseModel):
+        _x: int = PrivateAttr()
+
+        def __delattr__(self, item):
+            if item == 'test':
+                test_calls.append('success')
+            else:
+                super().__delattr__(item)
+
+    m = Model()
+    m._x = 1
+    assert m._x == 1
+    delattr(m, '_x')
+    with pytest.raises(AttributeError):
+        m._x
+    assert test_calls == []
+    delattr(m, 'test')
+    assert test_calls == ['success']

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2552,6 +2552,28 @@ def test_super_getattr_private():
     assert m.test == 'success'
 
 
+def test_super_delattr_extra():
+    test_calls = []
+
+    class Model(BaseModel):
+        model_config = {'extra': 'allow'}
+
+        def __delattr__(self, item):
+            if item == 'test':
+                test_calls.append('success')
+            else:
+                super().__delattr__(item)
+
+    m = Model(x=1)
+    assert m.x == 1
+    del m.x
+    with pytest.raises(AttributeError):
+        m._x
+    assert test_calls == []
+    del m.test
+    assert test_calls == ['success']
+
+
 def test_super_delattr_private():
     test_calls = []
 
@@ -2567,9 +2589,9 @@ def test_super_delattr_private():
     m = Model()
     m._x = 1
     assert m._x == 1
-    delattr(m, '_x')
+    del m._x
     with pytest.raises(AttributeError):
         m._x
     assert test_calls == []
-    delattr(m, 'test')
+    del m.test
     assert test_calls == ['success']


### PR DESCRIPTION
I think this is perhaps a better solution to #5946, as it ensures that you can call `super().__getattr__` and `super().__delattr__` when there are private attributes or allowed extra attributes, and things just work.

I think this would be easier to properly document than #6116, and is probably a better user experience either way. But it's a bit quirky, adding a custom class to the bases like this.

Selected Reviewer: @lig