### PR TITLE
💥 Use custom `PydanticDeprecationWarning` warning instead of the generic one

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -42,6 +42,7 @@ from .type_adapter import TypeAdapter
 from .types import *
 from .validate_call import validate_call
 from .version import VERSION
+from .warnings import *
 
 __version__ = VERSION
 
@@ -183,6 +184,8 @@ __all__ = [
     'TypeAdapter',
     # version
     'VERSION',
+    # warnings
+    'PydanticDeprecationWarning',
     # annotated handlers
     'GetCoreSchemaHandler',
     'GetJsonSchemaHandler',

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -185,6 +185,7 @@ __all__ = [
     # version
     'VERSION',
     # warnings
+    'PydanticDeprecatedSince20',
     'PydanticDeprecationWarning',
     # annotated handlers
     'GetCoreSchemaHandler',

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal, Self
 
 from ..config import ConfigDict, ExtraValues, JsonSchemaExtraCallable
 from ..errors import PydanticUserError
+from ..warnings import PydanticDeprecationWarning
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
 
@@ -197,7 +198,7 @@ def prepare_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> Co
         return ConfigDict()
 
     if not isinstance(config, dict):
-        warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
+        warnings.warn(PydanticDeprecationWarning(DEPRECATION_MESSAGE, since=(2, 0)))
         config = {k: getattr(config, k) for k in dir(config) if not k.startswith('__')}
 
     config_dict = cast(ConfigDict, config)

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal, Self
 
 from ..config import ConfigDict, ExtraValues, JsonSchemaExtraCallable
 from ..errors import PydanticUserError
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
 
@@ -198,7 +198,7 @@ def prepare_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> Co
         return ConfigDict()
 
     if not isinstance(config, dict):
-        warnings.warn(PydanticDeprecationWarning(DEPRECATION_MESSAGE, since=(2, 0)))
+        warnings.warn(DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
         config = {k: getattr(config, k) for k in dir(config) if not k.startswith('__')}
 
     config_dict = cast(ConfigDict, config)

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -10,6 +10,10 @@ from ..config import ConfigDict, ExtraValues, JsonSchemaExtraCallable
 from ..errors import PydanticUserError
 from ..warnings import PydanticDeprecatedSince20
 
+if not TYPE_CHECKING:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
+
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
 
 
@@ -198,7 +202,7 @@ def prepare_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> Co
         return ConfigDict()
 
     if not isinstance(config, dict):
-        warnings.warn(DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
+        warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
         config = {k: getattr(config, k) for k in dir(config) if not k.startswith('__')}
 
     config_dict = cast(ConfigDict, config)

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -11,7 +11,8 @@ from ..errors import PydanticUserError
 from ..warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -12,6 +12,7 @@ from typing_extensions import TypeGuard
 
 from ..errors import PydanticUndefinedAnnotation
 from ..fields import FieldInfo
+from ..warnings import PydanticDeprecationWarning
 from . import _config, _decorators, _typing_extra
 from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs
 from ._fields import collect_dataclass_fields
@@ -82,7 +83,9 @@ def complete_dataclass(
     """
     if hasattr(cls, '__post_init_post_parse__'):
         warnings.warn(
-            'Support for `__post_init_post_parse__` has been dropped, the method will not be called', DeprecationWarning
+            PydanticDeprecationWarning(
+                'Support for `__post_init_post_parse__` has been dropped, the method will not be called', since=(2, 0)
+            )
         )
 
     if types_namespace is None:

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -42,6 +42,10 @@ if typing.TYPE_CHECKING:
         __pydantic_config__: typing.ClassVar[ConfigDict]
         __pydantic_complete__: typing.ClassVar[bool]
 
+else:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
+
 
 def set_dataclass_fields(cls: type[StandardDataclass], types_namespace: dict[str, Any] | None = None) -> None:
     """Collect and set `cls.__pydantic_fields__`.
@@ -83,8 +87,7 @@ def complete_dataclass(
     """
     if hasattr(cls, '__post_init_post_parse__'):
         warnings.warn(
-            'Support for `__post_init_post_parse__` has been dropped, the method will not be called',
-            PydanticDeprecatedSince20,
+            'Support for `__post_init_post_parse__` has been dropped, the method will not be called', DeprecationWarning
         )
 
     if types_namespace is None:

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -43,7 +43,8 @@ if typing.TYPE_CHECKING:
         __pydantic_complete__: typing.ClassVar[bool]
 
 else:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -12,7 +12,7 @@ from typing_extensions import TypeGuard
 
 from ..errors import PydanticUndefinedAnnotation
 from ..fields import FieldInfo
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 from . import _config, _decorators, _typing_extra
 from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs
 from ._fields import collect_dataclass_fields
@@ -83,9 +83,8 @@ def complete_dataclass(
     """
     if hasattr(cls, '__post_init_post_parse__'):
         warnings.warn(
-            PydanticDeprecationWarning(
-                'Support for `__post_init_post_parse__` has been dropped, the method will not be called', since=(2, 0)
-            )
+            'Support for `__post_init_post_parse__` has been dropped, the method will not be called',
+            PydanticDeprecatedSince20,
         )
 
     if types_namespace is None:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -13,6 +13,7 @@ from typing_extensions import dataclass_transform, deprecated
 
 from ..errors import PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import Field, FieldInfo, ModelPrivateAttr, PrivateAttr
+from ..warnings import PydanticDeprecationWarning
 from ._config import ConfigWrapper
 from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs
 from ._decorators import ComputedFieldInfo, DecoratorInfos, PydanticDescriptorProxy
@@ -215,7 +216,11 @@ class ModelMetaclass(ABCMeta):
     @property
     @deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
     def __fields__(self) -> dict[str, FieldInfo]:
-        warnings.warn('The `__fields__` attribute is deprecated, use `model_fields` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning(
+                'The `__fields__` attribute is deprecated, use `model_fields` instead.', since=(2, 0)
+            )
+        )
         return self.model_fields
 
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -13,7 +13,7 @@ from typing_extensions import dataclass_transform, deprecated
 
 from ..errors import PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import Field, FieldInfo, ModelPrivateAttr, PrivateAttr
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 from ._config import ConfigWrapper
 from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs
 from ._decorators import ComputedFieldInfo, DecoratorInfos, PydanticDescriptorProxy
@@ -217,9 +217,7 @@ class ModelMetaclass(ABCMeta):
     @deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `__fields__` attribute is deprecated, use `model_fields` instead.', since=(2, 0)
-            )
+            'The `__fields__` attribute is deprecated, use `model_fields` instead.', PydanticDeprecatedSince20
         )
         return self.model_fields
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -29,6 +29,9 @@ if typing.TYPE_CHECKING:
     from inspect import Signature
 
     from ..main import BaseModel
+else:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 
 IGNORED_TYPES: tuple[Any, ...] = (
@@ -216,9 +219,7 @@ class ModelMetaclass(ABCMeta):
     @property
     @deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
     def __fields__(self) -> dict[str, FieldInfo]:
-        warnings.warn(
-            'The `__fields__` attribute is deprecated, use `model_fields` instead.', PydanticDeprecatedSince20
-        )
+        warnings.warn('The `__fields__` attribute is deprecated, use `model_fields` instead.', DeprecationWarning)
         return self.model_fields
 
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -30,7 +30,8 @@ if typing.TYPE_CHECKING:
 
     from ..main import BaseModel
 else:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 
@@ -217,7 +218,9 @@ class ModelMetaclass(ABCMeta):
         return field_names, class_vars, private_attributes
 
     @property
-    @deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
+    @deprecated(
+        'The `__fields__` attribute is deprecated, use `model_fields` instead.', category=PydanticDeprecatedSince20
+    )
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn('The `__fields__` attribute is deprecated, use `model_fields` instead.', DeprecationWarning)
         return self.model_fields

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -21,6 +21,7 @@ from typing_extensions import deprecated
 from ._internal import _repr, _utils
 from ._internal._schema_generation_shared import GetJsonSchemaHandler as _GetJsonSchemaHandler
 from .json_schema import JsonSchemaValue
+from .warnings import PydanticDeprecatedSince20
 
 ColorTuple = Union[Tuple[int, int, int], Tuple[int, int, int, float]]
 ColorType = Union[ColorTuple, str]
@@ -68,7 +69,8 @@ rads = 2 * math.pi
 
 @deprecated(
     'The `Color` class is deprecated, use `pydantic_extra_types` instead. '
-    'See https://pydantic-docs.helpmanual.io/usage/types/extra_types/color_types/.'
+    'See https://pydantic-docs.helpmanual.io/usage/types/extra_types/color_types/.',
+    category=PydanticDeprecatedSince20,
 )
 class Color(_repr.Representation):
     """Represents a color."""

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal, Protocol, TypedDict
 
 from ._migration import getattr_migration
 from .deprecated.config import BaseConfig
+from .warnings import PydanticDeprecationWarning
 
 __all__ = 'BaseConfig', 'ConfigDict', 'Extra'
 
@@ -29,8 +30,10 @@ class _Extra:
 
     def __getattribute__(self, __name: str) -> Any:
         warn(
-            '`pydantic.config.Extra` is deprecated, use literal values instead' " (e.g. `extra='allow'`)",
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                '`pydantic.config.Extra` is deprecated, use literal values instead' " (e.g. `extra='allow'`)",
+                since=(2, 0),
+            ),
             stacklevel=2,
         )
         return super().__getattribute__(__name)

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -11,7 +11,8 @@ from .deprecated.config import BaseConfig
 from .warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'BaseConfig', 'ConfigDict', 'Extra'

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal, Protocol, TypedDict
 
 from ._migration import getattr_migration
 from .deprecated.config import BaseConfig
-from .warnings import PydanticDeprecationWarning
+from .warnings import PydanticDeprecatedSince20
 
 __all__ = 'BaseConfig', 'ConfigDict', 'Extra'
 
@@ -30,10 +30,8 @@ class _Extra:
 
     def __getattribute__(self, __name: str) -> Any:
         warn(
-            PydanticDeprecationWarning(
-                '`pydantic.config.Extra` is deprecated, use literal values instead' " (e.g. `extra='allow'`)",
-                since=(2, 0),
-            ),
+            '`pydantic.config.Extra` is deprecated, use literal values instead' " (e.g. `extra='allow'`)",
+            PydanticDeprecatedSince20,
             stacklevel=2,
         )
         return super().__getattribute__(__name)

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,7 +1,7 @@
 """Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
-from typing import Any, Callable, overload
+from typing import TYPE_CHECKING, Any, Callable, overload
 from warnings import warn
 
 from typing_extensions import Literal, Protocol, TypedDict
@@ -9,6 +9,10 @@ from typing_extensions import Literal, Protocol, TypedDict
 from ._migration import getattr_migration
 from .deprecated.config import BaseConfig
 from .warnings import PydanticDeprecatedSince20
+
+if not TYPE_CHECKING:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'BaseConfig', 'ConfigDict', 'Extra'
 
@@ -31,7 +35,7 @@ class _Extra:
     def __getattribute__(self, __name: str) -> Any:
         warn(
             '`pydantic.config.Extra` is deprecated, use literal values instead' " (e.g. `extra='allow'`)",
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
             stacklevel=2,
         )
         return super().__getattribute__(__name)

--- a/pydantic/deprecated/class_validators.py
+++ b/pydantic/deprecated/class_validators.py
@@ -11,6 +11,7 @@ from typing_extensions import Literal, Protocol, TypeAlias
 
 from .._internal import _decorators, _decorators_v1
 from ..errors import PydanticUserError
+from ..warnings import PydanticDeprecationWarning
 
 _ALLOW_REUSE_WARNING_MESSAGE = '`allow_reuse` is deprecated and will be ignored; it should no longer be necessary'
 
@@ -105,7 +106,7 @@ def validator(
             function to be used as a validator.
     """
     if allow_reuse is True:  # pragma: no cover
-        warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
+        warn(PydanticDeprecationWarning(_ALLOW_REUSE_WARNING_MESSAGE, since=(2, 0)))
     fields = tuple((__field, *fields))
     if isinstance(fields[0], FunctionType):
         raise PydanticUserError(
@@ -121,10 +122,12 @@ def validator(
         )
 
     warn(
-        'Pydantic V1 style `@validator` validators are deprecated.'
-        ' You should migrate to Pydantic V2 style `@field_validator` validators,'
-        ' see the migration guide for more details',
-        DeprecationWarning,
+        PydanticDeprecationWarning(
+            'Pydantic V1 style `@validator` validators are deprecated.'
+            ' You should migrate to Pydantic V2 style `@field_validator` validators,'
+            ' see the migration guide for more details',
+            since=(2, 0),
+        ),
         stacklevel=2,
     )
 
@@ -205,10 +208,12 @@ def root_validator(
         Any: A decorator that can be used to decorate a function to be used as a root_validator.
     """
     warn(
-        'Pydantic V1 style `@root_validator` validators are deprecated.'
-        ' You should migrate to Pydantic V2 style `@model_validator` validators,'
-        ' see the migration guide for more details',
-        DeprecationWarning,
+        PydanticDeprecationWarning(
+            'Pydantic V1 style `@root_validator` validators are deprecated.'
+            ' You should migrate to Pydantic V2 style `@model_validator` validators,'
+            ' see the migration guide for more details',
+            since=(2, 0),
+        ),
         stacklevel=2,
     )
 
@@ -217,7 +222,7 @@ def root_validator(
         return root_validator()(*__args)  # type: ignore
 
     if allow_reuse is True:  # pragma: no cover
-        warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
+        warn(PydanticDeprecationWarning(_ALLOW_REUSE_WARNING_MESSAGE, since=(2, 0)))
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
     if pre is False and skip_on_failure is not True:
         raise PydanticUserError(

--- a/pydantic/deprecated/class_validators.py
+++ b/pydantic/deprecated/class_validators.py
@@ -73,6 +73,9 @@ if TYPE_CHECKING:
         _V1RootValidatorClsMethod,
         _PartialClsOrStaticMethod,
     )
+else:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 
 def validator(
@@ -106,7 +109,7 @@ def validator(
             function to be used as a validator.
     """
     if allow_reuse is True:  # pragma: no cover
-        warn(_ALLOW_REUSE_WARNING_MESSAGE, PydanticDeprecatedSince20)
+        warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
     fields = tuple((__field, *fields))
     if isinstance(fields[0], FunctionType):
         raise PydanticUserError(
@@ -125,7 +128,7 @@ def validator(
         'Pydantic V1 style `@validator` validators are deprecated.'
         ' You should migrate to Pydantic V2 style `@field_validator` validators,'
         ' see the migration guide for more details',
-        PydanticDeprecatedSince20,
+        DeprecationWarning,
         stacklevel=2,
     )
 
@@ -209,7 +212,7 @@ def root_validator(
         'Pydantic V1 style `@root_validator` validators are deprecated.'
         ' You should migrate to Pydantic V2 style `@model_validator` validators,'
         ' see the migration guide for more details',
-        PydanticDeprecatedSince20,
+        DeprecationWarning,
         stacklevel=2,
     )
 
@@ -218,7 +221,7 @@ def root_validator(
         return root_validator()(*__args)  # type: ignore
 
     if allow_reuse is True:  # pragma: no cover
-        warn(_ALLOW_REUSE_WARNING_MESSAGE, PydanticDeprecatedSince20)
+        warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
     if pre is False and skip_on_failure is not True:
         raise PydanticUserError(

--- a/pydantic/deprecated/class_validators.py
+++ b/pydantic/deprecated/class_validators.py
@@ -74,7 +74,8 @@ if TYPE_CHECKING:
         _PartialClsOrStaticMethod,
     )
 else:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 

--- a/pydantic/deprecated/class_validators.py
+++ b/pydantic/deprecated/class_validators.py
@@ -11,7 +11,7 @@ from typing_extensions import Literal, Protocol, TypeAlias
 
 from .._internal import _decorators, _decorators_v1
 from ..errors import PydanticUserError
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 
 _ALLOW_REUSE_WARNING_MESSAGE = '`allow_reuse` is deprecated and will be ignored; it should no longer be necessary'
 
@@ -106,7 +106,7 @@ def validator(
             function to be used as a validator.
     """
     if allow_reuse is True:  # pragma: no cover
-        warn(PydanticDeprecationWarning(_ALLOW_REUSE_WARNING_MESSAGE, since=(2, 0)))
+        warn(_ALLOW_REUSE_WARNING_MESSAGE, PydanticDeprecatedSince20)
     fields = tuple((__field, *fields))
     if isinstance(fields[0], FunctionType):
         raise PydanticUserError(
@@ -122,12 +122,10 @@ def validator(
         )
 
     warn(
-        PydanticDeprecationWarning(
-            'Pydantic V1 style `@validator` validators are deprecated.'
-            ' You should migrate to Pydantic V2 style `@field_validator` validators,'
-            ' see the migration guide for more details',
-            since=(2, 0),
-        ),
+        'Pydantic V1 style `@validator` validators are deprecated.'
+        ' You should migrate to Pydantic V2 style `@field_validator` validators,'
+        ' see the migration guide for more details',
+        PydanticDeprecatedSince20,
         stacklevel=2,
     )
 
@@ -208,12 +206,10 @@ def root_validator(
         Any: A decorator that can be used to decorate a function to be used as a root_validator.
     """
     warn(
-        PydanticDeprecationWarning(
-            'Pydantic V1 style `@root_validator` validators are deprecated.'
-            ' You should migrate to Pydantic V2 style `@model_validator` validators,'
-            ' see the migration guide for more details',
-            since=(2, 0),
-        ),
+        'Pydantic V1 style `@root_validator` validators are deprecated.'
+        ' You should migrate to Pydantic V2 style `@model_validator` validators,'
+        ' see the migration guide for more details',
+        PydanticDeprecatedSince20,
         stacklevel=2,
     )
 
@@ -222,7 +218,7 @@ def root_validator(
         return root_validator()(*__args)  # type: ignore
 
     if allow_reuse is True:  # pragma: no cover
-        warn(PydanticDeprecationWarning(_ALLOW_REUSE_WARNING_MESSAGE, since=(2, 0)))
+        warn(_ALLOW_REUSE_WARNING_MESSAGE, PydanticDeprecatedSince20)
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
     if pre is False and skip_on_failure is not True:
         raise PydanticUserError(

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -6,13 +6,14 @@ from typing import Any
 from typing_extensions import deprecated
 
 from .._internal import _config
+from ..warnings import PydanticDeprecationWarning
 
 __all__ = ('BaseConfig',)
 
 
 class _ConfigMetaclass(type):
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+        warnings.warn(PydanticDeprecationWarning(_config.DEPRECATION_MESSAGE, since=(2, 0)))
 
         try:
             return _config.config_defaults[item]
@@ -29,7 +30,7 @@ class BaseConfig(metaclass=_ConfigMetaclass):
     """
 
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+        warnings.warn(PydanticDeprecationWarning(_config.DEPRECATION_MESSAGE, since=(2, 0)))
         try:
             return super().__getattribute__(item)
         except AttributeError as exc:
@@ -40,5 +41,5 @@ class BaseConfig(metaclass=_ConfigMetaclass):
                 raise AttributeError(str(exc)) from exc
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+        warnings.warn(PydanticDeprecationWarning(_config.DEPRECATION_MESSAGE, since=(2, 0)))
         return super().__init_subclass__(**kwargs)

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -9,7 +9,8 @@ from .._internal import _config
 from ..warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = ('BaseConfig',)
@@ -25,7 +26,7 @@ class _ConfigMetaclass(type):
             raise AttributeError(f"type object '{self.__name__}' has no attribute {exc}") from exc
 
 
-@deprecated('BaseConfig is deprecated. Use the `pydantic.ConfigDict` instead.')
+@deprecated('BaseConfig is deprecated. Use the `pydantic.ConfigDict` instead.', category=PydanticDeprecatedSince20)
 class BaseConfig(metaclass=_ConfigMetaclass):
     """This class is only retained for backwards compatibility.
 

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -6,14 +6,14 @@ from typing import Any
 from typing_extensions import deprecated
 
 from .._internal import _config
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 
 __all__ = ('BaseConfig',)
 
 
 class _ConfigMetaclass(type):
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(PydanticDeprecationWarning(_config.DEPRECATION_MESSAGE, since=(2, 0)))
+        warnings.warn(_config.DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
 
         try:
             return _config.config_defaults[item]
@@ -30,7 +30,7 @@ class BaseConfig(metaclass=_ConfigMetaclass):
     """
 
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(PydanticDeprecationWarning(_config.DEPRECATION_MESSAGE, since=(2, 0)))
+        warnings.warn(_config.DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
         try:
             return super().__getattribute__(item)
         except AttributeError as exc:
@@ -41,5 +41,5 @@ class BaseConfig(metaclass=_ConfigMetaclass):
                 raise AttributeError(str(exc)) from exc
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        warnings.warn(PydanticDeprecationWarning(_config.DEPRECATION_MESSAGE, since=(2, 0)))
+        warnings.warn(_config.DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
         return super().__init_subclass__(**kwargs)

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -1,19 +1,23 @@
 from __future__ import annotations as _annotations
 
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import deprecated
 
 from .._internal import _config
 from ..warnings import PydanticDeprecatedSince20
 
+if not TYPE_CHECKING:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
+
 __all__ = ('BaseConfig',)
 
 
 class _ConfigMetaclass(type):
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(_config.DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
+        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
 
         try:
             return _config.config_defaults[item]
@@ -30,7 +34,7 @@ class BaseConfig(metaclass=_ConfigMetaclass):
     """
 
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(_config.DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
+        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
         try:
             return super().__getattribute__(item)
         except AttributeError as exc:
@@ -41,5 +45,5 @@ class BaseConfig(metaclass=_ConfigMetaclass):
                 raise AttributeError(str(exc)) from exc
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        warnings.warn(_config.DEPRECATION_MESSAGE, PydanticDeprecatedSince20)
+        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
         return super().__init_subclass__(**kwargs)

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -9,6 +9,7 @@ from ..alias_generators import to_pascal
 from ..errors import PydanticUserError
 from ..functional_validators import field_validator
 from ..main import BaseModel, create_model
+from ..warnings import PydanticDeprecationWarning
 
 __all__ = ('validate_arguments',)
 
@@ -34,7 +35,10 @@ def validate_arguments(func: 'AnyCallableT') -> 'AnyCallableT':
 def validate_arguments(func: Optional['AnyCallableT'] = None, *, config: 'ConfigType' = None) -> Any:
     """Decorator to validate the arguments passed to a function."""
     warnings.warn(
-        'The `validate_arguments` method is deprecated; use `validate_call` instead.', DeprecationWarning, stacklevel=2
+        PydanticDeprecationWarning(
+            'The `validate_arguments` method is deprecated; use `validate_call` instead.', since=(2, 0)
+        ),
+        stacklevel=2,
     )
 
     def validate(_func: 'AnyCallable') -> 'AnyCallable':

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -12,7 +12,8 @@ from ..main import BaseModel, create_model
 from ..warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = ('validate_arguments',)
@@ -25,13 +26,17 @@ if TYPE_CHECKING:
 
 
 @overload
-@deprecated('The `validate_arguments` method is deprecated; use `validate_call` instead.')
+@deprecated(
+    'The `validate_arguments` method is deprecated; use `validate_call` instead.', category=PydanticDeprecatedSince20
+)
 def validate_arguments(func: None = None, *, config: 'ConfigType' = None) -> Callable[['AnyCallableT'], 'AnyCallableT']:
     ...
 
 
 @overload
-@deprecated('The `validate_arguments` method is deprecated; use `validate_call` instead.')
+@deprecated(
+    'The `validate_arguments` method is deprecated; use `validate_call` instead.', category=PydanticDeprecatedSince20
+)
 def validate_arguments(func: 'AnyCallableT') -> 'AnyCallableT':
     ...
 

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -11,6 +11,10 @@ from ..functional_validators import field_validator
 from ..main import BaseModel, create_model
 from ..warnings import PydanticDeprecatedSince20
 
+if not TYPE_CHECKING:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
+
 __all__ = ('validate_arguments',)
 
 if TYPE_CHECKING:
@@ -35,9 +39,7 @@ def validate_arguments(func: 'AnyCallableT') -> 'AnyCallableT':
 def validate_arguments(func: Optional['AnyCallableT'] = None, *, config: 'ConfigType' = None) -> Any:
     """Decorator to validate the arguments passed to a function."""
     warnings.warn(
-        'The `validate_arguments` method is deprecated; use `validate_call` instead.',
-        PydanticDeprecatedSince20,
-        stacklevel=2,
+        'The `validate_arguments` method is deprecated; use `validate_call` instead.', DeprecationWarning, stacklevel=2
     )
 
     def validate(_func: 'AnyCallable') -> 'AnyCallable':

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -9,7 +9,7 @@ from ..alias_generators import to_pascal
 from ..errors import PydanticUserError
 from ..functional_validators import field_validator
 from ..main import BaseModel, create_model
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 
 __all__ = ('validate_arguments',)
 
@@ -35,9 +35,8 @@ def validate_arguments(func: 'AnyCallableT') -> 'AnyCallableT':
 def validate_arguments(func: Optional['AnyCallableT'] = None, *, config: 'ConfigType' = None) -> Any:
     """Decorator to validate the arguments passed to a function."""
     warnings.warn(
-        PydanticDeprecationWarning(
-            'The `validate_arguments` method is deprecated; use `validate_call` instead.', since=(2, 0)
-        ),
+        'The `validate_arguments` method is deprecated; use `validate_call` instead.',
+        PydanticDeprecatedSince20,
         stacklevel=2,
     )
 

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -15,6 +15,7 @@ from typing_extensions import deprecated
 from ..color import Color
 from ..networks import NameEmail
 from ..types import SecretBytes, SecretStr
+from ..warnings import PydanticDeprecationWarning
 
 __all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
 
@@ -78,7 +79,10 @@ def pydantic_encoder(obj: Any) -> Any:
 
     from ..main import BaseModel
 
-    warnings.warn('pydantic_encoder is deprecated, use BaseModel.model_dump instead.', DeprecationWarning, stacklevel=2)
+    warnings.warn(
+        PydanticDeprecationWarning('pydantic_encoder is deprecated, use BaseModel.model_dump instead.', since=(2, 0)),
+        stacklevel=2,
+    )
     if isinstance(obj, BaseModel):
         return obj.model_dump()
     elif is_dataclass(obj):
@@ -100,7 +104,10 @@ def pydantic_encoder(obj: Any) -> Any:
 def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]], obj: Any) -> Any:
     # Check the class type and its superclasses for a matching encoder
     warnings.warn(
-        'custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.', DeprecationWarning, stacklevel=2
+        PydanticDeprecationWarning(
+            'custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.', since=(2, 0)
+        ),
+        stacklevel=2,
     )
     for base in obj.__class__.__mro__[:-1]:
         try:
@@ -116,7 +123,7 @@ def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]]
 @deprecated('timedelta_isoformat is deprecated.')
 def timedelta_isoformat(td: datetime.timedelta) -> str:
     """ISO 8601 encoding for Python timedelta object."""
-    warnings.warn('timedelta_isoformat is deprecated.', DeprecationWarning, stacklevel=2)
+    warnings.warn(PydanticDeprecationWarning('timedelta_isoformat is deprecated.', since=(2, 0)), stacklevel=2)
     minutes, seconds = divmod(td.seconds, 60)
     hours, minutes = divmod(minutes, 60)
     return f'{"-" if td.days < 0 else ""}P{abs(td.days)}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S'

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -7,7 +7,7 @@ from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6
 from pathlib import Path
 from re import Pattern
 from types import GeneratorType
-from typing import Any, Callable, Dict, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union
 from uuid import UUID
 
 from typing_extensions import deprecated
@@ -16,6 +16,10 @@ from ..color import Color
 from ..networks import NameEmail
 from ..types import SecretBytes, SecretStr
 from ..warnings import PydanticDeprecatedSince20
+
+if not TYPE_CHECKING:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
 
@@ -79,9 +83,7 @@ def pydantic_encoder(obj: Any) -> Any:
 
     from ..main import BaseModel
 
-    warnings.warn(
-        'pydantic_encoder is deprecated, use BaseModel.model_dump instead.', PydanticDeprecatedSince20, stacklevel=2
-    )
+    warnings.warn('pydantic_encoder is deprecated, use BaseModel.model_dump instead.', DeprecationWarning, stacklevel=2)
     if isinstance(obj, BaseModel):
         return obj.model_dump()
     elif is_dataclass(obj):
@@ -103,9 +105,7 @@ def pydantic_encoder(obj: Any) -> Any:
 def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]], obj: Any) -> Any:
     # Check the class type and its superclasses for a matching encoder
     warnings.warn(
-        'custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.',
-        PydanticDeprecatedSince20,
-        stacklevel=2,
+        'custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.', DeprecationWarning, stacklevel=2
     )
     for base in obj.__class__.__mro__[:-1]:
         try:
@@ -121,7 +121,7 @@ def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]]
 @deprecated('timedelta_isoformat is deprecated.')
 def timedelta_isoformat(td: datetime.timedelta) -> str:
     """ISO 8601 encoding for Python timedelta object."""
-    warnings.warn('timedelta_isoformat is deprecated.', PydanticDeprecatedSince20, stacklevel=2)
+    warnings.warn('timedelta_isoformat is deprecated.', DeprecationWarning, stacklevel=2)
     minutes, seconds = divmod(td.seconds, 60)
     hours, minutes = divmod(minutes, 60)
     return f'{"-" if td.days < 0 else ""}P{abs(td.days)}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S'

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -15,7 +15,7 @@ from typing_extensions import deprecated
 from ..color import Color
 from ..networks import NameEmail
 from ..types import SecretBytes, SecretStr
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 
 __all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
 
@@ -80,8 +80,7 @@ def pydantic_encoder(obj: Any) -> Any:
     from ..main import BaseModel
 
     warnings.warn(
-        PydanticDeprecationWarning('pydantic_encoder is deprecated, use BaseModel.model_dump instead.', since=(2, 0)),
-        stacklevel=2,
+        'pydantic_encoder is deprecated, use BaseModel.model_dump instead.', PydanticDeprecatedSince20, stacklevel=2
     )
     if isinstance(obj, BaseModel):
         return obj.model_dump()
@@ -104,9 +103,8 @@ def pydantic_encoder(obj: Any) -> Any:
 def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]], obj: Any) -> Any:
     # Check the class type and its superclasses for a matching encoder
     warnings.warn(
-        PydanticDeprecationWarning(
-            'custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.', since=(2, 0)
-        ),
+        'custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.',
+        PydanticDeprecatedSince20,
         stacklevel=2,
     )
     for base in obj.__class__.__mro__[:-1]:
@@ -123,7 +121,7 @@ def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]]
 @deprecated('timedelta_isoformat is deprecated.')
 def timedelta_isoformat(td: datetime.timedelta) -> str:
     """ISO 8601 encoding for Python timedelta object."""
-    warnings.warn(PydanticDeprecationWarning('timedelta_isoformat is deprecated.', since=(2, 0)), stacklevel=2)
+    warnings.warn('timedelta_isoformat is deprecated.', PydanticDeprecatedSince20, stacklevel=2)
     minutes, seconds = divmod(td.seconds, 60)
     hours, minutes = divmod(minutes, 60)
     return f'{"-" if td.days < 0 else ""}P{abs(td.days)}DT{hours:d}H{minutes:d}M{seconds:d}.{td.microseconds:06d}S'

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -18,7 +18,8 @@ from ..types import SecretBytes, SecretStr
 from ..warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
@@ -77,7 +78,9 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
 }
 
 
-@deprecated('pydantic_encoder is deprecated, use pydantic_core.to_jsonable_python instead.')
+@deprecated(
+    'pydantic_encoder is deprecated, use pydantic_core.to_jsonable_python instead.', category=PydanticDeprecatedSince20
+)
 def pydantic_encoder(obj: Any) -> Any:
     from dataclasses import asdict, is_dataclass
 
@@ -101,7 +104,7 @@ def pydantic_encoder(obj: Any) -> Any:
 
 
 # TODO: Add a suggested migration path once there is a way to use custom encoders
-@deprecated('custom_pydantic_encoder is deprecated.')
+@deprecated('custom_pydantic_encoder is deprecated.', category=PydanticDeprecatedSince20)
 def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]], obj: Any) -> Any:
     # Check the class type and its superclasses for a matching encoder
     warnings.warn(
@@ -118,7 +121,7 @@ def custom_pydantic_encoder(type_encoders: Dict[Any, Callable[[Type[Any]], Any]]
         return pydantic_encoder(obj)
 
 
-@deprecated('timedelta_isoformat is deprecated.')
+@deprecated('timedelta_isoformat is deprecated.', category=PydanticDeprecatedSince20)
 def timedelta_isoformat(td: datetime.timedelta) -> str:
     """ISO 8601 encoding for Python timedelta object."""
     warnings.warn('timedelta_isoformat is deprecated.', DeprecationWarning, stacklevel=2)

--- a/pydantic/deprecated/parse.py
+++ b/pydantic/deprecated/parse.py
@@ -9,6 +9,8 @@ from typing import Any, Callable
 
 from typing_extensions import deprecated
 
+from ..warnings import PydanticDeprecationWarning
+
 
 class Protocol(str, Enum):
     json = 'json'
@@ -25,7 +27,7 @@ def load_str_bytes(
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
 ) -> Any:
-    warnings.warn('load_str_bytes is deprecated.', DeprecationWarning, stacklevel=2)
+    warnings.warn(PydanticDeprecationWarning('load_str_bytes is deprecated.', since=(2, 0)), stacklevel=2)
     if proto is None and content_type:
         if content_type.endswith(('json', 'javascript')):
             pass
@@ -59,7 +61,7 @@ def load_file(
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
 ) -> Any:
-    warnings.warn('load_file is deprecated.', DeprecationWarning, stacklevel=2)
+    warnings.warn(PydanticDeprecationWarning('load_file is deprecated.', since=(2, 0)), stacklevel=2)
     path = Path(path)
     b = path.read_bytes()
     if content_type is None:

--- a/pydantic/deprecated/parse.py
+++ b/pydantic/deprecated/parse.py
@@ -12,7 +12,8 @@ from typing_extensions import deprecated
 from ..warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 
@@ -21,7 +22,7 @@ class Protocol(str, Enum):
     pickle = 'pickle'
 
 
-@deprecated('load_str_bytes is deprecated.')
+@deprecated('load_str_bytes is deprecated.', category=PydanticDeprecatedSince20)
 def load_str_bytes(
     b: str | bytes,
     *,
@@ -55,7 +56,7 @@ def load_str_bytes(
         raise TypeError(f'Unknown protocol: {proto}')
 
 
-@deprecated('load_file is deprecated.')
+@deprecated('load_file is deprecated.', category=PydanticDeprecatedSince20)
 def load_file(
     path: str | Path,
     *,

--- a/pydantic/deprecated/parse.py
+++ b/pydantic/deprecated/parse.py
@@ -5,11 +5,15 @@ import pickle
 import warnings
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from typing_extensions import deprecated
 
 from ..warnings import PydanticDeprecatedSince20
+
+if not TYPE_CHECKING:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 
 class Protocol(str, Enum):
@@ -27,7 +31,7 @@ def load_str_bytes(
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
 ) -> Any:
-    warnings.warn('load_str_bytes is deprecated.', PydanticDeprecatedSince20, stacklevel=2)
+    warnings.warn('load_str_bytes is deprecated.', DeprecationWarning, stacklevel=2)
     if proto is None and content_type:
         if content_type.endswith(('json', 'javascript')):
             pass
@@ -61,7 +65,7 @@ def load_file(
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
 ) -> Any:
-    warnings.warn('load_file is deprecated.', PydanticDeprecatedSince20, stacklevel=2)
+    warnings.warn('load_file is deprecated.', DeprecationWarning, stacklevel=2)
     path = Path(path)
     b = path.read_bytes()
     if content_type is None:

--- a/pydantic/deprecated/parse.py
+++ b/pydantic/deprecated/parse.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 
 from typing_extensions import deprecated
 
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 
 
 class Protocol(str, Enum):
@@ -27,7 +27,7 @@ def load_str_bytes(
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
 ) -> Any:
-    warnings.warn(PydanticDeprecationWarning('load_str_bytes is deprecated.', since=(2, 0)), stacklevel=2)
+    warnings.warn('load_str_bytes is deprecated.', PydanticDeprecatedSince20, stacklevel=2)
     if proto is None and content_type:
         if content_type.endswith(('json', 'javascript')):
             pass
@@ -61,7 +61,7 @@ def load_file(
     allow_pickle: bool = False,
     json_loads: Callable[[str], Any] = json.loads,
 ) -> Any:
-    warnings.warn(PydanticDeprecationWarning('load_file is deprecated.', since=(2, 0)), stacklevel=2)
+    warnings.warn('load_file is deprecated.', PydanticDeprecatedSince20, stacklevel=2)
     path = Path(path)
     b = path.read_bytes()
     if content_type is None:

--- a/pydantic/deprecated/tools.py
+++ b/pydantic/deprecated/tools.py
@@ -8,6 +8,7 @@ from typing_extensions import deprecated
 
 from ..json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema
 from ..type_adapter import TypeAdapter
+from ..warnings import PydanticDeprecationWarning
 
 __all__ = 'parse_obj_as', 'schema_of', 'schema_json_of'
 
@@ -20,14 +21,16 @@ T = TypeVar('T')
 @deprecated('parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.')
 def parse_obj_as(type_: type[T], obj: Any, type_name: NameFactory | None = None) -> T:
     warnings.warn(
-        'parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.',
-        DeprecationWarning,
+        PydanticDeprecationWarning(
+            'parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.', since=(2, 0)
+        ),
         stacklevel=2,
     )
     if type_name is not None:  # pragma: no cover
         warnings.warn(
-            'The type_name parameter is deprecated. parse_obj_as no longer creates temporary models',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'The type_name parameter is deprecated. parse_obj_as no longer creates temporary models', since=(2, 0)
+            ),
             stacklevel=2,
         )
     return TypeAdapter(type_).validate_python(obj)
@@ -44,7 +47,10 @@ def schema_of(
 ) -> dict[str, Any]:
     """Generate a JSON schema (as dict) for the passed model or dynamically generated one."""
     warnings.warn(
-        'schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', DeprecationWarning, stacklevel=2
+        PydanticDeprecationWarning(
+            'schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', since=(2, 0)
+        ),
+        stacklevel=2,
     )
     res = TypeAdapter(type_).json_schema(
         by_alias=by_alias,
@@ -56,8 +62,9 @@ def schema_of(
             res['title'] = title
         else:
             warnings.warn(
-                'Passing a callable for the `title` parameter is deprecated and no longer supported',
-                DeprecationWarning,
+                PydanticDeprecationWarning(
+                    'Passing a callable for the `title` parameter is deprecated and no longer supported', since=(2, 0)
+                ),
                 stacklevel=2,
             )
             res['title'] = title(type_)
@@ -76,7 +83,10 @@ def schema_json_of(
 ) -> str:
     """Generate a JSON schema (as JSON) for the passed model or dynamically generated one."""
     warnings.warn(
-        'schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', DeprecationWarning, stacklevel=2
+        PydanticDeprecationWarning(
+            'schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', since=(2, 0)
+        ),
+        stacklevel=2,
     )
     return json.dumps(
         schema_of(type_, title=title, by_alias=by_alias, ref_template=ref_template, schema_generator=schema_generator),

--- a/pydantic/deprecated/tools.py
+++ b/pydantic/deprecated/tools.py
@@ -11,7 +11,8 @@ from ..type_adapter import TypeAdapter
 from ..warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'parse_obj_as', 'schema_of', 'schema_json_of'
@@ -22,7 +23,9 @@ NameFactory = Union[str, Callable[[Type[Any]], str]]
 T = TypeVar('T')
 
 
-@deprecated('parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.')
+@deprecated(
+    'parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.', category=PydanticDeprecatedSince20
+)
 def parse_obj_as(type_: type[T], obj: Any, type_name: NameFactory | None = None) -> T:
     warnings.warn(
         'parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.',
@@ -38,7 +41,9 @@ def parse_obj_as(type_: type[T], obj: Any, type_name: NameFactory | None = None)
     return TypeAdapter(type_).validate_python(obj)
 
 
-@deprecated('schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.')
+@deprecated(
+    'schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', category=PydanticDeprecatedSince20
+)
 def schema_of(
     type_: Any,
     *,
@@ -69,7 +74,9 @@ def schema_of(
     return res
 
 
-@deprecated('schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.')
+@deprecated(
+    'schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', category=PydanticDeprecatedSince20
+)
 def schema_json_of(
     type_: Any,
     *,

--- a/pydantic/deprecated/tools.py
+++ b/pydantic/deprecated/tools.py
@@ -8,7 +8,7 @@ from typing_extensions import deprecated
 
 from ..json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema
 from ..type_adapter import TypeAdapter
-from ..warnings import PydanticDeprecationWarning
+from ..warnings import PydanticDeprecatedSince20
 
 __all__ = 'parse_obj_as', 'schema_of', 'schema_json_of'
 
@@ -21,16 +21,14 @@ T = TypeVar('T')
 @deprecated('parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.')
 def parse_obj_as(type_: type[T], obj: Any, type_name: NameFactory | None = None) -> T:
     warnings.warn(
-        PydanticDeprecationWarning(
-            'parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.', since=(2, 0)
-        ),
+        'parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.',
+        PydanticDeprecatedSince20,
         stacklevel=2,
     )
     if type_name is not None:  # pragma: no cover
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The type_name parameter is deprecated. parse_obj_as no longer creates temporary models', since=(2, 0)
-            ),
+            'The type_name parameter is deprecated. parse_obj_as no longer creates temporary models',
+            PydanticDeprecatedSince20,
             stacklevel=2,
         )
     return TypeAdapter(type_).validate_python(obj)
@@ -47,9 +45,8 @@ def schema_of(
 ) -> dict[str, Any]:
     """Generate a JSON schema (as dict) for the passed model or dynamically generated one."""
     warnings.warn(
-        PydanticDeprecationWarning(
-            'schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', since=(2, 0)
-        ),
+        'schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.',
+        PydanticDeprecatedSince20,
         stacklevel=2,
     )
     res = TypeAdapter(type_).json_schema(
@@ -62,9 +59,8 @@ def schema_of(
             res['title'] = title
         else:
             warnings.warn(
-                PydanticDeprecationWarning(
-                    'Passing a callable for the `title` parameter is deprecated and no longer supported', since=(2, 0)
-                ),
+                'Passing a callable for the `title` parameter is deprecated and no longer supported',
+                PydanticDeprecatedSince20,
                 stacklevel=2,
             )
             res['title'] = title(type_)
@@ -83,9 +79,8 @@ def schema_json_of(
 ) -> str:
     """Generate a JSON schema (as JSON) for the passed model or dynamically generated one."""
     warnings.warn(
-        PydanticDeprecationWarning(
-            'schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', since=(2, 0)
-        ),
+        'schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.',
+        PydanticDeprecatedSince20,
         stacklevel=2,
     )
     return json.dumps(

--- a/pydantic/deprecated/tools.py
+++ b/pydantic/deprecated/tools.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Any, Callable, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Type, TypeVar, Union
 
 from typing_extensions import deprecated
 
 from ..json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema
 from ..type_adapter import TypeAdapter
 from ..warnings import PydanticDeprecatedSince20
+
+if not TYPE_CHECKING:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'parse_obj_as', 'schema_of', 'schema_json_of'
 
@@ -22,13 +26,13 @@ T = TypeVar('T')
 def parse_obj_as(type_: type[T], obj: Any, type_name: NameFactory | None = None) -> T:
     warnings.warn(
         'parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.',
-        PydanticDeprecatedSince20,
+        DeprecationWarning,
         stacklevel=2,
     )
     if type_name is not None:  # pragma: no cover
         warnings.warn(
             'The type_name parameter is deprecated. parse_obj_as no longer creates temporary models',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
             stacklevel=2,
         )
     return TypeAdapter(type_).validate_python(obj)
@@ -45,9 +49,7 @@ def schema_of(
 ) -> dict[str, Any]:
     """Generate a JSON schema (as dict) for the passed model or dynamically generated one."""
     warnings.warn(
-        'schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.',
-        PydanticDeprecatedSince20,
-        stacklevel=2,
+        'schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', DeprecationWarning, stacklevel=2
     )
     res = TypeAdapter(type_).json_schema(
         by_alias=by_alias,
@@ -60,7 +62,7 @@ def schema_of(
         else:
             warnings.warn(
                 'Passing a callable for the `title` parameter is deprecated and no longer supported',
-                PydanticDeprecatedSince20,
+                DeprecationWarning,
                 stacklevel=2,
             )
             res['title'] = title(type_)
@@ -79,9 +81,7 @@ def schema_json_of(
 ) -> str:
     """Generate a JSON schema (as JSON) for the passed model or dynamically generated one."""
     warnings.warn(
-        'schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.',
-        PydanticDeprecatedSince20,
-        stacklevel=2,
+        'schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.', DeprecationWarning, stacklevel=2
     )
     return json.dumps(
         schema_of(type_, title=title, by_alias=by_alias, ref_template=ref_template, schema_generator=schema_generator),

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -18,6 +18,7 @@ from typing_extensions import Unpack
 from . import types
 from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra, _utils
 from .errors import PydanticUserError
+from .warnings import PydanticDeprecationWarning
 
 if typing.TYPE_CHECKING:
     from ._internal._repr import ReprArgs
@@ -670,13 +671,21 @@ def Field(  # C901
 
     min_items = extra.pop('min_items', None)  # type: ignore
     if min_items is not None:
-        warn('`min_items` is deprecated and will be removed, use `min_length` instead', DeprecationWarning)
+        warn(
+            PydanticDeprecationWarning(
+                '`min_items` is deprecated and will be removed, use `min_length` instead', since=(2, 0)
+            )
+        )
         if min_length is None:
             min_length = min_items  # type: ignore
 
     max_items = extra.pop('max_items', None)  # type: ignore
     if max_items is not None:
-        warn('`max_items` is deprecated and will be removed, use `max_length` instead', DeprecationWarning)
+        warn(
+            PydanticDeprecationWarning(
+                '`max_items` is deprecated and will be removed, use `max_length` instead', since=(2, 0)
+            )
+        )
         if max_length is None:
             max_length = max_items  # type: ignore
 
@@ -692,7 +701,11 @@ def Field(  # C901
 
     allow_mutation = extra.pop('allow_mutation', None)  # type: ignore
     if allow_mutation is not None:
-        warn('`allow_mutation` is deprecated and will be removed. use `frozen` instead', DeprecationWarning)
+        warn(
+            PydanticDeprecationWarning(
+                '`allow_mutation` is deprecated and will be removed. use `frozen` instead', since=(2, 0)
+            )
+        )
         if allow_mutation is False:
             frozen = True
 
@@ -702,8 +715,10 @@ def Field(  # C901
 
     if extra:
         warn(
-            'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead',
+                since=(2, 0),
+            )
         )
         if not json_schema_extra:
             json_schema_extra = extra  # type: ignore

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -18,7 +18,7 @@ from typing_extensions import Unpack
 from . import types
 from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra, _utils
 from .errors import PydanticUserError
-from .warnings import PydanticDeprecationWarning
+from .warnings import PydanticDeprecatedSince20
 
 if typing.TYPE_CHECKING:
     from ._internal._repr import ReprArgs
@@ -671,21 +671,13 @@ def Field(  # C901
 
     min_items = extra.pop('min_items', None)  # type: ignore
     if min_items is not None:
-        warn(
-            PydanticDeprecationWarning(
-                '`min_items` is deprecated and will be removed, use `min_length` instead', since=(2, 0)
-            )
-        )
+        warn('`min_items` is deprecated and will be removed, use `min_length` instead', PydanticDeprecatedSince20)
         if min_length is None:
             min_length = min_items  # type: ignore
 
     max_items = extra.pop('max_items', None)  # type: ignore
     if max_items is not None:
-        warn(
-            PydanticDeprecationWarning(
-                '`max_items` is deprecated and will be removed, use `max_length` instead', since=(2, 0)
-            )
-        )
+        warn('`max_items` is deprecated and will be removed, use `max_length` instead', PydanticDeprecatedSince20)
         if max_length is None:
             max_length = max_items  # type: ignore
 
@@ -701,11 +693,7 @@ def Field(  # C901
 
     allow_mutation = extra.pop('allow_mutation', None)  # type: ignore
     if allow_mutation is not None:
-        warn(
-            PydanticDeprecationWarning(
-                '`allow_mutation` is deprecated and will be removed. use `frozen` instead', since=(2, 0)
-            )
-        )
+        warn('`allow_mutation` is deprecated and will be removed. use `frozen` instead', PydanticDeprecatedSince20)
         if allow_mutation is False:
             frozen = True
 
@@ -715,10 +703,8 @@ def Field(  # C901
 
     if extra:
         warn(
-            PydanticDeprecationWarning(
-                'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead',
-                since=(2, 0),
-            )
+            'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead',
+            PydanticDeprecatedSince20,
         )
         if not json_schema_extra:
             json_schema_extra = extra  # type: ignore

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -23,7 +23,8 @@ from .warnings import PydanticDeprecatedSince20
 if typing.TYPE_CHECKING:
     from ._internal._repr import ReprArgs
 else:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -22,6 +22,9 @@ from .warnings import PydanticDeprecatedSince20
 
 if typing.TYPE_CHECKING:
     from ._internal._repr import ReprArgs
+else:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 
 class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
@@ -671,13 +674,13 @@ def Field(  # C901
 
     min_items = extra.pop('min_items', None)  # type: ignore
     if min_items is not None:
-        warn('`min_items` is deprecated and will be removed, use `min_length` instead', PydanticDeprecatedSince20)
+        warn('`min_items` is deprecated and will be removed, use `min_length` instead', DeprecationWarning)
         if min_length is None:
             min_length = min_items  # type: ignore
 
     max_items = extra.pop('max_items', None)  # type: ignore
     if max_items is not None:
-        warn('`max_items` is deprecated and will be removed, use `max_length` instead', PydanticDeprecatedSince20)
+        warn('`max_items` is deprecated and will be removed, use `max_length` instead', DeprecationWarning)
         if max_length is None:
             max_length = max_items  # type: ignore
 
@@ -693,7 +696,7 @@ def Field(  # C901
 
     allow_mutation = extra.pop('allow_mutation', None)  # type: ignore
     if allow_mutation is not None:
-        warn('`allow_mutation` is deprecated and will be removed. use `frozen` instead', PydanticDeprecatedSince20)
+        warn('`allow_mutation` is deprecated and will be removed. use `frozen` instead', DeprecationWarning)
         if allow_mutation is False:
             frozen = True
 
@@ -704,7 +707,7 @@ def Field(  # C901
     if extra:
         warn(
             'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
         )
         if not json_schema_extra:
             json_schema_extra = extra  # type: ignore

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -48,6 +48,9 @@ if typing.TYPE_CHECKING:
     Model = typing.TypeVar('Model', bound='BaseModel')
     # should be `set[int] | set[str] | dict[int, IncEx] | dict[str, IncEx] | None`, but mypy can't cope
     IncEx: typing_extensions.TypeAlias = 'set[int] | set[str] | dict[int, Any] | dict[str, Any] | None'
+else:
+    # See PyCharm issues PY-21915 and PY-51428
+    DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'BaseModel', 'create_model'
 
@@ -822,16 +825,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @property
     @typing_extensions.deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
     def __fields__(self) -> dict[str, FieldInfo]:
-        warnings.warn(
-            'The `__fields__` attribute is deprecated, use `model_fields` instead.', PydanticDeprecatedSince20
-        )
+        warnings.warn('The `__fields__` attribute is deprecated, use `model_fields` instead.', DeprecationWarning)
         return self.model_fields
 
     @property
     @typing_extensions.deprecated('The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.')
     def __fields_set__(self) -> set[str]:
         warnings.warn(
-            'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.', PydanticDeprecatedSince20
+            'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.', DeprecationWarning
         )
         return self.__pydantic_fields_set__
 
@@ -846,7 +847,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> typing.Dict[str, Any]:  # noqa UP006
-        warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', PydanticDeprecatedSince20)
+        warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', DeprecationWarning)
         return self.model_dump(
             include=include,
             exclude=exclude,
@@ -870,7 +871,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         models_as_dict: bool = PydanticUndefined,  # type: ignore[assignment]
         **dumps_kwargs: Any,
     ) -> str:
-        warnings.warn('The `json` method is deprecated; use `model_dump_json` instead.', PydanticDeprecatedSince20)
+        warnings.warn('The `json` method is deprecated; use `model_dump_json` instead.', DeprecationWarning)
         if encoder is not PydanticUndefined:
             raise TypeError('The `encoder` argument is no longer supported; use field serializers instead.')
         if models_as_dict is not PydanticUndefined:
@@ -889,7 +890,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `parse_obj` method is deprecated; use `model_validate` instead.')
     def parse_obj(cls: type[Model], obj: Any) -> Model:  # noqa: D102
-        warnings.warn('The `parse_obj` method is deprecated; use `model_validate` instead.', PydanticDeprecatedSince20)
+        warnings.warn('The `parse_obj` method is deprecated; use `model_validate` instead.', DeprecationWarning)
         return cls.model_validate(obj)
 
     @classmethod
@@ -909,7 +910,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, '
             'otherwise load the data then use `model_validate` instead.',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
         )
         try:
             obj = _deprecated_parse.load_str_bytes(
@@ -959,7 +960,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
             'use `model_json_validate` otherwise `model_validate` instead.',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
         )
         obj = _deprecated_parse.load_file(
             path,
@@ -979,7 +980,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The `from_orm` method is deprecated; set `model_config["from_attributes"]=True` '
             'and use `model_validate` instead.',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
         )
         if not cls.model_config.get('from_attributes', None):
             raise PydanticUserError(
@@ -990,7 +991,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `construct` method is deprecated; use `model_construct` instead.')
     def construct(cls: type[Model], _fields_set: set[str] | None = None, **values: Any) -> Model:  # noqa: D102
-        warnings.warn('The `construct` method is deprecated; use `model_construct` instead.', PydanticDeprecatedSince20)
+        warnings.warn('The `construct` method is deprecated; use `model_construct` instead.', DeprecationWarning)
         return cls.model_construct(_fields_set=_fields_set, **values)
 
     @typing_extensions.deprecated('The copy method is deprecated; use `model_copy` instead.')
@@ -1027,7 +1028,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The `copy` method is deprecated; use `model_copy` instead. '
             'See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`.',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
         )
 
         values = dict(
@@ -1069,7 +1070,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     def schema(  # noqa: D102
         cls, by_alias: bool = True, ref_template: str = DEFAULT_REF_TEMPLATE
     ) -> typing.Dict[str, Any]:  # noqa UP006
-        warnings.warn('The `schema` method is deprecated; use `model_json_schema` instead.', PydanticDeprecatedSince20)
+        warnings.warn('The `schema` method is deprecated; use `model_json_schema` instead.', DeprecationWarning)
         return cls.model_json_schema(by_alias=by_alias, ref_template=ref_template)
 
     @classmethod
@@ -1083,7 +1084,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         warnings.warn(
             'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
         )
         from .deprecated.json import pydantic_encoder
 
@@ -1096,14 +1097,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `validate` method is deprecated; use `model_validate` instead.')
     def validate(cls: type[Model], value: Any) -> Model:  # noqa: D102
-        warnings.warn('The `validate` method is deprecated; use `model_validate` instead.', PydanticDeprecatedSince20)
+        warnings.warn('The `validate` method is deprecated; use `model_validate` instead.', DeprecationWarning)
         return cls.model_validate(value)
 
     @classmethod
     @typing_extensions.deprecated('The `update_forward_refs` method is deprecated; use `model_rebuild` instead.')
     def update_forward_refs(cls, **localns: Any) -> None:  # noqa: D102
         warnings.warn(
-            'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.', PydanticDeprecatedSince20
+            'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.', DeprecationWarning
         )
         if localns:  # pragma: no cover
             raise TypeError('`localns` arguments are not longer accepted.')
@@ -1111,9 +1112,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     @typing_extensions.deprecated('The private method `_iter` will be removed and should no longer be used.')
     def _iter(self, *args: Any, **kwargs: Any) -> Any:
-        warnings.warn(
-            'The private method `_iter` will be removed and should no longer be used.', PydanticDeprecatedSince20
-        )
+        warnings.warn('The private method `_iter` will be removed and should no longer be used.', DeprecationWarning)
         return _deprecated_copy_internals._iter(self, *args, **kwargs)  # type: ignore
 
     @typing_extensions.deprecated(
@@ -1122,7 +1121,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     def _copy_and_set_values(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
             'The private method  `_copy_and_set_values` will be removed and should no longer be used.',
-            PydanticDeprecatedSince20,
+            DeprecationWarning,
         )
         return _deprecated_copy_internals._copy_and_set_values(self, *args, **kwargs)  # type: ignore
 
@@ -1130,15 +1129,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The private method `_get_value` will be removed and should no longer be used.')
     def _get_value(cls, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            'The private method  `_get_value` will be removed and should no longer be used.', PydanticDeprecatedSince20
+            'The private method  `_get_value` will be removed and should no longer be used.', DeprecationWarning
         )
         return _deprecated_copy_internals._get_value(cls, *args, **kwargs)  # type: ignore
 
     @typing_extensions.deprecated('The private method `_calculate_keys` will be removed and should no longer be used.')
     def _calculate_keys(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            'The private method `_calculate_keys` will be removed and should no longer be used.',
-            PydanticDeprecatedSince20,
+            'The private method `_calculate_keys` will be removed and should no longer be used.', DeprecationWarning
         )
         return _deprecated_copy_internals._calculate_keys(self, *args, **kwargs)  # type: ignore
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -49,7 +49,8 @@ if typing.TYPE_CHECKING:
     # should be `set[int] | set[str] | dict[int, IncEx] | dict[str, IncEx] | None`, but mypy can't cope
     IncEx: typing_extensions.TypeAlias = 'set[int] | set[str] | dict[int, Any] | dict[str, Any] | None'
 else:
-    # See PyCharm issues PY-21915 and PY-51428
+    # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
+    # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
 __all__ = 'BaseModel', 'create_model'
@@ -823,20 +824,27 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     # ##### Deprecated methods from v1 #####
     @property
-    @typing_extensions.deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
+    @typing_extensions.deprecated(
+        'The `__fields__` attribute is deprecated, use `model_fields` instead.', category=PydanticDeprecatedSince20
+    )
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn('The `__fields__` attribute is deprecated, use `model_fields` instead.', DeprecationWarning)
         return self.model_fields
 
     @property
-    @typing_extensions.deprecated('The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.')
+    @typing_extensions.deprecated(
+        'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.',
+        category=PydanticDeprecatedSince20,
+    )
     def __fields_set__(self) -> set[str]:
         warnings.warn(
             'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.', DeprecationWarning
         )
         return self.__pydantic_fields_set__
 
-    @typing_extensions.deprecated('The `dict` method is deprecated; use `model_dump` instead.')
+    @typing_extensions.deprecated(
+        'The `dict` method is deprecated; use `model_dump` instead.', category=PydanticDeprecatedSince20
+    )
     def dict(  # noqa: D102
         self,
         *,
@@ -857,7 +865,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             exclude_none=exclude_none,
         )
 
-    @typing_extensions.deprecated('The `json` method is deprecated; use `model_dump_json` instead.')
+    @typing_extensions.deprecated(
+        'The `json` method is deprecated; use `model_dump_json` instead.', category=PydanticDeprecatedSince20
+    )
     def json(  # noqa: D102
         self,
         *,
@@ -888,7 +898,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         )
 
     @classmethod
-    @typing_extensions.deprecated('The `parse_obj` method is deprecated; use `model_validate` instead.')
+    @typing_extensions.deprecated(
+        'The `parse_obj` method is deprecated; use `model_validate` instead.', category=PydanticDeprecatedSince20
+    )
     def parse_obj(cls: type[Model], obj: Any) -> Model:  # noqa: D102
         warnings.warn('The `parse_obj` method is deprecated; use `model_validate` instead.', DeprecationWarning)
         return cls.model_validate(obj)
@@ -896,7 +908,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated(
         'The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, '
-        'otherwise load the data then use `model_validate` instead.'
+        'otherwise load the data then use `model_validate` instead.',
+        category=PydanticDeprecatedSince20,
     )
     def parse_raw(  # noqa: D102
         cls: type[Model],
@@ -946,7 +959,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated(
         'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
-        'use `model_json_validate` otherwise `model_validate` instead.'
+        'use `model_json_validate` otherwise `model_validate` instead.',
+        category=PydanticDeprecatedSince20,
     )
     def parse_file(  # noqa: D102
         cls: type[Model],
@@ -974,7 +988,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated(
         "The `from_orm` method is deprecated; set "
-        "`model_config['from_attributes']=True` and use `model_validate` instead."
+        "`model_config['from_attributes']=True` and use `model_validate` instead.",
+        category=PydanticDeprecatedSince20,
     )
     def from_orm(cls: type[Model], obj: Any) -> Model:  # noqa: D102
         warnings.warn(
@@ -989,12 +1004,16 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return cls.model_validate(obj)
 
     @classmethod
-    @typing_extensions.deprecated('The `construct` method is deprecated; use `model_construct` instead.')
+    @typing_extensions.deprecated(
+        'The `construct` method is deprecated; use `model_construct` instead.', category=PydanticDeprecatedSince20
+    )
     def construct(cls: type[Model], _fields_set: set[str] | None = None, **values: Any) -> Model:  # noqa: D102
         warnings.warn('The `construct` method is deprecated; use `model_construct` instead.', DeprecationWarning)
         return cls.model_construct(_fields_set=_fields_set, **values)
 
-    @typing_extensions.deprecated('The copy method is deprecated; use `model_copy` instead.')
+    @typing_extensions.deprecated(
+        'The copy method is deprecated; use `model_copy` instead.', category=PydanticDeprecatedSince20
+    )
     def copy(
         self: Model,
         *,
@@ -1066,7 +1085,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return _deprecated_copy_internals._copy_and_set_values(self, values, fields_set, extra, private, deep=deep)
 
     @classmethod
-    @typing_extensions.deprecated('The `schema` method is deprecated; use `model_json_schema` instead.')
+    @typing_extensions.deprecated(
+        'The `schema` method is deprecated; use `model_json_schema` instead.', category=PydanticDeprecatedSince20
+    )
     def schema(  # noqa: D102
         cls, by_alias: bool = True, ref_template: str = DEFAULT_REF_TEMPLATE
     ) -> typing.Dict[str, Any]:  # noqa UP006
@@ -1075,7 +1096,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     @classmethod
     @typing_extensions.deprecated(
-        'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.'
+        'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.',
+        category=PydanticDeprecatedSince20,
     )
     def schema_json(  # noqa: D102
         cls, *, by_alias: bool = True, ref_template: str = DEFAULT_REF_TEMPLATE, **dumps_kwargs: Any
@@ -1095,13 +1117,18 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         )
 
     @classmethod
-    @typing_extensions.deprecated('The `validate` method is deprecated; use `model_validate` instead.')
+    @typing_extensions.deprecated(
+        'The `validate` method is deprecated; use `model_validate` instead.', category=PydanticDeprecatedSince20
+    )
     def validate(cls: type[Model], value: Any) -> Model:  # noqa: D102
         warnings.warn('The `validate` method is deprecated; use `model_validate` instead.', DeprecationWarning)
         return cls.model_validate(value)
 
     @classmethod
-    @typing_extensions.deprecated('The `update_forward_refs` method is deprecated; use `model_rebuild` instead.')
+    @typing_extensions.deprecated(
+        'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.',
+        category=PydanticDeprecatedSince20,
+    )
     def update_forward_refs(cls, **localns: Any) -> None:  # noqa: D102
         warnings.warn(
             'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.', DeprecationWarning
@@ -1110,13 +1137,16 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             raise TypeError('`localns` arguments are not longer accepted.')
         cls.model_rebuild(force=True)
 
-    @typing_extensions.deprecated('The private method `_iter` will be removed and should no longer be used.')
+    @typing_extensions.deprecated(
+        'The private method `_iter` will be removed and should no longer be used.', category=PydanticDeprecatedSince20
+    )
     def _iter(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn('The private method `_iter` will be removed and should no longer be used.', DeprecationWarning)
         return _deprecated_copy_internals._iter(self, *args, **kwargs)  # type: ignore
 
     @typing_extensions.deprecated(
-        'The private method `_copy_and_set_values` will be removed and should no longer be used.'
+        'The private method `_copy_and_set_values` will be removed and should no longer be used.',
+        category=PydanticDeprecatedSince20,
     )
     def _copy_and_set_values(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
@@ -1126,14 +1156,20 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return _deprecated_copy_internals._copy_and_set_values(self, *args, **kwargs)  # type: ignore
 
     @classmethod
-    @typing_extensions.deprecated('The private method `_get_value` will be removed and should no longer be used.')
+    @typing_extensions.deprecated(
+        'The private method `_get_value` will be removed and should no longer be used.',
+        category=PydanticDeprecatedSince20,
+    )
     def _get_value(cls, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
             'The private method  `_get_value` will be removed and should no longer be used.', DeprecationWarning
         )
         return _deprecated_copy_internals._get_value(cls, *args, **kwargs)  # type: ignore
 
-    @typing_extensions.deprecated('The private method `_calculate_keys` will be removed and should no longer be used.')
+    @typing_extensions.deprecated(
+        'The private method `_calculate_keys` will be removed and should no longer be used.',
+        category=PydanticDeprecatedSince20,
+    )
     def _calculate_keys(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
             'The private method `_calculate_keys` will be removed and should no longer be used.', DeprecationWarning

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -31,6 +31,7 @@ from .deprecated import parse as _deprecated_parse
 from .errors import PydanticUndefinedAnnotation, PydanticUserError
 from .fields import ComputedFieldInfo, FieldInfo, ModelPrivateAttr
 from .json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMode, JsonSchemaValue, model_json_schema
+from .warnings import PydanticDeprecationWarning
 
 if typing.TYPE_CHECKING:
     from inspect import Signature
@@ -821,14 +822,20 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @property
     @typing_extensions.deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
     def __fields__(self) -> dict[str, FieldInfo]:
-        warnings.warn('The `__fields__` attribute is deprecated, use `model_fields` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning(
+                'The `__fields__` attribute is deprecated, use `model_fields` instead.', since=(2, 0)
+            )
+        )
         return self.model_fields
 
     @property
     @typing_extensions.deprecated('The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.')
     def __fields_set__(self) -> set[str]:
         warnings.warn(
-            'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.', DeprecationWarning
+            PydanticDeprecationWarning(
+                'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.', since=(2, 0)
+            )
         )
         return self.__pydantic_fields_set__
 
@@ -843,7 +850,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> typing.Dict[str, Any]:  # noqa UP006
-        warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning('The `dict` method is deprecated; use `model_dump` instead.', since=(2, 0))
+        )
         return self.model_dump(
             include=include,
             exclude=exclude,
@@ -867,7 +876,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         models_as_dict: bool = PydanticUndefined,  # type: ignore[assignment]
         **dumps_kwargs: Any,
     ) -> str:
-        warnings.warn('The `json` method is deprecated; use `model_dump_json` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning('The `json` method is deprecated; use `model_dump_json` instead.', since=(2, 0))
+        )
         if encoder is not PydanticUndefined:
             raise TypeError('The `encoder` argument is no longer supported; use field serializers instead.')
         if models_as_dict is not PydanticUndefined:
@@ -886,7 +897,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `parse_obj` method is deprecated; use `model_validate` instead.')
     def parse_obj(cls: type[Model], obj: Any) -> Model:  # noqa: D102
-        warnings.warn('The `parse_obj` method is deprecated; use `model_validate` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning(
+                'The `parse_obj` method is deprecated; use `model_validate` instead.', since=(2, 0)
+            )
+        )
         return cls.model_validate(obj)
 
     @classmethod
@@ -904,9 +919,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         allow_pickle: bool = False,
     ) -> Model:  # pragma: no cover
         warnings.warn(
-            'The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, '
-            'otherwise load the data then use `model_validate` instead.',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, '
+                'otherwise load the data then use `model_validate` instead.',
+                since=(2, 0),
+            )
         )
         try:
             obj = _deprecated_parse.load_str_bytes(
@@ -954,9 +971,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         allow_pickle: bool = False,
     ) -> Model:
         warnings.warn(
-            'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
-            'use `model_json_validate` otherwise `model_validate` instead.',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
+                'use `model_json_validate` otherwise `model_validate` instead.',
+                since=(2, 0),
+            ),
         )
         obj = _deprecated_parse.load_file(
             path,
@@ -974,9 +993,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     )
     def from_orm(cls: type[Model], obj: Any) -> Model:  # noqa: D102
         warnings.warn(
-            'The `from_orm` method is deprecated; set `model_config["from_attributes"]=True` '
-            'and use `model_validate` instead.',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'The `from_orm` method is deprecated; set `model_config["from_attributes"]=True` '
+                'and use `model_validate` instead.',
+                since=(2, 0),
+            )
         )
         if not cls.model_config.get('from_attributes', None):
             raise PydanticUserError(
@@ -987,7 +1008,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `construct` method is deprecated; use `model_construct` instead.')
     def construct(cls: type[Model], _fields_set: set[str] | None = None, **values: Any) -> Model:  # noqa: D102
-        warnings.warn('The `construct` method is deprecated; use `model_construct` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning(
+                'The `construct` method is deprecated; use `model_construct` instead.', since=(2, 0)
+            )
+        )
         return cls.model_construct(_fields_set=_fields_set, **values)
 
     @typing_extensions.deprecated('The copy method is deprecated; use `model_copy` instead.')
@@ -1022,9 +1047,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             A copy of the model with included, excluded and updated fields as specified.
         """
         warnings.warn(
-            'The `copy` method is deprecated; use `model_copy` instead. '
-            'See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`.',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'The `copy` method is deprecated; use `model_copy` instead. '
+                'See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`.',
+                since=(2, 0),
+            )
         )
 
         values = dict(
@@ -1066,7 +1093,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     def schema(  # noqa: D102
         cls, by_alias: bool = True, ref_template: str = DEFAULT_REF_TEMPLATE
     ) -> typing.Dict[str, Any]:  # noqa UP006
-        warnings.warn('The `schema` method is deprecated; use `model_json_schema` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning(
+                'The `schema` method is deprecated; use `model_json_schema` instead.', since=(2, 0)
+            )
+        )
         return cls.model_json_schema(by_alias=by_alias, ref_template=ref_template)
 
     @classmethod
@@ -1079,8 +1110,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         import json
 
         warnings.warn(
-            'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.', since=(2, 0)
+            )
         )
         from .deprecated.json import pydantic_encoder
 
@@ -1093,14 +1125,20 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `validate` method is deprecated; use `model_validate` instead.')
     def validate(cls: type[Model], value: Any) -> Model:  # noqa: D102
-        warnings.warn('The `validate` method is deprecated; use `model_validate` instead.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning(
+                'The `validate` method is deprecated; use `model_validate` instead.', since=(2, 0)
+            )
+        )
         return cls.model_validate(value)
 
     @classmethod
     @typing_extensions.deprecated('The `update_forward_refs` method is deprecated; use `model_rebuild` instead.')
     def update_forward_refs(cls, **localns: Any) -> None:  # noqa: D102
         warnings.warn(
-            'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.', DeprecationWarning
+            PydanticDeprecationWarning(
+                'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.', since=(2, 0)
+            )
         )
         if localns:  # pragma: no cover
             raise TypeError('`localns` arguments are not longer accepted.')
@@ -1108,7 +1146,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     @typing_extensions.deprecated('The private method `_iter` will be removed and should no longer be used.')
     def _iter(self, *args: Any, **kwargs: Any) -> Any:
-        warnings.warn('The private method `_iter` will be removed and should no longer be used.', DeprecationWarning)
+        warnings.warn(
+            PydanticDeprecationWarning(
+                'The private method `_iter` will be removed and should no longer be used.', since=(2, 0)
+            )
+        )
         return _deprecated_copy_internals._iter(self, *args, **kwargs)  # type: ignore
 
     @typing_extensions.deprecated(
@@ -1116,8 +1158,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     )
     def _copy_and_set_values(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            'The private method  `_copy_and_set_values` will be removed and should no longer be used.',
-            DeprecationWarning,
+            PydanticDeprecationWarning(
+                'The private method  `_copy_and_set_values` will be removed and should no longer be used.', since=(2, 0)
+            )
         )
         return _deprecated_copy_internals._copy_and_set_values(self, *args, **kwargs)  # type: ignore
 
@@ -1125,14 +1168,18 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The private method `_get_value` will be removed and should no longer be used.')
     def _get_value(cls, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            'The private method  `_get_value` will be removed and should no longer be used.', DeprecationWarning
+            PydanticDeprecationWarning(
+                'The private method  `_get_value` will be removed and should no longer be used.', since=(2, 0)
+            )
         )
         return _deprecated_copy_internals._get_value(cls, *args, **kwargs)  # type: ignore
 
     @typing_extensions.deprecated('The private method `_calculate_keys` will be removed and should no longer be used.')
     def _calculate_keys(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            'The private method `_calculate_keys` will be removed and should no longer be used.', DeprecationWarning
+            PydanticDeprecationWarning(
+                'The private method `_calculate_keys` will be removed and should no longer be used.', since=(2, 0)
+            )
         )
         return _deprecated_copy_internals._calculate_keys(self, *args, **kwargs)  # type: ignore
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -31,7 +31,7 @@ from .deprecated import parse as _deprecated_parse
 from .errors import PydanticUndefinedAnnotation, PydanticUserError
 from .fields import ComputedFieldInfo, FieldInfo, ModelPrivateAttr
 from .json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMode, JsonSchemaValue, model_json_schema
-from .warnings import PydanticDeprecationWarning
+from .warnings import PydanticDeprecatedSince20
 
 if typing.TYPE_CHECKING:
     from inspect import Signature
@@ -823,9 +823,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.')
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `__fields__` attribute is deprecated, use `model_fields` instead.', since=(2, 0)
-            )
+            'The `__fields__` attribute is deprecated, use `model_fields` instead.', PydanticDeprecatedSince20
         )
         return self.model_fields
 
@@ -833,9 +831,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.')
     def __fields_set__(self) -> set[str]:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.', since=(2, 0)
-            )
+            'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.', PydanticDeprecatedSince20
         )
         return self.__pydantic_fields_set__
 
@@ -850,9 +846,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> typing.Dict[str, Any]:  # noqa UP006
-        warnings.warn(
-            PydanticDeprecationWarning('The `dict` method is deprecated; use `model_dump` instead.', since=(2, 0))
-        )
+        warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', PydanticDeprecatedSince20)
         return self.model_dump(
             include=include,
             exclude=exclude,
@@ -876,9 +870,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         models_as_dict: bool = PydanticUndefined,  # type: ignore[assignment]
         **dumps_kwargs: Any,
     ) -> str:
-        warnings.warn(
-            PydanticDeprecationWarning('The `json` method is deprecated; use `model_dump_json` instead.', since=(2, 0))
-        )
+        warnings.warn('The `json` method is deprecated; use `model_dump_json` instead.', PydanticDeprecatedSince20)
         if encoder is not PydanticUndefined:
             raise TypeError('The `encoder` argument is no longer supported; use field serializers instead.')
         if models_as_dict is not PydanticUndefined:
@@ -897,11 +889,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `parse_obj` method is deprecated; use `model_validate` instead.')
     def parse_obj(cls: type[Model], obj: Any) -> Model:  # noqa: D102
-        warnings.warn(
-            PydanticDeprecationWarning(
-                'The `parse_obj` method is deprecated; use `model_validate` instead.', since=(2, 0)
-            )
-        )
+        warnings.warn('The `parse_obj` method is deprecated; use `model_validate` instead.', PydanticDeprecatedSince20)
         return cls.model_validate(obj)
 
     @classmethod
@@ -919,11 +907,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         allow_pickle: bool = False,
     ) -> Model:  # pragma: no cover
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, '
-                'otherwise load the data then use `model_validate` instead.',
-                since=(2, 0),
-            )
+            'The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, '
+            'otherwise load the data then use `model_validate` instead.',
+            PydanticDeprecatedSince20,
         )
         try:
             obj = _deprecated_parse.load_str_bytes(
@@ -971,11 +957,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         allow_pickle: bool = False,
     ) -> Model:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
-                'use `model_json_validate` otherwise `model_validate` instead.',
-                since=(2, 0),
-            ),
+            'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
+            'use `model_json_validate` otherwise `model_validate` instead.',
+            PydanticDeprecatedSince20,
         )
         obj = _deprecated_parse.load_file(
             path,
@@ -993,11 +977,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     )
     def from_orm(cls: type[Model], obj: Any) -> Model:  # noqa: D102
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `from_orm` method is deprecated; set `model_config["from_attributes"]=True` '
-                'and use `model_validate` instead.',
-                since=(2, 0),
-            )
+            'The `from_orm` method is deprecated; set `model_config["from_attributes"]=True` '
+            'and use `model_validate` instead.',
+            PydanticDeprecatedSince20,
         )
         if not cls.model_config.get('from_attributes', None):
             raise PydanticUserError(
@@ -1008,11 +990,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `construct` method is deprecated; use `model_construct` instead.')
     def construct(cls: type[Model], _fields_set: set[str] | None = None, **values: Any) -> Model:  # noqa: D102
-        warnings.warn(
-            PydanticDeprecationWarning(
-                'The `construct` method is deprecated; use `model_construct` instead.', since=(2, 0)
-            )
-        )
+        warnings.warn('The `construct` method is deprecated; use `model_construct` instead.', PydanticDeprecatedSince20)
         return cls.model_construct(_fields_set=_fields_set, **values)
 
     @typing_extensions.deprecated('The copy method is deprecated; use `model_copy` instead.')
@@ -1047,11 +1025,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             A copy of the model with included, excluded and updated fields as specified.
         """
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `copy` method is deprecated; use `model_copy` instead. '
-                'See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`.',
-                since=(2, 0),
-            )
+            'The `copy` method is deprecated; use `model_copy` instead. '
+            'See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`.',
+            PydanticDeprecatedSince20,
         )
 
         values = dict(
@@ -1093,11 +1069,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     def schema(  # noqa: D102
         cls, by_alias: bool = True, ref_template: str = DEFAULT_REF_TEMPLATE
     ) -> typing.Dict[str, Any]:  # noqa UP006
-        warnings.warn(
-            PydanticDeprecationWarning(
-                'The `schema` method is deprecated; use `model_json_schema` instead.', since=(2, 0)
-            )
-        )
+        warnings.warn('The `schema` method is deprecated; use `model_json_schema` instead.', PydanticDeprecatedSince20)
         return cls.model_json_schema(by_alias=by_alias, ref_template=ref_template)
 
     @classmethod
@@ -1110,9 +1082,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         import json
 
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.', since=(2, 0)
-            )
+            'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.',
+            PydanticDeprecatedSince20,
         )
         from .deprecated.json import pydantic_encoder
 
@@ -1125,20 +1096,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated('The `validate` method is deprecated; use `model_validate` instead.')
     def validate(cls: type[Model], value: Any) -> Model:  # noqa: D102
-        warnings.warn(
-            PydanticDeprecationWarning(
-                'The `validate` method is deprecated; use `model_validate` instead.', since=(2, 0)
-            )
-        )
+        warnings.warn('The `validate` method is deprecated; use `model_validate` instead.', PydanticDeprecatedSince20)
         return cls.model_validate(value)
 
     @classmethod
     @typing_extensions.deprecated('The `update_forward_refs` method is deprecated; use `model_rebuild` instead.')
     def update_forward_refs(cls, **localns: Any) -> None:  # noqa: D102
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.', since=(2, 0)
-            )
+            'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.', PydanticDeprecatedSince20
         )
         if localns:  # pragma: no cover
             raise TypeError('`localns` arguments are not longer accepted.')
@@ -1147,9 +1112,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The private method `_iter` will be removed and should no longer be used.')
     def _iter(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The private method `_iter` will be removed and should no longer be used.', since=(2, 0)
-            )
+            'The private method `_iter` will be removed and should no longer be used.', PydanticDeprecatedSince20
         )
         return _deprecated_copy_internals._iter(self, *args, **kwargs)  # type: ignore
 
@@ -1158,9 +1121,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     )
     def _copy_and_set_values(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The private method  `_copy_and_set_values` will be removed and should no longer be used.', since=(2, 0)
-            )
+            'The private method  `_copy_and_set_values` will be removed and should no longer be used.',
+            PydanticDeprecatedSince20,
         )
         return _deprecated_copy_internals._copy_and_set_values(self, *args, **kwargs)  # type: ignore
 
@@ -1168,18 +1130,15 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The private method `_get_value` will be removed and should no longer be used.')
     def _get_value(cls, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The private method  `_get_value` will be removed and should no longer be used.', since=(2, 0)
-            )
+            'The private method  `_get_value` will be removed and should no longer be used.', PydanticDeprecatedSince20
         )
         return _deprecated_copy_internals._get_value(cls, *args, **kwargs)  # type: ignore
 
     @typing_extensions.deprecated('The private method `_calculate_keys` will be removed and should no longer be used.')
     def _calculate_keys(self, *args: Any, **kwargs: Any) -> Any:
         warnings.warn(
-            PydanticDeprecationWarning(
-                'The private method `_calculate_keys` will be removed and should no longer be used.', since=(2, 0)
-            )
+            'The private method `_calculate_keys` will be removed and should no longer be used.',
+            PydanticDeprecatedSince20,
         )
         return _deprecated_copy_internals._calculate_keys(self, *args, **kwargs)  # type: ignore
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -41,6 +41,7 @@ from ._migration import getattr_migration
 from .config import ConfigDict
 from .errors import PydanticUserError
 from .json_schema import JsonSchemaValue
+from .warnings import PydanticDeprecatedSince20
 
 __all__ = (
     'Strict',
@@ -773,7 +774,8 @@ class PaymentCardBrand(str, Enum):
 
 @deprecated(
     'The `PaymentCardNumber` class is deprecated, use `pydantic_extra_types` instead. '
-    'See https://pydantic-docs.helpmanual.io/usage/types/extra_types/payment_cards/.'
+    'See https://pydantic-docs.helpmanual.io/usage/types/extra_types/payment_cards/.',
+    category=PydanticDeprecatedSince20,
 )
 class PaymentCardNumber(str):
     """Based on: https://en.wikipedia.org/wiki/Payment_card_number."""

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -1,0 +1,38 @@
+"""Pydantic-specific warnings."""
+from __future__ import annotations as _annotations
+
+__all__ = ('PydanticDeprecationWarning',)
+
+
+class PydanticDeprecationWarning(DeprecationWarning):
+    """A Pydantic specific deprecation warning.
+
+    This warning is raised when using deprecated functionality in Pydantic. It provides information on when the
+    deprecation was introduced and the expected version in which the corresponding functionality will be removed.
+
+    Attributes:
+        message: Description of the warning.
+        since: Pydantic version in what the deprecation was introduced.
+        expected_removal: Pydantic version in what the corresponding functionality expected to be removed.
+    """
+
+    message: str
+    since: tuple[int, int]
+    expected_removal: tuple[int, int]
+
+    def __init__(
+        self, message: str, *args: object, since: tuple[int, int], expected_removal: tuple[int, int] | None = None
+    ) -> None:
+        super().__init__(message, *args)
+        self.message = message.rstrip('.')
+        self.since = since
+        self.expected_removal = expected_removal if expected_removal is not None else (since[0] + 1, 0)
+
+    def __str__(self) -> str:
+        message = (
+            f'{self.message}. Deprecated in Pydantic V{self.since[0]}.{self.since[1]}'
+            f' to be removed in V{self.expected_removal[0]}.{self.expected_removal[1]}.'
+        )
+        if self.since == (2, 0):
+            message += ' See Pydantic V2 Migration Guide at https://errors.pydantic.dev/v2.0/migration/'
+        return message

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -1,7 +1,7 @@
 """Pydantic-specific warnings."""
 from __future__ import annotations as _annotations
 
-__all__ = ('PydanticDeprecationWarning',)
+__all__ = 'PydanticDeprecatedSince20', 'PydanticDeprecationWarning'
 
 
 class PydanticDeprecationWarning(DeprecationWarning):
@@ -36,3 +36,10 @@ class PydanticDeprecationWarning(DeprecationWarning):
         if self.since == (2, 0):
             message += ' See Pydantic V2 Migration Guide at https://errors.pydantic.dev/v2.0/migration/'
         return message
+
+
+class PydanticDeprecatedSince20(PydanticDeprecationWarning):
+    """A specific `PydanticDeprecationWarning` subclass defining functionality deprecated since Pydantic 2.0."""
+
+    def __init__(self, message: str, *args: object) -> None:
+        super().__init__(message, *args, since=(2, 0))

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -1,6 +1,8 @@
 """Pydantic-specific warnings."""
 from __future__ import annotations as _annotations
 
+from .version import VERSION
+
 __all__ = 'PydanticDeprecatedSince20', 'PydanticDeprecationWarning'
 
 
@@ -34,7 +36,7 @@ class PydanticDeprecationWarning(DeprecationWarning):
             f' to be removed in V{self.expected_removal[0]}.{self.expected_removal[1]}.'
         )
         if self.since == (2, 0):
-            message += ' See Pydantic V2 Migration Guide at https://errors.pydantic.dev/v2.0/migration/'
+            message += f' See Pydantic V2 Migration Guide at https://errors.pydantic.dev/{VERSION}/migration/'
         return message
 
 
@@ -42,4 +44,4 @@ class PydanticDeprecatedSince20(PydanticDeprecationWarning):
     """A specific `PydanticDeprecationWarning` subclass defining functionality deprecated since Pydantic 2.0."""
 
     def __init__(self, message: str, *args: object) -> None:
-        super().__init__(message, *args, since=(2, 0))
+        super().__init__(message, *args, since=(2, 0), expected_removal=(3, 0))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from pydantic import (
     BaseModel,
     Field,
     PrivateAttr,
+    PydanticDeprecatedSince20,
     PydanticSchemaGenerationError,
     ValidationError,
     create_model,
@@ -338,7 +339,7 @@ class TestsBaseConfig:
 
     def test_config_class_is_deprecated(self):
         with pytest.warns(
-            DeprecationWarning, match='Support for class-based `config` is deprecated, use ConfigDict instead.'
+            PydanticDeprecatedSince20, match='Support for class-based `config` is deprecated, use ConfigDict instead.'
         ):
 
             class Config(BaseConfig):
@@ -346,19 +347,19 @@ class TestsBaseConfig:
 
     def test_config_class_attributes_are_deprecated(self):
         with pytest.warns(
-            DeprecationWarning,
+            PydanticDeprecatedSince20,
             match='Support for class-based `config` is deprecated, use ConfigDict instead.',
         ):
             assert BaseConfig.validate_assignment is False
 
         with pytest.warns(
-            DeprecationWarning,
+            PydanticDeprecatedSince20,
             match='Support for class-based `config` is deprecated, use ConfigDict instead.',
         ):
             assert BaseConfig().validate_assignment is False
 
         with pytest.warns(
-            DeprecationWarning,
+            PydanticDeprecatedSince20,
             match='Support for class-based `config` is deprecated, use ConfigDict instead.',
         ):
 
@@ -366,13 +367,13 @@ class TestsBaseConfig:
                 pass
 
         with pytest.warns(
-            DeprecationWarning,
+            PydanticDeprecatedSince20,
             match='Support for class-based `config` is deprecated, use ConfigDict instead.',
         ):
             assert Config.validate_assignment is False
 
         with pytest.warns(
-            DeprecationWarning,
+            PydanticDeprecatedSince20,
             match='Support for class-based `config` is deprecated, use ConfigDict instead.',
         ):
             assert Config().validate_assignment is False

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 import pytest
 from pydantic_core import PydanticUndefined, ValidationError
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, PydanticDeprecatedSince20
 
 
 class Model(BaseModel):
@@ -80,7 +80,7 @@ def deprecated_copy(m: BaseModel, *, include=None, exclude=None, update=None, de
     that have been removed from `model_copy`. Otherwise, use the `copy_method` fixture below
     """
     with pytest.warns(
-        DeprecationWarning,
+        PydanticDeprecatedSince20,
         match=(
             'The `copy` method is deprecated; use `model_copy` instead. '
             'See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`.'
@@ -412,7 +412,8 @@ def test_copy_update_exclude():
         }
 
     with pytest.warns(
-        DeprecationWarning, match='The private method `_calculate_keys` will be removed and should no longer be used.'
+        PydanticDeprecatedSince20,
+        match='The private method `_calculate_keys` will be removed and should no longer be used.',
     ):
         assert m._calculate_keys(exclude={'x': ...}, include=None, exclude_unset=False) == {'c', 'd'}
         assert m._calculate_keys(exclude={'x': ...}, include=None, exclude_unset=False, update={'c': 42}) == {'d'}

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -8,6 +8,7 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
+    PydanticDeprecatedSince20,
     PydanticUserError,
     ValidationError,
     create_model,
@@ -182,7 +183,7 @@ def test_inheritance_validators_always():
 
 
 def test_inheritance_validators_all():
-    with pytest.warns(DeprecationWarning, match='Pydantic V1 style `@validator` validators are deprecated'):
+    with pytest.warns(PydanticDeprecatedSince20, match='Pydantic V1 style `@validator` validators are deprecated'):
 
         class BarModel(BaseModel):
             @validator('*')

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -19,6 +19,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     FieldValidationInfo,
+    PydanticDeprecatedSince20,
     PydanticUndefinedAnnotation,
     PydanticUserError,
     TypeAdapter,
@@ -308,7 +309,7 @@ def test_post_init_inheritance_chain():
 
 
 def test_post_init_post_parse():
-    with pytest.warns(DeprecationWarning, match='Support for `__post_init_post_parse__` has been dropped'):
+    with pytest.warns(PydanticDeprecatedSince20, match='Support for `__post_init_post_parse__` has been dropped'):
 
         @pydantic.dataclasses.dataclass
         class MyDataclass:
@@ -1829,7 +1830,7 @@ def test_config_as_type_deprecated():
         validate_assignment = True
 
     with pytest.warns(
-        DeprecationWarning, match='Support for class-based `config` is deprecated, use ConfigDict instead.'
+        PydanticDeprecatedSince20, match='Support for class-based `config` is deprecated, use ConfigDict instead.'
     ):
 
         @pydantic.dataclasses.dataclass(config=Config)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -9,7 +9,16 @@ from typing import Any, Dict, List, Type
 import pytest
 from typing_extensions import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, ValidationError, conlist, root_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PydanticDeprecatedSince20,
+    PydanticUserError,
+    ValidationError,
+    conlist,
+    root_validator,
+)
 from pydantic.config import Extra
 from pydantic.deprecated.decorator import validate_arguments
 from pydantic.deprecated.json import custom_pydantic_encoder, pydantic_encoder, timedelta_isoformat
@@ -25,7 +34,7 @@ else:
 
 def deprecated_from_orm(model_type: Type[BaseModel], obj: Any) -> Any:
     with pytest.warns(
-        DeprecationWarning,
+        PydanticDeprecatedSince20,
         match=re.escape(
             'The `from_orm` method is deprecated; set `model_config["from_attributes"]=True` '
             'and use `model_validate` instead.'
@@ -45,7 +54,9 @@ def test_from_attributes_root():
         en_name: str
         jp_name: str
 
-    with pytest.warns(DeprecationWarning, match='Pydantic V1 style `@root_validator` validators are deprecated.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='Pydantic V1 style `@root_validator` validators are deprecated.'
+    ):
 
         class PokemonList(BaseModel):
             root: List[Pokemon]
@@ -78,7 +89,9 @@ def test_from_attributes_root():
         Pokemon(en_name='Bulbasaur', jp_name='フシギダネ'),
     ]
 
-    with pytest.warns(DeprecationWarning, match='Pydantic V1 style `@root_validator` validators are deprecated.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='Pydantic V1 style `@root_validator` validators are deprecated.'
+    ):
 
         class PokemonDict(BaseModel):
             root: Dict[str, Pokemon]
@@ -261,7 +274,7 @@ def test_parse_raw_pass():
         x: int
         y: int
 
-    with pytest.warns(DeprecationWarning, match='The `parse_raw` method is deprecated'):
+    with pytest.warns(PydanticDeprecatedSince20, match='The `parse_raw` method is deprecated'):
         model = Model.parse_raw('{"x": 1, "y": 2}')
     assert model.model_dump() == {'x': 1, 'y': 2}
 
@@ -272,7 +285,7 @@ def test_parse_raw_pass_fail():
         x: int
         y: int
 
-    with pytest.warns(DeprecationWarning, match='The `parse_raw` method is deprecated'):
+    with pytest.warns(PydanticDeprecatedSince20, match='The `parse_raw` method is deprecated'):
         with pytest.raises(ValidationError, match='1 validation error for Model') as exc_info:
             Model.parse_raw('invalid')
 
@@ -295,10 +308,10 @@ def test_fields():
     m = Model(x=1)
     assert len(Model.model_fields) == 2
     assert len(m.model_fields) == 2
-    match = '^The `__fields__` attribute is deprecated, use `model_fields` instead.$'
-    with pytest.warns(DeprecationWarning, match=match):
+    match = '^The `__fields__` attribute is deprecated, use `model_fields` instead.'
+    with pytest.warns(PydanticDeprecatedSince20, match=match):
         assert len(Model.__fields__) == 2
-    with pytest.warns(DeprecationWarning, match=match):
+    with pytest.warns(PydanticDeprecatedSince20, match=match):
         assert len(m.__fields__) == 2
 
 
@@ -309,8 +322,8 @@ def test_fields_set():
 
     m = Model(x=1)
     assert m.model_fields_set == {'x'}
-    match = '^The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.$'
-    with pytest.warns(DeprecationWarning, match=match):
+    match = '^The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.'
+    with pytest.warns(PydanticDeprecatedSince20, match=match):
         assert m.__fields_set__ == {'x'}
 
 
@@ -320,7 +333,7 @@ def test_extra_used_as_enum(
     value: str,
 ) -> None:
     with pytest.warns(
-        DeprecationWarning,
+        PydanticDeprecatedSince20,
         match=re.escape("`pydantic.config.Extra` is deprecated, use literal values instead (e.g. `extra='allow'`)"),
     ):
         assert getattr(Extra, attribute) == value
@@ -328,7 +341,7 @@ def test_extra_used_as_enum(
 
 def test_field_min_items_deprecation():
     m = '`min_items` is deprecated and will be removed. use `min_length` instead'
-    with pytest.warns(DeprecationWarning, match=m):
+    with pytest.warns(PydanticDeprecatedSince20, match=m):
 
         class Model(BaseModel):
             x: List[int] = Field(None, min_items=1)
@@ -348,7 +361,7 @@ def test_field_min_items_deprecation():
 
 def test_field_min_items_with_min_length():
     m = '`min_items` is deprecated and will be removed. use `min_length` instead'
-    with pytest.warns(DeprecationWarning, match=m):
+    with pytest.warns(PydanticDeprecatedSince20, match=m):
 
         class Model(BaseModel):
             x: List[int] = Field(None, min_items=1, min_length=2)
@@ -368,7 +381,7 @@ def test_field_min_items_with_min_length():
 
 def test_field_max_items():
     m = '`max_items` is deprecated and will be removed. use `max_length` instead'
-    with pytest.warns(DeprecationWarning, match=m):
+    with pytest.warns(PydanticDeprecatedSince20, match=m):
 
         class Model(BaseModel):
             x: List[int] = Field(None, max_items=1)
@@ -388,7 +401,7 @@ def test_field_max_items():
 
 def test_field_max_items_with_max_length():
     m = '`max_items` is deprecated and will be removed. use `max_length` instead'
-    with pytest.warns(DeprecationWarning, match=m):
+    with pytest.warns(PydanticDeprecatedSince20, match=m):
 
         class Model(BaseModel):
             x: List[int] = Field(None, max_items=1, max_length=2)
@@ -429,7 +442,7 @@ def test_unique_items_conlist():
 
 def test_allow_mutation():
     m = '`allow_mutation` is deprecated and will be removed. use `frozen` instead'
-    with pytest.warns(DeprecationWarning, match=m):
+    with pytest.warns(PydanticDeprecatedSince20, match=m):
 
         class Model(BaseModel):
             model_config = ConfigDict(validate_assignment=True)
@@ -472,7 +485,7 @@ def test_modify_schema_error():
 
 def test_field_extra_arguments():
     m = 'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead'
-    with pytest.warns(DeprecationWarning, match=m):
+    with pytest.warns(PydanticDeprecatedSince20, match=m):
 
         class Model(BaseModel):
             x: str = Field('test', test='test')
@@ -484,7 +497,7 @@ def test_field_extra_arguments():
 
 def test_field_extra_does_not_rewrite_json_schema_extra():
     m = 'Extra keyword arguments on `Field` is deprecated and will be removed. use `json_schema_extra` instead'
-    with pytest.warns(DeprecationWarning, match=m):
+    with pytest.warns(PydanticDeprecatedSince20, match=m):
 
         class Model(BaseModel):
             x: str = Field('test', test='test', json_schema_extra={'test': 'json_schema_extra value'})
@@ -500,16 +513,18 @@ class SimpleModel(BaseModel):
 
 def test_dict():
     m = SimpleModel(x=1)
-    with pytest.warns(DeprecationWarning, match=r'^The `dict` method is deprecated; use `model_dump` instead\.$'):
+    with pytest.warns(PydanticDeprecatedSince20, match=r'^The `dict` method is deprecated; use `model_dump` instead\.'):
         assert m.dict() == {'x': 1}
 
 
 def test_json():
     m = SimpleModel(x=1)
-    with pytest.warns(DeprecationWarning, match=r'^The `json` method is deprecated; use `model_dump_json` instead\.$'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match=r'^The `json` method is deprecated; use `model_dump_json` instead\.'
+    ):
         assert m.json() == '{"x":1}'
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
         with pytest.raises(TypeError, match='The `encoder` argument is no longer supported'):
             m.json(encoder=1)
         with pytest.raises(TypeError, match='The `models_as_dict` argument is no longer supported'):
@@ -519,7 +534,9 @@ def test_json():
 
 
 def test_parse_obj():
-    with pytest.warns(DeprecationWarning, match='^The `parse_obj` method is deprecated; use `model_validate` instead.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='^The `parse_obj` method is deprecated; use `model_validate` instead.'
+    ):
         m = SimpleModel.parse_obj({'x': 1})
 
     assert m.model_dump() == {'x': 1}
@@ -528,12 +545,16 @@ def test_parse_obj():
 def test_parse_file(tmp_path):
     path = tmp_path / 'test.json'
     path.write_text('{"x": 12}')
-    with pytest.warns(DeprecationWarning, match='^The `parse_file` method is deprecated; load the data from file,'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='^The `parse_file` method is deprecated; load the data from file,'
+    ):
         assert SimpleModel.parse_file(str(path)).model_dump() == {'x': 12}
 
 
 def test_construct():
-    with pytest.warns(DeprecationWarning, match='The `construct` method is deprecated; use `model_construct` instead.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='The `construct` method is deprecated; use `model_construct` instead.'
+    ):
         m = SimpleModel.construct(x='not an int')
 
     assert m.x == 'not an int'
@@ -541,7 +562,9 @@ def test_construct():
 
 def test_json_schema():
     m = SimpleModel(x=1)
-    with pytest.warns(DeprecationWarning, match='^The `schema` method is deprecated; use `model_json_schema` instead.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='^The `schema` method is deprecated; use `model_json_schema` instead.'
+    ):
         assert m.schema() == {
             'title': 'SimpleModel',
             'type': 'object',
@@ -551,20 +574,24 @@ def test_json_schema():
 
 
 def test_validate():
-    with pytest.warns(DeprecationWarning, match='^The `validate` method is deprecated; use `model_validate` instead.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='^The `validate` method is deprecated; use `model_validate` instead.'
+    ):
         m = SimpleModel.validate({'x': 1})
 
     assert m.model_dump() == {'x': 1}
 
 
 def test_update_forward_refs():
-    with pytest.warns(DeprecationWarning, match='^The `update_forward_refs` method is deprecated;'):
+    with pytest.warns(PydanticDeprecatedSince20, match='^The `update_forward_refs` method is deprecated;'):
         SimpleModel.update_forward_refs()
 
 
 def test_copy_and_set_values():
     m = SimpleModel(x=1)
-    with pytest.warns(DeprecationWarning, match='^The private method  `_copy_and_set_values` will be removed and '):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='^The private method  `_copy_and_set_values` will be removed and '
+    ):
         m2 = m._copy_and_set_values(values={'x': 2}, fields_set={'x'}, deep=False)
 
     assert m2.x == 2
@@ -572,7 +599,7 @@ def test_copy_and_set_values():
 
 def test_get_value():
     m = SimpleModel(x=1)
-    with pytest.warns(DeprecationWarning, match='^The private method  `_get_value` will be removed and '):
+    with pytest.warns(PydanticDeprecatedSince20, match='^The private method  `_get_value` will be removed and '):
         v = m._get_value(
             [1, 2, 3],
             to_dict=False,
@@ -592,49 +619,51 @@ def test_deprecated_module(tmp_path: Path) -> None:
 
     assert hasattr(parse_obj_as, '__deprecated__')
     with pytest.warns(
-        DeprecationWarning, match='parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.'
+        PydanticDeprecatedSince20, match='parse_obj_as is deprecated. Use pydantic.TypeAdapter.validate_python instead.'
     ):
         parse_obj_as(Model, {'x': 1})
 
     assert hasattr(schema_json_of, '__deprecated__')
     with pytest.warns(
-        DeprecationWarning, match='schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.'
+        PydanticDeprecatedSince20, match='schema_json_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.'
     ):
         schema_json_of(Model)
 
     assert hasattr(schema_of, '__deprecated__')
     with pytest.warns(
-        DeprecationWarning, match='schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.'
+        PydanticDeprecatedSince20, match='schema_of is deprecated. Use pydantic.TypeAdapter.json_schema instead.'
     ):
         schema_of(Model)
 
     assert hasattr(load_str_bytes, '__deprecated__')
-    with pytest.warns(DeprecationWarning, match='load_str_bytes is deprecated.'):
+    with pytest.warns(PydanticDeprecatedSince20, match='load_str_bytes is deprecated.'):
         load_str_bytes('{"x": 1}')
 
     assert hasattr(load_file, '__deprecated__')
     file = tmp_path / 'main.py'
     file.write_text('{"x": 1}')
-    with pytest.warns(DeprecationWarning, match='load_file is deprecated.'):
+    with pytest.warns(PydanticDeprecatedSince20, match='load_file is deprecated.'):
         load_file(file)
 
     assert hasattr(pydantic_encoder, '__deprecated__')
-    with pytest.warns(DeprecationWarning, match='pydantic_encoder is deprecated, use BaseModel.model_dump instead.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='pydantic_encoder is deprecated, use BaseModel.model_dump instead.'
+    ):
         pydantic_encoder(Model(x=1))
 
     assert hasattr(custom_pydantic_encoder, '__deprecated__')
     with pytest.warns(
-        DeprecationWarning, match='custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.'
+        PydanticDeprecatedSince20, match='custom_pydantic_encoder is deprecated, use BaseModel.model_dump instead.'
     ):
         custom_pydantic_encoder({int: lambda x: str(x)}, Model(x=1))
 
     assert hasattr(timedelta_isoformat, '__deprecated__')
-    with pytest.warns(DeprecationWarning, match='timedelta_isoformat is deprecated.'):
+    with pytest.warns(PydanticDeprecatedSince20, match='timedelta_isoformat is deprecated.'):
         timedelta_isoformat(timedelta(seconds=1))
 
     assert all(hasattr(func, '__deprecated__') for func in get_overloads(validate_arguments))
     with pytest.warns(
-        DeprecationWarning, match='The `validate_arguments` method is deprecated; use `validate_call` instead.'
+        PydanticDeprecatedSince20, match='The `validate_arguments` method is deprecated; use `validate_call` instead.'
     ):
 
         def test(a: int, b: int):
@@ -646,7 +675,9 @@ def test_deprecated_module(tmp_path: Path) -> None:
 def test_deprecated_color():
     from pydantic.color import Color
 
-    with pytest.warns(DeprecationWarning, match='The `Color` class is deprecated, use `pydantic_extra_types` instead.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='The `Color` class is deprecated, use `pydantic_extra_types` instead.'
+    ):
         Color('red')
 
 
@@ -654,7 +685,7 @@ def test_deprecated_payment():
     from pydantic import PaymentCardNumber
 
     with pytest.warns(
-        DeprecationWarning,
+        PydanticDeprecatedSince20,
         match='The `PaymentCardNumber` class is deprecated, use `pydantic_extra_types` instead.',
     ):
         PaymentCardNumber('4242424242424242')

--- a/tests/test_deprecated_validate_arguments.py
+++ b/tests/test_deprecated_validate_arguments.py
@@ -8,7 +8,7 @@ import pytest
 from dirty_equals import IsInstance
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, PydanticDeprecatedSince20, ValidationError
 from pydantic.deprecated.decorator import ValidatedFunction
 from pydantic.deprecated.decorator import validate_arguments as validate_arguments_deprecated
 from pydantic.errors import PydanticUserError
@@ -17,7 +17,9 @@ skip_pre_38 = pytest.mark.skipif(sys.version_info < (3, 8), reason='testing >= 3
 
 
 def validate_arguments(*args, **kwargs):
-    with pytest.warns(DeprecationWarning, match='^The `validate_arguments` method is deprecated; use `validate_call`'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='^The `validate_arguments` method is deprecated; use `validate_call`'
+    ):
         return validate_arguments_deprecated(*args, **kwargs)
 
 
@@ -146,7 +148,7 @@ def test_field_can_provide_factory() -> None:
 
 @skip_pre_38
 def test_positional_only(create_module):
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
         module = create_module(
             # language=Python
             """

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -29,6 +29,7 @@ from typing_extensions import Annotated, get_args
 from pydantic import (
     BaseModel,
     ConfigDict,
+    PydanticDeprecatedSince20,
     PydanticInvalidForJsonSchema,
     PydanticSchemaGenerationError,
     TypeAdapter,
@@ -2153,7 +2154,7 @@ def test_iter_coverage():
         y: str = 'a'
 
     with pytest.warns(
-        DeprecationWarning, match='The private method `_iter` will be removed and should no longer be used.'
+        PydanticDeprecatedSince20, match='The private method `_iter` will be removed and should no longer be used.'
     ):
         assert list(MyModel()._iter(by_alias=True)) == [('x', 1), ('y', 'a')]
 
@@ -2317,7 +2318,7 @@ def test_abstractmethod_missing_for_all_decorators(bases):
         def my_model_validator(cls, values, handler, info):
             raise NotImplementedError
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(skip_on_failure=True)
             @classmethod
@@ -2325,7 +2326,7 @@ def test_abstractmethod_missing_for_all_decorators(bases):
             def my_root_validator(cls, values):
                 raise NotImplementedError
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @validator('side')
             @classmethod

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -41,6 +41,7 @@ from pydantic import (
     GetJsonSchemaHandler,
     ImportString,
     InstanceOf,
+    PydanticDeprecatedSince20,
     PydanticUserError,
     RootModel,
     ValidationError,
@@ -4111,7 +4112,7 @@ def test_model_with_schema_extra_callable_no_model_class():
 
 
 def test_model_with_schema_extra_callable_config_class():
-    with pytest.warns(DeprecationWarning, match='use ConfigDict instead'):
+    with pytest.warns(PydanticDeprecatedSince20, match='use ConfigDict instead'):
 
         class Model(BaseModel):
             name: str = None
@@ -4127,7 +4128,7 @@ def test_model_with_schema_extra_callable_config_class():
 
 
 def test_model_with_schema_extra_callable_no_model_class_config_class():
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
 
         class Model(BaseModel):
             name: str = None
@@ -4142,7 +4143,7 @@ def test_model_with_schema_extra_callable_no_model_class_config_class():
 
 
 def test_model_with_schema_extra_callable_classmethod():
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
 
         class Model(BaseModel):
             name: str = None
@@ -4160,7 +4161,7 @@ def test_model_with_schema_extra_callable_classmethod():
 
 
 def test_model_with_schema_extra_callable_instance_method():
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
 
         class Model(BaseModel):
             name: str = None

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -11,6 +11,7 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
+    PydanticDeprecatedSince20,
     PydanticUserError,
     RootModel,
     ValidationError,
@@ -175,7 +176,7 @@ def test_v1_compatibility_serializer():
     m = MyOuterModel.model_validate({'my_root': {'x': 1}})
 
     assert m.model_dump() == {'my_root': {'__root__': {'x': 1}}}
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
         assert m.dict() == {'my_root': {'__root__': {'x': 1}}}
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Mapping, Union
 
 import pytest
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, PydanticDeprecatedSince20, ValidationError
 from pydantic.dataclasses import dataclass
 from pydantic.deprecated.tools import parse_obj_as, schema_json_of, schema_of
 
@@ -56,7 +56,7 @@ def test_parsing_model_naming():
     assert str(exc_info.value).split('\n')[0] == '1 validation error for int'
 
     with pytest.raises(ValidationError) as exc_info:
-        with pytest.warns(DeprecationWarning, match='The type_name parameter is deprecated'):
+        with pytest.warns(PydanticDeprecatedSince20, match='The type_name parameter is deprecated'):
             parse_obj_as(int, 'a', type_name='ParsingModel')
     assert str(exc_info.value).split('\n')[0] == '1 validation error for int'
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -17,6 +17,7 @@ from pydantic import (
     ConfigDict,
     Field,
     FieldValidationInfo,
+    PydanticDeprecatedSince20,
     PydanticUserError,
     ValidationError,
     ValidationInfo,
@@ -507,7 +508,7 @@ def test_use_bare():
         class Model(BaseModel):
             a: str
 
-            with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+            with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
                 @validator
                 def checker(cls, v):
@@ -531,7 +532,7 @@ def test_use_no_fields():
         class Model(BaseModel):
             a: str
 
-            with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+            with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
                 @validator()
                 def checker(cls, v):
@@ -562,7 +563,7 @@ def test_validator_bad_fields_throws_configerror():
             a: str
             b: str
 
-            with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+            with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
                 @validator(['a', 'b'])
                 def check_fields(cls, v):
@@ -591,7 +592,7 @@ def test_validate_always():
     class Model(BaseModel):
         a: str = None
 
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             @validator('a', pre=True, always=True)
             @classmethod
@@ -632,7 +633,7 @@ def test_validate_always_on_inheritance():
         a: str = None
 
     class Model(ParentModel):
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             @validator('a', pre=True, always=True)
             @classmethod
@@ -689,7 +690,7 @@ def test_validate_not_always():
 @pytest.mark.parametrize(
     'decorator, pytest_warns',
     [
-        (validator, pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH)),
+        (validator, pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH)),
         (field_validator, contextlib.nullcontext()),
     ],
 )
@@ -730,7 +731,7 @@ def test_wildcard_validators(decorator, pytest_warns):
 @pytest.mark.parametrize(
     'decorator, pytest_warns',
     [
-        (validator, pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH)),
+        (validator, pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH)),
         (field_validator, contextlib.nullcontext()),
     ],
 )
@@ -822,7 +823,7 @@ def test_validate_child_extra():
 
 
 def test_validate_child_all():
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Parent(BaseModel):
             a: str
@@ -864,7 +865,7 @@ def test_validate_parent():
 
 
 def test_validate_parent_all():
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Parent(BaseModel):
             a: str
@@ -959,7 +960,7 @@ def test_inheritance_replace_root_validator():
     it replaces the existing validator and is run instead of it.
     """
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
 
         class Parent(BaseModel):
             a: List[str]
@@ -1000,7 +1001,7 @@ def test_inheritance_replace_root_validator():
 
 
 def test_validation_each_item():
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             foobar: Dict[int, int]
@@ -1017,7 +1018,7 @@ def test_validation_each_item_invalid_type():
     with pytest.raises(
         TypeError, match=re.escape('@validator(..., each_item=True)` cannot be applied to fields with a schema of int')
     ):
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             class Model(BaseModel):
                 foobar: int
@@ -1029,7 +1030,7 @@ def test_validation_each_item_invalid_type():
 
 
 def test_validation_each_item_nullable():
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             foobar: Optional[List[int]]
@@ -1043,7 +1044,7 @@ def test_validation_each_item_nullable():
 
 
 def test_validation_each_item_one_sublevel():
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             foobar: List[Tuple[int, int]]
@@ -1076,7 +1077,7 @@ def test_validator_always_optional():
     class Model(BaseModel):
         a: Optional[str] = None
 
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             @validator('a', pre=True, always=True)
             @classmethod
@@ -1116,7 +1117,7 @@ def test_validator_always_pre():
     class Model(BaseModel):
         a: str = None
 
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             @validator('a', pre=True, always=True)
             @classmethod
@@ -1155,7 +1156,7 @@ def test_validator_always_post():
         # But, I think this is a good thing, and I don't think we should try to support this.
         a: str = ''
 
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             @validator('a', always=True)
             @classmethod
@@ -1183,7 +1184,7 @@ def test_validator_always_post_optional():
     class Model(BaseModel):
         a: Optional[str] = None
 
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             @validator('a', pre=True, always=True)
             @classmethod
@@ -1213,7 +1214,7 @@ def test_datetime_validator():
     class Model(BaseModel):
         d: datetime = None
 
-        with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+        with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
             @validator('d', pre=True, always=True)
             @classmethod
@@ -1307,7 +1308,7 @@ def test_root_validator():
         def repeat_b(cls, v: Any):
             return v * 2
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(skip_on_failure=True)
             def example_root_validator(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -1363,7 +1364,7 @@ def test_root_validator_subclass():
     class Parent(BaseModel):
         x: int
         expected: Any
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(skip_on_failure=True)
             @classmethod
@@ -1375,7 +1376,7 @@ def test_root_validator_subclass():
         pass
 
     class Child2(Parent):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(skip_on_failure=True)
             @classmethod
@@ -1409,7 +1410,7 @@ def test_root_validator_pre():
         def repeat_b(cls, v: Any):
             return v * 2
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(pre=True)
             def root_validator(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -1442,7 +1443,7 @@ def test_root_validator_types():
         a: int = 1
         b: str
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(skip_on_failure=True)
             def root_validator(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -1461,7 +1462,7 @@ def test_root_validator_returns_none_exception():
     class Model(BaseModel):
         a: int = 1
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(skip_on_failure=True)
             def root_validator_repeated(cls, values):
@@ -1527,7 +1528,7 @@ def test_root_validator_classmethod(validator_classmethod, root_validator_classm
         if root_validator_classmethod:
             example_root_validator = classmethod(example_root_validator)
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
             example_root_validator = root_validator(skip_on_failure=True)(example_root_validator)
 
     assert Model(a='123', b='bar').model_dump() == {'a': 123, 'b': 'changed'}
@@ -1756,7 +1757,7 @@ def test_validating_assignment_pre_root_validator_fail():
         max_value: float
 
         model_config = ConfigDict(validate_assignment=True)
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             @root_validator(pre=True)
             def values_are_not_string(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -1816,7 +1817,9 @@ def test_validating_assignment_model_validator_before_fail():
 )
 def test_root_validator_skip_on_failure_invalid(kwargs: Dict[str, Any]):
     with pytest.raises(TypeError, match='MUST specify `skip_on_failure=True`'):
-        with pytest.warns(DeprecationWarning, match='Pydantic V1 style `@root_validator` validators are deprecated.'):
+        with pytest.warns(
+            PydanticDeprecatedSince20, match='Pydantic V1 style `@root_validator` validators are deprecated.'
+        ):
 
             class Model(BaseModel):
                 @root_validator(**kwargs)
@@ -1834,7 +1837,9 @@ def test_root_validator_skip_on_failure_invalid(kwargs: Dict[str, Any]):
     ],
 )
 def test_root_validator_skip_on_failure_valid(kwargs: Dict[str, Any]):
-    with pytest.warns(DeprecationWarning, match='Pydantic V1 style `@root_validator` validators are deprecated.'):
+    with pytest.warns(
+        PydanticDeprecatedSince20, match='Pydantic V1 style `@root_validator` validators are deprecated.'
+    ):
 
         class Model(BaseModel):
             @root_validator(**kwargs)
@@ -1871,7 +1876,7 @@ def _get_source_line(filename: str, lineno: int) -> str:
 
 
 def test_v1_validator_deprecated():
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH) as w:
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH) as w:
 
         class Point(BaseModel):
             y: int
@@ -1950,7 +1955,7 @@ def test_decorator_proxy():
 
 def test_root_validator_self():
     with pytest.raises(TypeError, match=r'`@root_validator` cannot be applied to instance methods'):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(PydanticDeprecatedSince20):
 
             class Model(BaseModel):
                 a: int = 1
@@ -1961,7 +1966,7 @@ def test_root_validator_self():
 
 
 def test_validator_self():
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
         with pytest.raises(TypeError, match=r'`@validator` cannot be applied to instance methods'):
 
             class Model(BaseModel):
@@ -1984,7 +1989,7 @@ def test_field_validator_self():
 
 
 def test_v1_validator_signature_kwargs_not_allowed() -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
         with pytest.raises(TypeError, match=r'Unsupported signature for V1 style validator'):
 
             class Model(BaseModel):
@@ -1996,7 +2001,7 @@ def test_v1_validator_signature_kwargs_not_allowed() -> None:
 
 
 def test_v1_validator_signature_kwargs1() -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             a: int
@@ -2012,7 +2017,7 @@ def test_v1_validator_signature_kwargs1() -> None:
 
 
 def test_v1_validator_signature_kwargs2() -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             a: int
@@ -2029,7 +2034,7 @@ def test_v1_validator_signature_kwargs2() -> None:
 
 
 def test_v1_validator_signature_with_values() -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             a: int
@@ -2045,7 +2050,7 @@ def test_v1_validator_signature_with_values() -> None:
 
 
 def test_v1_validator_signature_with_values_kw_only() -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             a: int
@@ -2061,7 +2066,7 @@ def test_v1_validator_signature_with_values_kw_only() -> None:
 
 
 def test_v1_validator_signature_with_field() -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
         with pytest.raises(TypeError, match=r'The `field` and `config` parameters are not available in Pydantic V2'):
 
             class Model(BaseModel):
@@ -2074,7 +2079,7 @@ def test_v1_validator_signature_with_field() -> None:
 
 
 def test_v1_validator_signature_with_config() -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
         with pytest.raises(TypeError, match=r'The `field` and `config` parameters are not available in Pydantic V2'):
 
             class Model(BaseModel):
@@ -2310,7 +2315,7 @@ def test_functools_partialmethod_validator_v2_cls_method(
 def test_functools_partial_validator_v1(
     func: Callable[..., Any],
 ) -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             x: int
@@ -2335,7 +2340,7 @@ def test_functools_partial_validator_v1(
 def test_functools_partialmethod_validator_v1(
     func: Callable[..., Any],
 ) -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             x: int
@@ -2360,7 +2365,7 @@ def test_functools_partialmethod_validator_v1(
 def test_functools_partialmethod_validator_v1_cls_method(
     func: Callable[..., Any],
 ) -> None:
-    with pytest.warns(DeprecationWarning, match=V1_VALIDATOR_DEPRECATION_MATCH):
+    with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
 
         class Model(BaseModel):
             x: int
@@ -2503,7 +2508,7 @@ def test_root_validator_allow_reuse_same_field():
 
 
 def test_root_validator_allow_reuse_inheritance():
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
 
         class Parent(BaseModel):
             x: int
@@ -2513,7 +2518,7 @@ def test_root_validator_allow_reuse_inheritance():
                 v['x'] += 1
                 return v
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(PydanticDeprecatedSince20):
 
         class Child(Parent):
             @root_validator(skip_on_failure=True)
@@ -2535,7 +2540,9 @@ def test_bare_root_validator():
             ' Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.'
         ),
     ):
-        with pytest.warns(DeprecationWarning, match='Pydantic V1 style `@root_validator` validators are deprecated.'):
+        with pytest.warns(
+            PydanticDeprecatedSince20, match='Pydantic V1 style `@root_validator` validators are deprecated.'
+        ):
 
             class Model(BaseModel):
                 @root_validator

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,31 @@
+from pydantic import PydanticDeprecationWarning
+
+
+def test_pydantic_deprecation_warning():
+    warning = PydanticDeprecationWarning('Warning message', 'Arbitrary argument', since=(2, 1), expected_removal=(4, 0))
+
+    assert str(warning) == 'Warning message. Deprecated in Pydantic V2.1 to be removed in V4.0.'
+    assert warning.args[0] == 'Warning message'
+    assert warning.args[1] == 'Arbitrary argument'
+
+
+def test_pydantic_deprecation_warning_tailing_dot_in_message():
+    warning = PydanticDeprecationWarning('Warning message.', since=(2, 1), expected_removal=(4, 0))
+
+    assert str(warning) == 'Warning message. Deprecated in Pydantic V2.1 to be removed in V4.0.'
+    assert warning.args[0] == 'Warning message.'
+
+
+def test_pydantic_deprecation_warning_calculated_expected_removal():
+    warning = PydanticDeprecationWarning('Warning message', since=(2, 1))
+
+    assert str(warning) == 'Warning message. Deprecated in Pydantic V2.1 to be removed in V3.0.'
+
+
+def test_pydantic_deprecation_warning_2_0_migration_guide_link():
+    warning = PydanticDeprecationWarning('Warning message', since=(2, 0))
+
+    assert (
+        str(warning)
+        == 'Warning message. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/v2.0/migration/'
+    )

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,4 +1,5 @@
 from pydantic import PydanticDeprecatedSince20, PydanticDeprecationWarning
+from pydantic.version import VERSION
 
 
 def test_pydantic_deprecation_warning():
@@ -27,7 +28,7 @@ def test_pydantic_deprecation_warning_2_0_migration_guide_link():
 
     assert (
         str(warning)
-        == 'Warning message. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/v2.0/migration/'
+        == f'Warning message. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/{VERSION}/migration/'
     )
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,4 +1,4 @@
-from pydantic import PydanticDeprecationWarning
+from pydantic import PydanticDeprecatedSince20, PydanticDeprecationWarning
 
 
 def test_pydantic_deprecation_warning():
@@ -29,3 +29,12 @@ def test_pydantic_deprecation_warning_2_0_migration_guide_link():
         str(warning)
         == 'Warning message. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/v2.0/migration/'
     )
+
+
+def test_pydantic_deprecated_since_2_0_warning():
+    warning = PydanticDeprecatedSince20('Warning message')
+
+    assert isinstance(warning, PydanticDeprecationWarning)
+    assert warning.message == 'Warning message'
+    assert warning.since == (2, 0)
+    assert warning.expected_removal == (3, 0)


### PR DESCRIPTION
## Change Summary

Implement custom `PydanticDeprecationWarning`.
- Provides a single class to ignore or test for.
- Provides info on Pydantic version the deprecation was introduced in.
- Provides a link to the V2 migration guide for things deprecated in v2.0. 

## Related issue number

Fixes #5571

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex