### PR TITLE
Change allow mutation wording

### DIFF
--- a/changes/6181-mark-todd.md
+++ b/changes/6181-mark-todd.md
@@ -1,0 +1,1 @@
+Updated docs to show frozen can be used instead of allow_mutation

--- a/changes/6181-mark-todd.md
+++ b/changes/6181-mark-todd.md
@@ -1,1 +1,0 @@
-Updated docs to show frozen can be used instead of allow_mutation

--- a/docs/blog/pydantic-v2-alpha.md
+++ b/docs/blog/pydantic-v2-alpha.md
@@ -133,7 +133,7 @@ a full migration guide, but for now the following pointers should be some help w
 
 The following config settings have been removed:
 
-* `allow_mutation`.
+* `allow_mutation` — this has been removed. You should be able to use [frozen](https://docs.pydantic.dev/dev-v2/api/config/#pydantic.config.ConfigDict) equivalently (inverse of current use).
 * `error_msg_templates`.
 * `fields` — this was the source of various bugs, so has been removed. You should be able to use `Annotated` on fields to modify them as desired.
 * `getter_dict` — `orm_mode` has been removed, and this implementation detail is no longer necessary.

--- a/docs/blog/pydantic-v2-alpha.md
+++ b/docs/blog/pydantic-v2-alpha.md
@@ -133,7 +133,7 @@ a full migration guide, but for now the following pointers should be some help w
 
 The following config settings have been removed:
 
-* `allow_mutation` — this has been removed. You should be able to use [frozen](https://docs.pydantic.dev/dev-v2/api/config/#pydantic.config.ConfigDict) equivalently (inverse of current use).
+* `allow_mutation` — this has been removed. You should be able to use [frozen](api/config.md#pydantic.config.ConfigDict) equivalently (inverse of current use).
 * `error_msg_templates`.
 * `fields` — this was the source of various bugs, so has been removed. You should be able to use `Annotated` on fields to modify them as desired.
 * `getter_dict` — `orm_mode` has been removed, and this implementation detail is no longer necessary.

--- a/docs/blog/pydantic-v2-alpha.md
+++ b/docs/blog/pydantic-v2-alpha.md
@@ -133,7 +133,7 @@ a full migration guide, but for now the following pointers should be some help w
 
 The following config settings have been removed:
 
-* `allow_mutation` — this has been removed. You should be able to use [frozen](api/config.md#pydantic.config.ConfigDict) equivalently (inverse of current use).
+* `allow_mutation` — this has been removed. You should be able to use [frozen](../api/config.md#pydantic.config.ConfigDict) equivalently (inverse of current use).
 * `error_msg_templates`.
 * `fields` — this was the source of various bugs, so has been removed. You should be able to use `Annotated` on fields to modify them as desired.
 * `getter_dict` — `orm_mode` has been removed, and this implementation detail is no longer necessary.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -142,7 +142,7 @@ The following properties have been removed from or changed in `Field`:
   in the namespace of the parent `BaseModel` subclass is now deprecated.
 
 * The following config settings have been removed:
-    * `allow_mutation`.
+    * `allow_mutation` — this has been removed. You should be able to use [frozen](api/config.md#pydantic.config.ConfigDict) equivalently (inverse of current use).
     * `error_msg_templates`.
     * `fields` — this was the source of various bugs, so has been removed.
       You should be able to use `Annotated` on fields to modify them as desired.


### PR DESCRIPTION
## Change Summary

Changed wording of blog post to show frozen can be used instead of allow_mutation.

## Related issue number

fix #6181

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
