### PR TITLE
Fixed literal validator errors for unhashable values

### DIFF
--- a/changes/6188-markus1978.md
+++ b/changes/6188-markus1978.md
@@ -1,0 +1,1 @@
+Fixed literal validator errors for unhashable values.

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -488,7 +488,7 @@ def make_literal_validator(type_: Any) -> Callable[[Any], Any]:
     def literal_validator(v: Any) -> Any:
         try:
             return allowed_choices[v]
-        except KeyError:
+        except (KeyError, TypeError):
             raise errors.WrongConstantError(given=v, permitted=permitted_choices)
 
     return literal_validator

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1189,6 +1189,24 @@ def test_literal_validator():
     ]
 
 
+def test_literal_validator_non_str_value():
+    class Model(BaseModel):
+        a: Literal['foo']
+
+    Model(a='foo')
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a={'bar': 'foo'})
+    assert exc_info.value.errors() == [
+        {
+            'loc': ('a',),
+            'msg': "unexpected value; permitted: 'foo'",
+            'type': 'value_error.const',
+            'ctx': {'given': {'bar': 'foo'}, 'permitted': ('foo',)},
+        }
+    ]
+
+
 def test_literal_validator_str_enum():
     class Bar(str, Enum):
         FIZ = 'fiz'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

<!-- Please give a short summary of the changes. -->
If a value is not hashable and used on the dict of expected values a `TypeError` is raised. The code now also catches the `TypeError` along side the `KeyError` to cause the validator to fail with a `WrongConstantError`. 

## Related issue number

fix #6188

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
