### PR TITLE
Replace if instead of elif in _internal/_fields.py

### DIFF
--- a/changes/6222-mo1ein.md
+++ b/changes/6222-mo1ein.md
@@ -1,0 +1,1 @@
+Replace if instead of elif in _internal/_fields.py.

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -182,12 +182,11 @@ def _is_finalvar_with_default_val(type_: type[Any], val: Any) -> bool:
 
     if not is_finalvar(type_):
         return False
-    elif val is PydanticUndefined:
+    if val is PydanticUndefined:
         return False
-    elif isinstance(val, FieldInfo) and (val.default is PydanticUndefined and val.default_factory is None):
+    if isinstance(val, FieldInfo) and (val.default is PydanticUndefined and val.default_factory is None):
         return False
-    else:
-        return True
+    return True
 
 
 def collect_dataclass_fields(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary
I think that when we have a `return` statement, we don't need `elif` or `else`.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
