### PR TITLE
correct deprecation warning for parse_file

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -942,7 +942,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     @typing_extensions.deprecated(
         'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
-        'use `model_json_validate` otherwise `model_validate` instead.'
+        'use `model_validate_json` otherwise `model_validate` instead.'
     )
     def parse_file(  # noqa: D102
         cls: type[Model],
@@ -955,7 +955,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     ) -> Model:
         warnings.warn(
             'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
-            'use `model_json_validate` otherwise `model_validate` instead.',
+            'use `model_validate_json` otherwise `model_validate` instead.',
             DeprecationWarning,
         )
         obj = _deprecated_parse.load_file(


### PR DESCRIPTION
## Change Summary

Corrects a typo in the deprecation message for `parse_file`.

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex