### PR TITLE
Add type key to enums

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -161,7 +161,7 @@ def is_builtin_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
 
     we check that
     - `_cls` is a dataclass
-    - `_cls` is not a processed pydantic dataclass (with a basemodel attached)
+    - `_cls` is not a processed pydantic dataclass (with a `BaseModel` attached)
     - `_cls` is not a pydantic dataclass inheriting directly from a stdlib dataclass
     e.g.
     ```py

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -557,12 +557,18 @@ class GenerateJsonSchema:
             return {'const': expected[0]}
         else:
             types = {type(e) for e in expected}
-            if types == {
-                str,
-            }:
+            if types == {str}:
                 return {'enum': expected, 'type': 'string'}
-            elif types.issubset({int, float}):
+            elif types == {int}:
+                return {'enum': expected, 'type': 'integer'}
+            elif types == {float}:
                 return {'enum': expected, 'type': 'number'}
+            elif types == {bool}:
+                return {'enum': expected, 'type': 'boolean'}
+            elif types == {list}:
+                return {'enum': expected, 'type': 'array'}
+            elif types == {None}:
+                return {'enum': expected, 'type': 'null'}
             else:
                 return {'enum': expected}
 

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -556,7 +556,15 @@ class GenerateJsonSchema:
         if len(expected) == 1:
             return {'const': expected[0]}
         else:
-            return {'enum': expected}
+            types = {type(e) for e in expected}
+            if types == {
+                str,
+            }:
+                return {'enum': expected, 'type': 'string'}
+            elif types.issubset({int, float}):
+                return {'enum': expected, 'type': 'number'}
+            else:
+                return {'enum': expected}
 
     def is_instance_schema(self, schema: core_schema.IsInstanceSchema) -> JsonSchemaValue:
         """Returns a schema that checks if a value is an instance of a class, equivalent to Python's `isinstance`

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -567,8 +567,8 @@ class GenerateJsonSchema:
                 return {'enum': expected, 'type': 'boolean'}
             elif types == {list}:
                 return {'enum': expected, 'type': 'array'}
-            elif types == {None}:
-                return {'enum': expected, 'type': 'null'}
+            # there is not None case because if it's mixed it hits the final `else`
+            # if it's a single Literal[None] then it becomes a `const` schema above
             else:
                 return {'enum': expected}
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,6 +1,7 @@
 import json
 import math
 import re
+import sys
 import typing
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -2078,7 +2079,11 @@ def test_literal_enum():
     }
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 8), reason="ListEnum doesn't work in 3.8")
 def test_literal_types() -> None:
+    """Test that we properly add `type` to json schema enums when there is a single type."""
+
+    # for float and array we use an Enum because Literal can only accept str, int, bool or None
     class FloatEnum(float, Enum):
         a = 123.0
         b = 123.1

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -252,7 +252,11 @@ def test_choices():
 
     # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
-        'type': 'object',
+        '$defs': {
+            'BarEnum': {'enum': [1, 2], 'title': 'BarEnum', 'type': 'integer'},
+            'FooEnum': {'enum': ['f', 'b'], 'title': 'FooEnum', 'type': 'string'},
+            'SpamEnum': {'enum': ['f', 'b'], 'title': 'SpamEnum', 'type': 'string'},
+        },
         'properties': {
             'foo': {'$ref': '#/$defs/FooEnum'},
             'bar': {'$ref': '#/$defs/BarEnum'},
@@ -260,11 +264,7 @@ def test_choices():
         },
         'required': ['foo', 'bar'],
         'title': 'Model',
-        '$defs': {
-            'BarEnum': {'enum': [1, 2], 'title': 'BarEnum', 'type': 'integer'},
-            'SpamEnum': {'enum': ['f', 'b'], 'title': 'SpamEnum', 'type': 'string'},
-            'FooEnum': {'enum': ['f', 'b'], 'title': 'FooEnum'},
-        },
+        'type': 'object',
     }
 
 
@@ -2066,11 +2066,15 @@ def test_literal_enum():
         kind: Literal[MyEnum.FOO]
         other: Literal[MyEnum.FOO, MyEnum.BAR]
 
+    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
+        'properties': {
+            'kind': {'const': 'foo', 'title': 'Kind'},
+            'other': {'enum': ['foo', 'bar'], 'title': 'Other', 'type': 'string'},
+        },
+        'required': ['kind', 'other'],
         'title': 'Model',
         'type': 'object',
-        'properties': {'kind': {'const': 'foo', 'title': 'Kind'}, 'other': {'enum': ['foo', 'bar'], 'title': 'Other'}},
-        'required': ['kind', 'other'],
     }
 
 
@@ -2358,18 +2362,20 @@ def test_schema_attributes():
     class Example(BaseModel):
         example: ExampleEnum
 
+    # insert_assert(Example.model_json_schema())
     assert Example.model_json_schema() == {
-        'title': 'Example',
-        'type': 'object',
-        'properties': {'example': {'$ref': '#/$defs/ExampleEnum'}},
-        'required': ['example'],
         '$defs': {
             'ExampleEnum': {
-                'title': 'ExampleEnum',
                 'description': 'This is a test description.',
                 'enum': ['GT', 'LT', 'GE', 'LE', 'ML', 'MO', 'RE'],
+                'title': 'ExampleEnum',
+                'type': 'string',
             }
         },
+        'properties': {'example': {'$ref': '#/$defs/ExampleEnum'}},
+        'required': ['example'],
+        'title': 'Example',
+        'type': 'object',
     }
 
 
@@ -2839,7 +2845,7 @@ def test_advanced_generic_schema():  # noqa: C901
 
     # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
-        '$defs': {'CustomType': {'enum': ['a', 'b'], 'title': 'CustomType'}},
+        '$defs': {'CustomType': {'enum': ['a', 'b'], 'title': 'CustomType', 'type': 'string'}},
         'properties': {
             'data0': {
                 'anyOf': [{'type': 'string'}, {'items': {'type': 'string'}, 'type': 'array'}],
@@ -3055,6 +3061,7 @@ def test_discriminated_union():
     class Model(BaseModel):
         pet: Union[Cat, Dog, Lizard] = Field(..., discriminator='pet_type')
 
+    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         '$defs': {
             'Cat': {
@@ -3070,7 +3077,7 @@ def test_discriminated_union():
                 'type': 'object',
             },
             'Lizard': {
-                'properties': {'pet_type': {'enum': ['reptile', 'lizard'], 'title': 'Pet Type'}},
+                'properties': {'pet_type': {'enum': ['reptile', 'lizard'], 'title': 'Pet Type', 'type': 'string'}},
                 'required': ['pet_type'],
                 'title': 'Lizard',
                 'type': 'object',
@@ -3087,11 +3094,7 @@ def test_discriminated_union():
                     },
                     'propertyName': 'pet_type',
                 },
-                'oneOf': [
-                    {'$ref': '#/$defs/Cat'},
-                    {'$ref': '#/$defs/Dog'},
-                    {'$ref': '#/$defs/Lizard'},
-                ],
+                'oneOf': [{'$ref': '#/$defs/Cat'}, {'$ref': '#/$defs/Dog'}, {'$ref': '#/$defs/Lizard'}],
                 'title': 'Pet',
             }
         },
@@ -3114,6 +3117,7 @@ def test_discriminated_annotated_union():
     class Model(BaseModel):
         pet: Annotated[Union[Cat, Dog, Lizard], Field(..., discriminator='pet_type')]
 
+    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         '$defs': {
             'Cat': {
@@ -3129,7 +3133,7 @@ def test_discriminated_annotated_union():
                 'type': 'object',
             },
             'Lizard': {
-                'properties': {'pet_type': {'enum': ['reptile', 'lizard'], 'title': 'Pet Type'}},
+                'properties': {'pet_type': {'enum': ['reptile', 'lizard'], 'title': 'Pet Type', 'type': 'string'}},
                 'required': ['pet_type'],
                 'title': 'Lizard',
                 'type': 'object',
@@ -3146,11 +3150,7 @@ def test_discriminated_annotated_union():
                     },
                     'propertyName': 'pet_type',
                 },
-                'oneOf': [
-                    {'$ref': '#/$defs/Cat'},
-                    {'$ref': '#/$defs/Dog'},
-                    {'$ref': '#/$defs/Lizard'},
-                ],
+                'oneOf': [{'$ref': '#/$defs/Cat'}, {'$ref': '#/$defs/Dog'}, {'$ref': '#/$defs/Lizard'}],
                 'title': 'Pet',
             }
         },


### PR DESCRIPTION
Fixes https://github.com/tiangolo/fastapi/discussions/9709#discussioncomment-6247094

While the `type` is not strictly required, and in fact cannot be included for mixed type enums, it does seem that Swagger does not render schemas correctly without it.

Refs:
- https://json-schema.org/understanding-json-schema/reference/type.html
- https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values

Selected Reviewer: @samuelcolvin