### PR TITLE
💚 Add timeout on `publish_docs` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,7 @@ jobs:
 
   publish_docs:
     needs: [check]
+    timeout-minutes: 30
     # `always()` is required to trigger this task even though test-fastapi is skipped
     if: "always() && needs.check.outputs.result == 'success' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `publish_job` job got stuck yesterday. This will at least prevent that from happening again on that job.

There's no global timeout for GitHub Actions.

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes.

Selected Reviewer: @dmontagu