### PR TITLE
Add ability to decorate descriptors

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,8 @@
 import pytest
 
-from pydantic import PydanticUserError
-from pydantic._internal._decorators import inspect_annotated_serializer, inspect_validator
+from pydantic import PydanticUserError, validate_arguments
+from pydantic._internal._decorators import (inspect_annotated_serializer,
+                                            inspect_validator)
 
 
 def test_inspect_validator_error_wrap():
@@ -51,3 +52,18 @@ def test_inspect_annotated_serializer(mode):
         inspect_annotated_serializer(serializer, mode=mode)
 
     assert e.value.code == 'field-serializer-signature'
+
+
+def test_validate_arguments():
+    class Test1:
+        @validate_arguments
+        def func1(self, arg: 'int'):
+            return arg
+
+        @validate_arguments
+        @classmethod
+        def func2(cls, arg: 'int'):
+            return arg
+
+    assert Test1().func1(7) == 7
+    assert Test1.func2(7) == 7


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary
Adds a(nother) wrapper layer that can wrap descriptors.
<!-- Please give a short summary of the changes. -->

## Related issue number
Fix #5329
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**