### PR TITLE
docs: use _pydantic_core.pyi as only docs source for now

### DIFF
--- a/docs/api/pydantic_core_init.md
+++ b/docs/api/pydantic_core_init.md
@@ -1,5 +1,7 @@
 ::: pydantic_core
     options:
+        allow_inspection: false
+        show_source: false
         members:
         - ArgsKwargs
         - MultiHostUrl


### PR DESCRIPTION
## Change Summary

Changes `mkdocstrings` parser to use the `.pyi` file in `pydantic_core` as the only source for documentation. This means that any documentation and attributes exposed by the Rust are ignored, and we'll have to update the `.pyi` file by hand, however this is probably the easiest way to get high-quality documentation in the short term.

I found the recommendation to use `allow_inspection` from the recent discussion in https://github.com/mkdocstrings/griffe/issues/156

Screenshot of the first couple of items after this change:

![image](https://github.com/pydantic/pydantic/assets/1939362/b02e8e47-a953-4e73-83b6-99c0568df489)

## Related issue number

N/A

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb