### PR TITLE
Update docs for validation errors

### DIFF
--- a/docs/plugins/conversion_table.py
+++ b/docs/plugins/conversion_table.py
@@ -1365,7 +1365,7 @@ table: list[Row] = [
         'Strict',
         'JSON',
         condition='Input value should be convertible to enum values.',
-        core_schemas=[core_schema.PlainValidatorFunctionSchema()],
+        core_schemas=[core_schema.PlainValidatorFunctionSchema],
     ),
     Row(
         Enum,
@@ -1388,7 +1388,7 @@ table: list[Row] = [
         'Strict',
         'JSON',
         condition='Input value should be convertible to enum values.',
-        core_schemas=[core_schema.PlainValidatorFunctionSchema()],
+        core_schemas=[core_schema.PlainValidatorFunctionSchema],
     ),
     Row(
         IntEnum,

--- a/docs/usage/validation_errors.md
+++ b/docs/usage/validation_errors.md
@@ -156,7 +156,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 ## `callable_type`
 
-This error is raised when the input value is valid as a `Callable`:
+This error is raised when the input value is not valid as a `Callable`:
 
 ```py
 from typing import Any, Callable

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -488,13 +488,13 @@ class GenerateSchema:
             pass
 
         if obj is Any or obj is object:
-            return core_schema.AnySchema(type='any')
+            return core_schema.any_schema()
         elif obj is None or obj is _typing_extra.NoneType:
-            return core_schema.NoneSchema(type='none')
+            return core_schema.none_schema()
         elif obj == type:
             return self._type_schema()
         elif _typing_extra.is_callable_type(obj):
-            return core_schema.CallableSchema(type='callable')
+            return core_schema.callable_schema()
         elif _typing_extra.is_literal_type(obj):
             return self._literal_schema(obj)
         elif is_typeddict(obj):
@@ -512,7 +512,7 @@ class GenerateSchema:
             return self._unsubstituted_typevar_schema(obj)
         elif is_finalvar(obj):
             if obj is Final:
-                return core_schema.AnySchema(type='any')
+                return core_schema.any_schema()
             return self.generate_schema(get_args(obj)[0])
         elif isinstance(obj, (FunctionType, LambdaType, MethodType, partial)):
             return self._callable_schema(obj)
@@ -851,12 +851,8 @@ class GenerateSchema:
             # annotations is empty, happens if namedtuple_cls defined via collections.namedtuple(...)
             annotations = {k: Any for k in namedtuple_cls._fields}
 
-        arguments_schema = core_schema.ArgumentsSchema(
-            type='arguments',
-            arguments_schema=[
-                self._generate_parameter_schema(field_name, annotation)
-                for field_name, annotation in annotations.items()
-            ],
+        arguments_schema = core_schema.arguments_schema(
+            [self._generate_parameter_schema(field_name, annotation) for field_name, annotation in annotations.items()],
             metadata=build_metadata_dict(js_prefer_positional_arguments=True),
         )
         return core_schema.call_schema(arguments_schema, namedtuple_cls)
@@ -1138,7 +1134,7 @@ class GenerateSchema:
         elif typevar.__constraints__:
             return self._union_schema(typing.Union[typevar.__constraints__])  # type: ignore
         else:
-            return core_schema.AnySchema(type='any')
+            return core_schema.any_schema()
 
     def _computed_field_schema(self, d: Decorator[ComputedFieldInfo]) -> core_schema.ComputedField:
         return_type_schema = self.generate_schema(d.info.return_type)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -11,6 +11,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 
 import pytest
+from pydantic_core import core_schema
 from pytest_examples import CodeExample, EvalExample, find_examples
 
 from pydantic.errors import PydanticErrorCodes
@@ -218,3 +219,17 @@ def test_error_codes():
     documented_error_codes = tuple(re.findall(r'^## .+ \{#(.+?)}$', error_text, flags=re.MULTILINE))
 
     assert code_error_codes == documented_error_codes, 'Error codes in code and docs do not match'
+
+
+def test_validation_error_codes():
+    error_text = (DOCS_ROOT / 'usage/validation_errors.md').read_text()
+
+    expected_validation_error_codes = set(core_schema.ErrorType.__args__)
+    # Remove codes that are not currently accessible from pydantic:
+    expected_validation_error_codes.remove('bool')  # this line can be removed if this gets removed from pydantic_core
+    expected_validation_error_codes.remove('timezone_offset')  # not currently exposed for configuration in pydantic
+    code_validation_error_codes = tuple(sorted(expected_validation_error_codes))
+
+    documented_validation_error_codes = tuple(re.findall(r'^## `(.+)`$', error_text, flags=re.MULTILINE))
+
+    assert code_validation_error_codes == documented_validation_error_codes, 'Error codes in code and docs do not match'

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -66,8 +66,8 @@ group_globals = GroupModuleGlobals()
 
 class MockedDatetime(datetime):
     @classmethod
-    def now(cls, *args, **kwargs):
-        return datetime(2032, 1, 2, 3, 4, 5, 6)
+    def now(cls, *args, tz=None, **kwargs):
+        return datetime(2032, 1, 2, 3, 4, 5, 6, tzinfo=tz)
 
 
 skip_reason = skip_docs_tests()
@@ -228,8 +228,29 @@ def test_validation_error_codes():
     # Remove codes that are not currently accessible from pydantic:
     expected_validation_error_codes.remove('bool')  # this line can be removed if this gets removed from pydantic_core
     expected_validation_error_codes.remove('timezone_offset')  # not currently exposed for configuration in pydantic
-    code_validation_error_codes = tuple(sorted(expected_validation_error_codes))
 
-    documented_validation_error_codes = tuple(re.findall(r'^## `(.+)`$', error_text, flags=re.MULTILINE))
+    test_failures = []
 
+    documented_validation_error_codes = []
+    error_code_section = None
+    printed_error_code = None
+    for line in error_text.splitlines():
+        section_match = re.fullmatch(r'## `(.+)`', line)
+        if section_match:
+            if error_code_section is not None and printed_error_code != error_code_section:
+                test_failures.append(f'Error code {error_code_section!r} is not printed in its example')
+            error_code_section = section_match.group(1)
+            if error_code_section not in expected_validation_error_codes:
+                test_failures.append(f'Documented error code {error_code_section!r} is not a member of ErrorType')
+            documented_validation_error_codes.append(error_code_section)
+            printed_error_code = None
+            continue
+
+        printed_match = re.search("#> '(.+)'", line)
+        if printed_match:
+            printed_error_code = printed_match.group(1)
+
+    assert test_failures == []
+
+    code_validation_error_codes = sorted(expected_validation_error_codes)
     assert code_validation_error_codes == documented_validation_error_codes, 'Error codes in code and docs do not match'


### PR DESCRIPTION
* Review and update `validation_errors.md`
* Fix a couple type errors in the conversion_table.py (noticed while trying to add examples to the `validation_errors.md`)
* Replace the direct use of the schema classes in GenerateSchema with schema functions for consistency with other schema creation (also noticed while trying to add examples to the `validation_errors.md`)
* Add a test that ensures that all error codes in `pydantic_core.core_schema.ErrorType` are either documented or manually removed from the expected values (this is done when the error cannot be produced by code paths currently exposed in pydantic, rather than pydantic-core)

This was brutal to go through, I think I got everything but wouldn't be surprised if there was still a couple minor inconsistencies or typos.

Selected Reviewer: @hramezani