### PR TITLE
🐛 Fix `TypeError` on mixed discriminated unions

### DIFF
--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -318,6 +318,12 @@ class _ApplyInferredDiscriminator:
         elif choice['type'] == 'typed-dict':
             return self._infer_discriminator_values_for_typed_dict_choice(choice, source_name=source_name)
 
+        elif choice['type'] == 'definition-ref':
+            schema_ref = choice['schema_ref']
+            if schema_ref not in self.definitions:
+                raise ValueError(f'Missing definition for inner ref {schema_ref!r}')
+            return self._infer_discriminator_values_for_choice(self.definitions[schema_ref], source_name=source_name)
+
         else:
             raise TypeError(
                 f'{choice["type"]!r} is not a valid discriminated union variant;'

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -38,8 +38,14 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType]):
 
     root: RootModelRootType
 
-    def __init__(__pydantic_self__, root: RootModelRootType = PydanticUndefined) -> None:  # type: ignore
+    def __init__(__pydantic_self__, root: RootModelRootType = PydanticUndefined, **data) -> None:  # type: ignore
         __tracebackhide__ = True
+        if data:
+            if root is not PydanticUndefined:
+                raise ValueError(
+                    '"RootModel.__init__" accepts either a single positional argument or arbitrary keyword arguments'
+                )
+            root = data  # type: ignore
         __pydantic_self__.__pydantic_validator__.validate_python(root, self_instance=__pydantic_self__)
 
     __init__.__pydantic_base_init__ = True  # type: ignore

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 import pytest
 from pydantic_core import CoreSchema
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
-from typing_extensions import Annotated
+from typing_extensions import Annotated, Literal
 
 from pydantic import (
     Base64Str,
@@ -488,3 +488,43 @@ def test_root_model_dump_with_base_model(order):
     assert m.root == [RModel(1), RModel(2), BModel.model_construct(value='abc')]
     assert m.model_dump() == [1, 2, {'value': 'abc'}]
     assert m.model_dump_json() == '[1,2,{"value":"abc"}]'
+
+
+@pytest.mark.parametrize(
+    'data',
+    [
+        pytest.param({'kind': 'IModel', 'int_value': 42}, id='IModel'),
+        pytest.param({'kind': 'SModel', 'str_value': 'abc'}, id='SModel'),
+    ],
+)
+def test_mixed_discriminated_union(data):
+    class IModel(BaseModel):
+        kind: Literal['IModel']
+        int_value: int
+
+    class RModel(RootModel):
+        root: IModel
+
+    class SModel(BaseModel):
+        kind: Literal['SModel']
+        str_value: str
+
+    class Model(RootModel):
+        root: Union[SModel, RModel] = Field(discriminator='kind')
+
+    assert Model(data).model_dump() == data
+    assert Model(**data).model_dump() == data
+
+
+def test_root_and_data_error():
+    class BModel(BaseModel):
+        value: int
+        other_value: str
+
+    Model = RootModel[BModel]
+
+    with pytest.raises(
+        ValueError,
+        match='"RootModel.__init__" accepts either a single positional argument or arbitrary keyword arguments',
+    ):
+        Model({'value': 42}, other_value='abc')


### PR DESCRIPTION
## Change Summary

Added support for `definition-ref` in discriminated unions.

## Related issue number

Fixes #6213 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb