### PR TITLE
🐛 Fix `RootModel.construct()` and `RootModel.__init__()` results aren't equal

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -213,11 +213,12 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             fields_values.update(values)
         _object_setattr(m, '__dict__', fields_values)
         _object_setattr(m, '__pydantic_fields_set__', _fields_set)
-        _object_setattr(m, '__pydantic_extra__', _extra)
+        if not cls.__pydantic_root_model__:
+            _object_setattr(m, '__pydantic_extra__', _extra)
 
         if cls.__pydantic_post_init__:
             m.model_post_init(None)
-        else:
+        elif not cls.__pydantic_root_model__:
             # Note: if there are any private attributes, cls.__pydantic_post_init__ would exist
             # Since it doesn't, that means that `__pydantic_private__` should be set to None
             _object_setattr(m, '__pydantic_private__', None)

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -310,8 +310,6 @@ def test_root_model_equality():
     assert RootModel[int](42) == RootModel[int](42)
     assert RootModel[int](42) != RootModel[int](7)
     assert RootModel[int](42) != RootModel[float](42)
-    print('***', vars(RootModel[int](42)))
-    print('***', vars(RootModel[int].model_construct(42)))
     assert RootModel[int](42) == RootModel[int].model_construct(42)
 
 

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -310,6 +310,9 @@ def test_root_model_equality():
     assert RootModel[int](42) == RootModel[int](42)
     assert RootModel[int](42) != RootModel[int](7)
     assert RootModel[int](42) != RootModel[float](42)
+    print('***', vars(RootModel[int](42)))
+    print('***', vars(RootModel[int].model_construct(42)))
+    assert RootModel[int](42) == RootModel[int].model_construct(42)
 
 
 def test_root_model_with_private_attrs_equality():


### PR DESCRIPTION
## Change Summary

Add `RootModel` specific logic to `BaseModel.construct()`

## Related issue number

Fixes #6195 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu