### PR TITLE
Add missing metadata to computed field JSON schemas

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1148,7 +1148,25 @@ class GenerateSchema:
             d.info.alias = alias
             d.info.alias_priority = 1
 
-        return core_schema.computed_field(d.cls_var_name, return_schema=return_type_schema, alias=d.info.alias)
+        def set_computed_field_metadata(schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+            json_schema = handler(schema)
+
+            json_schema['readOnly'] = True
+
+            title = d.info.title
+            if title is not None:
+                json_schema['title'] = title
+
+            description = d.info.description
+            if description is not None:
+                json_schema['description'] = description
+
+            return json_schema
+
+        metadata = build_metadata_dict(js_functions=[set_computed_field_metadata])
+        return core_schema.computed_field(
+            d.cls_var_name, return_schema=return_type_schema, alias=d.info.alias, metadata=metadata
+        )
 
     def _annotated_schema(self, annotated_type: Any) -> core_schema.CoreSchema:
         """Generate schema for an Annotated type, e.g. `Annotated[int, Field(...)]` or `Annotated[int, Gt(0)]`."""

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1239,7 +1239,7 @@ def test_json_schema_with_computed_field():
         '$defs': {
             'MyDataclass': {
                 'properties': {
-                    'double_x': {'title': 'Double X', 'type': 'integer'},
+                    'double_x': {'readOnly': True, 'title': 'Double X', 'type': 'integer'},
                     'x': {'title': 'X', 'type': 'integer'},
                 },
                 'required': ['x', 'double_x'],

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4317,7 +4317,10 @@ def test_computed_field():
         'type': 'object',
     }
     assert Model.model_json_schema(mode='serialization') == {
-        'properties': {'double_x': {'title': 'Double X', 'type': 'integer'}, 'x': {'title': 'X', 'type': 'integer'}},
+        'properties': {
+            'double_x': {'readOnly': True, 'title': 'Double X', 'type': 'integer'},
+            'x': {'title': 'X', 'type': 'integer'},
+        },
         'required': ['x', 'double_x'],
         'title': 'Model',
         'type': 'object',


### PR DESCRIPTION
Improves handling of JSON schema for computed fields and removes an xfailing test.