### PR TITLE
Move export_models to serialization

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -66,7 +66,7 @@ to help ease migration, but calling them will emit `DeprecationWarning`s.
     [`@model_serializer`](api/functional_serializers.md#pydantic.functional_serializers.model_serializer), and
     [`@computed_field`](api/fields.md#pydantic.fields.computed_field) decorators, which each address various
     shortcomings from Pydantic V1.
-    * See [Custom serializers](usage/exporting_models.md#custom-serializers) for the usage docs of these new decorators.
+    * See [Custom serializers](usage/serialization.md#custom-serializers) for the usage docs of these new decorators.
     * Due to performance overhead and implementation complexity, we have now removed support for specifying
         `json_encoders` in the model config. This functionality was originally added for the purpose of achieving custom
         serialization logic, and we think the new serialization decorators are a better choice in most common scenarios.
@@ -77,7 +77,7 @@ to help ease migration, but calling them will emit `DeprecationWarning`s.
   model. In V1, we would always include all fields from the subclass instance. In V2, when we dump a model, we only
   include the fields that are defined on the annotated type of the field. This helps prevent some accidental security
   bugs. You can read more about this (including how to opt out of this behavior) in the
-  [Subclass instances for fields of BaseModel, dataclasses, TypedDict](usage/exporting_models.md#subclass-instances-for-fields-of-basemodel-dataclasses-typeddict)
+  [Subclass instances for fields of BaseModel, dataclasses, TypedDict](usage/serialization.md#subclass-instances-for-fields-of-basemodel-dataclasses-typeddict)
   section of the model exporting docs.
 * `GetterDict` has been removed as it was just an implementation detail of `orm_mode`, which has been removed.
 

--- a/docs/usage/fields.md
+++ b/docs/usage/fields.md
@@ -663,7 +663,7 @@ print(user.model_dump())  # (1)!
 
 1. The `age` field is not included in the `model_dump()` output, since it is excluded.
 
-See the [Exporting Models] section for more details.
+See the [Serialization] section for more details.
 
 ## Customizing JSON Schema
 
@@ -730,4 +730,4 @@ TODO: Add `alias_priority` parameters.
 [init-only field]: https://docs.python.org/3/library/dataclasses.html#init-only-variables
 [frozen dataclass documentation]: https://docs.python.org/3/library/dataclasses.html#frozen-instances
 [Validate Assignment]: models.md#validate-assignment
-[Exporting Models]: exporting_models.md#model-and-field-level-include-and-exclude
+[Serialization]: serialization.md#model-and-field-level-include-and-exclude

--- a/docs/usage/json_schema.md
+++ b/docs/usage/json_schema.md
@@ -246,8 +246,8 @@ It has the following arguments:
 * `title`: if omitted, `field_name.title()` is used
 * `description`: if omitted and the annotation is a sub-model,
     the docstring of the sub-model will be used
-* `exclude`: exclude this field when dumping (`.dict` and `.json`) the instance. The exact syntax and configuration options are described in details in the [exporting models section](exporting_models.md#advanced-include-and-exclude).
-* `include`: include (only) this field when dumping (`.dict` and `.json`) the instance. The exact syntax and configuration options are described in details in the [exporting models section](exporting_models.md#advanced-include-and-exclude).
+* `exclude`: exclude this field when dumping (`.dict` and `.json`) the instance. The exact syntax and configuration options are described in details in [Serialization](serialization.md#advanced-include-and-exclude).
+* `include`: include (only) this field when dumping (`.dict` and `.json`) the instance. The exact syntax and configuration options are described in details in [Serialization](serialization.md#advanced-include-and-exclude).
 * `const`: this argument *must* be the same as the field's default value if present.
 * `gt`: for numeric values (``int``, `float`, `Decimal`), adds a validation of "greater than" and an annotation
   of `exclusiveMinimum` to the JSON Schema

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -86,11 +86,11 @@ Models possess the following methods and attributes:
 * `model_construct()`: a class method for creating models without running validation. See
     [Creating models without validation](#creating-models-without-validation).
 * `model_copy()`: returns a copy (by default, shallow copy) of the model. See
-    [Exporting models](exporting_models.md#modelcopy).
+    [Serialization](serialization.md#modelcopy).
 * `model_dump()`: returns a dictionary of the model's fields and values. See
-    [Exporting models](exporting_models.md#modeldump).
+    [Serialization](serialization.md#modeldump).
 * `model_dump_json()`: returns a JSON string representation of `model_dump()`. See
-    [Exporting models](exporting_models.md#modeldumpjson).
+    [Serialization](serialization.md#modeldumpjson).
 * `model_extra`: get extra fields set during validation.
 * `model_fields_set`: set of fields which were set when the model instance was initialised.
 * `model_json_schema()`: returns a dictionary representing the model as JSON Schema. See [JSON Schema](json_schema.md).
@@ -996,7 +996,7 @@ Field order is important in models for the following reasons:
   can access the values of earlier fields, but not later ones
 * field order is preserved in the model [schema](json_schema.md)
 * field order is preserved in [validation errors](#error-handling)
-* field order is preserved by [`.model_dump()` and `.model_dump_json()` etc.](exporting_models.md#modeldict)
+* field order is preserved by [`.model_dump()` and `.model_dump_json()` etc.](serialization.md#modeldict)
 
 ```py
 from pydantic import BaseModel, ValidationError

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -1,9 +1,18 @@
 Beyond accessing model attributes directly via their field names (e.g. `model.foobar`), models can be converted, dumped,
 serialized, and exported in a number of ways.
 
-!!! note "Serialize versus dump"
+!!! tip "Serialize versus dump"
     Pydantic uses the terms "serialize" and "dump" interchangeably. Both refer to the process of converting a model to a
     dictionary or JSON-encoded string.
+
+    Outside of Pydantic, the word "serialize" usually refers to converting in-memory data into a string or bytes.
+    However, in the context of Pydantic, there is a very close relationship between converting an object from a more
+    structured form &mdash; such as a Pydantic model, a dataclass, etc. &mdash; into a less structured form comprised of
+    Python built-ins such as dict.
+
+    While we could (and on occasion, do) distinguish between these scenarios by using the word "dump" when converting to
+    primitives and "serialize" when converting to string, for practical purposes, we frequently use the word "serialize"
+    to refer to both of these situations, even though it does not always imply conversion to a string or bytes.
 
 ## `model.model_dump(...)`
 

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -1,5 +1,9 @@
 Beyond accessing model attributes directly via their field names (e.g. `model.foobar`), models can be converted, dumped,
-serialized, and exported in a number of ways:
+serialized, and exported in a number of ways.
+
+!!! note "Serialize versus dump"
+    Pydantic uses the terms "serialize" and "dump" interchangeably. Both refer to the process of converting a model to a
+    dictionary or JSON-encoded string.
 
 ## `model.model_dump(...)`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
   - 'Model Config': usage/model_config.md
   - 'Fields': usage/fields.md
   - 'JSON Schema': usage/json_schema.md
-  - 'Exporting Models': usage/exporting_models.md
+  - 'Serialization': usage/serialization.md
   - 'Computed Fields': usage/computed_fields.md
   - 'Dataclasses': usage/dataclasses.md
   - 'Validation Decorator': usage/validation_decorator.md

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -142,7 +142,7 @@ def field_serializer(
 ) -> Callable[[Any], Any]:
     """Decorator that enables custom field serialization.
 
-    See [Custom serializers](../usage/exporting_models.md#custom-serializers) for more information.
+    See [Custom serializers](../usage/serialization.md#custom-serializers) for more information.
 
     Four signatures are supported:
 
@@ -208,7 +208,7 @@ def model_serializer(
 ) -> Callable[[Any], Any]:
     """Decorator that enables custom model serialization.
 
-    See [Custom serializers](../usage/exporting_models.md#custom-serializers) for more information.
+    See [Custom serializers](../usage/serialization.md#custom-serializers) for more information.
 
     Args:
         __f: The function to be decorated.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

- renames export_models.md to serialization.md
- updates all links
- adds a note about use of "serialize" and "dump" 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig