### PR TITLE
Remove warning on top of `docs/usage/types/callables.md`

### DIFF
--- a/docs/usage/types/callables.md
+++ b/docs/usage/types/callables.md
@@ -2,9 +2,6 @@
 description: Support for callable types.
 ---
 
-!!! warning
-    This page still needs to be updated for v2.0.
-
 `typing.Callable`
 : see below for more detail on parsing and validation
 


### PR DESCRIPTION
All the thing that are in this page seems correct to me