### PR TITLE
Update the error message shown for protected namespaces

### DIFF
--- a/docs/usage/model_config.md
+++ b/docs/usage/model_config.md
@@ -588,7 +588,9 @@ try:
 except NameError as e:
     print(e)
     """
-    Field "model_prefixed_field" has conflict with protected namespace "model_"
+    Field "model_prefixed_field" has conflict with protected namespace "model_".
+
+    You may be able to resolve this error by setting `model_config['protected_namespaces'] = ()`.
     """
 ```
 
@@ -610,7 +612,9 @@ try:
 except NameError as e:
     print(e)
     """
-    Field "also_protect_field" has conflict with protected namespace "also_protect_"
+    Field "also_protect_field" has conflict with protected namespace "also_protect_".
+
+    You may be able to resolve this error by setting `model_config['protected_namespaces'] = ('protect_me_',)`.
     """
 ```
 

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -109,7 +109,12 @@ def collect_model_fields(  # noqa: C901
             continue
         for protected_namespace in config_wrapper.protected_namespaces:
             if ann_name.startswith(protected_namespace):
-                raise NameError(f'Field "{ann_name}" has conflict with protected namespace "{protected_namespace}"')
+                valid_namespaces = tuple(x for x in config_wrapper.protected_namespaces if not ann_name.startswith(x))
+                raise NameError(
+                    f'Field "{ann_name}" has conflict with protected namespace "{protected_namespace}".'
+                    '\n\nYou may be able to resolve this error by setting'
+                    f" `model_config['protected_namespaces'] = {valid_namespaces}`."
+                )
         if is_classvar(ann_type):
             class_vars.add(ann_name)
             continue


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6322

Is there a good way to link to a docs page in a way that will cause a test failure if the link breaks? Not sure if we can/should change the error type here to achieve that. I'm also okay just hardcoding a link to the docs about `ConfigDict` if it feels it would be useful. Or not — I think this at least helps people figure out there's a way to address this problem.
