### PR TITLE
Fix tagged unions multiple processing in submodels

### DIFF
--- a/changes/6340-suharnikov.md
+++ b/changes/6340-suharnikov.md
@@ -1,0 +1,1 @@
+Fix tagged unions multiple processing in submodels

--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -23,6 +23,9 @@ def apply_discriminators(schema: core_schema.CoreSchema) -> core_schema.CoreSche
 
     def inner(s: core_schema.CoreSchema, recurse: _core_utils.Recurse) -> core_schema.CoreSchema:
         s = recurse(s, inner)
+        if s['type'] == 'tagged-union':
+            return s
+
         metadata = s.get('metadata', {})
         discriminator = metadata.get(CORE_SCHEMA_METADATA_DISCRIMINATOR_PLACEHOLDER_KEY, None)
         if discriminator is not None:

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1111,9 +1111,11 @@ def test_wrapped_nullable_union() -> None:
 def test_union_in_submodel() -> None:
     class UnionModel1(BaseModel):
         type: Literal[1] = 1
+        other: Literal['UnionModel1'] = 'UnionModel1'
 
     class UnionModel2(BaseModel):
         type: Literal[2] = 2
+        other: Literal['UnionModel2'] = 'UnionModel2'
 
     UnionModel = Annotated[Union[UnionModel1, UnionModel2], Field(discriminator='type')]
 
@@ -1125,3 +1127,92 @@ def test_union_in_submodel() -> None:
 
     class TestModel(BaseModel):
         submodel: Union[SubModel1, SubModel2]
+
+    m = TestModel.model_validate({'submodel': {'union_model': {'type': 1}}})
+    assert isinstance(m.submodel, SubModel1)
+    assert isinstance(m.submodel.union_model, UnionModel1)
+
+    m = TestModel.model_validate({'submodel': {'union_model': {'type': 2}}})
+    assert isinstance(m.submodel, SubModel1)
+    assert isinstance(m.submodel.union_model, UnionModel2)
+
+    with pytest.raises(ValidationError) as exc_info:
+        TestModel.model_validate({'submodel': {'union_model': {'type': 1, 'other': 'UnionModel2'}}})
+
+    # insert_assert(exc_info.value.errors())
+    assert exc_info.value.errors() == [
+        {
+            'type': 'literal_error',
+            'loc': ('submodel', 'SubModel1', 'union_model', 1, 'other'),
+            'msg': "Input should be 'UnionModel1'",
+            'input': 'UnionModel2',
+            'ctx': {'expected': "'UnionModel1'"},
+            'url': 'https://errors.pydantic.dev/2.0.1/v/literal_error',
+        },
+        {
+            'type': 'literal_error',
+            'loc': ('submodel', 'SubModel2', 'union_model', 1, 'other'),
+            'msg': "Input should be 'UnionModel1'",
+            'input': 'UnionModel2',
+            'ctx': {'expected': "'UnionModel1'"},
+            'url': 'https://errors.pydantic.dev/2.0.1/v/literal_error',
+        },
+    ]
+
+    # insert_assert(TestModel.model_json_schema())
+    assert TestModel.model_json_schema() == {
+        '$defs': {
+            'SubModel1': {
+                'properties': {
+                    'union_model': {
+                        'discriminator': {
+                            'mapping': {'1': '#/$defs/UnionModel1', '2': '#/$defs/UnionModel2'},
+                            'propertyName': 'type',
+                        },
+                        'oneOf': [{'$ref': '#/$defs/UnionModel1'}, {'$ref': '#/$defs/UnionModel2'}],
+                        'title': 'Union Model',
+                    }
+                },
+                'required': ['union_model'],
+                'title': 'SubModel1',
+                'type': 'object',
+            },
+            'SubModel2': {
+                'properties': {
+                    'union_model': {
+                        'discriminator': {
+                            'mapping': {'1': '#/$defs/UnionModel1', '2': '#/$defs/UnionModel2'},
+                            'propertyName': 'type',
+                        },
+                        'oneOf': [{'$ref': '#/$defs/UnionModel1'}, {'$ref': '#/$defs/UnionModel2'}],
+                        'title': 'Union Model',
+                    }
+                },
+                'required': ['union_model'],
+                'title': 'SubModel2',
+                'type': 'object',
+            },
+            'UnionModel1': {
+                'properties': {
+                    'type': {'const': 1, 'default': 1, 'title': 'Type'},
+                    'other': {'const': 'UnionModel1', 'default': 'UnionModel1', 'title': 'Other'},
+                },
+                'title': 'UnionModel1',
+                'type': 'object',
+            },
+            'UnionModel2': {
+                'properties': {
+                    'type': {'const': 2, 'default': 2, 'title': 'Type'},
+                    'other': {'const': 'UnionModel2', 'default': 'UnionModel2', 'title': 'Other'},
+                },
+                'title': 'UnionModel2',
+                'type': 'object',
+            },
+        },
+        'properties': {
+            'submodel': {'anyOf': [{'$ref': '#/$defs/SubModel1'}, {'$ref': '#/$defs/SubModel2'}], 'title': 'Submodel'}
+        },
+        'required': ['submodel'],
+        'title': 'TestModel',
+        'type': 'object',
+    }

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1106,3 +1106,22 @@ def test_wrapped_nullable_union() -> None:
             'from_attributes': True,
         },
     }
+
+
+def test_union_in_submodel() -> None:
+    class UnionModel1(BaseModel):
+        type: Literal[1] = 1
+
+    class UnionModel2(BaseModel):
+        type: Literal[2] = 2
+
+    UnionModel = Annotated[Union[UnionModel1, UnionModel2], Field(discriminator='type')]
+
+    class SubModel1(BaseModel):
+        union_model: UnionModel
+
+    class SubModel2(BaseModel):
+        union_model: UnionModel
+
+    class TestModel(BaseModel):
+        submodel: Union[SubModel1, SubModel2]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary
In some cases like that:
```py
import enum
from typing import Annotated, Literal

from pydantic import BaseModel, Field


class ComponentType(enum.IntEnum):
        SomeComponent1 = 1
        SomeComponent2 = 2

class SomeComponent1(BaseModel):
    type: Literal[ComponentType.SomeComponent1] = ComponentType.SomeComponent1
    
class SomeComponent2(BaseModel):
    type: Literal[ComponentType.SomeComponent2] = ComponentType.SomeComponent2

Component = Annotated[SomeComponent1|SomeComponent2, Field(discriminator='type')]

class TestModel1(BaseModel):
    components: list[Component]
    
class TestModel2(BaseModel):
    components: list[Component]
    
class TestModel3(BaseModel):
    submodels: TestModel1|TestModel2
```
`apply_discriminators` function could process tagged-unions because the `tagged-union` contains `discriminator`, but doesn't take that the schema was processed in another model. I excluded tagged-unions from the recursive processing.

I'm not sure about the place of the fix. Possibly a better place for this is `_ApplyInferredDiscriminator.apply`
https://github.com/pydantic/pydantic/blob/15d5e0b0abdd79fd63d34954e8dacaa9f1a255f8/pydantic/_internal/_discriminated_union.py#L154-L160

## Related issue number
Fix #6339
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig