### PR TITLE
Fix typo in `create_model` function

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1295,7 +1295,7 @@ def create_model(
                 f_annotation, f_value = f_def
             except ValueError as e:
                 raise PydanticUserError(
-                    'Field definitions should either be a `(<type>, <default>)`.',
+                    'Field definitions should be a `(<type>, <default>)`.',
                     code='create-model-field-definitions',
                 ) from e
         else:

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -483,7 +483,7 @@ def test_create_model_tuple():
 
 
 def test_create_model_tuple_3():
-    with pytest.raises(PydanticUserError, match=r'^Field definitions should either be a `\(<type>, <default>\)`\.\n'):
+    with pytest.raises(PydanticUserError, match=r'^Field definitions should be a `\(<type>, <default>\)`\.\n'):
         create_model('FooModel', foo=(Tuple[int, int], (1, 2), 'more'))
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

Previously, `create_model` were able to receive other parameters as well. The `either` was most likely forgotten to be removed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin