### PR TITLE
Fix import of create_model in tools.py

### DIFF
--- a/changes/6361-SharathHuddar.md
+++ b/changes/6361-SharathHuddar.md
@@ -1,0 +1,1 @@
+Importing create_model in tools.py through relative path instead of absolute path - so that it doesn't import V2 code when copied over to V2 branch

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -21,7 +21,7 @@ def _generate_parsing_type_name(type_: Any) -> str:
 
 @lru_cache(maxsize=2048)
 def _get_parsing_type(type_: Any, *, type_name: Optional[NameFactory] = None) -> Any:
-    from pydantic.main import create_model
+    from .main import create_model
 
     if type_name is None:
         type_name = _generate_parsing_type_name


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary
Importing `create_model` in `tools.py` through relative path instead of absolute path - so that `_get_parsing_type` doesn't import V2 code when copied over to main (V2) branch


<!-- Please give a short summary of the changes. -->

## Related issue number
fix #6361 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani