### PR TITLE
Adding extra field via `setattr` adds field to model_extra

### DIFF
--- a/changes/6365-aaraney.md
+++ b/changes/6365-aaraney.md
@@ -1,0 +1,2 @@
+Extra fields added via `setattr` (i.e. `m.some_extra_field = 'extra_value'`)
+are added to `.model_extra` if `model_config` `extra='allowed'`. Fixed #6333.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -737,6 +737,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         elif self.model_config.get('extra') != 'allow' and name not in self.model_fields:
             # TODO - matching error
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
+        elif self.model_config.get('extra') == 'allow' and name not in self.model_fields:
+            # SAFETY: __pydantic_extra__ is not None when extra = 'allow'
+            self.__pydantic_extra__[name] = value  # type: ignore
         else:
             self.__dict__[name] = value
             self.__pydantic_fields_set__.add(name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -230,6 +230,10 @@ def test_allow_extra():
     assert m.a == 10.2
     assert m.b == 12
     assert m.model_extra == {'b': 12}
+    m.c = 42
+    assert 'c' not in m.__dict__
+    assert m.__pydantic_extra__ == {'b': 12, 'c': 42}
+    assert m.model_dump() == {'a': 10.2, 'b': 12, 'c': 42}
 
 
 @pytest.mark.parametrize('extra', ['ignore', 'forbid', 'allow'])


### PR DESCRIPTION
## Change Summary

If extra fields are allowed and set via `setattr`, they are now added to `model_extra` (i.e. `__pydantic_extra__`).

## Related issue number

fix #6333

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
