### PR TITLE
Fix some uses of `Field` inside of `Annotated` 

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1295,6 +1295,23 @@ class GenerateSchema:
         if isinstance(metadata, FieldInfo):
             for field_metadata in metadata.metadata:
                 schema = self.apply_single_annotation(schema, field_metadata)
+            json_schema_update: JsonSchemaValue = {}
+            if metadata.title:
+                json_schema_update['title'] = metadata.title
+            if metadata.json_schema_extra:
+                json_schema_update.update(metadata.json_schema_extra)
+            if metadata.description:
+                json_schema_update['description'] = metadata.description
+            if metadata.examples:
+                json_schema_update['examples'] = metadata.examples
+            if json_schema_update:
+    
+                def json_schema_update_func(core_schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+                    json_schema = handler(core_schema)
+                    json_schema.update(json_schema_update)
+                    return json_schema
+
+                CoreMetadataHandler(schema).metadata.setdefault('pydantic_js_annotation_functions', []).append(json_schema_update_func)
             if metadata.discriminator is not None:
                 _discriminated_union.set_discriminator(
                     schema,

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1291,7 +1291,9 @@ class GenerateSchema:
             metadata.setdefault('pydantic_js_annotation_functions', []).extend(pydantic_js_annotation_functions)
         return schema
 
-    def apply_single_annotation(self, schema: core_schema.CoreSchema, metadata: Any) -> core_schema.CoreSchema:
+    def apply_single_annotation(  # noqa: C901
+        self, schema: core_schema.CoreSchema, metadata: Any
+    ) -> core_schema.CoreSchema:
         if isinstance(metadata, FieldInfo):
             for field_metadata in metadata.metadata:
                 schema = self.apply_single_annotation(schema, field_metadata)
@@ -1305,13 +1307,17 @@ class GenerateSchema:
             if metadata.examples:
                 json_schema_update['examples'] = metadata.examples
             if json_schema_update:
-    
-                def json_schema_update_func(core_schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+
+                def json_schema_update_func(
+                    core_schema: CoreSchemaOrField, handler: GetJsonSchemaHandler
+                ) -> JsonSchemaValue:
                     json_schema = handler(core_schema)
                     json_schema.update(json_schema_update)
                     return json_schema
 
-                CoreMetadataHandler(schema).metadata.setdefault('pydantic_js_annotation_functions', []).append(json_schema_update_func)
+                CoreMetadataHandler(schema).metadata.setdefault('pydantic_js_annotation_functions', []).append(
+                    json_schema_update_func
+                )
             if metadata.discriminator is not None:
                 _discriminated_union.set_discriminator(
                     schema,

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -95,8 +95,6 @@ from pydantic.types import (
     constr,
 )
 
-from pydantic.fields import FieldInfo
-
 try:
     import email_validator
 except ImportError:
@@ -4842,15 +4840,21 @@ def test_custom_type_gets_unpacked_ref() -> None:
     }
 
 
-
 @pytest.mark.parametrize(
-    'annotation, expected', [
+    'annotation, expected',
+    [
         (Annotated[int, Field(json_schema_extra={'title': 'abc'})], {'type': 'integer', 'title': 'abc'}),
-        (Annotated[int, Field(title='abc'), Field(description='xyz')], {'type': 'integer', 'title': 'abc', 'description': 'xyz'}),
+        (
+            Annotated[int, Field(title='abc'), Field(description='xyz')],
+            {'type': 'integer', 'title': 'abc', 'description': 'xyz'},
+        ),
         (Annotated[int, Field(gt=0)], {'type': 'integer', 'exclusiveMinimum': 0}),
-        (Annotated[int, Field(gt=0), Field(lt=100)], {'type': 'integer', 'exclusiveMinimum': 0, 'exclusiveMaximum': 100}),
+        (
+            Annotated[int, Field(gt=0), Field(lt=100)],
+            {'type': 'integer', 'exclusiveMinimum': 0, 'exclusiveMaximum': 100},
+        ),
     ],
-    ids=repr
+    ids=repr,
 )
 def test_field_json_schema_metadata(annotation: type[Any], expected: JsonSchemaValue) -> None:
     ta = TypeAdapter(annotation)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4853,6 +4853,7 @@ def test_custom_type_gets_unpacked_ref() -> None:
             Annotated[int, Field(gt=0), Field(lt=100)],
             {'type': 'integer', 'exclusiveMinimum': 0, 'exclusiveMaximum': 100},
         ),
+        (Annotated[int, Field(examples={'number': 1})], {'type': 'integer', 'examples': {'number': 1}}),
     ],
     ids=repr,
 )

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4856,6 +4856,6 @@ def test_custom_type_gets_unpacked_ref() -> None:
     ],
     ids=repr,
 )
-def test_field_json_schema_metadata(annotation: type[Any], expected: JsonSchemaValue) -> None:
+def test_field_json_schema_metadata(annotation: Type[Any], expected: JsonSchemaValue) -> None:
     ta = TypeAdapter(annotation)
     assert ta.json_schema() == expected

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -5,7 +5,7 @@ import pytest
 from annotated_types import MaxLen
 from typing_extensions import Annotated, TypeAliasType
 
-from pydantic import ValidationError
+from pydantic import ValidationError, Field
 from pydantic.type_adapter import TypeAdapter
 
 T = TypeVar('T')
@@ -299,4 +299,17 @@ def test_recursive_generic_type_alias_annotated_defs() -> None:
                 'maxItems': 1,
             },
         },
+    }
+
+
+def test_field() -> None:
+    SomeAlias = TypeAliasType('SomeAlias', Annotated[int, Field(description='number')])
+
+    ta = TypeAdapter(Annotated[SomeAlias, Field(title='abc')])
+
+    # insert_assert(ta.json_schema())
+    assert ta.json_schema() == {
+        '$defs': {'SomeAlias': {'type': 'integer'}},
+        'allOf': [{'$ref': '#/$defs/SomeAlias'}],
+        'title': 'abc',
     }

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -302,6 +302,7 @@ def test_recursive_generic_type_alias_annotated_defs() -> None:
     }
 
 
+@pytest.mark.xfail(reason='description is currently dropped')
 def test_field() -> None:
     SomeAlias = TypeAliasType('SomeAlias', Annotated[int, Field(description='number')])
 
@@ -309,7 +310,7 @@ def test_field() -> None:
 
     # insert_assert(ta.json_schema())
     assert ta.json_schema() == {
-        '$defs': {'SomeAlias': {'type': 'integer'}},
+        '$defs': {'SomeAlias': {'type': 'integer', 'description': 'number'}},
         'allOf': [{'$ref': '#/$defs/SomeAlias'}],
         'title': 'abc',
     }

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -5,7 +5,7 @@ import pytest
 from annotated_types import MaxLen
 from typing_extensions import Annotated, TypeAliasType
 
-from pydantic import ValidationError, Field
+from pydantic import Field, ValidationError
 from pydantic.type_adapter import TypeAdapter
 
 T = TypeVar('T')


### PR DESCRIPTION
Partially addresses https://github.com/pydantic/pydantic/issues/6353. It doesn't establish any sort of override semantics (although they do kinda work sometimes, they're just not thought out or consistent). Maybe replaces https://github.com/pydantic/pydantic/pull/6336?

Selected Reviewer: @Kludex