### PR TITLE
Remove warning from top of `docs/usage/types/encoded.md`

### DIFF
--- a/docs/usage/types/encoded.md
+++ b/docs/usage/types/encoded.md
@@ -2,9 +2,6 @@
 description: Support for storing data in an encoded form.
 ---
 
-!!! warning
-    This page still needs to be updated for v2.0.
-
 `EncodedBytes`
 : a bytes value which is decoded from/encoded into a (different) bytes value during validation/serialization
 


### PR DESCRIPTION
I've checked the content of this page and all seems correct to me

Selected Reviewer: @samuelcolvin