### PR TITLE
🐛 Fix generic tuple cannot have more than one item

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -858,7 +858,7 @@ class GenerateSchema:
 
         if typevars_map:
             annotations = {
-                field_name: typevars_map.get(annotation, annotation) for field_name, annotation in annotations.items()
+                field_name: replace_types(annotation, typevars_map) for field_name, annotation in annotations.items()
             }
 
         arguments_schema = core_schema.arguments_schema(
@@ -903,7 +903,7 @@ class GenerateSchema:
         params = get_args(tuple_type)
 
         if typevars_map:
-            params = tuple(typevars_map.get(param, param) for param in params)
+            params = tuple(replace_types(param, typevars_map) for param in params)
 
         # NOTE: subtle difference: `tuple[()]` gives `params=()`, whereas `typing.Tuple[()]` gives `params=((),)`
         # This is only true for <3.11, on Python 3.11+ `typing.Tuple[()]` gives `params=()`

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -229,6 +229,8 @@ def get_standard_typevars_map(cls: type[Any]) -> dict[TypeVarType, Any] | None:
     origin = get_origin(cls)
     if origin is None:
         return None
+    if not hasattr(origin, '__parameters__'):
+        return None
 
     # In this case, we know that cls is a _GenericAlias, and origin is the generic type
     # So it is safe to access cls.__args__ and origin.__parameters__

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2744,18 +2744,17 @@ def test_namedtuple_default():
     assert LocationBase(coords=Coordinates(1, 2)).coords == Coordinates(1, 2)
 
     assert LocationBase.model_json_schema() == {
-        'title': 'LocationBase',
-        'type': 'object',
-        'properties': {
-            'coords': {
-                'title': 'Coords',
-                'default': [34, 42],
-                'type': 'array',
-                'prefixItems': [{'title': 'X', 'type': 'number'}, {'title': 'Y', 'type': 'number'}],
-                'minItems': 2,
+        '$defs': {
+            'Coordinates': {
                 'maxItems': 2,
+                'minItems': 2,
+                'prefixItems': [{'title': 'X', 'type': 'number'}, {'title': 'Y', 'type': 'number'}],
+                'type': 'array',
             }
         },
+        'properties': {'coords': {'allOf': [{'$ref': '#/$defs/Coordinates'}], 'default': [34, 42]}},
+        'title': 'LocationBase',
+        'type': 'object',
     }
 
 
@@ -2775,16 +2774,15 @@ def test_namedtuple_modify_schema():
         coords: CustomCoordinates = CustomCoordinates(34, 42)
 
     assert Location.model_json_schema() == {
-        'properties': {
-            'coords': {
+        '$defs': {
+            'CustomCoordinates': {
                 'additionalProperties': False,
                 'properties': {'x': {'title': 'X', 'type': 'number'}, 'y': {'title': 'Y', 'type': 'number'}},
                 'required': ['x', 'y'],
-                'title': 'Coords',
                 'type': 'object',
-                'default': [34, 42],
             }
         },
+        'properties': {'coords': {'allOf': [{'$ref': '#/$defs/CustomCoordinates'}], 'default': [34, 42]}},
         'title': 'Location',
         'type': 'object',
     }

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -615,9 +615,9 @@ def test_set():
 @pytest.mark.parametrize(
     'field_type,extra_props',
     [
-        (tuple, {'items': {}}),
-        (Tuple, {'items': {}}),
-        (
+        pytest.param(tuple, {'items': {}}, id='tuple'),
+        pytest.param(Tuple, {'items': {}}, id='Tuple'),
+        pytest.param(
             Tuple[str, int, Union[str, int, float], float],
             {
                 'prefixItems': [
@@ -629,13 +629,11 @@ def test_set():
                 'minItems': 4,
                 'maxItems': 4,
             },
+            id='Tuple[str, int, Union[str, int, float], float]',
         ),
-        (Tuple[str], {'prefixItems': [{'type': 'string'}], 'minItems': 1, 'maxItems': 1}),
-        (Tuple[()], {'maxItems': 0, 'minItems': 0}),
-        (
-            Tuple[str, ...],
-            {'items': {'type': 'string'}, 'type': 'array'},
-        ),
+        pytest.param(Tuple[str], {'prefixItems': [{'type': 'string'}], 'minItems': 1, 'maxItems': 1}, id='Tuple[str]'),
+        pytest.param(Tuple[()], {'maxItems': 0, 'minItems': 0}, id='Tuple[()]'),
+        pytest.param(Tuple[str, ...], {'items': {'type': 'string'}, 'type': 'array'}, id='Tuple[str, ...]'),
     ],
 )
 def test_tuple(field_type, extra_props):


### PR DESCRIPTION
## Change Summary

For now reproduces the bug with generic tuple cannot have more than one item 

## Related issue number

Fixes #6383 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex