### PR TITLE
Do not recommend raising `TypeError` in validators

### DIFF
--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -77,7 +77,7 @@ A few things to note on validators:
   * `config`: the model config
   * `field`: the field being validated. Type of object is `pydantic.fields.ModelField`.
   * `**kwargs`: if provided, this will include the arguments above not explicitly listed in the signature
-* validators should either return the parsed value or raise a `ValueError`, `TypeError`, or `AssertionError`
+* validators should either return the parsed value or raise a `ValueError` or `AssertionError`
   (``assert`` statements may be used).
 
 !!! warning


### PR DESCRIPTION
Quick fix following https://github.com/pydantic/pydantic/pull/6179

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex