### PR TITLE
Fix type hint of `model_config`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -96,7 +96,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # of `BaseModel` here:
 
         # Class attributes
-        model_config: ClassVar[ConfigDict]
         model_fields: ClassVar[dict[str, FieldInfo]]
 
         __class_vars__: ClassVar[set[str]]
@@ -133,7 +132,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
 
-    model_config = ConfigDict()
+    model_config: ClassVar[ConfigDict] = ConfigDict()
     __pydantic_complete__ = False
     __pydantic_root_model__ = False
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

Related: https://github.com/pydantic/pydantic-settings/pull/97. Could it be possible for someone to try and see if they have the same issue (on VSCode) described in https://github.com/pydantic/pydantic-settings/pull/97 🙏? As I said, it seems this issue is inconsistent, and it might be pylance doing weird things.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt