### PR TITLE
Remove --verbose flag from docs build to clean up CI logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       run: pdm install -G docs
 
     - run: pdm run python -c 'import docs.plugins.main'
-    - run: pdm run mkdocs build --verbose
+    - run: pdm run mkdocs build
 
   test-memray:
     name: test memray


### PR DESCRIPTION


Selected Reviewer: @dmontagu