### PR TITLE
Allow single-item discriminated unions

### DIFF
--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -181,10 +181,11 @@ class _ApplyInferredDiscriminator:
             return definitions_wrapper
 
         if schema['type'] != 'union':
-            raise TypeError('`discriminator` can only be used with `Union` type with more than one variant')
-
-        if len(schema['choices']) < 2:
-            raise TypeError('`discriminator` can only be used with `Union` type with more than one variant')
+            # If the schema is not a union, it probably means it just had a single member and
+            # was flattened by pydantic_core.
+            # However, it still may make sense to apply the discriminator to this schema,
+            # as a way to get discriminated-union-style error messages, so we allow this here.
+            schema = core_schema.union_schema([schema])
 
         # Reverse the choices list before extending the stack so that they get handled in the order they occur
         self._choices_to_handle.extend(schema['choices'][::-1])

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -13,22 +13,48 @@ from pydantic._internal._discriminated_union import apply_discriminator
 from pydantic.errors import PydanticUserError
 
 
-def test_discriminated_union_only_union():
+def test_discriminated_union_type():
     with pytest.raises(
-        TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
+        TypeError, match="'str' is not a valid discriminated union variant; should be a `BaseModel` or `dataclass`"
     ):
 
         class Model(BaseModel):
             x: str = Field(..., discriminator='qwe')
 
 
-def test_discriminated_union_single_variant():
-    with pytest.raises(
-        TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
-    ):
+@pytest.mark.parametrize('union', [True, False])
+def test_discriminated_single_variant(union):
+    class InnerModel(BaseModel):
+        qwe: Literal['qwe']
 
-        class Model(BaseModel):
-            x: Union[str] = Field(..., discriminator='qwe')
+    class Model(BaseModel):
+        if union:
+            x: Union[InnerModel] = Field(..., discriminator='qwe')
+        else:
+            x: InnerModel = Field(..., discriminator='qwe')
+
+    assert Model(x={'qwe': 'qwe'}).x.qwe == 'qwe'
+    with pytest.raises(ValidationError) as exc_info:
+        Model(x={'qwe': 'asd'})
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'discriminator': "'qwe'", 'expected_tags': "'qwe'", 'tag': 'asd'},
+            'input': {'qwe': 'asd'},
+            'loc': ('x',),
+            'msg': "Input tag 'asd' found using 'qwe' does not match any of the expected " "tags: 'qwe'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+
+def test_discriminated_union_single_variant():
+    class InnerModel(BaseModel):
+        qwe: Literal['qwe']
+
+    class Model(BaseModel):
+        x: Union[InnerModel] = Field(..., discriminator='qwe')
+
+    assert Model(x={'qwe': 'qwe'}).x.qwe == 'qwe'
 
 
 def test_discriminated_union_invalid_type():
@@ -812,15 +838,6 @@ def test_invalid_discriminated_union_type() -> None:
 
         class Model(BaseModel):
             pet: Union[Cat, Dog, str] = Field(discriminator='pet_type')
-
-
-def test_single_item_union_error() -> None:
-    fields = {'kind': core_schema.typed_dict_field(core_schema.literal_schema(['only_choice']))}
-    schema = core_schema.union_schema([core_schema.typed_dict_schema(fields=fields)])
-    with pytest.raises(
-        TypeError, match='`discriminator` can only be used with `Union` type with more than one variant'
-    ):
-        apply_discriminator(schema, 'kind')
 
 
 def test_invalid_alias() -> None:


### PR DESCRIPTION
I don't have proof yet as I can't reproduce the issue, but I suspect this may resolve the issue brought up in https://github.com/pydantic/pydantic/issues/5163#issuecomment-1619203179.

Even if not, I think this is an improvement worth making, as I don't see any reason we should error if you produce a single-item discriminated union. In particular, it may be desirable to do this as a way to immediately fail validation if the tag is wrong rather than producing all the possible associated errors.