### PR TITLE
Bind `validate_call` to instance when decorating methods

### DIFF
--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -649,3 +649,15 @@ def test_do_not_call_repr_on_validate_call() -> None:
             assert False
 
     Class(50)
+
+
+def test_methods_are_not_rebound():
+    class Thing:
+        def a(self):
+            pass
+
+        c = validate_call(a)
+
+    thing = Thing()
+    assert thing.a == thing.a
+    assert thing.c == thing.c


### PR DESCRIPTION
Resolves https://github.com/pydantic/pydantic/issues/6390

I'll also note that this results in a **_100x_** speedup of the following (admittedly trivial) benchmark:
```python
import time

from pydantic import validate_call

class Thing:
    def a(self):
        pass

    c = validate_call(a)


thing = Thing()

t0 = time.time()
for _ in range(100_000):
    thing.c()
t1 = time.time()
print(f'{t1 - t0:.3f}')
#> without this change: ~6.0s
#> with this change: ~0.060s
```