### PR TITLE
💚 Use "result" instead of "status" on GitHub Action conditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,7 @@ jobs:
   send-tweet:
     name: Send tweet
     needs: [release]
-    if: needs.release.status == 'success'
+    if: needs.release.result == 'success'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Let's pretend this never happened.

Ref.: https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context