### PR TITLE
Improve `BaseModel.__getattr__` to raise a better error in case of AttributeError in model property

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -703,7 +703,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                     except KeyError as exc:
                         raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
                 else:
-                    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
+                    if hasattr(self.__class__, item):
+                        raise AttributeError(
+                            f'{type(self).__name__!r} object has an attribute {item!r} - it looks like the property '
+                            'raised an `AttributeError` which this `__getattr__` method has muted, sorry.'
+                        )
+                    else:
+                        # this is the current error
+                        raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name in self.__class_vars__:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -705,9 +705,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 else:
                     if hasattr(self.__class__, item):
                         return super().__getattribute__(item)  # Raises AttributeError if appropriate
-                            f'{type(self).__name__!r} object has an attribute {item!r} - it looks like the property '
-                            'raised an `AttributeError` which this `__getattr__` method has muted, sorry.'
-                        )
                     else:
                         # this is the current error
                         raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -704,7 +704,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                         raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
                 else:
                     if hasattr(self.__class__, item):
-                        raise AttributeError(
+                        return super().__getattribute__(item)  # Raises AttributeError if appropriate
                             f'{type(self).__name__!r} object has an attribute {item!r} - it looks like the property '
                             'raised an `AttributeError` which this `__getattr__` method has muted, sorry.'
                         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -318,13 +318,7 @@ def test_model_property_attribute_error():
         def a_property(self):
             raise AttributeError('Internal Error')
 
-    with pytest.raises(
-        AttributeError,
-        match=(
-            "'Model' object has an attribute 'a_property' - it looks like the property raised an "
-            "`AttributeError` which this `__getattr__` method has muted, sorry."
-        ),
-    ):
+    with pytest.raises(AttributeError, match='Internal Error'):
         Model().a_property
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -312,6 +312,22 @@ def test_assign_extra_validate():
         model.b = 2
 
 
+def test_model_property_attribute_error():
+    class Model(BaseModel):
+        @property
+        def a_property(self):
+            raise AttributeError('Internal Error')
+
+    with pytest.raises(
+        AttributeError,
+        match=(
+            "'Model' object has an attribute 'a_property' - it looks like the property raised an "
+            "`AttributeError` which this `__getattr__` method has muted, sorry."
+        ),
+    ):
+        Model().a_property
+
+
 def test_extra_allowed():
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow')


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6360
Based on [@samuelcolvin comment](https://github.com/pydantic/pydantic/issues/6360#issuecomment-1617725012)


Selected Reviewer: @dmontagu