### PR TITLE
💚 Use `main-pv2` FastAPI branch in integration tests

### DIFF
--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -5,10 +5,10 @@ set -e
 
 cd fastapi
 git fetch --tags
-# TODO: Remove the comments once FastAPI 0.100.0 is released.
-# latest_tag_commit=$(git rev-list --tags --max-count=1)
-# latest_tag=$(git describe --tags "${latest_tag_commit}")
-latest_tag="0.100.0-beta1"
+
+# TODO: Use the proper latest tag once FastAPI stable release is compatible with Pydantic V2.
+# latest_tag=$(git describe --tags --abbrev=0)
+latest_tag="main-pv2"
 git checkout "${latest_tag}"
 
 pip install -r requirements.txt


### PR DESCRIPTION
## Change Summary

For now use the tip of the FastAPI branch compatible with Pydantic V2 

## Related issue number

None

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
