### PR TITLE
Docs: Fixing constr argument regex -> pattern // Typo

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -512,7 +512,7 @@ Pydantic V1 used Python's regex library. Pydantic V2 uses the Rust [regex crate]
 This crate is not just a "Rust version of regular expressions", it's a completely different approach to regular expressions.
 In particular, it promises linear time searching of strings in exchange for dropping a couple of features (namely look arounds and backreferences).
 We believe this is a tradeoff worth making, in particular because Pydantic is used to validate untrusted input where ensuring things don't accidentally run in exponential time depending on the untrusted input is important.
-One the flipside, for anyone not using these features complex regex validation should be orders of magnitude faster because it's done in Rust and in linear time.
+On the flipside, for anyone not using these features complex regex validation should be orders of magnitude faster because it's done in Rust and in linear time.
 If you need those regex features you can create a custom validator that does the regex validation in Python:
 
 ```py

--- a/docs/plugins/schema_mappings.toml
+++ b/docs/plugins/schema_mappings.toml
@@ -430,8 +430,8 @@ additional = ""
 defined_in = "JSON Schema Core"
 notes = "If the type has values declared for the constraints, they are included as validations. See the mapping for `constr` below."
 
-["constr(regex='^text$', min_length=2, max_length=10)"]
-py_type = "constr(regex='^text$', min_length=2, max_length=10)"
+["constr(pattern='^text$', min_length=2, max_length=10)"]
+py_type = "constr(pattern='^text$', min_length=2, max_length=10)"
 json_type = "string"
 defined_in = "JSON Schema Validation"
 notes = "Any argument not passed to the function (not defined) will not be included in the schema."

--- a/docs/usage/types/string_types.md
+++ b/docs/usage/types/string_types.md
@@ -99,5 +99,4 @@ The following arguments are available when using the `constr` type function
 - `strict: bool = False`: controls type coercion
 - `min_length: int = None`: minimum length of the string
 - `max_length: int = None`: maximum length of the string
-- `curtail_length: int = None`: shrinks the string length to the set value when it is longer than the set value
-- `regex: str = None`: regex to validate the string against
+- `pattern: str = None`: regex to validate the string against


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

Fixing docs for `constr`, argument `regex` -> `pattern`. Fixed typo.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
