### PR TITLE
Mention PyObject (v1) moving to ImportString (v2) in migration doc

### DIFF
--- a/changes/6456-slafs.md
+++ b/changes/6456-slafs.md
@@ -1,0 +1,1 @@
+Update the migration guide to reference `PyObject` and `ImportString`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -694,9 +694,10 @@ which may be installed separately if needed.
 
 ### `PyObject` replaced with `ImportString`
 
-The type `PyObject` has been replaced with `ImportString`, which is a string that can be imported as a module.
-There are some subtle differences between how values are validated for the two types, so if you were using `PyObject`
-in Pydantic V1, you may need to make some changes beyond just changing the name of the type.
+The type `PyObject` has been replaced with `ImportString`, which is a string that represents a module or module
+attribute. While these two types are very similar, there are some subtle differences between how values are validated
+for the two types, so if you were using `PyObject` in Pydantic V1 you may need to make some changes beyond just
+changing the name of the type.
 
 See the [`ImportString` docs](usage/types/string_types.md#importstring) for more information.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -704,6 +704,7 @@ which may be installed separately if needed.
 | `pydantic.error_wrappers.ValidationError` | `pydantic.ValidationError` |
 | `pydantic.utils.to_camel` | `pydantic.alias_generators.to_pascal` |
 | `pydantic.utils.to_lower_camel` | `pydantic.alias_generators.to_camel` |
+| `pydantic.PyObject` | [`pydantic.ImportString`](usage/types/string_types/#importstring) |
 
 ## Deprecated and moved in Pydantic V2
 
@@ -747,7 +748,6 @@ which may be installed separately if needed.
 - `pydantic.NoneStr`
 - `pydantic.NoneStrBytes`
 - `pydantic.Protocol`
-- `pydantic.PyObject`
 - `pydantic.Required`
 - `pydantic.StrBytes`
 - `pydantic.compiled`

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -692,6 +692,14 @@ which may be installed separately if needed.
 * [Color Types](usage/types/extra_types/color_types.md)
 * [Payment Card Numbers](usage/types/extra_types/payment_cards.md)
 
+### `PyObject` replaced with `ImportString`
+
+The type `PyObject` has been replaced with `ImportString`, which is a string that can be imported as a module.
+There are some subtle differences between how values are validated for the two types, so if you were using `PyObject`
+in Pydantic V1, you may need to make some changes beyond just changing the name of the type.
+
+See the [`ImportString` docs](usage/types/string_types.md#importstring) for more information.
+
 ## Moved in Pydantic V2
 
 | Pydantic V1 | Pydantic V2 |
@@ -704,7 +712,6 @@ which may be installed separately if needed.
 | `pydantic.error_wrappers.ValidationError` | `pydantic.ValidationError` |
 | `pydantic.utils.to_camel` | `pydantic.alias_generators.to_pascal` |
 | `pydantic.utils.to_lower_camel` | `pydantic.alias_generators.to_camel` |
-| `pydantic.PyObject` | [`pydantic.ImportString`](usage/types/string_types/#importstring) |
 
 ## Deprecated and moved in Pydantic V2
 
@@ -748,6 +755,7 @@ which may be installed separately if needed.
 - `pydantic.NoneStr`
 - `pydantic.NoneStrBytes`
 - `pydantic.Protocol`
+- `pydantic.PyObject`
 - `pydantic.Required`
 - `pydantic.StrBytes`
 - `pydantic.compiled`

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -692,15 +692,6 @@ which may be installed separately if needed.
 * [Color Types](usage/types/extra_types/color_types.md)
 * [Payment Card Numbers](usage/types/extra_types/payment_cards.md)
 
-### `PyObject` replaced with `ImportString`
-
-The type `PyObject` has been replaced with `ImportString`, which is a string that represents a module or module
-attribute. While these two types are very similar, there are some subtle differences between how values are validated
-for the two types, so if you were using `PyObject` in Pydantic V1 you may need to make some changes beyond just
-changing the name of the type.
-
-See the [`ImportString` docs](usage/types/string_types.md#importstring) for more information.
-
 ## Moved in Pydantic V2
 
 | Pydantic V1 | Pydantic V2 |
@@ -713,6 +704,7 @@ See the [`ImportString` docs](usage/types/string_types.md#importstring) for more
 | `pydantic.error_wrappers.ValidationError` | `pydantic.ValidationError` |
 | `pydantic.utils.to_camel` | `pydantic.alias_generators.to_pascal` |
 | `pydantic.utils.to_lower_camel` | `pydantic.alias_generators.to_camel` |
+| `pydantic.PyObject` | [`pydantic.ImportString`](usage/types/string_types/#importstring) |
 
 ## Deprecated and moved in Pydantic V2
 
@@ -756,7 +748,6 @@ See the [`ImportString` docs](usage/types/string_types.md#importstring) for more
 - `pydantic.NoneStr`
 - `pydantic.NoneStrBytes`
 - `pydantic.Protocol`
-- `pydantic.PyObject`
 - `pydantic.Required`
 - `pydantic.StrBytes`
 - `pydantic.compiled`

--- a/docs/usage/types/string_types.md
+++ b/docs/usage/types/string_types.md
@@ -83,7 +83,10 @@ class ImportThings(BaseModel):
 
 # Create an instance
 m = ImportThings(obj='math:cos')
-m.model_dump_json()
+print(m)
+#> obj=<built-in function cos>
+print(m.model_dump_json())
+#> {"obj":"math.cos"}
 ```
 
 ## Constrained Types

--- a/pydantic/_migration.py
+++ b/pydantic/_migration.py
@@ -10,6 +10,8 @@ MOVED_IN_V2 = {
     'pydantic.error_wrappers:ValidationError': 'pydantic:ValidationError',
     'pydantic.utils:to_camel': 'pydantic.alias_generators:to_pascal',
     'pydantic.utils:to_lower_camel': 'pydantic.alias_generators:to_camel',
+    'pydantic:PyObject': 'pydantic.types:ImportString',
+    'pydantic.types:PyObject': 'pydantic.types:ImportString',
 }
 
 DEPRECATED_MOVED_IN_V2 = {
@@ -56,7 +58,6 @@ REMOVED_IN_V2 = {
     'pydantic:NoneStr',
     'pydantic:NoneStrBytes',
     'pydantic:Protocol',
-    'pydantic:PyObject',
     'pydantic:Required',
     'pydantic:StrBytes',
     'pydantic:compiled',
@@ -186,7 +187,6 @@ REMOVED_IN_V2 = {
     'pydantic.types:NoneBytes',
     'pydantic.types:NoneStr',
     'pydantic.types:NoneStrBytes',
-    'pydantic.types:PyObject',
     'pydantic.types:StrBytes',
     'pydantic.typing:evaluate_forwardref',
     'pydantic.typing:AbstractSetIntStr',


### PR DESCRIPTION
## Context

It seems like the equivalent of PyObject from v1
is the ImportString type in v2,
but there's no mention of it in the migration docs.

## Change Summary

Add `pydantic.PyObject` -> `pydantic.ImportString` row
in the "Moved in Pydantic V2" table.

### Open questions

- There's a "known limitation" note in the ImportString docs,
not sure if I should mention it in the migration doc.
- Also, not sure if I should update `pydantic/_migration.py` too 🤔.

## Notes

BTW the doc also states:
> This is actively being worked on.

can this be tracked somewhere?




## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
