### PR TITLE
Revise the section on required / optional / nullable fields.

### DIFF
--- a/changes/6468-ybressler.md
+++ b/changes/6468-ybressler.md
@@ -1,0 +1,1 @@
+Update the migration guide to more explicitly call out breaking changes to optional/required fields.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -479,26 +479,18 @@ In Pydantic V2, we recognize that the value is an instance of one of the cases a
 
 Pydantic V2 changes some of the logic for specifying whether a field annotated as `Optional` is required
 (i.e., has no default value) or not (i.e., has a default value of `None`), and now more closely matches the
-behavior of `dataclasses`.
+behavior of `dataclasses`. Similarly, fields annotated as `Any` no longer have a default value of `None`.
 
 The following table describes the behavior of field annotations in V2:
 
-| State                        | Field Definition           |
-|------------------------------|----------------------------|
-| Required, cannot be None     | `f1: str`              |
-| Required, can be None        | `f2: Optional[str]`        |
-| Not required, can be None    | `f3: Optional[str] = None` |
-| Not required, cannot be None | `f4: str = 'Foobar'`       |
-
-
-
-| Required | Can be `None` | Field Definition |
-|----------|---------------|------------------|
-| ✔        | X             | `f1: str`        |
-| ✔         | ✔             | `f2: Optional[str]`        |
-| X        | ✔             | `f3: Optional[str] = None` |
-| X        | X             | `f4: str = 'Foobar'`       |
-
+| State                                            | Field Definition           |
+|--------------------------------------------------|----------------------------|
+| Required, cannot be `None`                       | `f1: str`                  |
+| Required, can be `None`                          | `f2: Optional[str]`        |
+| Not required, can be `None`                      | `f3: Optional[str] = None` |
+| Not required, cannot be `None`                   | `f4: str = 'Foobar'`       |
+| Required, can be any type (including `None`)     | `f5: Any`                  |
+| Not required, can be any type (including `None`) | `f6: Any = None`           |
 
 
 !!! note

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -483,22 +483,24 @@ behavior of `dataclasses`. Similarly, fields annotated as `Any` no longer have a
 
 The following table describes the behavior of field annotations in V2:
 
-| State                                            | Field Definition           |
-|--------------------------------------------------|----------------------------|
-| Required, cannot be `None`                       | `f1: str`                  |
+| State                                                 | Field Definition            |
+|-------------------------------------------------------|-----------------------------|
+| Required, cannot be `None`                            | `f1: str`                   |
 | Not required, cannot be `None`, is `'abc'` by default | `f3: str = 'abc'`           |
 | Required, can be `None`                               | `f2: Optional[str]`         |
 | Not required, can be `None`, is `None` by default     | `f3: Optional[str] = None`  |
 | Not required, can be `None`, is `'abc'` by default    | `f3: Optional[str] = 'abc'` |
-| Not required, cannot be `None`                   | `f4: str = 'Foobar'`       |
-| Required, can be any type (including `None`)     | `f5: Any`                  |
-| Not required, can be any type (including `None`) | `f6: Any = None`           |
+| Not required, cannot be `None`                        | `f4: str = 'Foobar'`        |
+| Required, can be any type (including `None`)          | `f5: Any`                   |
+| Not required, can be any type (including `None`)      | `f6: Any = None`            |
 
 
 !!! note
     A field annotated as `typing.Optional[T]` will be required, and will allow for a value of `None`.
     It does not mean that the field has a default value of `None`. _(This is a breaking change from V1.)_
 
+!!! note
+    Any default value if provided makes a field not required.
 
 Here is a code example demonstrating the above:
 ```py

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -505,7 +505,7 @@ In V2, fields are specified as follows:
     It does not mean that the field has a default value of `None`. _(This is a breaking change from V1.)_
 
 
-Code example demonstrating the above:
+Here is a code example demonstrating the above:
 ```py
 from typing import Optional
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -481,7 +481,7 @@ Pydantic V2 changes some of the logic for specifying whether a field annotated a
 (i.e., has no default value) or not (i.e., has a default value of `None`), and now more closely matches the
 behavior of `dataclasses`.
 
-In V2, fields are specified as follows:
+The following table describes the behavior of field annotations in V2:
 
 | State                        | Field Definition           |
 |------------------------------|----------------------------|

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -477,11 +477,35 @@ In Pydantic V2, we recognize that the value is an instance of one of the cases a
 
 #### Required, optional, and nullable fields
 
-Pydantic V1 had a somewhat loose idea about "required" versus "nullable" fields. In Pydantic V2, these concepts are
-more clearly defined.
+Pydantic V2 introduces stricter definitions for specifying if a field is `required` or `optional` – more closely
+matching the behavior `dataclasses`.
 
-Pydantic V2 will move to match `dataclasses`, thus you may explicitly specify a field as `required` or `optional` and whether the field accepts `None` or not.
+In V2, fields are specified as follows:
 
+| State                        | Field Definition           |
+|------------------------------|----------------------------|
+| Required, cannot be None     | `f1: str`              |
+| Required, can be None        | `f2: Optional[str]`        |
+| Not required, can be None    | `f3: Optional[str] = None` |
+| Not required, cannot be None | `f4: str = 'Foobar'`       |
+
+
+
+| Required | Can be `None` | Field Definition |
+|----------|---------------|------------------|
+| ✔        | X             | `f1: str`        |
+| ✔         | ✔             | `f2: Optional[str]`        |
+| X        | ✔             | `f3: Optional[str] = None` |
+| X        | X             | `f4: str = 'Foobar'`       |
+
+
+
+!!! note
+    A field annotated as `typing.Optional[T]` will be required, and will allow for a value of `None`.
+    It does not mean that the field has a default value of `None`. _(This is a breaking change from V1.)_
+
+
+Code example demonstrating the above:
 ```py
 from typing import Optional
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -486,8 +486,10 @@ The following table describes the behavior of field annotations in V2:
 | State                                            | Field Definition           |
 |--------------------------------------------------|----------------------------|
 | Required, cannot be `None`                       | `f1: str`                  |
-| Required, can be `None`                          | `f2: Optional[str]`        |
-| Not required, can be `None`                      | `f3: Optional[str] = None` |
+| Not required, cannot be `None`, is `'abc'` by default | `f3: str = 'abc'`           |
+| Required, can be `None`                               | `f2: Optional[str]`         |
+| Not required, can be `None`, is `None` by default     | `f3: Optional[str] = None`  |
+| Not required, can be `None`, is `'abc'` by default    | `f3: Optional[str] = 'abc'` |
 | Not required, cannot be `None`                   | `f4: str = 'Foobar'`       |
 | Required, can be any type (including `None`)     | `f5: Any`                  |
 | Not required, can be any type (including `None`) | `f6: Any = None`           |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -478,7 +478,7 @@ In Pydantic V2, we recognize that the value is an instance of one of the cases a
 #### Required, optional, and nullable fields
 
 Pydantic V2 changes some of the logic for specifying whether a field annotated as `Optional` is required
-(i.e., has no default value) or not (i.e., has a default value of `None`), and now more closely matches the
+(i.e., has no default value) or not (i.e., has a default value of `None` or any other value of the corresponding type), and now more closely matches the
 behavior of `dataclasses`. Similarly, fields annotated as `Any` no longer have a default value of `None`.
 
 The following table describes the behavior of field annotations in V2:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -477,8 +477,9 @@ In Pydantic V2, we recognize that the value is an instance of one of the cases a
 
 #### Required, optional, and nullable fields
 
-Pydantic V2 introduces stricter definitions for specifying if a field is `required` or `optional` – more closely
-matching the behavior `dataclasses`.
+Pydantic V2 changes some of the logic for specifying whether a field annotated as `Optional` is required
+(i.e., has no default value) or not (i.e., has a default value of `None`), and now more closely matches the
+behavior of `dataclasses`.
 
 In V2, fields are specified as follows:
 


### PR DESCRIPTION
## Change Summary
Small enhancements to migration documentation – explicitly call out the breaking change of optional fields. (Related to https://github.com/pydantic/pydantic/issues/6463)

**Note:**
I created 2 alternative tables for demonstrating how fields are defined, cause I'm not sure which one we should go with. (Or, if we should keep it as a bullet pointed list. Or, if we should scrap it and just keep the code example below it.)

## Checklist

* [ ] ~Unit tests for the changes exist~
* [ ] ~Tests pass on CI and coverage remains at 100%~
* [X] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig