### PR TITLE
Replace TransformSchema with GetPydanticSchema

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -180,6 +180,7 @@ __all__ = [
     'SkipValidation',
     'InstanceOf',
     'WithJsonSchema',
+    'GetPydanticSchema',
     # type_adapter
     'TypeAdapter',
     # version

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -37,7 +37,6 @@ from ._internal import (
     _utils,
     _validators,
 )
-from ._internal._annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ._migration import getattr_migration
 from .config import ConfigDict
 from .errors import PydanticUserError
@@ -1342,8 +1341,8 @@ class GetPydanticSchema:
     `__get_pydantic_json_schema__`, and `__prepare_pydantic_annotations__` with a single annotation.
     """
 
-    get_pydantic_core_schema: Callable[[Any, GetCoreSchemaHandler], CoreSchema] | None = None
-    get_pydantic_json_schema: Callable[[Any, GetJsonSchemaHandler], JsonSchemaValue] | None = None
+    get_pydantic_core_schema: Callable[[Any, _annotated_handlers.GetCoreSchemaHandler], CoreSchema] | None = None
+    get_pydantic_json_schema: Callable[[Any, _annotated_handlers.GetJsonSchemaHandler], JsonSchemaValue] | None = None
     prepare_pydantic_annotations: Callable[[Any, tuple[Any, ...], ConfigDict], tuple[Any, Iterable[Any]]] | None = None
 
     @staticmethod
@@ -1374,6 +1373,6 @@ class GetPydanticSchema:
         elif item == '__prepare_pydantic_annotations__' and self.prepare_pydantic_annotations:
             return self.prepare_pydantic_annotations
         else:
-            return super().__getattribute__(item)
+            return object.__getattribute__(self, item)
 
     __hash__ = object.__hash__


### PR DESCRIPTION
`GetPydanticSchema` is meant to be a convenience type that eliminates the need to make "marker classes" when doing simple things related to custom types.

I specifically worked on this to provide a good way to handle https://github.com/pydantic/pydantic/issues/6477 with versions of python/numpy where `numpy.typing.NDArray` is not actually a type, as I couldn't do this easily with our existing annotations. (I'll include a comment below demonstrating that this works for this, so I can more easily link to it in that issue.)

While I understand there may be some hesitancy to introduce another annotation type like this, I think this implementation will "stand the test of time" because it directly matches the custom hooks interface — this type will reduce boilerplate and not require breaking changes for as long as we don't introduce breaking changes into the custom hooks types.

---

Also, considering `TransformSchema` is not in `pydantic.types.__all__`, is completely undocumented, and migrating usage of it to `GetPydanticSchema` is essentially trivial, I think it's okay to remove it, which I am currently doing in this PR.

That said, we could definitely keep it and just add `GetPydanticSchema` as a new type, I just think it has been mostly rendered redundant.


skip change file check

Selected Reviewer: @adriangb