### PR TITLE
Adding missing validation error (Issue #6439)

### DIFF
--- a/changes/6439-gamaleonardo.md
+++ b/changes/6439-gamaleonardo.md
@@ -1,0 +1,1 @@
+Adding `enum` validation error to the documentation. It was missing there. 

--- a/docs/usage/validation_errors.md
+++ b/docs/usage/validation_errors.md
@@ -498,6 +498,28 @@ except ValidationError as exc:
     #> 'dict_type'
 ```
 
+## `enum`
+
+This error is raised when the input value's does not exist in a `enum` field:
+
+```py
+from enum import Enum
+from pydantic import BaseModel, ValidationError
+
+class MyEnum(str, Enum):
+    option = "option"
+
+class Model(BaseModel):
+    x: MyEnum
+
+
+try:
+    Model(x="other_option")
+except ValidationError as exc:
+    print(repr(exc.errors()[0]['type']))
+    #> 'enum'
+```
+
 ## `extra_forbidden`
 
 This error is raised when the input value contains extra fields, but `model_config['extra'] == 'forbid'`:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

I just updated the documentation because the validation error (https://docs.pydantic.dev/latest/usage/validation_errors/) `enum` was missing there.

## Related issue number

Fix [#6439](https://github.com/pydantic/pydantic/issues/6439)

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/6439-gamaleonardo.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
