### PR TITLE
📌 Pin `typing-extensions` on Python 3.7 to prevent using unsupported version

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -693,7 +693,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
-content_hash = "sha256:48f631f9b31db6e3be008c9e66deaf4f182bfc840b5b8250e5393a64b0426487"
+content_hash = "sha256:2d6bed0c1729456f9a2228942ca50ec19828073d0d70d9f8f32ede6f570ebf10"
 
 [metadata.files]
 "annotated-types 0.5.0" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,15 @@ classifiers = [
     'Topic :: Internet',
 ]
 requires-python = '>=3.7'
-dependencies = [
-    'typing-extensions>=4.6.1',
-    'annotated-types>=0.4.0',
-    'pydantic-core==2.1.2',
-]
 dynamic = ['version', 'readme']
+
+[project.dependencies]
+annotated-types = '>=0.4.0'
+pydantic-core = '==2.1.2'
+typing_extensions = [
+    { version = '>=4.6.1,<4.8', markers = 'python_version == "3.7"' },
+    { version = '>=4.6.1', markers = 'python_version >= "3.8"' },
+]
 
 [project.optional-dependencies]
 email = ['email-validator>=2.0.0']


### PR DESCRIPTION
## Change Summary

Pin `typing-extensions` to `<4.8` on Python 3.7 as `typing-extensions` will drop Python 3.7 support in `4.8.0` release https://github.com/python/typing_extensions/commit/8860c6a143c0a4b3bf6aa0103ca6afee7d0cd5b1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3

## Related issue number

None

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
