### PR TITLE
Add redirect for types documentation

### DIFF
--- a/changes/6513-tpdorsey.md
+++ b/changes/6513-tpdorsey.md
@@ -1,0 +1,1 @@
+Docs: Add redirect for types documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,4 +200,5 @@ plugins:
       'pycharm_plugin.md': 'integrations/pycharm.md'
       'usage/devtools.md': 'integrations/devtools.md'
       'usage/rich.md': 'integrations/rich.md'
+      'usage/types.md': 'usage/types/types.md'
 - external-markdown:


### PR DESCRIPTION
Redirects /usage/types/ to /usage/types/types/.

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/6501

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani