### PR TITLE
Defer evaluation of return type hints for serializer functions

### DIFF
--- a/pydantic/_internal/_annotated_handlers.py
+++ b/pydantic/_internal/_annotated_handlers.py
@@ -78,9 +78,6 @@ class GetCoreSchemaHandler:
         """
         raise NotImplementedError
 
-    def get_types_namespace(self) -> dict[str, Any] | None:
-        raise NotImplementedError
-
     def generate_schema(self, __source_type: Any) -> core_schema.CoreSchema:
         """Generate a schema unrelated to the current context.
         Use this function if e.g. you are handling schema generation for a sequence
@@ -110,4 +107,8 @@ class GetCoreSchemaHandler:
         Returns:
             A concrete `CoreSchema`.
         """
+        raise NotImplementedError
+
+    def _get_types_namespace(self) -> dict[str, Any] | None:
+        """Internal method used during type resolution for serializer annotations."""
         raise NotImplementedError

--- a/pydantic/_internal/_annotated_handlers.py
+++ b/pydantic/_internal/_annotated_handlers.py
@@ -78,6 +78,9 @@ class GetCoreSchemaHandler:
         """
         raise NotImplementedError
 
+    def get_types_namespace(self) -> dict[str, Any] | None:
+        raise NotImplementedError
+
     def generate_schema(self, __source_type: Any) -> core_schema.CoreSchema:
         """Generate a schema unrelated to the current context.
         Use this function if e.g. you are handling schema generation for a sequence

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -206,6 +206,9 @@ class _WalkCoreSchema:
         schema: core_schema.CoreSchema | None = ser_schema.get('schema', None)
         if schema is not None:
             ser_schema['schema'] = self.walk(schema, f)  # type: ignore
+        return_schema: core_schema.CoreSchema | None = ser_schema.get('return_schema', None)
+        if return_schema is not None:
+            ser_schema['return_schema'] = self.walk(return_schema, f)  # type: ignore
         return ser_schema
 
     def handle_definitions_schema(self, schema: core_schema.DefinitionsSchema, f: Walk) -> core_schema.CoreSchema:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1505,10 +1505,17 @@ class GenerateSchema:
             serializer = serializers[-1]
             is_field_serializer, info_arg = inspect_field_serializer(serializer.func, serializer.info.mode)
 
-            if serializer.info.return_type is PydanticUndefined:
+            try:
+                return_type = _decorators.get_function_return_type(
+                    serializer.func, serializer.info.return_type, self.types_namespace
+                )
+            except NameError as e:
+                raise PydanticUndefinedAnnotation.from_name_error(e) from e
+
+            if return_type is PydanticUndefined:
                 return_schema = None
             else:
-                return_schema = self.generate_schema(serializer.info.return_type)
+                return_schema = self.generate_schema(return_type)
 
             if serializer.info.mode == 'wrap':
                 schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
@@ -1538,10 +1545,16 @@ class GenerateSchema:
             serializer = list(serializers)[-1]
             info_arg = inspect_model_serializer(serializer.func, serializer.info.mode)
 
-            if serializer.info.return_type is PydanticUndefined:
+            try:
+                return_type = _decorators.get_function_return_type(
+                    serializer.func, serializer.info.return_type, self.types_namespace
+                )
+            except NameError as e:
+                raise PydanticUndefinedAnnotation.from_name_error(e) from e
+            if return_type is PydanticUndefined:
                 return_schema = None
             else:
-                return_schema = self.generate_schema(serializer.info.return_type)
+                return_schema = self.generate_schema(return_type)
 
             if serializer.info.mode == 'wrap':
                 ser_schema: core_schema.SerSchema = core_schema.wrap_serializer_function_ser_schema(

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -38,7 +38,7 @@ from ..config import ConfigDict
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import AliasChoices, AliasPath, FieldInfo
 from ..json_schema import JsonSchemaValue
-from . import _discriminated_union, _known_annotated_metadata, _typing_extra
+from . import _decorators, _discriminated_union, _known_annotated_metadata, _typing_extra
 from ._annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ._config import ConfigWrapper
 from ._core_metadata import (
@@ -1226,7 +1226,18 @@ class GenerateSchema:
             return core_schema.any_schema()
 
     def _computed_field_schema(self, d: Decorator[ComputedFieldInfo]) -> core_schema.ComputedField:
-        return_type_schema = self.generate_schema(d.info.return_type)
+        try:
+            return_type = _decorators.get_function_return_type(d.func, d.info.return_type, self.types_namespace)
+        except NameError as e:
+            raise PydanticUndefinedAnnotation.from_name_error(e) from e
+        if return_type is PydanticUndefined:
+            raise PydanticUserError(
+                'Computed field is missing return type annotation or specifying `return_type`'
+                ' to the `@computed_field` decorator (e.g. `@computed_field(return_type=int|str)`)',
+                code='model-field-missing-annotation',
+            )
+
+        return_type_schema = self.generate_schema(return_type)
 
         # Handle alias_generator using similar logic to that from
         # pydantic._internal._generate_schema.GenerateSchema._common_field_schema,
@@ -1494,7 +1505,7 @@ class GenerateSchema:
             serializer = serializers[-1]
             is_field_serializer, info_arg = inspect_field_serializer(serializer.func, serializer.info.mode)
 
-            if serializer.info.return_type is None:
+            if serializer.info.return_type is PydanticUndefined:
                 return_schema = None
             else:
                 return_schema = self.generate_schema(serializer.info.return_type)
@@ -1527,7 +1538,7 @@ class GenerateSchema:
             serializer = list(serializers)[-1]
             info_arg = inspect_model_serializer(serializer.func, serializer.info.mode)
 
-            if serializer.info.return_type is None:
+            if serializer.info.return_type is PydanticUndefined:
                 return_schema = None
             else:
                 return_schema = self.generate_schema(serializer.info.return_type)

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -89,7 +89,7 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
         else:  # ref_mode = 'unpack
             return self.resolve_ref_schema(schema)
 
-    def get_types_namespace(self) -> dict[str, Any] | None:
+    def _get_types_namespace(self) -> dict[str, Any] | None:
         return self._generate_schema.types_namespace
 
     def generate_schema(self, __source_type: Any) -> core_schema.CoreSchema:

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -89,6 +89,9 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
         else:  # ref_mode = 'unpack
             return self.resolve_ref_schema(schema)
 
+    def get_types_namespace(self) -> dict[str, Any] | None:
+        return self._generate_schema.types_namespace
+
     def generate_schema(self, __source_type: Any) -> core_schema.CoreSchema:
         return self._generate_schema.generate_schema(__source_type)
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -227,7 +227,9 @@ def eval_type_lenient(value: Any, globalns: dict[str, Any] | None, localns: dict
         return value
 
 
-def get_function_type_hints(function: Callable[..., Any], *, include_keys: set[str] | None = None) -> dict[str, Any]:
+def get_function_type_hints(
+    function: Callable[..., Any], *, include_keys: set[str] | None = None, types_namespace: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Like `typing.get_type_hints`, but doesn't convert `X` to `Optional[X]` if the default value is `None`, also
     copes with `partial`.
     """
@@ -246,7 +248,7 @@ def get_function_type_hints(function: Callable[..., Any], *, include_keys: set[s
         elif isinstance(value, str):
             value = _make_forward_ref(value)
 
-        type_hints[name] = typing._eval_type(value, globalns, None)  # type: ignore
+        type_hints[name] = typing._eval_type(value, globalns, types_namespace)  # type: ignore
 
     return type_hints
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -972,8 +972,9 @@ def computed_field(
 
     def dec(f: Any) -> Any:
         nonlocal description, return_type, alias_priority
-        if description is None and f.__doc__:
-            description = inspect.cleandoc(f.__doc__)
+        unwrapped = _decorators.unwrap_wrapped_function(f)
+        if description is None and unwrapped.__doc__:
+            description = inspect.cleandoc(unwrapped.__doc__)
 
         # if the function isn't already decorated with `@property` (or another descriptor), then we wrap it now
         f = _decorators.ensure_property(f)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -905,7 +905,7 @@ class ComputedFieldInfo:
 
     decorator_repr: ClassVar[str] = '@computed_field'
     wrapped_property: property
-    return_type: type[Any]
+    return_type: Any
     alias: str | None
     alias_priority: int | None
     title: str | None
@@ -921,7 +921,7 @@ PropertyT = typing.TypeVar('PropertyT')
 @typing.overload
 def computed_field(
     *,
-    return_type: Any = None,
+    return_type: Any = PydanticUndefined,
     alias: str | None = None,
     alias_priority: int | None = None,
     title: str | None = None,
@@ -944,7 +944,7 @@ def computed_field(
     title: str | None = None,
     description: str | None = None,
     repr: bool = True,
-    return_type: Any = None,
+    return_type: Any = PydanticUndefined,
 ) -> PropertyT | typing.Callable[[PropertyT], PropertyT]:
     """Decorator to include `property` and `cached_property` when serializing models.
 
@@ -974,14 +974,6 @@ def computed_field(
         nonlocal description, return_type, alias_priority
         if description is None and f.__doc__:
             description = inspect.cleandoc(f.__doc__)
-
-        return_type = _decorators.get_function_return_type(f, return_type)
-        if return_type is None:
-            raise PydanticUserError(
-                'Computed field is missing return type annotation or specifying `return_type`'
-                ' to the `@computed_field` decorator (e.g. `@computed_field(return_type=int|str)`)',
-                code='model-field-missing-annotation',
-            )
 
         # if the function isn't already decorated with `@property` (or another descriptor), then we wrap it now
         f = _decorators.ensure_property(f)

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -42,7 +42,7 @@ class PlainSerializer:
         schema = handler(source_type)
         try:
             return_type = _decorators.get_function_return_type(
-                self.func, self.return_type, handler.get_types_namespace()
+                self.func, self.return_type, handler._get_types_namespace()
             )
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
@@ -87,7 +87,7 @@ class WrapSerializer:
         schema = handler(source_type)
         try:
             return_type = _decorators.get_function_return_type(
-                self.func, self.return_type, handler.get_types_namespace()
+                self.func, self.return_type, handler._get_types_namespace()
             )
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
@@ -183,7 +183,7 @@ def field_serializer(
         dec_info = _decorators.FieldSerializerDecoratorInfo(
             fields=fields,
             mode=mode,
-            return_type=_decorators.get_function_return_type(f, return_type),
+            return_type=return_type,
             when_used=when_used,
             check_fields=check_fields,
         )
@@ -236,9 +236,7 @@ def model_serializer(
     """
 
     def dec(f: Callable[..., Any]) -> _decorators.PydanticDescriptorProxy[Any]:
-        dec_info = _decorators.ModelSerializerDecoratorInfo(
-            mode=mode, return_type=_decorators.get_function_return_type(f, return_type), when_used=when_used
-        )
+        dec_info = _decorators.ModelSerializerDecoratorInfo(mode=mode, return_type=return_type, when_used=when_used)
         return _decorators.PydanticDescriptorProxy(f, dec_info)
 
     if __f is None:

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 from functools import partialmethod
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, overload
 
-from pydantic_core import core_schema
+from pydantic_core import PydanticUndefined, core_schema
 from pydantic_core import core_schema as _core_schema
 from typing_extensions import Annotated, Literal, TypeAlias
 
+from . import PydanticUndefinedAnnotation
 from ._internal import _annotated_handlers, _decorators, _internal_dataclass
 
 
@@ -23,7 +24,7 @@ class PlainSerializer:
     """
 
     func: core_schema.SerializerFunction
-    return_type: Any = None
+    return_type: Any = PydanticUndefined
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
     def __get_pydantic_core_schema__(
@@ -39,8 +40,13 @@ class PlainSerializer:
             The Pydantic core schema.
         """
         schema = handler(source_type)
-        return_type = _decorators.get_function_return_type(self.func, self.return_type)
-        return_schema = None if return_type is None else handler.generate_schema(return_type)
+        try:
+            return_type = _decorators.get_function_return_type(
+                self.func, self.return_type, handler.get_types_namespace()
+            )
+        except NameError as e:
+            raise PydanticUndefinedAnnotation.from_name_error(e) from e
+        return_schema = None if return_type is PydanticUndefined else handler.generate_schema(return_type)
         schema['serialization'] = core_schema.plain_serializer_function_ser_schema(
             function=self.func,
             info_arg=_decorators.inspect_annotated_serializer(self.func, 'plain'),
@@ -63,7 +69,7 @@ class WrapSerializer:
     """
 
     func: core_schema.WrapSerializerFunction
-    return_type: Any = None
+    return_type: Any = PydanticUndefined
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
     def __get_pydantic_core_schema__(
@@ -79,8 +85,13 @@ class WrapSerializer:
             The generated core schema of the class.
         """
         schema = handler(source_type)
-        return_type = _decorators.get_function_return_type(self.func, self.return_type)
-        return_schema = None if return_type is None else handler.generate_schema(return_type)
+        try:
+            return_type = _decorators.get_function_return_type(
+                self.func, self.return_type, handler.get_types_namespace()
+            )
+        except NameError as e:
+            raise PydanticUndefinedAnnotation.from_name_error(e) from e
+        return_schema = None if return_type is PydanticUndefined else handler.generate_schema(return_type)
         schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
             function=self.func,
             info_arg=_decorators.inspect_annotated_serializer(self.func, 'wrap'),
@@ -136,7 +147,7 @@ def field_serializer(
 def field_serializer(
     *fields: str,
     mode: Literal['plain', 'wrap'] = 'plain',
-    return_type: Any = None,
+    return_type: Any = PydanticUndefined,
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always',
     check_fields: bool | None = None,
 ) -> Callable[[Any], Any]:
@@ -204,7 +215,7 @@ def model_serializer(
     *,
     mode: Literal['plain', 'wrap'] = 'plain',
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always',
-    return_type: Any = None,
+    return_type: Any = PydanticUndefined,
 ) -> Callable[[Any], Any]:
     """Decorator that enables custom model serialization.
 

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -466,16 +466,16 @@ class GenerateJsonSchema:
                 TypeError: If an unexpected schema type is encountered.
             """
             # Generate the core-schema-type-specific bits of the schema generation:
+            json_schema: JsonSchemaValue | None = None
             if self.mode == 'serialization' and 'serialization' in schema_or_field:
-                # Technically this is invalid because this will give us a SerSchema, not a CoreSchema.
-                # However, it works, and making the SerSchema stuff typecheck everywhere will require
-                # a lot of refactoring. TODO: Make schema_or_field into a CoreSchemaOrSerSchemaOrField
-                schema_or_field = schema_or_field['serialization']  # type: ignore
-            if _core_utils.is_core_schema(schema_or_field) or _core_utils.is_core_schema_field(schema_or_field):
-                generate_for_schema_type = self._schema_type_to_method[schema_or_field['type']]
-                json_schema = generate_for_schema_type(schema_or_field)
-            else:
-                raise TypeError(f'Unexpected schema type: schema={schema_or_field}')
+                ser_schema = schema_or_field['serialization']  # type: ignore
+                json_schema = self.ser_schema(ser_schema)
+            if json_schema is None:
+                if _core_utils.is_core_schema(schema_or_field) or _core_utils.is_core_schema_field(schema_or_field):
+                    generate_for_schema_type = self._schema_type_to_method[schema_or_field['type']]
+                    json_schema = generate_for_schema_type(schema_or_field)
+                else:
+                    raise TypeError(f'Unexpected schema type: schema={schema_or_field}')
             if _core_utils.is_core_schema(schema_or_field):
                 json_schema = populate_defs(schema_or_field, json_schema)
                 json_schema = convert_to_all_of(json_schema)
@@ -842,13 +842,6 @@ class GenerateJsonSchema:
         self,
         schema: _core_utils.AnyFunctionSchema,
     ) -> JsonSchemaValue:
-        # Note: 'return_schema' is only in the SerSchema versions
-        # See the note: TODO: Make schema_or_field into a CoreSchemaOrSerSchemaOrField
-        # above to see how a SerSchema can end up passed to this function call.
-        # (This should eventually be fixed.)
-        if self.mode == 'serialization' and 'return_schema' in schema and schema['type'] != 'function-before':
-            return self.generate_inner(schema['return_schema'])  # type: ignore
-
         if _core_utils.is_function_with_inner_schema(schema):
             # This could be wrong if the function's mode is 'before', but in practice will often be right, and when it
             # isn't, I think it would be hard to automatically infer what the desired schema should be.
@@ -1672,6 +1665,31 @@ class GenerateJsonSchema:
         core_ref = CoreRef(schema['schema_ref'])
         _, ref_json_schema = self.get_cache_defs_ref_schema(core_ref)
         return ref_json_schema
+
+    def ser_schema(
+        self, schema: core_schema.SerSchema | core_schema.IncExSeqSerSchema | core_schema.IncExDictSerSchema
+    ) -> JsonSchemaValue | None:
+        """Generates a JSON schema that matches a schema that defines a serialized object.
+
+        Args:
+            schema: The core schema.
+
+        Returns:
+            The generated JSON schema.
+        """
+        schema_type = schema['type']
+        if schema_type == 'function-plain' or schema_type == 'function-wrap':
+            # PlainSerializerFunctionSerSchema or WrapSerializerFunctionSerSchema
+            return_schema = schema.get('return_schema')
+            if return_schema is not None:
+                return self.generate_inner(return_schema)
+        elif schema_type == 'format' or schema_type == 'to-string':
+            # FormatSerSchema or ToStringSerSchema
+            return self.str_schema(core_schema.str_schema())
+        elif schema['type'] == 'model':
+            # ModelSerSchema
+            return self.generate_inner(schema['schema'])
+        return None
 
     # ### Utility methods
 

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -383,7 +383,7 @@ def test_private_computed_field():
     assert m.model_dump() == {'x': 2, '_double': 4}
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason='fails before 3.9 - Do we want to fix this???')
+@pytest.mark.skipif(sys.version_info < (3, 9), reason='@computed_field @classmethod @property only works in 3.9+')
 def test_classmethod():
     class MyModel(BaseModel):
         x: int

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -936,7 +936,7 @@ def test_forward_ref_for_serializers(as_annotation, mode):
             x: Annotated[int, annotation]
         else:
             x: int
-            ser_model = field_serializer('x', mode=mode)(ser_model_func)
+            ser_model = field_serializer('x', mode=mode)(ser_model_method)
 
     class OtherModel(BaseModel):
         y: int

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -4,7 +4,7 @@ New tests for v2 of serialization logic.
 import json
 import re
 from functools import partial, partialmethod
-from typing import Any, Callable, Dict, Optional, Pattern
+from typing import Any, Callable, ClassVar, Dict, Optional, Pattern
 
 import pytest
 from pydantic_core import PydanticSerializationError, core_schema, to_jsonable_python
@@ -19,6 +19,7 @@ from pydantic import (
     SerializeAsAny,
     SerializerFunctionWrapHandler,
     TypeAdapter,
+    computed_field,
     errors,
     field_serializer,
     model_serializer,
@@ -906,3 +907,86 @@ def test_serialize_as_any() -> None:
         'as_any': {'name': 'pydantic', 'password': '**********'},
         'without': {'name': 'pydantic'},
     }
+
+
+@pytest.mark.parametrize('as_annotation', [True, False])
+@pytest.mark.parametrize('mode', ['plain', 'wrap'])
+def test_forward_ref_for_serializers(as_annotation, mode):
+    if mode == 'plain':
+
+        def ser_model_func(v) -> 'SomeOtherModel':  # noqa F821
+            return OtherModel(y=v + 1)
+
+        def ser_model_method(self, v) -> 'SomeOtherModel':  # noqa F821
+            return ser_model_func(v)
+
+        annotation = PlainSerializer(ser_model_func)
+    else:
+
+        def ser_model_func(v, handler) -> 'SomeOtherModel':  # noqa F821
+            return OtherModel(y=v + 1)
+
+        def ser_model_method(self, v, handler) -> 'SomeOtherModel':  # noqa F821
+            return ser_model_func(v, handler)
+
+        annotation = WrapSerializer(ser_model_func)
+
+    class Model(BaseModel):
+        if as_annotation:
+            x: Annotated[int, annotation]
+        else:
+            x: int
+            ser_model = field_serializer('x', mode=mode)(ser_model_func)
+
+    class OtherModel(BaseModel):
+        y: int
+
+    Model.model_rebuild(_types_namespace={'SomeOtherModel': OtherModel})
+
+    assert Model(x=1).model_dump() == {'x': {'y': 2}}
+    assert Model.model_json_schema(mode='serialization') == {
+        '$defs': {
+            'OtherModel': {
+                'properties': {'y': {'title': 'Y', 'type': 'integer'}},
+                'required': ['y'],
+                'title': 'OtherModel',
+                'type': 'object',
+            }
+        },
+        'properties': {'x': {'allOf': [{'$ref': '#/$defs/OtherModel'}], 'title': 'X'}},
+        'required': ['x'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
+def test_forward_ref_for_computed_fields():
+    class Model(BaseModel):
+        x: int
+        y: ClassVar[int] = 4
+
+        @computed_field
+        @property
+        def two_x(self) -> 'IntAlias':  # noqa F821
+            return self.x * 2
+
+        @computed_field
+        @classmethod
+        @property
+        def two_y(cls) -> 'IntAlias':  # noqa F821
+            return cls.y * 2
+
+    Model.model_rebuild(_types_namespace={'IntAlias': int})
+
+    assert Model.model_json_schema(mode='serialization') == {
+        'properties': {
+            'two_x': {'readOnly': True, 'title': 'Two X', 'type': 'integer'},
+            'two_y': {'readOnly': True, 'title': 'Two Y', 'type': 'integer'},
+            'x': {'title': 'X', 'type': 'integer'},
+        },
+        'required': ['x', 'two_x', 'two_y'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+    assert Model(x=1).model_dump() == {'two_x': 2, 'two_y': 8, 'x': 1}


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6489

Also fixes the same issue for `PlainSerializer` etc.

skip change file check

Selected Reviewer: @Kludex