### PR TITLE
Give better error message attempting to compute the json schema of a model with undefined fields

### DIFF
--- a/pydantic/_internal/_mock_validator.py
+++ b/pydantic/_internal/_mock_validator.py
@@ -39,6 +39,13 @@ class MockValidator:
         getattr(SchemaValidator, item)
         raise PydanticUserError(self._error_message, code=self._code)
 
+    def force_rebuild(self) -> SchemaValidator:
+        if self._attempt_rebuild:
+            validator = self._attempt_rebuild()
+            if validator is not None:
+                return validator
+        raise PydanticUserError(self._error_message, code=self._code)
+
 
 def set_basemodel_mock_validator(cls: type[BaseModel], cls_name: str, undefined_name: str) -> None:
     undefined_type_error_message = (

--- a/pydantic/_internal/_mock_validator.py
+++ b/pydantic/_internal/_mock_validator.py
@@ -50,8 +50,7 @@ class MockValidator:
 def set_basemodel_mock_validator(cls: type[BaseModel], cls_name: str, undefined_name: str) -> None:
     undefined_type_error_message = (
         f'`{cls_name}` is not fully defined; you should define {undefined_name},'
-        f' then call `{cls_name}.model_rebuild()`'
-        f' before the first `{cls_name}` instance is created.'
+        f' then call `{cls_name}.model_rebuild()`.'
     )
 
     def attempt_rebuild() -> SchemaValidator | None:
@@ -68,8 +67,7 @@ def set_basemodel_mock_validator(cls: type[BaseModel], cls_name: str, undefined_
 def set_dataclass_mock_validator(cls: type[PydanticDataclass], cls_name: str, undefined_name: str) -> None:
     undefined_type_error_message = (
         f'`{cls_name}` is not fully defined; you should define {undefined_name},'
-        f' then call `pydantic.dataclasses.rebuild_dataclass({cls_name})`'
-        f' before the first `{cls_name}` instance is created.'
+        f' then call `pydantic.dataclasses.rebuild_dataclass({cls_name})`.'
     )
 
     def attempt_rebuild() -> SchemaValidator | None:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1586,7 +1586,7 @@ def test_cross_module_cyclic_reference_dataclass(create_module):
         PydanticUserError,
         match=re.escape(
             '`D1` is not fully defined; you should define `D2`, then call'
-            ' `pydantic.dataclasses.rebuild_dataclass(D1)` before the first `D1` instance is created.'
+            ' `pydantic.dataclasses.rebuild_dataclass(D1)`.'
         ),
     ):
         D1()

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -862,7 +862,7 @@ def pytest_raises_user_error_for_undefined_type(defining_class_name, missing_typ
         PydanticUserError,
         match=re.escape(
             f'`{defining_class_name}` is not fully defined; you should define `{missing_type_name}`, then call'
-            f' `{defining_class_name}.model_rebuild()` before the first `{defining_class_name}` instance is created.'
+            f' `{defining_class_name}.model_rebuild()`.'
         ),
     )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2695,3 +2695,16 @@ def test_arbitrary_types_not_a_type() -> None:
 
     bar = Bar()
     assert ta.validate_python(bar) is bar
+
+
+def test_deferred_core_schema() -> None:
+    class Foo(BaseModel):
+        x: 'Bar'
+
+    with pytest.raises(PydanticUserError, match='`Foo` is not fully defined'):
+        Foo.__pydantic_core_schema__
+
+    class Bar(BaseModel):
+        pass
+
+    assert Foo.__pydantic_core_schema__


### PR DESCRIPTION
Right now, if you run the following:
```python
from pydantic import BaseModel

class Foo(BaseModel):
    x: 'Bar'

Foo.model_json_schema()
```
it produces the error:
```
Traceback (most recent call last):
  File "/Users/davidmontague/Library/Application Support/JetBrains/PyCharm2023.1/scratches/scratch_638.py", line 6, in <module>
    Foo.model_json_schema()
  File "/Users/davidmontague/Programming/pydantic/pydantic/pydantic/main.py", line 372, in model_json_schema
    return model_json_schema(
  File "/Users/davidmontague/Programming/pydantic/pydantic/pydantic/json_schema.py", line 2033, in model_json_schema
    return schema_generator_instance.generate(cls.__pydantic_core_schema__, mode=mode)
  File "/Users/davidmontague/Programming/pydantic/pydantic/pydantic/_internal/_model_construction.py", line 193, in __getattr__
    raise AttributeError(item)
AttributeError: __pydantic_core_schema__. Did you mean: '__get_pydantic_core_schema__'?
```

With this change, it produces:
```
pydantic.errors.PydanticUserError: `Foo` is not fully defined; you should define `Bar`, then call `Foo.model_rebuild()`.

For further information visit https://errors.pydantic.dev/2.0.2/u/class-not-fully-defined
```

skip change file check