### PR TITLE
Add a `replace_types` option to `ConfigDict`

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -59,6 +59,7 @@ class ConfigWrapper:
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
+    replace_types: dict[type, type] | None
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -191,6 +192,7 @@ config_defaults = ConfigDict(
     validate_return=False,
     protected_namespaces=('model_',),
     hide_input_in_errors=False,
+    replace_types=None,
 )
 
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -366,6 +366,12 @@ def set_model_fields(
     typevars_map = get_model_typevars_map(cls)
     fields, class_vars = collect_model_fields(cls, bases, config_wrapper, types_namespace, typevars_map=typevars_map)
 
+    if config_wrapper.replace_types:
+        replace_types = config_wrapper.replace_types
+        for fld in fields.values():
+            if fld.annotation in replace_types:
+                fld.annotation = replace_types[fld.annotation]  # type: ignore
+
     cls.model_fields = fields
     cls.__class_vars__.update(class_vars)
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -129,6 +129,7 @@ class ConfigDict(TypedDict, total=False):
         hide_input_in_errors: Whether to hide inputs when printing errors. Defaults to `False`.
 
             See [Hide Input in Errors](../usage/model_config.md#hide-input-in-errors).
+        replace_types: A `dict` of types to replace with other annotations. Defaults to None.
     """
 
     title: str | None
@@ -164,6 +165,7 @@ class ConfigDict(TypedDict, total=False):
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
+    replace_types: dict[type, type] | None
 
 
 __getattr__ = getattr_migration(__name__)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from dirty_equals import HasRepr, IsPartialDict
 from pydantic_core import SchemaError
 
 from pydantic import (
+    AfterValidator,
     BaseConfig,
     BaseModel,
     BeforeValidator,
@@ -680,3 +681,15 @@ def test_replace_types_nested():
             'url': 'https://errors.pydantic.dev/2.1.2/v/string_type',
         }
     ]
+
+
+def test_replace_types_annotated():
+    DoubleStr = Annotated[str, AfterValidator(lambda x: x * 2)]
+
+    class Model(BaseModel):
+        x: Annotated[str, AfterValidator(str.lower)]
+        model_config = {'replace_types': {str: DoubleStr}}
+
+    user = Model(x='ABC')
+
+    assert user.model_dump() == {'x': 'abcabc'}


### PR DESCRIPTION

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

Fixes #6045

Introduced new config option `replace_types` that allows to patch fields annotations after class creation:

```Python
LaxStr = Annotated[str, BeforeValidator(str_validator)]

class LaxStrBase(BaseModel):
    model_config: ConfigDict = {'replace_types': {str: LaxStr}} # !!!!!!!!!

class Data(LaxStrBase):
    f: str
    i: str
    d: str

user = Data(f=1.1, i=1, d=Decimal('1.1'))
# will equal to {'f': '1.1', 'i': '1', 'd': '1.1'}
```

this also allows a pydantic global override string behaviour:
```Python
BaseModel.model_config['replace_types'] = {str: LaxStr}
```

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
