### PR TITLE
add "north star" benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _build/
 
 # Benchmark and test files
 /benchmarks/*.json
+/tests/benchmarks/*.json
 /htmlcov/
 /codecov.sh
 /coverage.lcov

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ test-pyright: .pdm
 test: .pdm
 	pdm run coverage run -m pytest --durations=10
 
+.PHONY: benchmark  ## Run all benchmarks
+benchmark: .pdm
+	pdm run coverage run -m pytest --durations=10 --benchmark-enable tests/benchmarks
+
 .PHONY: testcov  ## Run tests and generate a coverage report, skipping the type-checker integration tests
 testcov: test
 	@echo "building coverage html"

--- a/pdm.lock
+++ b/pdm.lock
@@ -151,6 +151,16 @@ version = "1.2.0"
 summary = "Get the currently executing AST node of a frame, and other information"
 
 [[package]]
+name = "faker"
+version = "18.13.0"
+requires_python = ">=3.7"
+summary = "Faker is a Python package that generates fake data for you."
+dependencies = [
+    "python-dateutil>=2.4",
+    "typing-extensions>=3.10.0.1; python_version < \"3.8\"",
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 summary = "Copy your docs directly to the gh-pages branch."
@@ -266,7 +276,7 @@ summary = "A deep merge function for 🐍."
 name = "mike"
 version = "1.2.0.dev0"
 git = "https://github.com/jimporter/mike.git"
-revision = "2d9af5cf2238f8e0ccaf9312716ade144e2b0f29"
+revision = "be1aafe244bc86172fbce52a903c9ab83e2e4a26"
 summary = "Manage multiple versions of your MkDocs-powered documentation"
 dependencies = [
     "importlib-metadata",
@@ -440,6 +450,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+summary = "Get CPU info with pure Python"
+
+[[package]]
 name = "pydantic-core"
 version = "2.1.2"
 requires_python = ">=3.7"
@@ -454,7 +469,7 @@ version = "2.0.0"
 requires_python = ">=3.7"
 git = "https://github.com/pydantic/pydantic-extra-types.git"
 ref = "main"
-revision = "10269e13e39f088f081203f319aa3787fcfb27e8"
+revision = "2b6b7975228f9e231ce6c28e53206a7475da41d2"
 summary = "Extra Pydantic types."
 dependencies = [
     "pydantic>=2.0b3",
@@ -505,6 +520,16 @@ dependencies = [
     "packaging",
     "pluggy<2.0,>=0.12",
     "tomli>=1.0.0; python_version < \"3.11\"",
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "4.0.0"
+requires_python = ">=3.7"
+summary = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
+dependencies = [
+    "py-cpuinfo",
+    "pytest>=3.8",
 ]
 
 [[package]]
@@ -693,7 +718,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
-content_hash = "sha256:48f631f9b31db6e3be008c9e66deaf4f182bfc840b5b8250e5393a64b0426487"
+content_hash = "sha256:c08cbe6f5bb242f878d94987d7c591599fc334af5e8da21f2509f534213b6272"
 
 [metadata.files]
 "annotated-types 0.5.0" = [
@@ -917,6 +942,10 @@ content_hash = "sha256:48f631f9b31db6e3be008c9e66deaf4f182bfc840b5b8250e5393a64b
 "executing 1.2.0" = [
     {url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a1588c9215a87271b6178cc5498acaa83885211f5d4d9e693/executing-1.2.0-py2.py3-none-any.whl", hash = "sha256:0314a69e37426e3608aada02473b4161d4caf5a4b244d1d0c48072b8fee7bacc"},
     {url = "https://files.pythonhosted.org/packages/8f/ac/89ff37d8594b0eef176b7cec742ac868fef853b8e18df0309e3def9f480b/executing-1.2.0.tar.gz", hash = "sha256:19da64c18d2d851112f09c287f8d3dbbdf725ab0e569077efb6cdcbd3497c107"},
+]
+"faker 18.13.0" = [
+    {url = "https://files.pythonhosted.org/packages/3b/5f/949fa58c4bac00b6d5e74eef05c2c7c2efc6bea3d56cd3adb257faf0bf8b/Faker-18.13.0-py3-none-any.whl", hash = "sha256:801d1a2d71f1fc54d332de2ab19de7452454309937233ea2f7485402882d67b3"},
+    {url = "https://files.pythonhosted.org/packages/41/a0/a559a58fb4747197f2be37ca864350c523c987bfdf1d283e32f68a1a68c3/Faker-18.13.0.tar.gz", hash = "sha256:84bcf92bb725dd7341336eea4685df9a364f16f2470c4d29c1d7e6c5fd5a457d"},
 ]
 "ghp-import 2.1.0" = [
     {url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
@@ -1188,6 +1217,10 @@ content_hash = "sha256:48f631f9b31db6e3be008c9e66deaf4f182bfc840b5b8250e5393a64b
     {url = "https://files.pythonhosted.org/packages/51/32/4a79112b8b87b21450b066e102d6608907f4c885ed7b04c3fdb085d4d6ae/pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
     {url = "https://files.pythonhosted.org/packages/8a/42/8f2833655a29c4e9cb52ee8a2be04ceac61bcff4a680fb338cbd3d1e322d/pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
+"py-cpuinfo 9.0.0" = [
+    {url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
+    {url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
+]
 "pydantic-core 2.1.2" = [
     {url = "https://files.pythonhosted.org/packages/01/77/53917e943ab939802f0f88d2e0c03f9bee4c167979af3ce2c49f1847073a/pydantic_core-2.1.2-cp312-cp312-manylinux_2_24_ppc64le.whl", hash = "sha256:dc737506b4a0ba2922a2626fc6d620ce50a46aebd0fe2fbcad1b93bbdd8c7e78"},
     {url = "https://files.pythonhosted.org/packages/02/f0/f27685a4d0b9596487f4cb552d791e7760e844ecf3f49c861db5534c7678/pydantic_core-2.1.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68a2a767953c707d9575dcf14d8edee7930527ee0141a8bb612c22d1f1059f9a"},
@@ -1310,6 +1343,10 @@ content_hash = "sha256:48f631f9b31db6e3be008c9e66deaf4f182bfc840b5b8250e5393a64b
 "pytest 7.4.0" = [
     {url = "https://files.pythonhosted.org/packages/33/b2/741130cbcf2bbfa852ed95a60dc311c9e232c7ed25bac3d9b8880a8df4ae/pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
     {url = "https://files.pythonhosted.org/packages/a7/f3/dadfbdbf6b6c8b5bd02adb1e08bc9fbb45ba51c68b0893fa536378cdf485/pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+]
+"pytest-benchmark 4.0.0" = [
+    {url = "https://files.pythonhosted.org/packages/28/08/e6b0067efa9a1f2a1eb3043ecd8a0c48bfeb60d3255006dcc829d72d5da2/pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1"},
+    {url = "https://files.pythonhosted.org/packages/4d/a1/3b70862b5b3f830f0422844f25a823d0470739d994466be9dbbbb414d85a/pytest_benchmark-4.0.0-py3-none-any.whl", hash = "sha256:fdb7db64e31c8b277dff9850d2a2556d8b60bcb0ea6524e36e28ffd7c87f71d6"},
 ]
 "pytest-examples 0.0.9" = [
     {url = "https://files.pythonhosted.org/packages/8b/60/a29aaeb7daee6f02090be1c668d61eb5078800abac5a4dcdfd9f46ad1a4b/pytest_examples-0.0.9.tar.gz", hash = "sha256:d5f9d670d4ae16f55f3e4ef79949e1133ee5e52856cc482fb9e305f2cdf4016a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ testing = [
     "pytest-mock",
     "pytest-pretty",
     "pytest-examples",
+    "faker>=18.13.0",
+    "pytest-benchmark>=4.0.0",
 ]
 mypy = [
     "mypy",
@@ -150,6 +152,12 @@ filterwarnings = [
     'ignore:path is deprecated.*:DeprecationWarning:',
     # Work around https://github.com/pytest-dev/pytest/issues/10977 for Python 3.12
     'ignore:(ast\.Str|ast\.NameConstant|ast\.Num|Attribute s) is deprecated and will be removed.*:DeprecationWarning:',
+]
+addopts = [
+    '--benchmark-columns', 'min,mean,stddev,outliers,rounds,iterations',
+    '--benchmark-group-by', 'group',
+    '--benchmark-warmup', 'on',
+    '--benchmark-disable',  # this is enable by `make benchmark` when you actually want to run benchmarks
 ]
 
 # configuring https://github.com/pydantic/hooky

--- a/tests/benchmarks/generate_north_star_data.py
+++ b/tests/benchmarks/generate_north_star_data.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+from typing import Any, Callable, List, TypeVar, Union
+
+from faker import Faker
+
+f = Faker()
+Faker.seed(0)
+
+
+T = TypeVar('T')
+
+## Helper functions
+
+# by default faker uses upper bound of now for datetime, which
+# is not helpful for reproducing benchmark data
+_END_DATETIME = datetime(2023, 1, 1, 0, 0, 0, 0)
+
+
+def one_of(*callables: Callable[[], Any]) -> Any:
+    return f.random.choice(callables)()
+
+
+def list_of(callable: Callable[[], T], max_length: int) -> List[T]:
+    return [callable() for _ in range(f.random_int(max=max_length))]
+
+
+def lax_int(*args: Any, **kwargs: Any) -> Union[int, float, str]:
+    return f.random.choice((int, float, str))(f.random_int(*args, **kwargs))
+
+
+def lax_float(*args: Any, **kwargs: Any) -> Union[int, float, str]:
+    return f.random.choice((int, float, str))(f.pyfloat(*args, **kwargs))
+
+
+def time_seconds() -> int:
+    dt = f.date_time(end_datetime=_END_DATETIME)
+    midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    return (dt - midnight).total_seconds()
+
+
+def time_microseconds() -> float:
+    return float(time_seconds()) + (f.random_int(max=999999) * 1e-6)
+
+
+def time_string() -> str:
+    return f.time()
+
+
+def lax_time() -> Union[int, float, str]:
+    return one_of(time_seconds, time_microseconds, time_string)
+
+
+def date_string() -> str:
+    return f.date(end_datetime=_END_DATETIME).format('%Y-%m-%d')
+
+
+def datetime_timestamp() -> int:
+    dt = f.date_time(end_datetime=_END_DATETIME)
+    midnight = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    return (dt - midnight).total_seconds()
+
+
+def datetime_microseconds() -> float:
+    return float(datetime_timestamp()) + (f.random_int(max=999999) * 1e-6)
+
+
+def datetime_str() -> str:
+    return f.date_time(end_datetime=_END_DATETIME).isoformat()
+
+
+def lax_datetime() -> Union[int, float, str]:
+    return one_of(datetime_timestamp, datetime_microseconds, datetime_str)
+
+
+## Sample data generators
+
+
+def blog() -> dict:
+    return {
+        'type': 'blog',
+        'title': f.text(max_nb_chars=40),
+        'post_count': lax_int(),
+        'readers': lax_int(),
+        'avg_post_rating': lax_float(min_value=0, max_value=5),
+        'url': f.url(),
+    }
+
+
+def social_profile() -> dict:
+    return {
+        'type': 'profile',
+        'username': f.user_name(),
+        'join_date': date_string(),
+        **one_of(facebook_profile, twitter_profile, linkedin_profile),
+    }
+
+
+def facebook_profile() -> dict:
+    return {'network': 'facebook', 'friends': lax_int()}
+
+
+def twitter_profile() -> dict:
+    return {'network': 'twitter', 'followers': lax_int()}
+
+
+def linkedin_profile() -> dict:
+    return {'network': 'linkedin', 'connections': min(f.random_int(), 500)}
+
+
+def website() -> dict:
+    return one_of(blog, social_profile)
+
+
+def person() -> dict:
+    return {
+        'id': f.uuid4(),
+        'name': f.name(),
+        'email': f.safe_email(),
+        'height': str(f.pydecimal(min_value=1, max_value=2, right_digits=2)),
+        'entry_created_date': date_string(),
+        'entry_created_time': lax_time(),
+        'entry_updated_at': lax_datetime(),
+        'websites': list_of(website, max_length=5),
+    }
+
+
+def person_data(length: int) -> List[dict]:
+    return [person() for _ in range(length)]

--- a/tests/benchmarks/test_north_star.py
+++ b/tests/benchmarks/test_north_star.py
@@ -1,0 +1,154 @@
+"""
+An integration-style benchmark of a model with a class of what should
+(hopefully) be some of the most common field types used in pydantic validation.
+
+Used to gauge overall pydantic performance.
+"""
+import json
+from datetime import date, datetime, time
+from decimal import Decimal
+from hashlib import md5
+from pathlib import Path
+from typing import List, Union
+from uuid import UUID
+
+import pytest
+from typing_extensions import Annotated, Literal
+
+from pydantic.networks import EmailStr
+
+try:
+    import email_validator
+except ImportError:
+    email_validator = None
+
+
+@pytest.fixture(scope='module')
+def pydantic_type_adapter():
+    from pydantic import BaseModel, Field, TypeAdapter
+    from pydantic.networks import AnyHttpUrl
+
+    if not email_validator:
+        raise pytest.skip(reason='email_validator not installed')
+
+    class Blog(BaseModel):
+        type: Literal['blog']
+        title: str
+        post_count: int
+        readers: int
+        avg_post_rating: float
+        url: AnyHttpUrl
+
+    class SocialProfileBase(BaseModel):
+        type: Literal['profile']
+        network: Literal['facebook', 'twitter', 'linkedin']
+        username: str
+        join_date: date
+
+    class FacebookProfile(SocialProfileBase):
+        network: Literal['facebook']
+        friends: int
+
+    class TwitterProfile(SocialProfileBase):
+        network: Literal['twitter']
+        followers: int
+
+    class LinkedinProfile(SocialProfileBase):
+        network: Literal['linkedin']
+        connections: Annotated[int, Field(le=500)]
+
+    SocialProfile = Annotated[Union[FacebookProfile, TwitterProfile, LinkedinProfile], Field(discriminator='network')]
+
+    Website = Annotated[Union[Blog, SocialProfile], Field(discriminator='type')]
+
+    class Person(BaseModel):
+        id: UUID
+        name: str
+        email: EmailStr
+        height: Decimal
+        entry_created_date: date
+        entry_created_time: time
+        entry_updated_at: datetime
+        websites: List[Website] = Field(default_factory=list)
+
+    return TypeAdapter(List[Person])
+
+
+_NORTH_STAR_DATA_PATH = Path(__file__).parent / 'north_star_data.json'
+_EXPECTED_NORTH_STAR_DATA_MD5 = '40bd2ee46ddbcc07ee8c693dc666fa17'
+
+
+@pytest.fixture(scope='module')
+def north_star_data_bytes():
+    return _north_star_data_bytes()
+
+
+def _north_star_data_bytes() -> bytes:
+    from .generate_north_star_data import person_data
+
+    needs_generating = not _NORTH_STAR_DATA_PATH.exists()
+    if needs_generating:
+        data = json.dumps(person_data(length=1000)).encode()
+        _NORTH_STAR_DATA_PATH.write_bytes(data)
+    else:
+        data = _NORTH_STAR_DATA_PATH.read_bytes()
+
+    # To make benchmarks a stable metric, validate the MD5 hash of the
+    # existing generated data. If the data is deliberately changed,
+    # update _EXPECTED_NORTH_STAR_DATA_MD5 above.
+    #
+    # NB updating Faker will almost certainly change the benchmark data.
+    data_md5 = md5(data).hexdigest()
+    if data_md5 != _EXPECTED_NORTH_STAR_DATA_MD5:
+        if needs_generating:
+            raise ValueError(
+                f'Expected hash {_EXPECTED_NORTH_STAR_DATA_MD5} for north star data, but generated {data_md5}'
+            )
+        else:
+            # MD5 hash mismatch, maybe shape of the data has changed. Delete
+            # and regenerate.
+            _NORTH_STAR_DATA_PATH.unlink()
+            return _north_star_data_bytes()
+
+    return data
+
+
+def test_north_star_validate_json(pydantic_type_adapter, north_star_data_bytes, benchmark):
+    benchmark(pydantic_type_adapter.validate_json, north_star_data_bytes)
+
+
+def test_north_star_validate_json_strict(pydantic_type_adapter, north_star_data_bytes, benchmark):
+    coerced_north_star_data = pydantic_type_adapter.dump_json(
+        pydantic_type_adapter.validate_json(north_star_data_bytes)
+    )
+    benchmark(pydantic_type_adapter.validate_json, coerced_north_star_data, strict=True)
+
+
+def test_north_star_dump_json(pydantic_type_adapter, north_star_data_bytes, benchmark):
+    parsed = pydantic_type_adapter.validate_json(north_star_data_bytes)
+    benchmark(pydantic_type_adapter.dump_json, parsed)
+
+
+def test_north_star_validate_python(pydantic_type_adapter, north_star_data_bytes, benchmark):
+    benchmark(pydantic_type_adapter.validate_python, json.loads(north_star_data_bytes))
+
+
+def test_north_star_validate_python_strict(pydantic_type_adapter, north_star_data_bytes, benchmark):
+    coerced_north_star_data = pydantic_type_adapter.dump_python(
+        pydantic_type_adapter.validate_json(north_star_data_bytes)
+    )
+    benchmark(pydantic_type_adapter.validate_python, coerced_north_star_data, strict=True)
+
+
+def test_north_star_dump_python(pydantic_type_adapter, north_star_data_bytes, benchmark):
+    parsed = pydantic_type_adapter.validate_python(json.loads(north_star_data_bytes))
+    benchmark(pydantic_type_adapter.dump_python, parsed)
+
+
+def test_north_star_json_loads(north_star_data_bytes, benchmark):
+    benchmark(json.loads, north_star_data_bytes)
+
+
+def test_north_star_json_dumps(north_star_data_bytes, benchmark):
+    parsed = json.loads(north_star_data_bytes)
+    benchmark(json.dumps, parsed)


### PR DESCRIPTION
## Change Summary

This adds a new `tests/benchmarks` directory containing a "north star" benchmark which contains a first start at a benchmark to use to understand how changes affect performance.

I suspect the bulk of meaningful changes will come to changes in `pydantic-core`, so I'd like to find a way to run these same benchmarks on `pydantic-core` PRs.

skip change file check

## Related issue number

N/A

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani