### PR TITLE
Allow updating docs without release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docs-update
     tags:
       - '**'
   pull_request: {}
@@ -304,59 +303,8 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
-  publish_docs:
-    needs: [check]
-    timeout-minutes: 30
-    if: >
-      needs.check.outputs.result == 'success' &&
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/'))
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: checkout docs-site
-        uses: actions/checkout@v3
-        with:
-          ref: docs-site
-
-      - name: checkout current branch
-        uses: actions/checkout@v3
-
-      - uses: pdm-project/setup-pdm@v3
-        with:
-          python-version: '3.10'
-          cache: true
-          version: 2.7.0
-
-      - name: install
-        run: |
-          pdm install -G docs
-          pdm run pip install https://files.scolvin.com/${MKDOCS_TOKEN}/mkdocs-material/mkdocs_material-9.1.5+insiders.4.32.4-py3-none-any.whl
-        env:
-          MKDOCS_TOKEN: ${{ secrets.MKDOCS_TOKEN }}
-
-      - run: pdm run python -c 'import docs.plugins.main'
-
-      - name: Set git credentials
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - run: pdm run mike deploy -b docs-site dev-v2 --push
-        if: github.ref == 'refs/heads/main'
-
-      - name: check version
-        if: "github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')"
-        id: check-version
-        uses: samuelcolvin/check-python-version@v4
-        with:
-          version_file_path: 'pydantic/version.py'
-          skip_env_check: true
-
-      - run: pdm run mike deploy -b docs-site ${{ steps.check-version.outputs.VERSION_MAJOR_MINOR }} latest --update-aliases --push
-        if: "(github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')) && !fromJSON(steps.check-version.outputs.IS_PRERELEASE)"
-
   release:
-    needs: [check, publish_docs]
+    needs: [check]
     if: needs.check.outputs.result == 'success' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
 
       - name: check version
         id: check-tag
-        uses: samuelcolvin/check-python-version@v3.2
+        uses: samuelcolvin/check-python-version@v4.1
         with:
           version_file_path: pydantic/version.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - docs-update
     tags:
       - '**'
   pull_request: {}
@@ -306,7 +307,9 @@ jobs:
   publish_docs:
     needs: [check]
     timeout-minutes: 30
-    if: needs.check.outputs.result == 'success' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    if: >
+      needs.check.outputs.result == 'success' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
 
     steps:
@@ -342,14 +345,15 @@ jobs:
         if: github.ref == 'refs/heads/main'
 
       - name: check version
-        if: "startsWith(github.ref, 'refs/tags/')"
+        if: "github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')"
         id: check-version
-        uses: samuelcolvin/check-python-version@v3.2
+        uses: samuelcolvin/check-python-version@v4
         with:
           version_file_path: 'pydantic/version.py'
+          skip_env_check: true
 
       - run: pdm run mike deploy -b docs-site ${{ steps.check-version.outputs.VERSION_MAJOR_MINOR }} latest --update-aliases --push
-        if: "startsWith(github.ref, 'refs/tags/') && !fromJSON(steps.check-version.outputs.IS_PRERELEASE)"
+        if: "(github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')) && !fromJSON(steps.check-version.outputs.IS_PRERELEASE)"
 
   release:
     needs: [check, publish_docs]

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,101 @@
+name: Update Docs
+
+on:
+  push:
+    branches:
+      - main
+      - docs-update
+    tags:
+      - '**'
+
+env:
+  COLUMNS: 150
+  PDM_DEPS: 'urllib3<2'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: '3.11'
+          cache: true
+          version: '2.7.0'
+
+      - name: install
+        run: pdm install -G linting -G email
+
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files --verbose
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: '3.11'
+          cache: true
+          version: '2.7.0'
+
+      - name: install deps
+        run: pdm install -G testing
+
+      - run: pdm info && pdm list
+
+      - run: 'pdm run python -c "import pydantic.version; print(pydantic.version.version_info())"'
+
+      - run: make test
+
+  publish_docs:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: checkout docs-site
+        uses: actions/checkout@v3
+        with:
+          ref: docs-site
+
+      - name: checkout current branch
+        uses: actions/checkout@v3
+
+      - uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: '3.10'
+          cache: true
+          version: 2.7.0
+
+      - name: install
+        run: |
+          pdm install -G docs
+          pdm run pip install https://files.scolvin.com/${MKDOCS_TOKEN}/mkdocs-material/mkdocs_material-9.1.5+insiders.4.32.4-py3-none-any.whl
+        env:
+          MKDOCS_TOKEN: ${{ secrets.MKDOCS_TOKEN }}
+
+      - run: pdm run python -c 'import docs.plugins.main'
+
+      - name: Set git credentials
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - run: pdm run mike deploy -b docs-site dev-v2 --push
+        if: "github.ref == 'refs/heads/main'"
+
+      - if: "github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')"
+        id: check-version
+        uses: samuelcolvin/check-python-version@v4
+        with:
+          version_file_path: 'pydantic/version.py'
+          skip_env_check: true
+
+      - run: pdm run mike deploy -b docs-site ${{ steps.check-version.outputs.VERSION_MAJOR_MINOR }} latest --update-aliases --push
+        if: "(github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')) && !fromJSON(steps.check-version.outputs.IS_PRERELEASE)"
+        with:
+          PYDANTIC_VERSION: ${{ steps.check-version.outputs.VERSION }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -97,5 +97,5 @@ jobs:
 
       - run: pdm run mike deploy -b docs-site ${{ steps.check-version.outputs.VERSION_MAJOR_MINOR }} latest --update-aliases --push
         if: "(github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')) && !fromJSON(steps.check-version.outputs.IS_PRERELEASE)"
-        with:
+        env:
           PYDANTIC_VERSION: ${{ steps.check-version.outputs.VERSION }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -51,7 +51,7 @@ jobs:
 
       - run: make test
 
-  publish_docs:
+  publish:
     needs: [lint, test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -90,7 +90,7 @@ jobs:
 
       - if: "github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')"
         id: check-version
-        uses: samuelcolvin/check-python-version@v4
+        uses: samuelcolvin/check-python-version@v4.1
         with:
           version_file_path: 'pydantic/version.py'
           skip_env_check: true
@@ -98,4 +98,4 @@ jobs:
       - run: pdm run mike deploy -b docs-site ${{ steps.check-version.outputs.VERSION_MAJOR_MINOR }} latest --update-aliases --push
         if: "(github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')) && !fromJSON(steps.check-version.outputs.IS_PRERELEASE)"
         env:
-          PYDANTIC_VERSION: ${{ steps.check-version.outputs.VERSION }}
+          PYDANTIC_VERSION: v${{ steps.check-version.outputs.VERSION }}

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -179,6 +179,7 @@ def add_version(markdown: str, page: Page) -> str | None:
         version_str = f'Documentation for development version: [{sha}]({url})'
     else:
         version_str = 'Documentation for development version'
+    print(f'Setting version prefix: {version_str!r}')
     markdown = re.sub(r'{{ *version *}}', version_str, markdown)
     return markdown
 

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -166,8 +166,10 @@ def add_version(markdown: str, page: Page) -> str | None:
     if page.file.src_uri != 'index.md':
         return None
 
-    version_ref = os.getenv('GITHUB_REF')
-    if version_ref and version_ref.startswith('refs/tags/'):
+    if version := os.getenv('PYDANTIC_VERSION'):
+        url = f'https://github.com/pydantic/pydantic/releases/tag/{version}'
+        version_str = f'Documentation for version: [{version}]({url})'
+    elif (version_ref := os.getenv('GITHUB_REF')) and version_ref.startswith('refs/tags/'):
         version = re.sub('^refs/tags/', '', version_ref.lower())
         url = f'https://github.com/pydantic/pydantic/releases/tag/{version}'
         version_str = f'Documentation for version: [{version}]({url})'


### PR DESCRIPTION
From now on, to update the docs without a release:
* create a pull request to the `docs-update` branch
* Before making new releases we need to merge any changes in `docs-update` into `main`
* We could also setup an action to optionally "backport" prs to `main` to `docs-update`