### PR TITLE
Make it harder to hit collisions with json schema defrefs

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1748,7 +1748,9 @@ class GenerateJsonSchema:
         Returns:
             The normalized name.
         """
-        return re.sub(r'[^a-zA-Z0-9.\-_]', '_', name).replace('.', '__')
+        normalized = re.sub(r'[^a-zA-Z0-9.\-_]', '_', name)
+        normalized = re.sub('(__+)', r'_\1', normalized)  # convert any double-or-more underscores to be triple-or-more
+        return normalized.replace('.', '__')  # use double underscores where periods would have been
 
     def get_defs_ref(self, core_mode_ref: CoreModeRef) -> DefsRef:
         """Override this method to change the way that definitions keys are generated from a core reference.
@@ -1775,9 +1777,9 @@ class GenerateJsonSchema:
         # be generated for any other core_ref. Currently, this should be the case because we include
         # the id of the source type in the core_ref
         name = DefsRef(self.normalize_name(short_ref))
-        name_mode = DefsRef(self.normalize_name(short_ref + mode_title))
+        name_mode = DefsRef(self.normalize_name(short_ref) + f'__{mode_title}')
         module_qualname = DefsRef(self.normalize_name(core_ref_no_id))
-        module_qualname_mode = DefsRef(module_qualname + mode_title)
+        module_qualname_mode = DefsRef(f'{module_qualname}__{mode_title}')
         module_qualname_id = DefsRef(self.normalize_name(core_ref))
         occurrence_index = self._collision_index.get(module_qualname_id)
         if occurrence_index is None:
@@ -1785,7 +1787,7 @@ class GenerateJsonSchema:
             occurrence_index = self._collision_index[module_qualname_id] = self._collision_counter[module_qualname]
 
         module_qualname_occurrence = DefsRef(f'{module_qualname}__{occurrence_index}')
-        module_qualname_occurrence_mode = DefsRef(f'{module_qualname}{mode_title}__{occurrence_index}')
+        module_qualname_occurrence_mode = DefsRef(f'{module_qualname_mode}__{occurrence_index}')
 
         self._prioritized_defsref_choices[module_qualname_occurrence_mode] = [
             name,

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -48,6 +48,7 @@ from pydantic import (
     ValidationError,
     WithJsonSchema,
     computed_field,
+    field_serializer,
     field_validator,
 )
 from pydantic._internal._core_metadata import CoreMetadataHandler, build_metadata_dict
@@ -2729,6 +2730,167 @@ class MyModel(BaseModel):
         f'{module_1.__name__}__MyModel',
         f'{module_2.__name__}__MyEnum',
         f'{module_2.__name__}__MyModel',
+    }
+
+
+def test_mode_name_causes_no_conflict():
+    class Organization(BaseModel):
+        pass
+
+    class OrganizationInput(BaseModel):
+        pass
+
+    class OrganizationOutput(BaseModel):
+        pass
+
+    class Model(BaseModel):
+        # Ensure the validation and serialization schemas are different:
+        x: Organization = Field(validation_alias='x_validation', serialization_alias='x_serialization')
+        y: OrganizationInput
+        z: OrganizationOutput
+
+    assert Model.model_json_schema(mode='validation') == {
+        '$defs': {
+            'Organization': {'properties': {}, 'title': 'Organization', 'type': 'object'},
+            'OrganizationInput': {'properties': {}, 'title': 'OrganizationInput', 'type': 'object'},
+            'OrganizationOutput': {'properties': {}, 'title': 'OrganizationOutput', 'type': 'object'},
+        },
+        'properties': {
+            'x_validation': {'$ref': '#/$defs/Organization'},
+            'y': {'$ref': '#/$defs/OrganizationInput'},
+            'z': {'$ref': '#/$defs/OrganizationOutput'},
+        },
+        'required': ['x_validation', 'y', 'z'],
+        'title': 'Model',
+        'type': 'object',
+    }
+    assert Model.model_json_schema(mode='serialization') == {
+        '$defs': {
+            'Organization': {'properties': {}, 'title': 'Organization', 'type': 'object'},
+            'OrganizationInput': {'properties': {}, 'title': 'OrganizationInput', 'type': 'object'},
+            'OrganizationOutput': {'properties': {}, 'title': 'OrganizationOutput', 'type': 'object'},
+        },
+        'properties': {
+            'x_serialization': {'$ref': '#/$defs/Organization'},
+            'y': {'$ref': '#/$defs/OrganizationInput'},
+            'z': {'$ref': '#/$defs/OrganizationOutput'},
+        },
+        'required': ['x_serialization', 'y', 'z'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
+def test_ref_conflict_resolution_without_mode_difference():
+    class OrganizationInput(BaseModel):
+        pass
+
+    class Organization(BaseModel):
+        x: int
+
+    schema_with_defs, defs = GenerateJsonSchema().generate_definitions(
+        [
+            (Organization, 'validation', Organization.__pydantic_core_schema__),
+            (Organization, 'serialization', Organization.__pydantic_core_schema__),
+            (OrganizationInput, 'validation', OrganizationInput.__pydantic_core_schema__),
+        ]
+    )
+    assert schema_with_defs == {
+        (Organization, 'serialization'): {'$ref': '#/$defs/Organization'},
+        (Organization, 'validation'): {'$ref': '#/$defs/Organization'},
+        (OrganizationInput, 'validation'): {'$ref': '#/$defs/OrganizationInput'},
+    }
+
+    assert defs == {
+        'OrganizationInput': {'properties': {}, 'title': 'OrganizationInput', 'type': 'object'},
+        'Organization': {
+            'properties': {'x': {'title': 'X', 'type': 'integer'}},
+            'required': ['x'],
+            'title': 'Organization',
+            'type': 'object',
+        },
+    }
+
+
+def test_ref_conflict_resolution_with_mode_difference():
+    class OrganizationInput(BaseModel):
+        pass
+
+    class Organization(BaseModel):
+        x: int
+
+        @field_serializer('x')
+        def serialize_x(self, v: int) -> str:
+            return str(v)
+
+    schema_with_defs, defs = GenerateJsonSchema().generate_definitions(
+        [
+            (Organization, 'validation', Organization.__pydantic_core_schema__),
+            (Organization, 'serialization', Organization.__pydantic_core_schema__),
+            (OrganizationInput, 'validation', OrganizationInput.__pydantic_core_schema__),
+        ]
+    )
+    assert schema_with_defs == {
+        (Organization, 'serialization'): {'$ref': '#/$defs/Organization__Output'},
+        (Organization, 'validation'): {'$ref': '#/$defs/Organization__Input'},
+        (OrganizationInput, 'validation'): {'$ref': '#/$defs/OrganizationInput'},
+    }
+
+    assert defs == {
+        'OrganizationInput': {'properties': {}, 'title': 'OrganizationInput', 'type': 'object'},
+        'Organization__Input': {
+            'properties': {'x': {'title': 'X', 'type': 'integer'}},
+            'required': ['x'],
+            'title': 'Organization',
+            'type': 'object',
+        },
+        'Organization__Output': {
+            'properties': {'x': {'title': 'X', 'type': 'string'}},
+            'required': ['x'],
+            'title': 'Organization',
+            'type': 'object',
+        },
+    }
+
+
+def test_conflicting_names():
+    class Organization__Input(BaseModel):
+        pass
+
+    class Organization(BaseModel):
+        x: int
+
+        @field_serializer('x')
+        def serialize_x(self, v: int) -> str:
+            return str(v)
+
+    schema_with_defs, defs = GenerateJsonSchema().generate_definitions(
+        [
+            (Organization, 'validation', Organization.__pydantic_core_schema__),
+            (Organization, 'serialization', Organization.__pydantic_core_schema__),
+            (Organization__Input, 'validation', Organization__Input.__pydantic_core_schema__),
+        ]
+    )
+    assert schema_with_defs == {
+        (Organization, 'serialization'): {'$ref': '#/$defs/Organization__Output'},
+        (Organization, 'validation'): {'$ref': '#/$defs/Organization__Input'},
+        (Organization__Input, 'validation'): {'$ref': '#/$defs/Organization___Input'},
+    }
+
+    assert defs == {
+        'Organization___Input': {'properties': {}, 'title': 'Organization__Input', 'type': 'object'},
+        'Organization__Input': {
+            'properties': {'x': {'title': 'X', 'type': 'integer'}},
+            'required': ['x'],
+            'title': 'Organization',
+            'type': 'object',
+        },
+        'Organization__Output': {
+            'properties': {'x': {'title': 'X', 'type': 'string'}},
+            'required': ['x'],
+            'title': 'Organization',
+            'type': 'object',
+        },
     }
 
 


### PR DESCRIPTION
Addresses an issue where, if you had a model called `Model` and another called `ModelInput`, it would detect a potential naming conflict and replace `ModelInput` with `ModelInputInput`.

I spent a lot of effort trying to rework this function to only respect actual conflicts and not potential conflicts, but the challenge is that remapping the defs refs requires modifications to the referenced definitions, and these references may be present in nested schemas which might become "unified" after replacing the input/output refs with a common one. This basically means that it requires iteration to determine what simplifications can be made, and doing so is somewhat complex. I don't see a good way around this, so for now, I have just tried to make it harder to run into this scenario by introducing double underscores.

It is still possible to achieve an unintentional conflict based on the mode, but with the changes in this PR, the only way to do that would be to have `my_package.MyModule.Input` and `my_package.MyModule__Input` both be classes. Considering that nesting basemodel definitions is rare, and having modules named in PascalCase is rare, and even if you did one of those you'd still need to have a conflict on the specific name, this seems safe to me.

The biggest concern I have is that having one model called `OrganizationInput` and another called `Organization` which has a difference between its input and output schemas (and therefore gets the ref `Organization__Input`) might result in problems if trying to generate a client based on an OpenAPI spec or whatever. (I'm thinking both might be given the class name `OrganizationInput`, but I'm not totally sure.)

I'll note that there are various complex cases with defs-ref generation that are easy to forget about (and which I wasted time trying other things before discovering they would cause problems), so some approaches that might seem obvious and work in the "normal" case may still have problems. But if anyone has a problem with this approach, or especially has other suggestions, I'm happy to consider them.
