### PR TITLE
Deque's maxlen property dropped on V1 validation

### DIFF
--- a/changes/6581-maciekglowka.md
+++ b/changes/6581-maciekglowka.md
@@ -1,0 +1,1 @@
+Fixes the `maxlen` property being dropped on `deque` validation. Happened only if the deque item has been typed. Changes the `_validate_sequence_like` func.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -943,7 +943,7 @@ class ModelField(Representation):
         elif self.shape == SHAPE_TUPLE_ELLIPSIS:
             converted = tuple(result)
         elif self.shape == SHAPE_DEQUE:
-            converted = deque(result)
+            converted = deque(result, maxlen=getattr(v, 'maxlen', None))
         elif self.shape == SHAPE_SEQUENCE:
             if isinstance(v, tuple):
                 converted = tuple(result)
@@ -952,7 +952,7 @@ class ModelField(Representation):
             elif isinstance(v, Generator):
                 converted = iter(result)
             elif isinstance(v, deque):
-                converted = deque(result)
+                converted = deque(result, maxlen=getattr(v, 'maxlen', None))
         return converted, None
 
     def _validate_iterable(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3123,6 +3123,25 @@ def test_deque_generic_success(cls, value, result):
     assert Model(v=value).v == result
 
 
+def test_deque_maxlen():
+    class DequeTypedModel(BaseModel):
+        field: Deque[int] = deque(maxlen=10)
+
+    assert DequeTypedModel(field=deque(maxlen=25)).field.maxlen == 25
+    assert DequeTypedModel().field.maxlen == 10
+
+    class DequeUnTypedModel(BaseModel):
+        field: deque = deque(maxlen=10)
+
+    assert DequeUnTypedModel(field=deque(maxlen=25)).field.maxlen == 25
+    assert DequeTypedModel().field.maxlen == 10
+
+    class DeuqueNoDefaultModel(BaseModel):
+        field: deque
+
+    assert DeuqueNoDefaultModel(field=deque(maxlen=25)).field.maxlen == 25
+
+
 @pytest.mark.parametrize(
     'cls,value,errors',
     (


### PR DESCRIPTION
## Change Summary

Initial proposal to fix the `maxlen` property being dropped on `deque` validation. Happened only if the deque item has been typed.
Fix happens only in the `_validate_sequence_like` func. Do not know pydantic's code base, so if there is a neater place / way to solve it I am more than happy to make a change if directed

## Related issue number

fix #6581 



Selected Reviewer: @PrettyWood