### PR TITLE
Fix various docstrings using fixed pytest-examples

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "pytest-examples"
-version = "0.0.9"
+version = "0.0.10"
 requires_python = ">=3.7"
 summary = "Pytest plugin for testing examples in docstrings and markdown files."
 dependencies = [
@@ -716,9 +716,8 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.2"
-cross_platform = true
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
-content_hash = "sha256:f1a4767e86b811f54bd86c21269524faca0714d5b5c8a4dd265c52954fb16f0a"
+content_hash = "sha256:c8e823e2f5b090f12386b16b6c52b2d1ba4dba9e946bfe526e46644068912f99"
 
 [metadata.files]
 "annotated-types 0.5.0" = [
@@ -1348,9 +1347,9 @@ content_hash = "sha256:f1a4767e86b811f54bd86c21269524faca0714d5b5c8a4dd265c52954
     {url = "https://files.pythonhosted.org/packages/28/08/e6b0067efa9a1f2a1eb3043ecd8a0c48bfeb60d3255006dcc829d72d5da2/pytest-benchmark-4.0.0.tar.gz", hash = "sha256:fb0785b83efe599a6a956361c0691ae1dbb5318018561af10f3e915caa0048d1"},
     {url = "https://files.pythonhosted.org/packages/4d/a1/3b70862b5b3f830f0422844f25a823d0470739d994466be9dbbbb414d85a/pytest_benchmark-4.0.0-py3-none-any.whl", hash = "sha256:fdb7db64e31c8b277dff9850d2a2556d8b60bcb0ea6524e36e28ffd7c87f71d6"},
 ]
-"pytest-examples 0.0.9" = [
-    {url = "https://files.pythonhosted.org/packages/8b/60/a29aaeb7daee6f02090be1c668d61eb5078800abac5a4dcdfd9f46ad1a4b/pytest_examples-0.0.9.tar.gz", hash = "sha256:d5f9d670d4ae16f55f3e4ef79949e1133ee5e52856cc482fb9e305f2cdf4016a"},
-    {url = "https://files.pythonhosted.org/packages/a5/00/30349de6979cf6f7ccc432a186cb79bd795f3a108c9dd833a62aa769c625/pytest_examples-0.0.9-py3-none-any.whl", hash = "sha256:a37c798289580bd8fce47582a67cf821e6dda0d45b63fa8e9cbbd4713ed2bf08"},
+"pytest-examples 0.0.10" = [
+    {url = "https://files.pythonhosted.org/packages/0a/4b/1aa9afeed3029ea53591c4dcd0a5104512487415e5d62d2797882d880e1e/pytest_examples-0.0.10.tar.gz", hash = "sha256:5d34d22e689aca2bbad8dd6b7cdcc9d0107e2942853b3154f3a3c68d145d91c5"},
+    {url = "https://files.pythonhosted.org/packages/85/74/4c09d847e082f4f779800c2a200336419804f444298b26045d3bd25ce152/pytest_examples-0.0.10-py3-none-any.whl", hash = "sha256:3d0b52424e454846beed8621a12b85db88c6c17049f65c2f417211372c20dc9e"},
 ]
 "pytest-memray 1.4.0" = [
     {url = "https://files.pythonhosted.org/packages/aa/17/53b10c79a76e019e29e79a717ffab4cf9d21c9411e91e30ed9283dd3e4c9/pytest_memray-1.4.0-py3-none-any.whl", hash = "sha256:cbac61c0a278011e77d57f0afc72ae08de41e59600d2a3f5406874251ed89785"},

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -258,15 +258,14 @@ class FieldInfo(_repr.Representation):
             one of the (not first) arguments in `Annotated` are an instance of `FieldInfo`, e.g.:
 
             ```python
-            import typing
-
             import annotated_types
+            from typing_extensions import Annotated
 
             import pydantic
 
             class MyModel(pydantic.BaseModel):
-                foo: typing.Annotated[int, annotated_types.Gt(42)]
-                bar: typing.Annotated[int, pydantic.Field(gt=42)]
+                foo: Annotated[int, annotated_types.Gt(42)]
+                bar: Annotated[int, pydantic.Field(gt=42)]
             ```
 
         """
@@ -303,16 +302,15 @@ class FieldInfo(_repr.Representation):
 
         Example:
             ```python
-            import typing
-
             import annotated_types
+            from typing_extensions import Annotated
 
             import pydantic
 
             class MyModel(pydantic.BaseModel):
                 foo: int = 4  # <-- like this
-                bar: typing.Annotated[int, annotated_types.Gt(4)] = 4  # <-- or this
-                spam: typing.Annotated[int, pydantic.Field(gt=4)] = 4  # <-- or this
+                bar: Annotated[int, annotated_types.Gt(4)] = 4  # <-- or this
+                spam: Annotated[int, pydantic.Field(gt=4)] = 4  # <-- or this
             ```
         """
         final = False

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -227,7 +227,7 @@ class FieldInfo(_repr.Representation):
             import pydantic
 
             class MyModel(pydantic.BaseModel):
-                foo: int = pydantic.Field(4, ...)
+                foo: int = pydantic.Field(4)
             ```
         """
         if 'annotation' in kwargs:
@@ -249,6 +249,7 @@ class FieldInfo(_repr.Representation):
 
             ```python
             import pydantic
+
             class MyModel(pydantic.BaseModel):
                 foo: int  # <-- like this
             ```
@@ -257,11 +258,15 @@ class FieldInfo(_repr.Representation):
             one of the (not first) arguments in `Annotated` are an instance of `FieldInfo`, e.g.:
 
             ```python
-            import pydantic, annotated_types, typing
+            import typing
+
+            import annotated_types
+
+            import pydantic
 
             class MyModel(pydantic.BaseModel):
                 foo: typing.Annotated[int, annotated_types.Gt(42)]
-                bar: typing.Annotated[int, Field(gt=42)]
+                bar: typing.Annotated[int, pydantic.Field(gt=42)]
             ```
 
         """
@@ -298,7 +303,11 @@ class FieldInfo(_repr.Representation):
 
         Example:
             ```python
-            import pydantic, annotated_types, typing
+            import typing
+
+            import annotated_types
+
+            import pydantic
 
             class MyModel(pydantic.BaseModel):
                 foo: int = 4  # <-- like this

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -95,7 +95,7 @@ class BeforeValidator:
 
     Example:
         ```py
-        from typing import Annotated
+        from typing_extensions import Annotated
 
         from pydantic import BaseModel, BeforeValidator
 
@@ -137,7 +137,7 @@ class PlainValidator:
 
     Example:
         ```py
-        from typing import Annotated
+        from typing_extensions import Annotated
 
         from pydantic import BaseModel, PlainValidator
 
@@ -172,7 +172,8 @@ class WrapValidator:
 
     ```py
     from datetime import datetime
-    from typing import Annotated
+
+    from typing_extensions import Annotated
 
     from pydantic import BaseModel, ValidationError, WrapValidator
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -178,7 +178,7 @@ else:
                 email: EmailStr
 
             print(Model(email='contact@mail.com'))
-            # > email='contact@mail.com'
+            #> email='contact@mail.com'
             ```
         """
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -43,18 +43,21 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
 
     a.py
     ```python
-    from typing import List, Dict
+    from typing import Dict, List
+
     IntList = List[int]
     OuterDict = Dict[str, 'IntList']
     ```
 
     b.py
-    ```python
-    from pydantic import TypeAdapter
+    ```python test="skip"
     from a import OuterDict
+
+    from pydantic import TypeAdapter
+
     IntList = int  # replaces the symbol the forward reference is looking for
     v = TypeAdapter(OuterDict)
-    v({"x": 1})  # should fail but doesn't
+    v({'x': 1})  # should fail but doesn't
     ```
 
     If OuterDict were a `BaseModel`, this would work because it would resolve

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -111,7 +111,6 @@ class Strict(_fields.PydanticMetadata):
 
         from pydantic.types import Strict
 
-
         StrictBool = Annotated[bool, Strict()]
         ```
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ docs = [
     "mike @ git+https://github.com/jimporter/mike.git",
     "mkdocs-embed-external-markdown>=2.3.0",
     "black>=23.3.0",
-    "pytest-examples>=0.0.9",
+    "pytest-examples>=0.0.10",
     "pydantic-settings>=2.0b1",
     "pydantic-extra-types @ git+https://github.com/pydantic/pydantic-extra-types.git@main"
 ]


### PR DESCRIPTION
There was a bug where single-line docstrings were causing files to be mishandled by pytest-examples.

With this PR https://github.com/pydantic/pytest-examples/pull/15, these get caught, and as a result I was able to find these issues.

Also I'll note that this other PR https://github.com/pydantic/pytest-examples/pull/14 makes it so that we can run `pytest --update-examples` and it doesn't produce any invalid example updates that need to be reverted.

I've opened this as a draft because I don't think we should merge this PR until we can update pytest-examples, so this can serve as a reminder that we need to do that.