### PR TITLE
Fixed mypy type inferrence for TypeAdapter

### DIFF
--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -128,6 +128,17 @@ class TypeAdapter(Generic[T]):
             """A class representing the type adapter."""
             raise NotImplementedError
 
+        @overload
+        def __init__(self, type: type[T], *, config: ConfigDict | None = None, _parent_depth: int = 2) -> None:
+            ...
+
+        # this overload is for non-type things like Union[int, str]
+        # Pyright currently handles this "correctly", but MyPy understands this as TypeAdapter[object]
+        # so an explicit type cast is needed
+        @overload
+        def __init__(self, type: T, *, config: ConfigDict | None = None, _parent_depth: int = 2) -> None:
+            ...
+
     def __init__(self, type: Any, *, config: ConfigDict | None = None, _parent_depth: int = 2) -> None:
         """Initializes the TypeAdapter object."""
         config_wrapper = _config.ConfigWrapper(config)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary
Add `__init__` `TYPE_CHECKING` block to `TypeAdaptor` similar to one for `__new__`.

## Related issue number
fix #6615
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin