### PR TITLE
🐛 Support defining `json_schema_extra` on `RootModel` using `Field`

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1261,7 +1261,7 @@ class GenerateJsonSchema:
             if json_schema_extra and root_json_schema_extra:
                 raise ValueError(
                     '"model_config[\'json_schema_extra\']" and "Field.json_schema_extra" on "RootModel.root"'
-                    ' field could not be set simultaneously'
+                    ' field must not be set simultaneously'
                 )
             if root_json_schema_extra:
                 json_schema_extra = root_json_schema_extra

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1256,6 +1256,16 @@ class GenerateJsonSchema:
         title = config.get('title')
 
         json_schema_extra = config.get('json_schema_extra')
+        if cls.__pydantic_root_model__:
+            root_json_schema_extra = cls.model_fields['root'].json_schema_extra
+            if json_schema_extra and root_json_schema_extra:
+                raise ValueError(
+                    '"model_config[\'json_schema_extra\']" and "Field.json_schema_extra" on "RootModel.root"'
+                    ' field could not be set simultaneously'
+                )
+            if root_json_schema_extra:
+                json_schema_extra = root_json_schema_extra
+
         json_schema = self._update_class_schema(json_schema, title, config.get('extra', None), cls, json_schema_extra)
 
         return json_schema

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -591,5 +591,5 @@ def test_json_schema_extra_on_model_and_on_field():
         model_config = ConfigDict(json_schema_extra={'schema key on model': 'schema value on model'})
         root: str = Field(json_schema_extra={'schema key on field': 'schema value on field'})
 
-    with pytest.raises(ValueError, match=r'json_schema_extra.*?could not be set simultaneously'):
+    with pytest.raises(ValueError, match=r'json_schema_extra.*?must not be set simultaneously'):
         Model.model_json_schema()

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -561,3 +561,35 @@ def test_pickle_root_model(create_module):
 
     MyRootModel = module.MyRootModel
     assert MyRootModel(root='abc') == pickle.loads(pickle.dumps(MyRootModel(root='abc')))
+
+
+def test_json_schema_extra_on_model():
+    class Model(RootModel):
+        model_config = ConfigDict(json_schema_extra={'schema key': 'schema value'})
+        root: str
+
+    assert Model.model_json_schema() == {
+        'schema key': 'schema value',
+        'title': 'Model',
+        'type': 'string',
+    }
+
+
+def test_json_schema_extra_on_field():
+    class Model(RootModel):
+        root: str = Field(json_schema_extra={'schema key': 'schema value'})
+
+    assert Model.model_json_schema() == {
+        'schema key': 'schema value',
+        'title': 'Model',
+        'type': 'string',
+    }
+
+
+def test_json_schema_extra_on_model_and_on_field():
+    class Model(RootModel):
+        model_config = ConfigDict(json_schema_extra={'schema key on model': 'schema value on model'})
+        root: str = Field(json_schema_extra={'schema key on field': 'schema value on field'})
+
+    with pytest.raises(ValueError, match=r'json_schema_extra.*?could not be set simultaneously'):
+        Model.model_json_schema()


### PR DESCRIPTION
## Change Summary

Add support for `json_schema_extra` using `Field` on `Root.root`

## Related issue number

Fix #6579

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu