### PR TITLE
Produce more accurate signatures for pydantic dataclasses

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -185,6 +185,7 @@ def dataclass(
 
         cls = dataclasses.dataclass(  # type: ignore[call-overload]
             cls,
+            # the value of init here doesn't affect anything except that it makes it easier to generate a signature
             init=True,
             repr=repr,
             eq=eq,

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -185,7 +185,7 @@ def dataclass(
 
         cls = dataclasses.dataclass(  # type: ignore[call-overload]
             cls,
-            init=init,
+            init=True,
             repr=repr,
             eq=eq,
             order=order,

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,4 +1,5 @@
 import dataclasses
+import inspect
 import pickle
 import re
 import sys
@@ -2408,3 +2409,18 @@ def test_dataclass_field_default_factory_with_init():
         x: int = dataclasses.field(default_factory=lambda: 3, init=False)
 
     assert Model().x == 3
+
+
+def test_signature():
+    @pydantic.dataclasses.dataclass
+    class Model:
+        x: int
+        y: str = 'y'
+        z: float = dataclasses.field(default=1.0)
+        a: float = dataclasses.field(default_factory=float)
+        b: float = Field(default=1.0)
+        c: float = Field(default_factory=float)
+
+    assert str(inspect.signature(Model)) == (
+        "(x: int, y: str = 'y', z: float = 1.0, a: float = <factory>, b: float = 1.0, c: float = <factory>) -> None"
+    )


### PR DESCRIPTION
Closes #6623

This is necessary for FastAPI to to produce a collection of query param dependencies from a pydantic dataclass:

```python
from typing import Union

from fastapi import FastAPI, Depends

import pydantic
from pydantic.dataclasses import dataclass as pydantic_dataclass

app = FastAPI()


@pydantic_dataclass()
class QueryParams:
    q: Union[str, None] = None
    skip: int = pydantic.Field(default=0)
    limit: int = 100


@app.get("/")
def home(query_params: QueryParams = Depends()):
    return query_params
```