### PR TITLE
Add xfailing test for pydantic-core PR 766

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -403,8 +403,10 @@ def test_validating_assignment_value_change(ValidateAssignmentModel):
     assert p.c == 0
     p.c = 3
     assert p.c == 6
+    assert p.model_dump()['c'] == 6
 
 
+@pytest.mark.xfail(reason='requires https://github.com/pydantic/pydantic-core/pull/766')
 def test_validating_assignment_extra(ValidateAssignmentModel):
     p = ValidateAssignmentModel(b='hello', extra_field=1.23)
     assert p.extra_field == 1.23
@@ -414,6 +416,7 @@ def test_validating_assignment_extra(ValidateAssignmentModel):
     assert p.extra_field == 1.23
     p.extra_field = 'bye'
     assert p.extra_field == 'bye'
+    assert p.model_dump()['extra_field'] == 'bye'
 
 
 def test_validating_assignment_dict(ValidateAssignmentModel):


### PR DESCRIPTION
Updates a test and makes it xfail; that test will start passing once https://github.com/pydantic/pydantic-core/pull/766 is merged and in the pydantic-core version being used.

Also see: https://github.com/pydantic/pydantic/issues/6613