### PR TITLE
Fix list markdown in `transform` docstring

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -422,6 +422,7 @@ class PydanticModelTransformer:
         """Configures the BaseModel subclass according to the plugin settings.
 
         In particular:
+
         * determines the model config and fields,
         * adds a fields-aware signature for the initializer and construct methods
         * freezes the class if frozen = True


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->


## Change Summary
Fix list markdown in transform docstring by adding an empty line.
Before:
![Screenshot 2023-07-13 150150](https://github.com/pydantic/pydantic/assets/28559054/8e9eb5e8-54b4-4329-a22a-7bc200b0751b)
After:
![Screenshot 2023-07-13 150032](https://github.com/pydantic/pydantic/assets/28559054/1bb3462c-6dd7-4204-87f0-e61f3edac425)
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X ] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
