### PR TITLE
✨ Add `SkipJsonSchema` annotation

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2085,7 +2085,7 @@ def models_json_schema(
     description: str | None = None,
     ref_template: str = DEFAULT_REF_TEMPLATE,
     schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
-) -> tuple[dict[tuple[type[BaseModel] | type[PydanticDataclass], JsonSchemaMode], JsonSchemaValue,], JsonSchemaValue]:
+) -> tuple[dict[tuple[type[BaseModel] | type[PydanticDataclass], JsonSchemaMode], JsonSchemaValue], JsonSchemaValue]:
     """Utility function to generate a JSON Schema for multiple models.
 
     Args:
@@ -2245,7 +2245,7 @@ if TYPE_CHECKING:
     SkipJsonSchema = Annotated[AnyType, ...]
 else:
 
-    @_internal_dataclass.slots_dataclass
+    @dataclasses.dataclass(**_internal_dataclass.slots_true)
     class SkipJsonSchema:
         """Add this as an annotation on a field to skip generating a JSON schema for that field.
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -62,6 +62,7 @@ from pydantic.json_schema import (
     GenerateJsonSchema,
     JsonSchemaValue,
     PydanticJsonSchemaWarning,
+    SkipJsonSchema,
     model_json_schema,
     models_json_schema,
 )
@@ -4832,6 +4833,25 @@ def test_examples_annotation() -> None:
         'examples': {'Constants': [3.14, 2.71], 'Fibonacci': [1, 1, 2, 3, 5]},
         'items': {'type': 'number'},
         'type': 'array',
+    }
+
+
+def test_skip_json_schema_annotation() -> None:
+    class Model(BaseModel):
+        x: int | SkipJsonSchema[None] = None
+        y: int | SkipJsonSchema[None] = 1
+        z: int | SkipJsonSchema[str] = 'foo'
+
+    assert Model(y=None).y is None
+    # insert_assert(Model.model_json_schema())
+    assert Model.model_json_schema() == {
+        'properties': {
+            'x': {'default': None, 'title': 'X', 'type': 'integer'},
+            'y': {'default': 1, 'title': 'Y', 'type': 'integer'},
+            'z': {'default': 'foo', 'title': 'Z', 'type': 'integer'},
+        },
+        'title': 'Model',
+        'type': 'object',
     }
 
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4838,9 +4838,9 @@ def test_examples_annotation() -> None:
 
 def test_skip_json_schema_annotation() -> None:
     class Model(BaseModel):
-        x: int | SkipJsonSchema[None] = None
-        y: int | SkipJsonSchema[None] = 1
-        z: int | SkipJsonSchema[str] = 'foo'
+        x: Union[int, SkipJsonSchema[None]] = None
+        y: Union[int, SkipJsonSchema[None]] = 1
+        z: Union[int, SkipJsonSchema[str]] = 'foo'
 
     assert Model(y=None).y is None
     # insert_assert(Model.model_json_schema())


### PR DESCRIPTION
This PR solves #6647 on Pydantic side, in the sense that it allows the user to not generate the JSON schema on a type.

Although this is nice to have on Pydantic, it's not ideal for FastAPI users to do `T | SkipJsonSchema[None]`, mainly because of dev experience. That said, @dmontagu proposed that FastAPI would use a `FastAPIGeneratorJsonSchema` on their side which would skip nullable fields _if is not a `Body`_. - I'm going to push a PR in FastAPI to help on this.

Selected Reviewer: @lig