### PR TITLE
Use OrderedDict from typing_extensions

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -16,6 +16,7 @@ from functools import partial
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import Any, Callable, Iterable, TypeVar
 
+import typing_extensions
 from pydantic_core import (
     CoreSchema,
     MultiHostUrl,
@@ -611,7 +612,7 @@ MAPPING_ORIGIN_MAP: dict[Any, Any] = {
     typing.DefaultDict: collections.defaultdict,
     collections.defaultdict: collections.defaultdict,
     collections.OrderedDict: collections.OrderedDict,
-    typing.OrderedDict: collections.OrderedDict,
+    typing_extensions.OrderedDict: collections.OrderedDict,
     dict: dict,
     typing.Dict: dict,
     collections.Counter: collections.Counter,


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6426

Note that this is the relevant code in `typing_extensions`:
```python
# 3.7.2+
if hasattr(typing, 'OrderedDict'):
    OrderedDict = typing.OrderedDict
# 3.7.0-3.7.2
else:
    OrderedDict = typing._alias(collections.OrderedDict, (KT, VT))
```

Given that, I think this is safe to merge. @Kludex I understand where you are coming from with not fixing it but given its so simple I think it's worth just doing it.

Selected Reviewer: @adriangb