### PR TITLE
Remove redundant `@classmethod` decorators from field/model validator methods

### DIFF
--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -307,7 +307,6 @@ class Cat(BaseModel):
     pet_type: Literal['cat']
 
     @field_validator('pet_type', mode='before')
-    @classmethod
     def validate_pet_type(cls, v):
         if v == 'kitten':
             return 'cat'
@@ -342,7 +341,6 @@ class Cat(BaseModel):
     pet_type: Literal['cat']
 
     @field_validator('pet_type', mode='before')
-    @classmethod
     def validate_pet_type(cls, v):
         if v == 'kitten':
             return 'cat'
@@ -771,7 +769,6 @@ try:
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a(cls):
             return 'a'
 

--- a/docs/usage/postponed_annotations.md
+++ b/docs/usage/postponed_annotations.md
@@ -154,7 +154,6 @@ class Node(BaseModel):
     children: List['Node'] = field(default_factory=list)
 
     @field_validator('children', mode='wrap')
-    @classmethod
     def drop_cyclic_references(cls, children, h):
         try:
             return h(children)

--- a/docs/usage/validation_errors.md
+++ b/docs/usage/validation_errors.md
@@ -40,7 +40,6 @@ class Model(BaseModel):
     x: int
 
     @field_validator('x')
-    @classmethod
     def force_x_positive(cls, v):
         assert v > 0
         return v
@@ -1904,7 +1903,6 @@ class Model(BaseModel):
     x: str
 
     @field_validator('x')
-    @classmethod
     def repeat_b(cls, v):
         raise ValueError()
 

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -484,7 +484,6 @@ class DemoDataclass:
     product_id: str  # should be a five-digit string, may have leading zeros
 
     @field_validator('product_id', mode='before')
-    @classmethod
     def convert_int_serial(cls, v):
         if isinstance(v, int):
             v = str(v).zfill(5)
@@ -510,7 +509,6 @@ class Model(BaseModel):
     text: str
 
     @field_validator('text')
-    @classmethod
     def remove_stopwords(cls, v: str, info: FieldValidationInfo):
         context = info.context
         if context:
@@ -558,7 +556,6 @@ class Model(BaseModel):
     choice: str
 
     @field_validator('choice')
-    @classmethod
     def validate_choice(cls, v: str, info: FieldValidationInfo):
         allowed_choices = info.context.get('allowed_choices')
         if allowed_choices and v not in allowed_choices:
@@ -626,7 +623,6 @@ class Model(BaseModel):
         )
 
     @field_validator('my_number')
-    @classmethod
     def multiply_with_context(
         cls, value: int, info: FieldValidationInfo
     ) -> int:

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -237,7 +237,6 @@ class ValidatedFunction:
 
         class DecoratorBaseModel(BaseModel):
             @field_validator(self.v_args_name, check_fields=False)
-            @classmethod
             def check_args(cls, v: Optional[List[Any]]) -> Optional[List[Any]]:
                 if takes_args or v is None:
                     return v
@@ -245,7 +244,6 @@ class ValidatedFunction:
                 raise TypeError(f'{pos_args} positional arguments expected but {pos_args + len(v)} given')
 
             @field_validator(self.v_kwargs_name, check_fields=False)
-            @classmethod
             def check_kwargs(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
                 if takes_kwargs or v is None:
                     return v
@@ -255,7 +253,6 @@ class ValidatedFunction:
                 raise TypeError(f'unexpected keyword argument{plural}: {keys}')
 
             @field_validator(V_POSITIONAL_ONLY_NAME, check_fields=False)
-            @classmethod
             def check_positional_only(cls, v: Optional[List[str]]) -> None:
                 if v is None:
                     return
@@ -265,7 +262,6 @@ class ValidatedFunction:
                 raise TypeError(f'positional-only argument{plural} passed as keyword argument{plural}: {keys}')
 
             @field_validator(V_DUPLICATE_KWARGS, check_fields=False)
-            @classmethod
             def check_duplicate_kwargs(cls, v: Optional[List[str]]) -> None:
                 if v is None:
                     return

--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -289,7 +289,6 @@ def foo() -> None:
         custom_validator = get_my_custom_validator('number')  # type: ignore[pydantic-field]
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.0.1/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/mypy-default_ini/plugin_success.py
@@ -295,7 +295,6 @@ def foo() -> None:
 # MYPY: error: Unused "type: ignore" comment
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.0.1/mypy-plugin-strict_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin-strict_ini/plugin_success.py
@@ -291,7 +291,6 @@ def foo() -> None:
         custom_validator = get_my_custom_validator('number')  # type: ignore[pydantic-field]
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.0.1/mypy-plugin_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin_ini/plugin_success.py
@@ -289,7 +289,6 @@ def foo() -> None:
         custom_validator = get_my_custom_validator('number')  # type: ignore[pydantic-field]
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.0.1/pyproject-plugin-strict_toml/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-plugin-strict_toml/plugin_success.py
@@ -291,7 +291,6 @@ def foo() -> None:
         custom_validator = get_my_custom_validator('number')  # type: ignore[pydantic-field]
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.0.1/pyproject-plugin_toml/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-plugin_toml/plugin_success.py
@@ -289,7 +289,6 @@ def foo() -> None:
         custom_validator = get_my_custom_validator('number')  # type: ignore[pydantic-field]
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.1.1/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.1.1/mypy-default_ini/plugin_success.py
@@ -296,7 +296,6 @@ def foo() -> None:
 # MYPY: error: Unused "type: ignore" comment
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.2.0/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.2.0/mypy-default_ini/plugin_success.py
@@ -294,7 +294,6 @@ def foo() -> None:
 # MYPY: error: Unused "type: ignore" comment
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/mypy/outputs/1.4.1/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.4.1/mypy-default_ini/plugin_success.py
@@ -294,7 +294,6 @@ def foo() -> None:
 # MYPY: error: Unused "type: ignore" comment  [unused-ignore]
 
         @model_validator(mode='before')
-        @classmethod
         def validate_values(cls, values: Any) -> Any:
             return values
 

--- a/tests/test_assert_in_validators.py
+++ b/tests/test_assert_in_validators.py
@@ -24,7 +24,6 @@ def test_assert_raises_validation_error():
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v):
             assert v == 'a', 'invalid a'
             return v

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -152,7 +152,6 @@ def test_custom_config_extras():
 def test_inheritance_validators():
     class BarModel(BaseModel):
         @field_validator('a', check_fields=False)
-        @classmethod
         def check_a(cls, v):
             if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
@@ -168,7 +167,6 @@ def test_inheritance_validators():
 def test_inheritance_validators_always():
     class BarModel(BaseModel):
         @field_validator('a', check_fields=False)
-        @classmethod
         def check_a(cls, v):
             if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -142,7 +142,6 @@ def test_validate_assignment_value_change():
         a: int
 
         @field_validator('a')
-        @classmethod
         def double_a(cls, v: int) -> int:
             return v * 2
 
@@ -1717,7 +1716,6 @@ def test_field_validator():
         b: float
 
         @field_validator('b')
-        @classmethod
         def double_b(cls, v):
             return v * 2
 
@@ -1778,7 +1776,6 @@ def test_parent_post_init():
     @pydantic.dataclasses.dataclass
     class B(A):
         @field_validator('a')
-        @classmethod
         def validate_a(cls, value, _):
             value += 3
             return value
@@ -1797,7 +1794,6 @@ def test_subclass_post_init_order():
             self.a *= 2
 
         @field_validator('a')
-        @classmethod
         def validate_a(cls, value):
             value += 3
             return value
@@ -1816,7 +1812,6 @@ def test_subclass_post_init_inheritance():
             self.a *= 2
 
         @field_validator('a')
-        @classmethod
         def validate_a(cls, value):
             value += 3
             return value
@@ -1857,7 +1852,6 @@ def test_validator_info_field_name_data_before():
         b: str
 
         @field_validator('b', mode='before')
-        @classmethod
         def check_a(cls, v: Any, info: FieldValidationInfo) -> Any:
             assert v == b'but my barbaz is better'
             assert info.field_name == 'b'
@@ -1890,19 +1884,16 @@ def test_inheritance_replace(decorator1: Callable[[Any], Any], expected_parent: 
         a: List[str]
 
         @field_validator('a')
-        @classmethod
         def parent_val_before(cls, v: List[str]):
             v.append('parent before')
             return v
 
         @field_validator('a')
-        @classmethod
         def val(cls, v: List[str]):
             v.append('parent')
             return v
 
         @field_validator('a')
-        @classmethod
         def parent_val_after(cls, v: List[str]):
             v.append('parent after')
             return v
@@ -1910,19 +1901,16 @@ def test_inheritance_replace(decorator1: Callable[[Any], Any], expected_parent: 
     @pydantic.dataclasses.dataclass
     class Child(Parent):
         @field_validator('a')
-        @classmethod
         def child_val_before(cls, v: List[str]):
             v.append('child before')
             return v
 
         @field_validator('a')
-        @classmethod
         def val(cls, v: List[str]):
             v.append('child')
             return v
 
         @field_validator('a')
-        @classmethod
         def child_val_after(cls, v: List[str]):
             v.append('child after')
             return v
@@ -1971,7 +1959,6 @@ def test_dataclass_config_validate_default():
         x: int = -1
 
         @field_validator('x')
-        @classmethod
         def force_x_positive(cls, v):
             assert v > 0
             return v

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1469,7 +1469,6 @@ def test_validated_optional_subfields():
         a: Optional[int]
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v):
             return v
 
@@ -1685,7 +1684,6 @@ def test_modify_fields():
         foo: List[List[int]]
 
         @field_validator('foo')
-        @classmethod
         def check_something(cls, value):
             return value
 
@@ -1791,7 +1789,6 @@ def test_optional_validator():
         something: Optional[str]
 
         @field_validator('something')
-        @classmethod
         def check_something(cls, v):
             val_calls.append(v)
             return v
@@ -2154,7 +2151,6 @@ def test_default_factory_validator_child():
         foo: List[str] = Field(default_factory=list)
 
         @field_validator('foo', mode='before')
-        @classmethod
         def mutate_foo(cls, v):
             return [f'{x}-1' for x in v]
 
@@ -2344,13 +2340,11 @@ def test_abstractmethod_missing_for_all_decorators(bases):
         side: float
 
         @field_validator('side')
-        @classmethod
         @abstractmethod
         def my_field_validator(cls, v):
             raise NotImplementedError
 
         @model_validator(mode='wrap')
-        @classmethod
         @abstractmethod
         def my_model_validator(cls, values, handler, info):
             raise NotImplementedError

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -100,7 +100,6 @@ def test_value_validation():
         data: T
 
         @field_validator('data')
-        @classmethod
         def validate_value_nonzero(cls, v: Any):
             if any(x == 0 for x in v.values()):
                 raise ValueError('some value is zero')
@@ -474,7 +473,6 @@ def test_generic():
         positive_number: int
 
         @field_validator('error')
-        @classmethod
         def validate_error(cls, v: Optional[error_type], info: ValidationInfo) -> Optional[error_type]:
             values = info.data
             if values.get('data', None) is None and v is None:
@@ -484,7 +482,6 @@ def test_generic():
             return v
 
         @field_validator('positive_number')
-        @classmethod
         def validate_positive_number(cls, v: int) -> int:
             if v < 0:
                 raise ValueError

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -13,7 +13,6 @@ def test_model_validator_wrap() -> None:
         y: int
 
         @model_validator(mode='wrap')
-        @classmethod
         def val_model(cls, values: dict[str, Any] | Model, handler: ValidatorFunctionWrapHandler) -> Model:
             if isinstance(values, dict):
                 assert values == {'x': 1, 'y': 2}
@@ -101,7 +100,6 @@ def test_model_validator_after() -> None:
 def test_subclass() -> None:
     class Human(BaseModel):
         @model_validator(mode='before')
-        @classmethod
         def run_model_validator(cls, values: dict[str, Any]) -> dict[str, Any]:
             values['age'] *= 2
             return values
@@ -119,7 +117,6 @@ def test_nested_models() -> None:
         inner: Union[Model, None]  # noqa
 
         @model_validator(mode='before')
-        @classmethod
         def validate_model_before(cls, values: dict[str, Any]) -> dict[str, Any]:
             calls.append('before')
             return values

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -77,7 +77,6 @@ def test_model_validate_root():
         # I couldn't see a nice way to create a decorator that reduces the boilerplate,
         # but if we want to discourage this pattern, perhaps that's okay?
         @model_validator(mode='before')
-        @classmethod
         def populate_root(cls, values):
             return {'root': values}
 
@@ -114,7 +113,6 @@ def test_parse_root_list():
         root: List[str]
 
         @model_validator(mode='before')
-        @classmethod
         def populate_root(cls, values):
             return {'root': values}
 
@@ -144,7 +142,6 @@ def test_parse_nested_root_list():
         root: List[NestedData]
 
         @model_validator(mode='before')
-        @classmethod
         def populate_root(cls, values):
             return {'root': values}
 
@@ -177,7 +174,6 @@ def test_parse_nested_root_tuple():
         root: Tuple[int, NestedData]
 
         @model_validator(mode='before')
-        @classmethod
         def populate_root(cls, values):
             return {'root': values}
 
@@ -210,7 +206,6 @@ def test_parse_nested_custom_root():
         root: List[str]
 
         @model_validator(mode='before')
-        @classmethod
         def populate_root(cls, values):
             return {'root': values}
 
@@ -230,7 +225,6 @@ def test_parse_nested_custom_root():
         root: NestedModel
 
         @model_validator(mode='before')
-        @classmethod
         def populate_root(cls, values):
             return {'root': values}
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2145,7 +2145,6 @@ def test_infinite_iterable_validate_first():
         b: int
 
         @field_validator('it')
-        @classmethod
         def infinite_first_int(cls, it):
             return itertools.chain([next(it)], it)
 
@@ -3706,7 +3705,6 @@ def test_json_before_validator():
         json_obj: Json[str]
 
         @field_validator('json_obj', mode='before')
-        @classmethod
         def check(cls, v):
             assert v == '"foobar"'
             nonlocal call_count

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -741,38 +741,32 @@ def test_typeddict_field_validator(TypedDict: Any) -> None:
         a: List[str]
 
         @field_validator('a')
-        @classmethod
         def parent_val_before(cls, v: List[str]):
             v.append('parent before')
             return v
 
         @field_validator('a')
-        @classmethod
         def val(cls, v: List[str]):
             v.append('parent')
             return v
 
         @field_validator('a')
-        @classmethod
         def parent_val_after(cls, v: List[str]):
             v.append('parent after')
             return v
 
     class Child(Parent):
         @field_validator('a')
-        @classmethod
         def child_val_before(cls, v: List[str]):
             v.append('child before')
             return v
 
         @field_validator('a')
-        @classmethod
         def val(cls, v: List[str]):
             v.append('child')
             return v
 
         @field_validator('a')
-        @classmethod
         def child_val_after(cls, v: List[str]):
             v.append('child after')
             return v
@@ -796,7 +790,6 @@ def test_typeddict_model_validator(TypedDict) -> None:
         y: float
 
         @model_validator(mode='before')
-        @classmethod
         def val_model_before(cls, value: Dict[str, Any]) -> Dict[str, Any]:
             return dict(x=value['x'] + 1, y=value['y'] + 2)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -166,7 +166,6 @@ def test_simple():
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v: Any):
             if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
@@ -287,13 +286,11 @@ def test_validate_whole():
         a: List[int]
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a1(cls, v: List[Any]) -> List[Any]:
             v.append('123')
             return v
 
         @field_validator('a')
-        @classmethod
         def check_a2(cls, v: List[int]) -> List[Any]:
             v.append(456)
             return v
@@ -308,7 +305,6 @@ def test_validate_pre_error():
         a: List[int]
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a1(cls, v: Any):
             calls.append(f'check_a1 {v}')
             if 1 in v:
@@ -317,7 +313,6 @@ def test_validate_pre_error():
             return v
 
         @field_validator('a')
-        @classmethod
         def check_a2(cls, v: Any):
             calls.append(f'check_a2 {v}')
             if 10 in v:
@@ -364,7 +359,6 @@ def validate_assignment_model_fixture():
         c: int = 0
 
         @field_validator('b')
-        @classmethod
         def b_length(cls, v, info):
             values = info.data
             if 'a' in values and len(v) < values['a']:
@@ -372,7 +366,6 @@ def validate_assignment_model_fixture():
             return v
 
         @field_validator('c')
-        @classmethod
         def double_c(cls, v: Any):
             return v * 2
 
@@ -440,7 +433,6 @@ def test_validating_assignment_values_dict():
         b: int
 
         @field_validator('b')
-        @classmethod
         def validate_b(cls, b, info: FieldValidationInfo):
             if 'm' in info.data:
                 return b + info.data['m'].a  # this fails if info.data['m'] is a dict
@@ -461,7 +453,6 @@ def test_validate_multiple():
         b: str
 
         @field_validator('a', 'b')
-        @classmethod
         def check_a_and_b(cls, v: Any, info: FieldValidationInfo) -> Any:
             if len(v) < 4:
                 field = cls.model_fields[info.field_name]
@@ -495,7 +486,6 @@ def test_classmethod():
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v: Any):
             assert cls is Model
             return v
@@ -617,7 +607,6 @@ def test_field_validator_validate_default():
         a: str = Field(None, validate_default=True)
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a(cls, v: Any):
             nonlocal check_calls
             check_calls += 1
@@ -659,7 +648,6 @@ def test_field_validator_validate_default_on_inheritance():
 
     class Model(ParentModel):
         @field_validator('a', mode='before')
-        @classmethod
         def check_a(cls, v: Any):
             nonlocal check_calls
             check_calls += 1
@@ -678,7 +666,6 @@ def test_validate_not_always():
         a: Optional[str] = None
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a(cls, v: Any):
             nonlocal check_calls
             check_calls += 1
@@ -790,7 +777,6 @@ def test_validate_child():
 
     class Child(Parent):
         @field_validator('a')
-        @classmethod
         def check_a(cls, v: Any):
             if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
@@ -807,7 +793,6 @@ def test_validate_child_extra():
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a_one(cls, v: Any):
             if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
@@ -815,7 +800,6 @@ def test_validate_child_extra():
 
     class Child(Parent):
         @field_validator('a')
-        @classmethod
         def check_a_two(cls, v: Any):
             return v.upper()
 
@@ -850,7 +834,6 @@ def test_validate_parent():
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v: Any):
             if 'foobar' not in v:
                 raise ValueError('"foobar" not found in a')
@@ -896,7 +879,6 @@ def test_inheritance_keep():
         a: int
 
         @field_validator('a')
-        @classmethod
         def add_to_a(cls, v: Any):
             return v + 1
 
@@ -916,38 +898,32 @@ def test_inheritance_replace():
         a: List[str]
 
         @field_validator('a')
-        @classmethod
         def parent_val_before(cls, v: List[str]):
             v.append('parent before')
             return v
 
         @field_validator('a')
-        @classmethod
         def val(cls, v: List[str]):
             v.append('parent')
             return v
 
         @field_validator('a')
-        @classmethod
         def parent_val_after(cls, v: List[str]):
             v.append('parent after')
             return v
 
     class Child(Parent):
         @field_validator('a')
-        @classmethod
         def child_val_before(cls, v: List[str]):
             v.append('child before')
             return v
 
         @field_validator('a')
-        @classmethod
         def val(cls, v: List[str]):
             v.append('child')
             return v
 
         @field_validator('a')
-        @classmethod
         def child_val_after(cls, v: List[str]):
             v.append('child after')
             return v
@@ -1067,7 +1043,6 @@ def test_key_validation():
         foobar: Dict[int, int]
 
         @field_validator('foobar')
-        @classmethod
         def check_foobar(cls, value):
             return {k + 1: v + 1 for k, v in value.items()}
 
@@ -1102,7 +1077,6 @@ def test_field_validator_validate_default_optional():
         a: Optional[str] = Field(None, validate_default=True)
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a(cls, v: Any):
             nonlocal check_calls
             check_calls += 1
@@ -1141,7 +1115,6 @@ def test_field_validator_validate_default_pre():
         a: str = Field(None, validate_default=True)
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a(cls, v: Any):
             nonlocal check_calls
             check_calls += 1
@@ -1175,7 +1148,6 @@ def test_field_validator_validate_default_post():
         a: str = Field('', validate_default=True)
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v: Any):
             return v or 'default value'
 
@@ -1203,7 +1175,6 @@ def test_field_validator_validate_default_post_optional():
         a: Optional[str] = Field(None, validate_default=True)
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a(cls, v: Any):
             return v or 'default value'
 
@@ -1241,7 +1212,6 @@ def test_datetime_field_validator():
         d: datetime = Field(None, validate_default=True)
 
         @field_validator('d', mode='before')
-        @classmethod
         def check_d(cls, v: Any):
             nonlocal check_calls
             check_calls += 1
@@ -1262,7 +1232,6 @@ def test_pre_called_once():
         a: Tuple[int, int, int]
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a(cls, v: Any):
             nonlocal check_calls
             check_calls += 1
@@ -1277,7 +1246,6 @@ def test_assert_raises_validation_error():
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v: Any):
             assert v == 'a', 'invalid a'
             return v
@@ -1307,7 +1275,6 @@ def test_root_validator():
         c: str
 
         @field_validator('b')
-        @classmethod
         def repeat_b(cls, v: Any):
             return v * 2
 
@@ -1409,7 +1376,6 @@ def test_root_validator_pre():
         b: str
 
         @field_validator('b')
-        @classmethod
         def repeat_b(cls, v: Any):
             return v * 2
 
@@ -1571,7 +1537,6 @@ def test_assignment_validator_cls():
         model_config = ConfigDict(validate_assignment=True)
 
         @field_validator('name')
-        @classmethod
         def check_foo(cls, value):
             nonlocal validator_calls
             validator_calls += 1
@@ -1672,13 +1637,11 @@ def test_field_that_is_being_validated_is_excluded_from_validator_values():
         model_config = ConfigDict(validate_assignment=True)
 
         @field_validator('foo')
-        @classmethod
         def validate_foo(cls, v: Any, info: FieldValidationInfo) -> Any:
             check_values({**info.data})
             return v
 
         @field_validator('bar')
-        @classmethod
         def validate_bar(cls, v: Any, info: FieldValidationInfo) -> Any:
             check_values({**info.data})
             return v
@@ -1706,7 +1669,6 @@ def test_exceptions_in_field_validators_restore_original_field_value():
         model_config = ConfigDict(validate_assignment=True)
 
         @field_validator('foo')
-        @classmethod
         def validate_foo(cls, v: Any):
             if v == 'raise_exception':
                 raise RuntimeError('test error')
@@ -1917,7 +1879,6 @@ def test_info_field_name_data_before():
         b: str
 
         @field_validator('b', mode='before')
-        @classmethod
         def check_a(cls, v: Any, info: FieldValidationInfo) -> Any:
             assert v == b'but my barbaz is better'
             assert info.field_name == 'b'
@@ -1945,7 +1906,6 @@ def test_decorator_proxy():
             return v + 1
 
         @field_validator('x')
-        @classmethod
         def val2(cls, v: int) -> int:
             return v + 1
 
@@ -2099,7 +2059,6 @@ def test_model_config_validate_default():
         x: int = -1
 
         @field_validator('x')
-        @classmethod
         def force_x_positive(cls, v):
             assert v > 0
             return v
@@ -2590,7 +2549,6 @@ def test_validator_function_error_hide_input(mode, config, input_str):
         model_config = ConfigDict(**config)
 
         @field_validator('x', mode=mode)
-        @classmethod
         def check_a1(cls, v: str) -> str:
             raise ValueError('foo')
 

--- a/tests/test_validators_dataclass.py
+++ b/tests/test_validators_dataclass.py
@@ -14,7 +14,6 @@ def test_simple():
         a: str
 
         @field_validator('a')
-        @classmethod
         def change_a(cls, v):
             return v + ' changed'
 
@@ -27,13 +26,11 @@ def test_validate_before():
         a: List[int]
 
         @field_validator('a', mode='before')
-        @classmethod
         def check_a1(cls, v: List[Any]) -> List[Any]:
             v.append('123')
             return v
 
         @field_validator('a')
-        @classmethod
         def check_a2(cls, v: List[int]) -> List[int]:
             v.append(456)
             return v
@@ -48,7 +45,6 @@ def test_validate_multiple():
         b: str
 
         @field_validator('a', 'b')
-        @classmethod
         def check_a_and_b(cls, v, info):
             if len(v) < 4:
                 raise ValueError(f'{info.field_name} is too short')
@@ -83,7 +79,6 @@ def test_type_error():
         b: str
 
         @field_validator('a', 'b')
-        @classmethod
         def check_a_and_b(cls, v, info):
             if len(v) < 4:
                 raise TypeError(f'{info.field_name} is too short')
@@ -101,7 +96,6 @@ def test_classmethod():
         a: str
 
         @field_validator('a')
-        @classmethod
         def check_a(cls, v):
             assert cls is MyDataclass and is_dataclass(MyDataclass)
             return v
@@ -117,7 +111,6 @@ def test_validate_parent():
         a: str
 
         @field_validator('a')
-        @classmethod
         def change_a(cls, v):
             return v + ' changed'
 
@@ -135,14 +128,12 @@ def test_inheritance_replace():
         a: int
 
         @field_validator('a')
-        @classmethod
         def add_to_a(cls, v):
             return v + 1
 
     @dataclass
     class Child(Parent):
         @field_validator('a')
-        @classmethod
         def add_to_a(cls, v):
             return v + 5
 
@@ -158,7 +149,6 @@ def test_model_validator():
         b: str
 
         @field_validator('b')
-        @classmethod
         def repeat_b(cls, v: str) -> str:
             return v * 2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- We're currently in the process of rewriting pydantic in preparation for V2, see https://docs.pydantic.dev/blog/pydantic-v2/. -->
<!-- **Note:** if you're making a pull request to fix pydantic v1.10, please make it against the `1.10.X-fixes` branch. -->

## Change Summary

The code base and docs contain many occurrences of field and model validator methods that are also decorated with `@classmethod`. Those are redundant for both field validators

https://github.com/pydantic/pydantic/blob/d5d9dfc2c92e9e5969903b32e18c7f5c812d2874/pydantic/functional_validators.py#L328-L329

and model validators

https://github.com/pydantic/pydantic/blob/d5d9dfc2c92e9e5969903b32e18c7f5c812d2874/pydantic/functional_validators.py#L468-L469

if I read those code sections right. So, I've removed them for simplicity and consistency.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani