### PR TITLE
Fix incorrect subclass check for secretstr

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -728,7 +728,7 @@ class _SecretFieldValidator:
     inner_schema: CoreSchema = _dataclasses.field(init=False)
 
     def validate(self, value: _SecretField[SecretType] | SecretType, _: core_schema.ValidationInfo) -> Any:
-        error_prefix: Literal['string', 'bytes'] = 'string' if self.field_type is SecretStr else 'bytes'
+        error_prefix: Literal['string', 'bytes'] = 'string' if issubclass(self.field_type, SecretStr) else 'bytes'
         if self.min_length is not None and len(value) < self.min_length:
             short_kind: core_schema.ErrorType = f'{error_prefix}_too_short'  # type: ignore[assignment]
             raise PydanticKnownError(short_kind, {'min_length': self.min_length})
@@ -771,8 +771,8 @@ class _SecretFieldValidator:
     def __get_pydantic_core_schema__(
         self, source: type[Any], handler: _annotated_handlers.GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        self.inner_schema = handler(str if self.field_type is SecretStr else bytes)
-        error_kind = 'string_type' if self.field_type is SecretStr else 'bytes_type'
+        self.inner_schema = handler(str if issubclass(self.field_type, SecretStr) else bytes)
+        error_kind = 'string_type' if issubclass(self.field_type, SecretStr) else 'bytes_type'
         return core_schema.general_after_validator_function(
             self.validate,
             core_schema.union_schema(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3894,6 +3894,39 @@ def test_secretstr():
     assert f.empty_password.get_secret_value() == ''
 
 
+def test_secretstr_subclass():
+    class DecryptableStr(SecretStr):
+        """
+        Simulate a SecretStr with decryption capabilities.
+        """
+
+        def decrypt_value(self) -> str:
+            return f'MOCK DECRYPTED {self.get_secret_value()}'
+
+    class Foobar(BaseModel):
+        password: DecryptableStr
+        empty_password: SecretStr
+
+    # Initialize the model.
+    f = Foobar(password='1234', empty_password='')
+
+    # Assert correct types.
+    assert f.password.__class__.__name__ == 'DecryptableStr'
+    assert f.empty_password.__class__.__name__ == 'SecretStr'
+
+    # Assert str and repr are correct.
+    assert str(f.password) == '**********'
+    assert str(f.empty_password) == ''
+    assert repr(f.password) == "DecryptableStr('**********')"
+    assert repr(f.empty_password) == "SecretStr('')"
+    assert len(f.password) == 4
+    assert len(f.empty_password) == 0
+
+    # Assert retrieval of secret value is correct
+    assert f.password.get_secret_value() == '1234'
+    assert f.empty_password.get_secret_value() == ''
+
+
 def test_secretstr_equality():
     assert SecretStr('abc') == SecretStr('abc')
     assert SecretStr('123') != SecretStr('321')


### PR DESCRIPTION
Currently subclasses of SecretStr fail to evaluate `self.field_type is SecretStr` and default to `bytes_type`. This is not how it should go as the subclass explicitly subclasses the SecretStr type.

This fix tests if the type is of SecretStr with `issubclass` which states:

>  A class is considered a subclass of itself

Which makes is backwards compatible for the actual SecretStr as well.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Allow pydantic scheme creation to work with subclasses of `SecretStr`


## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #6729

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt