### PR TITLE
Allow customizing core schema generation by making `GenerateSchema` public

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -17,6 +17,7 @@ from ._internal._annotated_handlers import (
 from ._internal._annotated_handlers import (
     GetJsonSchemaHandler as GetJsonSchemaHandler,
 )
+from ._internal._generate_schema import GenerateSchema as GenerateSchema
 from ._migration import getattr_migration
 from .config import ConfigDict, Extra
 from .deprecated.class_validators import root_validator, validator
@@ -192,6 +193,7 @@ __all__ = [
     # annotated handlers
     'GetCoreSchemaHandler',
     'GetJsonSchemaHandler',
+    'GenerateSchema',
 ]
 
 # A mapping of {<member name>: <module name>} defining dynamic imports

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -15,6 +15,9 @@ if not TYPE_CHECKING:
     # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
+if TYPE_CHECKING:
+    from .._internal._schema_generation_shared import GenerateSchema
+
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
 
 
@@ -61,6 +64,7 @@ class ConfigWrapper:
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
     defer_build: bool
+    schema_generator: type[GenerateSchema] | None
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -195,6 +199,7 @@ config_defaults = ConfigDict(
     hide_input_in_errors=False,
     json_encoders=None,
     defer_build=False,
+    schema_generator=None,
 )
 
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -335,8 +335,11 @@ class GenerateSchema:
         return self._config_wrapper.arbitrary_types_allowed
 
     def str_schema(self) -> CoreSchema:
+        """Generate a CoreSchema for `str`"""
         return core_schema.str_schema()
 
+    # the following methods can be overridden but should be considered
+    # unstable / private APIs
     def _list_schema(self, tp: Any, items_type: Any) -> CoreSchema:
         return core_schema.list_schema(self.generate_schema(items_type))
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -8,7 +8,7 @@ import re
 import sys
 import typing
 import warnings
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from copy import copy
 from enum import Enum
 from functools import partial
@@ -20,6 +20,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ContextManager,
     Dict,
     ForwardRef,
     Iterable,
@@ -97,6 +98,13 @@ AnyFieldDecorator = Union[
 
 ModifyCoreSchemaWrapHandler = GetCoreSchemaHandler
 GetCoreSchemaFunction = Callable[[Any, ModifyCoreSchemaWrapHandler], core_schema.CoreSchema]
+
+
+TUPLE_TYPES: list[type] = [tuple, typing.Tuple]
+LIST_TYPES: list[type] = [list, typing.List, collections.abc.MutableSequence]
+SET_TYPES: list[type] = [set, typing.Set, collections.abc.MutableSet]
+FROZEN_SET_TYPES: list[type] = [frozenset, typing.FrozenSet, collections.abc.Set]
+DICT_TYPES: list[type] = [dict, typing.Dict, collections.abc.MutableMapping, collections.abc.Mapping]
 
 
 def check_validator_fields_against_field_name(
@@ -250,10 +258,36 @@ def _add_custom_serialization_from_json_encoders(
     return schema
 
 
+class ConfigWrapperStack:
+    """A stack of `ConfigWrapper` instances."""
+
+    def __init__(self, config_wrapper: ConfigWrapper):
+        self._config_wrapper_stack: list[ConfigWrapper] = [config_wrapper]
+
+    @property
+    def tail(self) -> ConfigWrapper:
+        return self._config_wrapper_stack[-1]
+
+    def push(self, config_wrapper: ConfigWrapper | ConfigDict | None) -> ContextManager[None]:
+        if config_wrapper is None:
+            return nullcontext()
+
+        if not isinstance(config_wrapper, ConfigWrapper):
+            config_wrapper = ConfigWrapper(config_wrapper, check=False)
+
+        @contextmanager
+        def _context_manager() -> Iterator[None]:
+            self._config_wrapper_stack.append(config_wrapper)
+            try:
+                yield
+            finally:
+                self._config_wrapper_stack.pop()
+
+        return _context_manager()
+
+
 class GenerateSchema:
     """Generate core schema for a Pydantic model, dataclass and types like `str`, `datatime`, ... ."""
-
-    __slots__ = '_config_wrapper_stack', 'types_namespace', 'typevars_map', 'recursion_cache', 'definitions', 'defs'
 
     def __init__(
         self,
@@ -262,19 +296,88 @@ class GenerateSchema:
         typevars_map: dict[Any, Any] | None = None,
     ):
         # we need a stack for recursing into child models
-        self._config_wrapper_stack: list[ConfigWrapper] = [config_wrapper]
-        self.types_namespace = types_namespace
-        self.typevars_map = typevars_map
-
+        self._config_wrapper_stack = ConfigWrapperStack(config_wrapper)
+        self._types_namespace = types_namespace
+        self._typevars_map = typevars_map
         self.defs = _Definitions()
 
-    @property
-    def config_wrapper(self) -> ConfigWrapper:
-        return self._config_wrapper_stack[-1]
+    @classmethod
+    def __from_parent(
+        cls,
+        config_wrapper_stack: ConfigWrapperStack,
+        types_namespace: dict[str, Any] | None,
+        typevars_map: dict[Any, Any] | None,
+        defs: _Definitions,
+    ) -> GenerateSchema:
+        obj = cls.__new__(cls)
+        obj._config_wrapper_stack = config_wrapper_stack
+        obj._types_namespace = types_namespace
+        obj._typevars_map = typevars_map
+        obj.defs = defs
+        return obj
 
     @property
-    def arbitrary_types(self) -> bool:
-        return self.config_wrapper.arbitrary_types_allowed
+    def _config_wrapper(self) -> ConfigWrapper:
+        return self._config_wrapper_stack.tail
+
+    @property
+    def _current_generate_schema(self) -> GenerateSchema:
+        cls = self._config_wrapper.schema_generator or GenerateSchema
+        return cls.__from_parent(
+            self._config_wrapper_stack,
+            self._types_namespace,
+            self._typevars_map,
+            self.defs,
+        )
+
+    @property
+    def _arbitrary_types(self) -> bool:
+        return self._config_wrapper.arbitrary_types_allowed
+
+    def str_schema(self) -> CoreSchema:
+        return core_schema.str_schema()
+
+    def _list_schema(self, tp: Any, items_type: Any) -> CoreSchema:
+        return core_schema.list_schema(self.generate_schema(items_type))
+
+    def _dict_schema(self, tp: Any, keys_type: Any, values_type: Any) -> CoreSchema:
+        return core_schema.dict_schema(self.generate_schema(keys_type), self.generate_schema(values_type))
+
+    def _set_schema(self, tp: Any, items_type: Any) -> CoreSchema:
+        return core_schema.set_schema(self.generate_schema(items_type))
+
+    def _frozenset_schema(self, tp: Any, items_type: Any) -> CoreSchema:
+        return core_schema.frozenset_schema(self.generate_schema(items_type))
+
+    def _tuple_variable_schema(self, tp: Any, items_type: Any) -> CoreSchema:
+        return core_schema.tuple_variable_schema(self.generate_schema(items_type))
+
+    def _tuple_positional_schema(self, tp: Any, items_types: list[Any]) -> CoreSchema:
+        items_schemas = [self.generate_schema(items_type) for items_type in items_types]
+        return core_schema.tuple_positional_schema(items_schemas)
+
+    def _arbitrary_type_schema(self, tp: Any) -> CoreSchema:
+        if not isinstance(tp, type):
+            warn(
+                f'{tp!r} is not a Python type (it may be an instance of an object),'
+                ' Pydantic will allow any object with no validation since we cannot even'
+                ' enforce that the input is an instance of the given type.'
+                ' To get rid of this error wrap the type with `pydantic.SkipValidation`.',
+                UserWarning,
+            )
+            return core_schema.any_schema()
+        return core_schema.is_instance_schema(tp)
+
+    def _unknown_type_schema(self, obj: Any) -> CoreSchema:
+        raise PydanticSchemaGenerationError(
+            f'Unable to generate pydantic-core schema for {obj!r}. '
+            'Set `arbitrary_types_allowed=True` in the model_config to ignore this error'
+            ' or implement `__get_pydantic_core_schema__` on your type to fully support it.'
+            '\n\nIf you got this error by calling handler(<some type>) within'
+            ' `__get_pydantic_core_schema__` then you likely need to call'
+            ' `handler.generate_schema(<some type>)` since we do not call'
+            ' `__get_pydantic_core_schema__` on `<some type>` otherwise to avoid infinite recursion.'
+        )
 
     def collect_definitions(self, schema: CoreSchema) -> CoreSchema:
         ref = cast('str | None', schema.get('ref', None))
@@ -357,7 +460,7 @@ class GenerateSchema:
             if metadata_schema:
                 self._add_js_function(metadata_schema, metadata_js_function)
 
-        schema = _add_custom_serialization_from_json_encoders(self.config_wrapper.json_encoders, obj, schema)
+        schema = _add_custom_serialization_from_json_encoders(self._config_wrapper.json_encoders, obj, schema)
 
         return schema
 
@@ -401,51 +504,49 @@ class GenerateSchema:
                             extra_validator = self.generate_schema(extra_items_type)
                             break
 
-            if cls.__pydantic_root_model__:
-                root_field = self._common_field_schema('root', fields['root'], decorators)
-                inner_schema = root_field['schema']
-                inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
-                model_schema = core_schema.model_schema(
-                    cls,
-                    inner_schema,
-                    custom_init=getattr(cls, '__pydantic_custom_init__', None),
-                    root_model=True,
-                    post_init=getattr(cls, '__pydantic_post_init__', None),
-                    config=core_config,
-                    ref=model_ref,
-                    metadata=metadata,
-                )
-            else:
-                self._config_wrapper_stack.append(config_wrapper)
-                try:
+            with self._config_wrapper_stack.push(config_wrapper):
+                self = self._current_generate_schema
+                if cls.__pydantic_root_model__:
+                    root_field = self._common_field_schema('root', fields['root'], decorators)
+                    inner_schema = root_field['schema']
+                    inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
+                    model_schema = core_schema.model_schema(
+                        cls,
+                        inner_schema,
+                        custom_init=getattr(cls, '__pydantic_custom_init__', None),
+                        root_model=True,
+                        post_init=getattr(cls, '__pydantic_post_init__', None),
+                        config=core_config,
+                        ref=model_ref,
+                        metadata=metadata,
+                    )
+                else:
                     fields_schema: core_schema.CoreSchema = core_schema.model_fields_schema(
                         {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
                         computed_fields=[self._computed_field_schema(d) for d in decorators.computed_fields.values()],
                         extra_validator=extra_validator,
                         model_name=cls.__name__,
                     )
-                finally:
-                    self._config_wrapper_stack.pop()
 
-                inner_schema = apply_validators(fields_schema, decorators.root_validators.values(), None)
-                inner_schema = define_expected_missing_refs(inner_schema, recursively_defined_type_refs())
-                inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
+                    inner_schema = apply_validators(fields_schema, decorators.root_validators.values(), None)
+                    inner_schema = define_expected_missing_refs(inner_schema, recursively_defined_type_refs())
+                    inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
 
-                model_schema = core_schema.model_schema(
-                    cls,
-                    inner_schema,
-                    custom_init=getattr(cls, '__pydantic_custom_init__', None),
-                    root_model=False,
-                    post_init=getattr(cls, '__pydantic_post_init__', None),
-                    config=core_config,
-                    ref=model_ref,
-                    metadata=metadata,
-                )
+                    model_schema = core_schema.model_schema(
+                        cls,
+                        inner_schema,
+                        custom_init=getattr(cls, '__pydantic_custom_init__', None),
+                        root_model=False,
+                        post_init=getattr(cls, '__pydantic_post_init__', None),
+                        config=core_config,
+                        ref=model_ref,
+                        metadata=metadata,
+                    )
 
-            schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
-            schema = apply_model_validators(schema, model_validators, 'outer')
-            self.defs.definitions[model_ref] = schema
-            return core_schema.definition_reference_schema(model_ref)
+                schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
+                schema = apply_model_validators(schema, model_validators, 'outer')
+                self.defs.definitions[model_ref] = schema
+                return core_schema.definition_reference_schema(model_ref)
 
     def _generate_schema_from_prepare_annotations(self, obj: Any) -> core_schema.CoreSchema | None:
         """Try to generate schema from either the `__prepare_pydantic_annotations__` function or
@@ -518,7 +619,7 @@ class GenerateSchema:
         # class Model(BaseModel):
         #   x: SomeImportedTypeAliasWithAForwardReference
         try:
-            obj = _typing_extra.evaluate_fwd_ref(obj, globalns=self.types_namespace)
+            obj = _typing_extra.evaluate_fwd_ref(obj, globalns=self._types_namespace)
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
 
@@ -526,8 +627,8 @@ class GenerateSchema:
         if isinstance(obj, ForwardRef):
             raise PydanticUndefinedAnnotation(obj.__forward_arg__, f'Unable to evaluate forward reference {obj}')
 
-        if self.typevars_map:
-            obj = replace_types(obj, self.typevars_map)
+        if self._typevars_map:
+            obj = replace_types(obj, self._typevars_map)
 
         return obj
 
@@ -553,7 +654,16 @@ class GenerateSchema:
             return Any
         return args[0]
 
-    def _generate_schema(self, obj: Any) -> core_schema.CoreSchema:  # noqa: C901
+    def _get_first_two_args_or_any(self, obj: Any) -> tuple[Any, Any]:
+        args = self._get_args_resolving_forward_refs(obj)
+        if not args:
+            return (Any, Any)
+        if len(args) < 2:
+            origin = get_origin(obj)
+            raise TypeError(f'Expected two type arguments for {origin}, got 1')
+        return args[0], args[1]
+
+    def _generate_schema(self, obj: Any) -> core_schema.CoreSchema:
         """Recursively generate a pydantic-core schema for any supported python type."""
         if isinstance(obj, dict):
             # we assume this is already a valid schema
@@ -573,19 +683,47 @@ class GenerateSchema:
         if isinstance(obj, PydanticRecursiveRef):
             return core_schema.definition_reference_schema(schema_ref=obj.type_ref)
 
-        try:
-            if obj in {bool, int, float, str, bytes, list, set, frozenset, dict}:
-                # Note: obj may fail to be hashable if it has an unhashable annotation
-                return {'type': obj.__name__}
-            elif obj is tuple:
-                return {'type': 'tuple-variable'}
-        except TypeError:  # obj not hashable; can happen due to unhashable annotations
-            pass
+        return self.match_type(obj)
 
-        if obj is Any or obj is object:
+    def match_type(self, obj: Any) -> core_schema.CoreSchema:  # noqa: C901
+        """Main mapping of types to schemas.
+
+        The general structure is a series of if statements starting with the simple cases
+        (non-generic primitive types) and then handling generics and other more complex cases.
+
+        Each case either generates a schema directly, calls into a public user-overridable method
+        (like `GenerateSchema.tuple_variable_schema`) or calls into a private method that handles some
+        boilerplate before calling into the user-facing method (e.g. `GenerateSchema._tuple_schema`).
+
+        The idea is that we'll evolve this into adding more and more user facing methods over time
+        as they get requested and we figure out what the right API for them is.
+        """
+        if obj is str:
+            return self.str_schema()
+        elif obj is bytes:
+            return core_schema.bytes_schema()
+        elif obj is int:
+            return core_schema.int_schema()
+        elif obj is float:
+            return core_schema.float_schema()
+        elif obj is bool:
+            return core_schema.bool_schema()
+        elif obj is Any or obj is object:
             return core_schema.any_schema()
         elif obj is None or obj is _typing_extra.NoneType:
             return core_schema.none_schema()
+        elif obj in TUPLE_TYPES:
+            return self._tuple_schema(obj)
+        elif obj in LIST_TYPES:
+            return self._list_schema(obj, self._get_first_arg_or_any(obj))
+        elif obj in SET_TYPES:
+            return self._set_schema(obj, self._get_first_arg_or_any(obj))
+        elif obj in FROZEN_SET_TYPES:
+            return self._frozenset_schema(obj, self._get_first_arg_or_any(obj))
+        elif obj in DICT_TYPES:
+            return self._dict_schema(obj, *self._get_first_two_args_or_any(obj))
+        elif isinstance(obj, TypeAliasType):
+            return self._type_alias_type_schema(obj)
         elif obj == type:
             return self._type_schema()
         elif _typing_extra.is_callable_type(obj):
@@ -609,17 +747,14 @@ class GenerateSchema:
             if obj is Final:
                 return core_schema.any_schema()
             return self.generate_schema(
-                self._get_args_resolving_forward_refs(
-                    obj,
-                    required=True,
-                )[0]
+                self._get_first_arg_or_any(obj),
             )
         elif isinstance(obj, (FunctionType, LambdaType, MethodType, partial)):
             return self._callable_schema(obj)
         elif inspect.isclass(obj) and issubclass(obj, Enum):
             from ._std_types_schema import get_enum_core_schema
 
-            return get_enum_core_schema(obj, self.config_wrapper.config_dict)
+            return get_enum_core_schema(obj, self._config_wrapper.config_dict)
 
         if _typing_extra.is_dataclass(obj):
             return self._dataclass_schema(obj, None)
@@ -630,12 +765,16 @@ class GenerateSchema:
             return self._apply_annotations(source_type, annotations)
 
         origin = get_origin(obj)
+        if origin is not None:
+            return self._match_generic_type(obj, origin)
 
-        if isinstance(obj, TypeAliasType) or isinstance(origin, TypeAliasType):
+        if self._arbitrary_types:
+            return self._arbitrary_type_schema(obj)
+        return self._unknown_type_schema(obj)
+
+    def _match_generic_type(self, obj: Any, origin: Any) -> CoreSchema:  # noqa: C901
+        if isinstance(origin, TypeAliasType):
             return self._type_alias_type_schema(obj)
-
-        if origin is None:
-            return self._arbitrary_type_schema(obj, obj)
 
         # Need to handle generic dataclasses before looking for the schema properties because attribute accesses
         # on _GenericAlias delegate to the origin type, so lose the information about the concrete parametrization
@@ -652,50 +791,30 @@ class GenerateSchema:
 
         if _typing_extra.origin_is_union(origin):
             return self._union_schema(obj)
-        elif issubclass(origin, typing.Tuple):  # type: ignore[arg-type]
+        elif origin in TUPLE_TYPES:
             return self._tuple_schema(obj)
+        elif origin in LIST_TYPES:
+            return self._list_schema(obj, self._get_first_arg_or_any(obj))
+        elif origin in SET_TYPES:
+            return self._set_schema(obj, self._get_first_arg_or_any(obj))
+        elif origin in FROZEN_SET_TYPES:
+            return self._frozenset_schema(obj, self._get_first_arg_or_any(obj))
+        elif origin in DICT_TYPES:
+            return self._dict_schema(obj, *self._get_first_two_args_or_any(obj))
         elif is_typeddict(origin):
             return self._typed_dict_schema(obj, origin)
-        elif issubclass(origin, typing.Type):  # type: ignore[arg-type]
+        elif origin in (typing.Type, type):
             return self._subclass_schema(obj)
-        elif issubclass(origin, typing.Sequence):
-            if origin in {typing.Sequence, collections.abc.Sequence}:
-                return self._sequence_schema(obj)
-            else:
-                return self._arbitrary_type_schema(obj, origin)
-        elif issubclass(origin, (typing.Iterable, collections.abc.Iterable)):
-            # Because typing.Iterable does not have a specified `__init__` signature, we don't validate into subclasses
-            if origin in {typing.Iterable, collections.abc.Iterable, typing.Generator, collections.abc.Generator}:
-                return self._iterable_schema(obj)
-            else:
-                return self._arbitrary_type_schema(obj, origin)
-        elif issubclass(origin, (re.Pattern, typing.Pattern)):
+        elif origin in {typing.Sequence, collections.abc.Sequence}:
+            return self._sequence_schema(obj)
+        elif origin in {typing.Iterable, collections.abc.Iterable, typing.Generator, collections.abc.Generator}:
+            return self._iterable_schema(obj)
+        elif origin in (re.Pattern, typing.Pattern):
             return self._pattern_schema(obj)
-        else:
-            return self._arbitrary_type_schema(obj, origin)
 
-    def _arbitrary_type_schema(self, obj: Any, type_: Any) -> CoreSchema:
-        if self.arbitrary_types:
-            if not isinstance(type_, type):
-                warn(
-                    f'{obj!r} is not a Python type (it may be an instance of an object),'
-                    ' Pydantic will allow any object with no validation since we cannot even'
-                    ' enforce that the input is an instance of the given type.'
-                    ' To get rid of this error wrap the type with `pydantic.SkipValidation`.',
-                    UserWarning,
-                )
-                return core_schema.any_schema()
-            return core_schema.is_instance_schema(type_)
-        else:
-            raise PydanticSchemaGenerationError(
-                f'Unable to generate pydantic-core schema for {obj!r}. '
-                'Set `arbitrary_types_allowed=True` in the model_config to ignore this error'
-                ' or implement `__get_pydantic_core_schema__` on your type to fully support it.'
-                '\n\nIf you got this error by calling handler(<some type>) within'
-                ' `__get_pydantic_core_schema__` then you likely need to call'
-                ' `handler.generate_schema(<some type>)` since we do not call'
-                ' `__get_pydantic_core_schema__` on `<some type>` otherwise to avoid infinite recursion.'
-            )
+        if self._arbitrary_types:
+            return self._arbitrary_type_schema(origin)
+        return self._unknown_type_schema(obj)
 
     def _generate_td_field_schema(
         self,
@@ -756,11 +875,11 @@ class GenerateSchema:
     def _common_field_schema(self, name: str, field_info: FieldInfo, decorators: DecoratorInfos) -> _CommonField:
         # Update FieldInfo annotation if appropriate:
         if has_instance_in_type(field_info.annotation, (ForwardRef, str)):
-            types_namespace = self.types_namespace
-            if self.typevars_map:
+            types_namespace = self._types_namespace
+            if self._typevars_map:
                 types_namespace = (types_namespace or {}).copy()
                 # Ensure that typevars get mapped to their concrete types:
-                types_namespace.update({k.__name__: v for k, v in self.typevars_map.items()})
+                types_namespace.update({k.__name__: v for k, v in self._typevars_map.items()})
 
             evaluated = _typing_extra.eval_type_lenient(field_info.annotation, types_namespace, None)
             if evaluated is not field_info.annotation and not has_instance_in_type(evaluated, PydanticRecursiveRef):
@@ -825,7 +944,7 @@ class GenerateSchema:
         metadata = build_metadata_dict(js_annotation_functions=[json_schema_update_func])
 
         # apply alias generator
-        alias_generator = self.config_wrapper.alias_generator
+        alias_generator = self._config_wrapper.alias_generator
         if alias_generator and (field_info.alias_priority is None or field_info.alias_priority <= 1):
             alias = alias_generator(name)
             if not isinstance(alias, str):
@@ -879,21 +998,21 @@ class GenerateSchema:
             if maybe_schema is not None:
                 return maybe_schema
 
-            namespace = (self.types_namespace or {}).copy()
+            namespace = (self._types_namespace or {}).copy()
             new_namespace = {**_typing_extra.get_cls_types_namespace(origin), **namespace}
             annotation = origin.__value__
 
-            self.types_namespace = new_namespace
+            self._types_namespace = new_namespace
             typevars_map = get_standard_typevars_map(obj)
             annotation = replace_types(annotation, typevars_map)
             schema = self.generate_schema(annotation)
             assert schema['type'] != 'definitions'
             schema['ref'] = ref  # type: ignore
-            self.types_namespace = namespace or None
+            self._types_namespace = namespace or None
             self.defs.definitions[ref] = schema
             return core_schema.definition_reference_schema(ref)
 
-    def _literal_schema(self, literal_type: Any) -> core_schema.LiteralSchema:
+    def _literal_schema(self, literal_type: Any) -> CoreSchema:
         """Generate schema for a Literal."""
         expected = _typing_extra.all_literal_values(literal_type)
         assert expected, f'literal "expected" cannot be empty, obj={literal_type}'
@@ -929,54 +1048,56 @@ class GenerateSchema:
                     code='typed-dict-version',
                 )
 
-            config: ConfigDict | None = getattr(typed_dict_cls, '__pydantic_config__', None)
-            config_wrapper = ConfigWrapper(config)
-            core_config = config_wrapper.core_config(None)
+            config = getattr(typed_dict_cls, '__pydantic_config__', None)
+            with self._config_wrapper_stack.push(config):
+                core_config = self._config_wrapper.core_config(typed_dict_cls)
 
-            required_keys: frozenset[str] = typed_dict_cls.__required_keys__
+                self = self._current_generate_schema
 
-            fields: dict[str, core_schema.TypedDictField] = {}
+                required_keys: frozenset[str] = typed_dict_cls.__required_keys__
 
-            decorators = DecoratorInfos.build(typed_dict_cls)
+                fields: dict[str, core_schema.TypedDictField] = {}
 
-            for field_name, annotation in get_type_hints_infer_globalns(
-                typed_dict_cls, localns=self.types_namespace, include_extras=True
-            ).items():
-                annotation = replace_types(annotation, typevars_map)
-                required = field_name in required_keys
+                decorators = DecoratorInfos.build(typed_dict_cls)
 
-                if get_origin(annotation) == _typing_extra.Required:
-                    required = True
-                    annotation = self._get_args_resolving_forward_refs(
-                        annotation,
-                        required=True,
-                    )[0]
-                elif get_origin(annotation) == _typing_extra.NotRequired:
-                    required = False
-                    annotation = self._get_args_resolving_forward_refs(
-                        annotation,
-                        required=True,
-                    )[0]
+                for field_name, annotation in get_type_hints_infer_globalns(
+                    typed_dict_cls, localns=self._types_namespace, include_extras=True
+                ).items():
+                    annotation = replace_types(annotation, typevars_map)
+                    required = field_name in required_keys
 
-                field_info = FieldInfo.from_annotation(annotation)
-                fields[field_name] = self._generate_td_field_schema(
-                    field_name, field_info, decorators, required=required
+                    if get_origin(annotation) == _typing_extra.Required:
+                        required = True
+                        annotation = self._get_args_resolving_forward_refs(
+                            annotation,
+                            required=True,
+                        )[0]
+                    elif get_origin(annotation) == _typing_extra.NotRequired:
+                        required = False
+                        annotation = self._get_args_resolving_forward_refs(
+                            annotation,
+                            required=True,
+                        )[0]
+
+                    field_info = FieldInfo.from_annotation(annotation)
+                    fields[field_name] = self._generate_td_field_schema(
+                        field_name, field_info, decorators, required=required
+                    )
+
+                metadata = build_metadata_dict(js_functions=[partial(modify_model_json_schema, cls=typed_dict_cls)])
+
+                td_schema = core_schema.typed_dict_schema(
+                    fields,
+                    computed_fields=[self._computed_field_schema(d) for d in decorators.computed_fields.values()],
+                    ref=typed_dict_ref,
+                    metadata=metadata,
+                    config=core_config,
                 )
 
-            metadata = build_metadata_dict(js_functions=[partial(modify_model_json_schema, cls=typed_dict_cls)])
-
-            td_schema = core_schema.typed_dict_schema(
-                fields,
-                computed_fields=[self._computed_field_schema(d) for d in decorators.computed_fields.values()],
-                ref=typed_dict_ref,
-                metadata=metadata,
-                config=core_config,
-            )
-
-            schema = self._apply_model_serializers(td_schema, decorators.model_serializers.values())
-            schema = apply_model_validators(schema, decorators.model_validators.values(), 'all')
-            self.defs.definitions[typed_dict_ref] = schema
-            return core_schema.definition_reference_schema(typed_dict_ref)
+                schema = self._apply_model_serializers(td_schema, decorators.model_serializers.values())
+                schema = apply_model_validators(schema, decorators.model_validators.values(), 'all')
+                self.defs.definitions[typed_dict_ref] = schema
+                return core_schema.definition_reference_schema(typed_dict_ref)
 
     def _namedtuple_schema(self, namedtuple_cls: Any, origin: Any) -> core_schema.CoreSchema:
         """Generate schema for a NamedTuple."""
@@ -988,7 +1109,7 @@ class GenerateSchema:
                 namedtuple_cls = origin
 
             annotations: dict[str, Any] = get_type_hints_infer_globalns(
-                namedtuple_cls, include_extras=True, localns=self.types_namespace
+                namedtuple_cls, include_extras=True, localns=self._types_namespace
             )
             if not annotations:
                 # annotations is empty, happens if namedtuple_cls defined via collections.namedtuple(...)
@@ -1034,13 +1155,14 @@ class GenerateSchema:
         if field.alias is not None:
             parameter_schema['alias'] = field.alias
         else:
-            alias_generator = self.config_wrapper.alias_generator
+            alias_generator = self._config_wrapper.alias_generator
             if alias_generator:
                 parameter_schema['alias'] = alias_generator(name)
         return parameter_schema
 
     def _tuple_schema(self, tuple_type: Any) -> core_schema.CoreSchema:
         """Generate schema for a Tuple, e.g. `tuple[int, str]` or `tuple[int, ...]`."""
+        # TODO: do we really need to resolve type vars here?
         typevars_map = get_standard_typevars_map(tuple_type)
         params = self._get_args_resolving_forward_refs(tuple_type)
 
@@ -1050,28 +1172,23 @@ class GenerateSchema:
         # NOTE: subtle difference: `tuple[()]` gives `params=()`, whereas `typing.Tuple[()]` gives `params=((),)`
         # This is only true for <3.11, on Python 3.11+ `typing.Tuple[()]` gives `params=()`
         if not params:
-            if tuple_type == typing.Tuple:
+            if tuple_type in TUPLE_TYPES:
                 return core_schema.tuple_variable_schema()
             else:
                 # special case for `tuple[()]` which means `tuple[]` - an empty tuple
                 return core_schema.tuple_positional_schema([])
         elif params[-1] is Ellipsis:
             if len(params) == 2:
-                sv = core_schema.tuple_variable_schema(self.generate_schema(params[0]))
-                return sv
-
-            # NOTE: This is not valid in Python, but not removing it because it's
-            # going to be useful for https://github.com/pydantic/pydantic/issues/5952
-            *items_schema, extra_schema = params  # pragma: no cover
-            return core_schema.tuple_positional_schema(  # pragma: no cover
-                [self.generate_schema(p) for p in items_schema], extra_schema=self.generate_schema(extra_schema)
-            )
+                return self._tuple_variable_schema(tuple_type, params[0])
+            else:
+                # TODO: something like https://github.com/pydantic/pydantic/issues/5952
+                raise ValueError('Variable tuples can only have one type')
         elif len(params) == 1 and params[0] == ():
             # special case for `Tuple[()]` which means `Tuple[]` - an empty tuple
             # NOTE: This conditional can be removed when we drop support for Python 3.10.
-            return core_schema.tuple_positional_schema([])
+            return self._tuple_positional_schema(tuple_type, [])
         else:
-            return core_schema.tuple_positional_schema([self.generate_schema(p) for p in params])
+            return self._tuple_positional_schema(tuple_type, list(params))
 
     def _type_schema(self) -> core_schema.CoreSchema:
         return core_schema.custom_error_schema(
@@ -1172,66 +1289,60 @@ class GenerateSchema:
             if origin is not None:
                 dataclass = origin
 
-            from ._dataclasses import is_pydantic_dataclass
-
-            if is_pydantic_dataclass(dataclass):
-                fields = dataclass.__pydantic_fields__
-                if typevars_map:
-                    for field in fields.values():
-                        field.apply_typevars_map(typevars_map, self.types_namespace)
-            else:
-                fields = collect_dataclass_fields(
-                    dataclass,
-                    self.types_namespace,
-                    typevars_map=typevars_map,
-                )
-            decorators = dataclass.__dict__.get('__pydantic_decorators__') or DecoratorInfos.build(dataclass)
-            # Move kw_only=False args to the start of the list, as this is how vanilla dataclasses work.
-            # Note that when kw_only is missing or None, it is treated as equivalent to kw_only=True
-            args = sorted(
-                (self._generate_dc_field_schema(k, v, decorators) for k, v in fields.items()),
-                key=lambda a: a.get('kw_only') is not False,
-            )
-            has_post_init = hasattr(dataclass, '__post_init__')
-            has_slots = hasattr(dataclass, '__slots__')
-
             config = getattr(dataclass, '__pydantic_config__', None)
-            if config is not None:
-                config_wrapper = ConfigWrapper(config, check=False)
-                self._config_wrapper_stack.append(config_wrapper)
-                core_config = config_wrapper.core_config(dataclass)
-            else:
-                core_config = None
+            with self._config_wrapper_stack.push(config):
+                core_config = self._config_wrapper.core_config(dataclass)
 
-            try:
+                self = self._current_generate_schema
+
+                from ._dataclasses import is_pydantic_dataclass
+
+                if is_pydantic_dataclass(dataclass):
+                    fields = dataclass.__pydantic_fields__
+                    if typevars_map:
+                        for field in fields.values():
+                            field.apply_typevars_map(typevars_map, self._types_namespace)
+                else:
+                    fields = collect_dataclass_fields(
+                        dataclass,
+                        self._types_namespace,
+                        typevars_map=typevars_map,
+                    )
+                decorators = dataclass.__dict__.get('__pydantic_decorators__') or DecoratorInfos.build(dataclass)
+                # Move kw_only=False args to the start of the list, as this is how vanilla dataclasses work.
+                # Note that when kw_only is missing or None, it is treated as equivalent to kw_only=True
+                args = sorted(
+                    (self._generate_dc_field_schema(k, v, decorators) for k, v in fields.items()),
+                    key=lambda a: a.get('kw_only') is not False,
+                )
+                has_post_init = hasattr(dataclass, '__post_init__')
+                has_slots = hasattr(dataclass, '__slots__')
+
                 args_schema = core_schema.dataclass_args_schema(
                     dataclass.__name__,
                     args,
                     computed_fields=[self._computed_field_schema(d) for d in decorators.computed_fields.values()],
                     collect_init_only=has_post_init,
                 )
-            finally:
-                if config is not None:
-                    self._config_wrapper_stack.pop()
 
-            inner_schema = apply_validators(args_schema, decorators.root_validators.values(), None)
+                inner_schema = apply_validators(args_schema, decorators.root_validators.values(), None)
 
-            model_validators = decorators.model_validators.values()
-            inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
+                model_validators = decorators.model_validators.values()
+                inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
 
-            dc_schema = core_schema.dataclass_schema(
-                dataclass,
-                inner_schema,
-                post_init=has_post_init,
-                ref=dataclass_ref,
-                fields=[field.name for field in dataclasses.fields(dataclass)],
-                slots=has_slots,
-                config=core_config,
-            )
-            schema = self._apply_model_serializers(dc_schema, decorators.model_serializers.values())
-            schema = apply_model_validators(schema, model_validators, 'outer')
-            self.defs.definitions[dataclass_ref] = schema
-            return core_schema.definition_reference_schema(dataclass_ref)
+                dc_schema = core_schema.dataclass_schema(
+                    dataclass,
+                    inner_schema,
+                    post_init=has_post_init,
+                    ref=dataclass_ref,
+                    fields=[field.name for field in dataclasses.fields(dataclass)],
+                    slots=has_slots,
+                    config=core_config,
+                )
+                schema = self._apply_model_serializers(dc_schema, decorators.model_serializers.values())
+                schema = apply_model_validators(schema, model_validators, 'outer')
+                self.defs.definitions[dataclass_ref] = schema
+                return core_schema.definition_reference_schema(dataclass_ref)
 
     def _callable_schema(self, function: Callable[..., Any]) -> core_schema.CallSchema:
         """Generate schema for a Callable.
@@ -1269,7 +1380,7 @@ class GenerateSchema:
                 var_kwargs_schema = self.generate_schema(annotation)
 
         return_schema: core_schema.CoreSchema | None = None
-        config_wrapper = self.config_wrapper
+        config_wrapper = self._config_wrapper
         if config_wrapper.validate_return:
             return_hint = type_hints.get('return')
             if return_hint is not None:
@@ -1298,7 +1409,7 @@ class GenerateSchema:
 
     def _computed_field_schema(self, d: Decorator[ComputedFieldInfo]) -> core_schema.ComputedField:
         try:
-            return_type = _decorators.get_function_return_type(d.func, d.info.return_type, self.types_namespace)
+            return_type = _decorators.get_function_return_type(d.func, d.info.return_type, self._types_namespace)
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
         if return_type is PydanticUndefined:
@@ -1313,7 +1424,7 @@ class GenerateSchema:
         # Handle alias_generator using similar logic to that from
         # pydantic._internal._generate_schema.GenerateSchema._common_field_schema,
         # with field_info -> d.info and name -> d.cls_var_name
-        alias_generator = self.config_wrapper.alias_generator
+        alias_generator = self._config_wrapper.alias_generator
         if alias_generator and (d.info.alias_priority is None or d.info.alias_priority <= 1):
             alias = alias_generator(d.cls_var_name)
             if not isinstance(alias, str):
@@ -1368,7 +1479,7 @@ class GenerateSchema:
             return None
 
         for gen in PREPARE_METHODS:
-            res = gen(obj, annotations, self.config_wrapper.config_dict)
+            res = gen(obj, annotations, self._config_wrapper.config_dict)
             if res is not None:
                 return res
 
@@ -1386,7 +1497,7 @@ class GenerateSchema:
         annotations = tuple(annotations)  # make them immutable to avoid confusion over mutating them
 
         if prepare is not None:
-            source_type, annotations = prepare(source_type, tuple(annotations), self.config_wrapper.config_dict)
+            source_type, annotations = prepare(source_type, tuple(annotations), self._config_wrapper.config_dict)
             annotations = list(annotations)
         else:
             res = self._get_prepare_pydantic_annotations_for_known_type(source_type, annotations)
@@ -1418,7 +1529,7 @@ class GenerateSchema:
         idx = -1
         prepare = getattr(source_type, '__prepare_pydantic_annotations__', None)
         if prepare:
-            source_type, annotations = prepare(source_type, tuple(annotations), self.config_wrapper.config_dict)
+            source_type, annotations = prepare(source_type, tuple(annotations), self._config_wrapper.config_dict)
             annotations = list(annotations)
         else:
             res = self._get_prepare_pydantic_annotations_for_known_type(source_type, tuple(annotations))
@@ -1456,7 +1567,7 @@ class GenerateSchema:
             if prepare is not None:
                 previous = annotations[:idx]
                 remaining = annotations[idx + 1 :]
-                new_source_type, remaining = prepare(source_type, tuple(remaining), self.config_wrapper.config_dict)
+                new_source_type, remaining = prepare(source_type, tuple(remaining), self._config_wrapper.config_dict)
                 annotations = previous + list(remaining)
                 if new_source_type is not source_type:
                     return self._apply_annotations(
@@ -1473,12 +1584,12 @@ class GenerateSchema:
         if pydantic_js_annotation_functions:
             metadata = CoreMetadataHandler(schema).metadata
             metadata.setdefault('pydantic_js_annotation_functions', []).extend(pydantic_js_annotation_functions)
-        return _add_custom_serialization_from_json_encoders(self.config_wrapper.json_encoders, source_type, schema)
+        return _add_custom_serialization_from_json_encoders(self._config_wrapper.json_encoders, source_type, schema)
 
-    def apply_single_annotation(self, schema: core_schema.CoreSchema, metadata: Any) -> core_schema.CoreSchema:
+    def _apply_single_annotation(self, schema: core_schema.CoreSchema, metadata: Any) -> core_schema.CoreSchema:
         if isinstance(metadata, FieldInfo):
             for field_metadata in metadata.metadata:
-                schema = self.apply_single_annotation(schema, field_metadata)
+                schema = self._apply_single_annotation(schema, field_metadata)
 
             if metadata.discriminator is not None:
                 _discriminated_union.set_discriminator(
@@ -1490,7 +1601,7 @@ class GenerateSchema:
         if schema['type'] == 'nullable':
             # for nullable schemas, metadata is automatically applied to the inner schema
             inner = schema.get('schema', core_schema.any_schema())
-            inner = self.apply_single_annotation(inner, metadata)
+            inner = self._apply_single_annotation(inner, metadata)
             if inner:
                 schema['schema'] = inner
             return schema
@@ -1518,12 +1629,12 @@ class GenerateSchema:
             return maybe_updated_schema
         return original_schema
 
-    def apply_single_annotation_json_schema(
+    def _apply_single_annotation_json_schema(
         self, schema: core_schema.CoreSchema, metadata: Any
     ) -> core_schema.CoreSchema:
         if isinstance(metadata, FieldInfo):
             for field_metadata in metadata.metadata:
-                schema = self.apply_single_annotation_json_schema(schema, field_metadata)
+                schema = self._apply_single_annotation_json_schema(schema, field_metadata)
             json_schema_update: JsonSchemaValue = {}
             if metadata.title:
                 json_schema_update['title'] = metadata.title
@@ -1563,8 +1674,8 @@ class GenerateSchema:
 
         def new_handler(source: Any) -> core_schema.CoreSchema:
             schema = metadata_get_schema(source, get_inner_schema)
-            schema = self.apply_single_annotation(schema, annotation)
-            schema = self.apply_single_annotation_json_schema(schema, annotation)
+            schema = self._apply_single_annotation(schema, annotation)
+            schema = self._apply_single_annotation_json_schema(schema, annotation)
 
             metadata_js_function = _extract_get_pydantic_json_schema(annotation, schema)
             if metadata_js_function is not None:
@@ -1594,7 +1705,7 @@ class GenerateSchema:
 
             try:
                 return_type = _decorators.get_function_return_type(
-                    serializer.func, serializer.info.return_type, self.types_namespace
+                    serializer.func, serializer.info.return_type, self._types_namespace
                 )
             except NameError as e:
                 raise PydanticUndefinedAnnotation.from_name_error(e) from e
@@ -1634,7 +1745,7 @@ class GenerateSchema:
 
             try:
                 return_type = _decorators.get_function_return_type(
-                    serializer.func, serializer.info.return_type, self.types_namespace
+                    serializer.func, serializer.info.return_type, self._types_namespace
                 )
             except NameError as e:
                 raise PydanticUndefinedAnnotation.from_name_error(e) from e

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -90,7 +90,7 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
             return self.resolve_ref_schema(schema)
 
     def _get_types_namespace(self) -> dict[str, Any] | None:
-        return self._generate_schema.types_namespace
+        return self._generate_schema._types_namespace
 
     def generate_schema(self, __source_type: Any) -> core_schema.CoreSchema:
         return self._generate_schema.generate_schema(__source_type)

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,13 +1,16 @@
 """Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
-from typing import Any, Callable, Dict, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union
 
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 from ._migration import getattr_migration
 from .deprecated.config import BaseConfig
 from .deprecated.config import Extra as _Extra
+
+if TYPE_CHECKING:
+    from ._internal._generate_schema import GenerateSchema as _GenerateSchema
 
 __all__ = 'BaseConfig', 'ConfigDict', 'Extra'
 
@@ -182,6 +185,7 @@ class ConfigDict(TypedDict, total=False):
 
     See [Hide Input in Errors](../usage/model_config.md#hide-input-in-errors).
     """
+
     defer_build: bool
     """
     Whether to defer model validator and serializer construction until the first model validation.
@@ -189,6 +193,18 @@ class ConfigDict(TypedDict, total=False):
     This can be useful to avoid the overhead of building models which are only
     used nested within other models, or when you want to manually define type namespace via
     [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild]. Defaults to False.
+    """
+
+    schema_generator: type[_GenerateSchema] | None
+    """
+    A custom core schema generator class to use when generating JSON schemas. 
+    Useful if you want to change the way types are validated across an entire model/schema.
+    
+    The `GenerateSchema` interface is subject to change, currently only the `string_schema` method is public.
+    
+    See [#6737](https://github.com/pydantic/pydantic/pull/6737) for details.
+    
+    Defaults to `None`.
     """
 
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -197,13 +197,13 @@ class ConfigDict(TypedDict, total=False):
 
     schema_generator: type[_GenerateSchema] | None
     """
-    A custom core schema generator class to use when generating JSON schemas. 
+    A custom core schema generator class to use when generating JSON schemas.
     Useful if you want to change the way types are validated across an entire model/schema.
-    
+
     The `GenerateSchema` interface is subject to change, currently only the `string_schema` method is public.
-    
+
     See [#6737](https://github.com/pydantic/pydantic/pull/6737) for details.
-    
+
     Defaults to `None`.
     """
 

--- a/tests/mypy/modules/dataclass_no_any.py
+++ b/tests/mypy/modules/dataclass_no_any.py
@@ -6,6 +6,6 @@ class Foo:
     foo: int
 
 
-@dataclass(config=dict(title='Bar Title'))
+@dataclass(config={'title': 'Bar Title'})
 class Bar:
     bar: str

--- a/tests/mypy/outputs/1.0.1/mypy-plugin-strict-no-any_ini/dataclass_no_any.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin-strict-no-any_ini/dataclass_no_any.py
@@ -6,6 +6,6 @@ class Foo:
     foo: int
 
 
-@dataclass(config=dict(title='Bar Title'))
+@dataclass(config={'title': 'Bar Title'})
 class Bar:
     bar: str

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from pydantic import (
     BaseConfig,
     BaseModel,
     Field,
+    GenerateSchema,
     PrivateAttr,
     PydanticDeprecatedSince20,
     PydanticSchemaGenerationError,
@@ -522,10 +523,13 @@ def test_multiple_inheritance_config():
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='different on older versions')
 def test_config_wrapper_match():
-    config_dict_annotations = [(k, str(v)) for k, v in get_type_hints(ConfigDict).items()]
+    localns = {'_GenerateSchema': GenerateSchema, 'GenerateSchema': GenerateSchema}
+    config_dict_annotations = [(k, str(v)) for k, v in get_type_hints(ConfigDict, localns=localns).items()]
     config_dict_annotations.sort()
     # remove config
-    config_wrapper_annotations = [(k, str(v)) for k, v in get_type_hints(ConfigWrapper).items() if k != 'config_dict']
+    config_wrapper_annotations = [
+        (k, str(v)) for k, v in get_type_hints(ConfigWrapper, localns=localns).items() if k != 'config_dict'
+    ]
     config_wrapper_annotations.sort()
 
     assert (
@@ -535,7 +539,8 @@ def test_config_wrapper_match():
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='different on older versions')
 def test_config_defaults_match():
-    config_dict_keys = sorted(list(get_type_hints(ConfigDict).keys()))
+    localns = {'_GenerateSchema': GenerateSchema, 'GenerateSchema': GenerateSchema}
+    config_dict_keys = sorted(list(get_type_hints(ConfigDict, localns=localns).keys()))
     config_defaults_keys = sorted(list(config_defaults.keys()))
 
     assert config_dict_keys == config_defaults_keys, 'ConfigDict and config_defaults must have the same keys'

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -619,29 +619,6 @@ class Model(BaseModel):
     assert m.model_dump_json() == '{"foo_user":{"x":"user1"},"user":"User(user2)"}'
 
 
-def test_json_encoder_forward_ref(create_module):
-    # TODO: Replace the use of json_encoders with a root_serializer
-    module = create_module(
-        # language=Python
-        """
-from typing import List, Optional
-from typing_extensions import Annotated
-from pydantic import BaseModel, PlainSerializer
-
-def serialize_user(user):
-    return f'User({user.name})'
-
-class User(BaseModel):
-    name: str
-    friends: Optional[List[Annotated['User', PlainSerializer(serialize_user)]]] = None
-
-"""
-    )
-
-    m = module.User(name='anne', friends=[{'name': 'ben'}, {'name': 'charlie'}])
-    assert m.model_dump_json() == '{"name":"anne","friends":["User(ben)","User(charlie)"]}'
-
-
 skip_pep585 = pytest.mark.skipif(
     sys.version_info < (3, 9), reason='PEP585 generics only supported for python 3.9 and above'
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,6 +31,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    GenerateSchema,
     GetCoreSchemaHandler,
     PrivateAttr,
     PydanticDeprecatedSince20,
@@ -2794,3 +2795,15 @@ def test_cannot_use_leading_underscore_field_names():
 
         class Model3(BaseModel):
             ___: int = Field(default=1)
+
+
+def test_schema_generator_customize_type() -> None:
+    class LaxStrGenerator(GenerateSchema):
+        def str_schema(self) -> CoreSchema:
+            return core_schema.no_info_plain_validator_function(str)
+
+    class Model(BaseModel):
+        x: str
+        model_config = ConfigDict(schema_generator=LaxStrGenerator)
+
+    assert Model(x=1).x == '1'


### PR DESCRIPTION
The idea here is to make a more constrained version of schema generation customization that we can expand over time.

Fix #6045

EDIT by @Kludex: Closes #6726

Selected Reviewer: @lig