### PR TITLE
Fix mypy plugin handling of @model_validator(mode="after")

### DIFF
--- a/tests/mypy/modules/plugin_success.py
+++ b/tests/mypy/modules/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -290,7 +292,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.0.1/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/mypy-default_ini/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -296,7 +298,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.0.1/mypy-plugin-strict_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin-strict_ini/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -292,7 +294,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.0.1/mypy-plugin_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin_ini/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -290,7 +292,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.0.1/pyproject-plugin-strict_toml/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-plugin-strict_toml/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -292,7 +294,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.0.1/pyproject-plugin_toml/plugin_success.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-plugin_toml/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -290,7 +292,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.1.1/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.1.1/mypy-default_ini/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -297,7 +299,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.2.0/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.2.0/mypy-default_ini/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -295,7 +297,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)

--- a/tests/mypy/outputs/1.4.1/mypy-default_ini/plugin_success.py
+++ b/tests/mypy/outputs/1.4.1/mypy-default_ini/plugin_success.py
@@ -1,5 +1,7 @@
 from typing import Any, ClassVar, Generic, List, Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 from pydantic import BaseModel, ConfigDict, Field, create_model, field_validator, model_validator, validator
 from pydantic.dataclasses import dataclass
 
@@ -295,7 +297,11 @@ def foo() -> None:
 
         @model_validator(mode='before')
         @classmethod
-        def validate_values(cls, values: Any) -> Any:
+        def validate_before(cls, values: Any) -> Any:
             return values
+
+        @model_validator(mode='after')
+        def validate_after(self) -> Self:
+            return self
 
     MyModel(number=2)


### PR DESCRIPTION
## Change Summary

The mypy plugin would convert any method decorated with @model_validator to a classmethod, but that's wrong for the after mode, where it expects a normal method.

## Related issue number

Fix #6709

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu