### PR TITLE
Fix bug where calling `help(BaseModelSubclass)` raises errors

### DIFF
--- a/pydantic/_internal/_mock_validator.py
+++ b/pydantic/_internal/_mock_validator.py
@@ -39,12 +39,14 @@ class MockValidator:
         getattr(SchemaValidator, item)
         raise PydanticUserError(self._error_message, code=self._code)
 
-    def force_rebuild(self) -> SchemaValidator:
+    def rebuild(self) -> SchemaValidator | None:
         if self._attempt_rebuild:
             validator = self._attempt_rebuild()
             if validator is not None:
                 return validator
-        raise PydanticUserError(self._error_message, code=self._code)
+            else:
+                raise PydanticUserError(self._error_message, code=self._code)
+        return None
 
 
 def set_basemodel_mock_validator(cls: type[BaseModel], cls_name: str, undefined_name: str) -> None:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -199,8 +199,10 @@ class ModelMetaclass(ABCMeta):
                 # This means the class didn't get a schema generated for it, likely because there was an undefined reference
                 maybe_mock_validator = getattr(self, '__pydantic_validator__', None)
                 if isinstance(maybe_mock_validator, MockValidator):
-                    maybe_mock_validator.force_rebuild()
-                    return getattr(self, '__pydantic_core_schema__')
+                    rebuilt_validator = maybe_mock_validator.rebuild()
+                    if rebuilt_validator is not None:
+                        # In this case, a validator was built, and so `__pydantic_core_schema__` should now be set
+                        return getattr(self, '__pydantic_core_schema__')
             raise AttributeError(item)
 
     @classmethod

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2727,6 +2727,8 @@ def test_deferred_core_schema() -> None:
 
 
 def test_help(create_module):
+    # since pydoc/help access all attributes to generate their documentation,
+    # this triggers the deprecation warnings.
     with pytest.warns(PydanticDeprecatedSince20):
         module = create_module(
             # language=Python

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,6 +33,7 @@ from pydantic import (
     Field,
     GetCoreSchemaHandler,
     PrivateAttr,
+    PydanticDeprecatedSince20,
     PydanticUndefinedAnnotation,
     PydanticUserError,
     SecretStr,
@@ -2723,3 +2724,23 @@ def test_deferred_core_schema() -> None:
         pass
 
     assert Foo.__pydantic_core_schema__
+
+
+def test_help(create_module):
+    with pytest.warns(PydanticDeprecatedSince20):
+        module = create_module(
+            # language=Python
+            """
+import pydoc
+
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    x: int
+
+
+help_result_string = pydoc.render_doc(Model)
+"""
+        )
+
+    assert 'class Model' in module.help_result_string

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -593,3 +593,20 @@ def test_json_schema_extra_on_model_and_on_field():
 
     with pytest.raises(ValueError, match=r'json_schema_extra.*?must not be set simultaneously'):
         Model.model_json_schema()
+
+
+def test_help(create_module):
+    with pytest.warns(PydanticDeprecatedSince20):
+        module = create_module(
+            # language=Python
+            """
+import pydoc
+
+from pydantic import RootModel
+
+
+help_result_string = pydoc.render_doc(RootModel)
+"""
+        )
+
+    assert 'class RootModel' in module.help_result_string

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -596,6 +596,8 @@ def test_json_schema_extra_on_model_and_on_field():
 
 
 def test_help(create_module):
+    # since pydoc/help access all attributes to generate their documentation,
+    # this triggers the deprecation warnings.
     with pytest.warns(PydanticDeprecatedSince20):
         module = create_module(
             # language=Python


### PR DESCRIPTION
closes https://github.com/pydantic/pydantic/issues/6743

There are some deprecation warnings when calling `help` or using `pydoc` to generate the help because they are accessing all the attributes for generating the doc