### PR TITLE
rework decimal validator for better performance

### DIFF
--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -437,19 +437,7 @@ def test_tuple_value_error():
             'msg': 'Input should be a valid number, unable to parse string as a number',
             'input': 'y',
         },
-        {
-            'type': 'is_instance_of',
-            'loc': ('v', 2, 'is-instance[Decimal]'),
-            'msg': 'Input should be an instance of Decimal',
-            'input': 'x',
-            'ctx': {'class': 'Decimal'},
-        },
-        {
-            'type': 'decimal_parsing',
-            'loc': ('v', 2, 'function-after[to_decimal(), union[float,int,constrained-str]]'),
-            'msg': 'Input should be a valid decimal',
-            'input': 'x',
-        },
+        {'type': 'decimal_parsing', 'loc': ('v', 2), 'msg': 'Input should be a valid decimal', 'input': 'x'},
     ]
 
 
@@ -1234,26 +1222,10 @@ def test_multiple_errors():
             'input': 'foobar',
         },
         {
-            'type': 'is_instance_of',
-            'loc': (
-                'a',
-                'function-after[check_digits_validator(), json-or-python[json=function-after[to_decimal(), '
-                'union[float,int,constrained-str]],python=lax-or-strict[lax=union[is-instance[Decimal],'
-                'function-after[to_decimal(), union[float,int,constrained-str]]],strict=is-instance[Decimal]]]]',
-                'is-instance[Decimal]',
-            ),
-            'msg': 'Input should be an instance of Decimal',
-            'input': 'foobar',
-            'ctx': {'class': 'Decimal'},
-        },
-        {
             'type': 'decimal_parsing',
             'loc': (
                 'a',
-                'function-after[check_digits_validator(), json-or-python[json=function-after[to_decimal(), '
-                'union[float,int,constrained-str]],python=lax-or-strict[lax=union[is-instance[Decimal],'
-                'function-after[to_decimal(), union[float,int,constrained-str]]],strict=is-instance[Decimal]]]]',
-                'function-after[to_decimal(), union[float,int,constrained-str]]',
+                'function-after[check_digits_validator(), json-or-python[json=function-after[accept_decimal(), union[float,int,constrained-str]],python=lax-or-strict[lax=function-plain[accept_decimal()],strict=is-instance[Decimal]]]]',
             ),
             'msg': 'Input should be a valid decimal',
             'input': 'foobar',


### PR DESCRIPTION
## Change Summary

Related to https://github.com/pydantic/pydantic-core/pull/763

The idea is that in `validate_python` value we can rely on the `Decimal` constructor to reject invalid data, rather than go via the union schema (which needs to do several isinstance checks).

This is a possible alternative to the Rust validator in https://github.com/pydantic/pydantic-core/pull/763 - as per the benchmark there this is only about ~50% slower than the Rust implementation.

`_core` is the Rust implementation
`_pyd` is a copypaste of this implementation into the pydantic-core benchmark suite
`_limit` is just calling `decimal.Decimal`

  | Benchmark | main | dh/decimal | Change
-- | -- | -- | -- | --
🆕 | test_decimal_from_string_core | N/A | 35.1 µs | N/A
🆕 | test_decimal_from_string_pyd | N/A | 54.3 µs | N/A
🆕 | test_decimal_from_string_limit | N/A | 20.1 µs | N/A

## Related issue number

N/A 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
