### PR TITLE
add pydantic-core build info to `version_info()`

### DIFF
--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -26,7 +26,8 @@ def version_info() -> str:
 
     info = {
         'pydantic version': VERSION,
-        'pydantic-core version': f'{pdc.__version__} {pdc.build_profile} build profile',
+        'pydantic-core version': pdc.__version__,
+        'pydantic-core build': getattr(pdc, 'build_info', None) or pdc.build_profile,
         'install path': Path(__file__).resolve().parent,
         'python version': sys.version,
         'platform': platform.platform(),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,7 +9,7 @@ from pydantic.version import version_info
 def test_version_info():
     s = version_info()
     assert re.match(' *pydantic version: ', s)
-    assert s.count('\n') == 5
+    assert s.count('\n') == 6
 
 
 def test_standard_version():


### PR DESCRIPTION
Adding info from https://github.com/pydantic/pydantic-core/pull/749, namely PGO and allocator.

Selected Reviewer: @davidhewitt