### PR TITLE
🚧 Move type replacing into `GenerateSchema`

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -59,6 +59,7 @@ class ConfigWrapper:
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
+    replace_types: dict[type, type] | None
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -191,6 +192,7 @@ config_defaults = ConfigDict(
     validate_return=False,
     protected_namespaces=('model_',),
     hide_input_in_errors=False,
+    replace_types=None,
 )
 
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -373,6 +373,12 @@ def set_model_fields(
     typevars_map = get_model_typevars_map(cls)
     fields, class_vars = collect_model_fields(cls, bases, config_wrapper, types_namespace, typevars_map=typevars_map)
 
+    if config_wrapper.replace_types:
+        replace_types = config_wrapper.replace_types
+        for fld in fields.values():
+            if fld.annotation in replace_types:
+                fld.annotation = replace_types[fld.annotation]  # type: ignore
+
     cls.model_fields = fields
     cls.__class_vars__.update(class_vars)
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -373,11 +373,11 @@ def set_model_fields(
     typevars_map = get_model_typevars_map(cls)
     fields, class_vars = collect_model_fields(cls, bases, config_wrapper, types_namespace, typevars_map=typevars_map)
 
-    if config_wrapper.replace_types:
-        replace_types = config_wrapper.replace_types
-        for fld in fields.values():
-            if fld.annotation in replace_types:
-                fld.annotation = replace_types[fld.annotation]  # type: ignore
+    # if config_wrapper.replace_types:
+    #     replace_types = config_wrapper.replace_types
+    #     for fld in fields.values():
+    #         if fld.annotation in replace_types:
+    #             fld.annotation = replace_types[fld.annotation]  # type: ignore
 
     cls.model_fields = fields
     cls.__class_vars__.update(class_vars)
@@ -424,9 +424,10 @@ def complete_model_class(
     """
     typevars_map = get_model_typevars_map(cls)
     gen_schema = GenerateSchema(
-        config_wrapper,
-        types_namespace,
-        typevars_map,
+        config_wrapper=config_wrapper,
+        types_namespace=types_namespace,
+        typevars_map=typevars_map,
+        types_replace_map=config_wrapper.replace_types,
     )
 
     handler = CallbackGetCoreSchemaHandler(
@@ -443,13 +444,13 @@ def complete_model_class(
         set_basemodel_mock_validator(cls, cls_name, f'`{e.name}`')
         return False
 
-    core_config = config_wrapper.core_config(cls)
-
     schema = gen_schema.collect_definitions(schema)
     schema = apply_discriminators(flatten_schema_defs(schema))
     if collect_invalid_schemas(schema):
         set_basemodel_mock_validator(cls, cls_name, 'all referenced types')
         return False
+
+    core_config = config_wrapper.core_config(cls)
 
     # debug(schema)
     cls.__pydantic_core_schema__ = schema

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -125,6 +125,7 @@ class ConfigDict(TypedDict, total=False):
         hide_input_in_errors: Whether to hide inputs when printing errors. Defaults to `False`.
 
             See [Hide Input in Errors](../usage/model_config.md#hide-input-in-errors).
+        replace_types: A `dict` of types to replace with other annotations. Defaults to None.
     """
 
     title: str | None
@@ -160,6 +161,7 @@ class ConfigDict(TypedDict, total=False):
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
+    replace_types: dict[type, type] | None
 
 
 __getattr__ = getattr_migration(__name__)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from dirty_equals import HasRepr, IsPartialDict
 from pydantic_core import SchemaError
 
 from pydantic import (
+    AfterValidator,
     BaseConfig,
     BaseModel,
     BeforeValidator,
@@ -680,3 +681,15 @@ def test_replace_types_nested():
             'url': 'https://errors.pydantic.dev/2.1.2/v/string_type',
         }
     ]
+
+
+def test_replace_types_annotated():
+    DoubleStr = Annotated[str, AfterValidator(lambda x: x * 2)]
+
+    class Model(BaseModel):
+        x: Annotated[str, AfterValidator(str.lower)]
+        model_config = {'replace_types': {str: DoubleStr}}
+
+    user = Model(x='ABC')
+
+    assert user.model_dump() == {'x': 'abcabc'}


### PR DESCRIPTION
## Change Summary

An attempt to move type replacing logic into `GenerateSchema` based on #6535 

TODO:
- Apply type replacement for types like `Dict[str, str]`.
- Get it working with `TypedDict`: as of now `replace_types` config has no effect.

## Related issue number

Fix #6045 and some other cases

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
