### PR TITLE
Make it so callable JSON schema extra works

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -248,7 +248,7 @@ def collect_dataclass_fields(
             field_info = FieldInfo.from_annotated_attribute(ann_type, dataclass_field)
         fields[ann_name] = field_info
 
-        if field_info.default is not PydanticUndefined and isinstance(getattr(cls, ann_name), FieldInfo):
+        if field_info.default is not PydanticUndefined and isinstance(getattr(cls, ann_name, field_info), FieldInfo):
             # We need this to fix the default when the "default" from __dataclass_fields__ is a pydantic.FieldInfo
             setattr(cls, ann_name, field_info.default)
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -323,6 +323,9 @@ class FieldInfo(_repr.Representation):
         if isinstance(default, cls):
             default.annotation, annotation_metadata = cls._extract_metadata(annotation)
             default.metadata += annotation_metadata
+            default = default.merge_field_infos(
+                *[x for x in annotation_metadata if isinstance(x, cls)], default, annotation=default.annotation
+            )
             default.frozen = final or default.frozen
             return default
         elif isinstance(default, dataclasses.Field):
@@ -339,6 +342,11 @@ class FieldInfo(_repr.Representation):
             pydantic_field = cls._from_dataclass_field(default)
             pydantic_field.annotation, annotation_metadata = cls._extract_metadata(annotation)
             pydantic_field.metadata += annotation_metadata
+            pydantic_field = pydantic_field.merge_field_infos(
+                *[x for x in annotation_metadata if isinstance(x, cls)],
+                pydantic_field,
+                annotation=pydantic_field.annotation,
+            )
             pydantic_field.frozen = final or pydantic_field.frozen
             pydantic_field.init_var = init_var
             pydantic_field.kw_only = getattr(default, 'kw_only', None)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -58,7 +58,7 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
     max_digits: int | None
     decimal_places: int | None
     discriminator: str | None
-    json_schema_extra: dict[str, Any] | None
+    json_schema_extra: dict[str, Any] | typing.Callable[[dict[str, Any]], None] | None
     frozen: bool | None
     validate_default: bool | None
     repr: bool
@@ -113,7 +113,7 @@ class FieldInfo(_repr.Representation):
     exclude: bool | None
     include: bool | None
     discriminator: str | None
-    json_schema_extra: dict[str, Any] | None
+    json_schema_extra: dict[str, Any] | typing.Callable[[dict[str, Any]], None] | None
     frozen: bool | None
     validate_default: bool | None
     repr: bool
@@ -279,7 +279,8 @@ class FieldInfo(_repr.Representation):
             first_arg, *extra_args = typing_extensions.get_args(annotation)
             if _typing_extra.is_finalvar(first_arg):
                 final = True
-            field_info = cls._find_field_info_arg(extra_args)
+            field_info_annotations = [a for a in extra_args if isinstance(a, FieldInfo)]
+            field_info = cls.merge_field_infos(*field_info_annotations, annotation=first_arg)
             if field_info:
                 new_field_info = copy(field_info)
                 new_field_info.annotation = first_arg
@@ -356,14 +357,27 @@ class FieldInfo(_repr.Representation):
     def merge_field_infos(*field_infos: FieldInfo, **overrides: Any) -> FieldInfo:
         """Merge `FieldInfo` instances keeping only explicitly set attributes.
 
+        Later `FieldInfo` instances override earlier ones.
+
         Returns:
             FieldInfo: A merged FieldInfo instance.
         """
+        flattened_field_infos: list[FieldInfo] = []
+        for field_info in field_infos:
+            flattened_field_infos.extend(x for x in field_info.metadata if isinstance(x, FieldInfo))
+            flattened_field_infos.append(field_info)
+        field_infos = tuple(flattened_field_infos)
         new_kwargs: dict[str, Any] = {}
+        metadata = {}
         for field_info in field_infos:
             new_kwargs.update(field_info._attributes_set)
+            for x in field_info.metadata:
+                if not isinstance(x, FieldInfo):
+                    metadata[type(x)] = x
         new_kwargs.update(overrides)
-        return FieldInfo(**new_kwargs)
+        field_info = FieldInfo(**new_kwargs)
+        field_info.metadata = list(metadata.values())
+        return field_info
 
     @classmethod
     def _from_dataclass_field(cls, dc_field: DataclassField[Any]) -> typing_extensions.Self:
@@ -411,18 +425,6 @@ class FieldInfo(_repr.Representation):
                 return first_arg, list(extra_args)
 
         return annotation, []
-
-    @staticmethod
-    def _find_field_info_arg(args: Any) -> FieldInfo | None:
-        """Find an instance of `FieldInfo` in the provided arguments.
-
-        Args:
-            args: The argument list to search for `FieldInfo`.
-
-        Returns:
-            An instance of `FieldInfo` if found, otherwise `None`.
-        """
-        return next((a for a in args if isinstance(a, FieldInfo)), None)
 
     @classmethod
     def _collect_metadata(cls, kwargs: dict[str, Any]) -> list[Any]:
@@ -650,7 +652,7 @@ def Field(  # noqa: C901
     exclude: bool | None = _Unset,
     include: bool | None = _Unset,
     discriminator: str | None = _Unset,
-    json_schema_extra: dict[str, Any] | None = _Unset,
+    json_schema_extra: dict[str, Any] | typing.Callable[[dict[str, Any]], None] | None = _Unset,
     frozen: bool | None = _Unset,
     validate_default: bool | None = _Unset,
     repr: bool = _Unset,

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4874,6 +4874,21 @@ def test_skip_json_schema_annotation() -> None:
     }
 
 
+def test_skip_json_schema_exclude_default():
+    class Model(BaseModel):
+        x: Annotated[Union[int, SkipJsonSchema[None]], Field(json_schema_extra=lambda s: s.pop('default'))] = None
+
+    assert Model().x is None
+    # insert_assert(Model.model_json_schema())
+    assert Model.model_json_schema() == {
+        'properties': {
+            'x': {'title': 'X', 'type': 'integer'},
+        },
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
 def test_typeddict_field_required_missing() -> None:
     """https://github.com/pydantic/pydantic/issues/6192"""
 


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6647

Note that as [mentioned here](https://github.com/pydantic/pydantic/pull/6653#issuecomment-1646211152), the better solution for FastAPI is to use a custom `GenerateJsonSchema` that generates the JSON schema differently for `Optional` query params, etc.. But this at least makes it possible to express what you want on the pydantic side via:
```python
from typing import Annotated

from pydantic import BaseModel, Field
from pydantic.json_schema import SkipJsonSchema


class Model(BaseModel):
    x: Annotated[int | SkipJsonSchema[None], Field(json_schema_extra=lambda x: x.pop('default'))] = None

print(Model.model_json_schema())
#> {'properties': {'x': {'title': 'X', 'type': 'integer'}}, 'title': 'Model', 'type': 'object'}
```

Selected Reviewer: @samuelcolvin