### PR TITLE
Fix annotated_types.MaxLen validator for custom sequence types

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -263,7 +263,7 @@ def min_length_validator(x: Any, min_length: Any) -> Any:
 
 
 def max_length_validator(x: Any, max_length: Any) -> Any:
-    if not (len(x) <= max_length):
+    if len(x) > max_length:
         raise PydanticKnownError(
             'too_long',
             {'field_type': 'Value', 'max_length': max_length, 'actual_length': len(x)},

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -263,7 +263,7 @@ def min_length_validator(x: Any, min_length: Any) -> Any:
 
 
 def max_length_validator(x: Any, max_length: Any) -> Any:
-    if not (len(x) < max_length):
+    if not (len(x) <= max_length):
         raise PydanticKnownError(
             'too_long',
             {'field_type': 'Value', 'max_length': max_length, 'actual_length': len(x)},

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5423,7 +5423,7 @@ def test_constraints_arbitrary_type() -> None:
         lt=CustomType(-1),
         le=CustomType(0),
         min_length=CustomType([1, 2]),
-        max_length=CustomType([]),
+        max_length=CustomType([1]),
         multiple_of=CustomType(4),
         predicate=CustomType(1),
     )


### PR DESCRIPTION
## Change Summary

Makes the validator function used for `annotated_types.MaxLen` with custom sequences use an inclusive upper bound.

## Related issue number

fix #6808

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu