### PR TITLE
remove email validation from the north star benchmark

### DIFF
--- a/tests/benchmarks/generate_north_star_data.py
+++ b/tests/benchmarks/generate_north_star_data.py
@@ -115,7 +115,6 @@ def person() -> dict:
     return {
         'id': f.uuid4(),
         'name': f.name(),
-        'email': f.safe_email(),
         'height': str(f.pydecimal(min_value=1, max_value=2, right_digits=2)),
         'entry_created_date': date_string(),
         'entry_created_time': lax_time(),

--- a/tests/benchmarks/test_north_star.py
+++ b/tests/benchmarks/test_north_star.py
@@ -15,21 +15,11 @@ from uuid import UUID
 import pytest
 from typing_extensions import Annotated, Literal
 
-from pydantic.networks import EmailStr
-
-try:
-    import email_validator
-except ImportError:
-    email_validator = None
-
 
 @pytest.fixture(scope='module')
 def pydantic_type_adapter():
     from pydantic import BaseModel, Field, TypeAdapter
     from pydantic.networks import AnyHttpUrl
-
-    if not email_validator:
-        raise pytest.skip(reason='email_validator not installed')
 
     class Blog(BaseModel):
         type: Literal['blog']
@@ -64,7 +54,6 @@ def pydantic_type_adapter():
     class Person(BaseModel):
         id: UUID
         name: str
-        email: EmailStr
         height: Decimal
         entry_created_date: date
         entry_created_time: time
@@ -75,7 +64,7 @@ def pydantic_type_adapter():
 
 
 _NORTH_STAR_DATA_PATH = Path(__file__).parent / 'north_star_data.json'
-_EXPECTED_NORTH_STAR_DATA_MD5 = '40bd2ee46ddbcc07ee8c693dc666fa17'
+_EXPECTED_NORTH_STAR_DATA_MD5 = '0ff34599a0861026cf25b6cdbb4bbe81'
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
## Change Summary

Removes the `email` field from the "north star" benchmark. The email validation is implemented in pure python and is a very complex problem, so performs significantly slower than the rest of `pydantic`'s validation. (Approx 75% of the time was spent in email validation.)

Removing it gives us a truer measurement on the performance of pydantic's internals.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig