### PR TITLE
Add `config.defer_build` to optionally make model building lazy

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -60,6 +60,7 @@ class ConfigWrapper:
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
+    defer_model_build: bool
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -193,6 +194,7 @@ config_defaults = ConfigDict(
     protected_namespaces=('model_',),
     hide_input_in_errors=False,
     json_encoders=None,
+    defer_model_build=False,
 )
 
 

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -60,7 +60,7 @@ class ConfigWrapper:
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
-    defer_model_build: bool
+    defer_build: bool
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -194,7 +194,7 @@ config_defaults = ConfigDict(
     protected_namespaces=('model_',),
     hide_input_in_errors=False,
     json_encoders=None,
-    defer_model_build=False,
+    defer_build=False,
 )
 
 

--- a/pydantic/_internal/_mock_validator.py
+++ b/pydantic/_internal/_mock_validator.py
@@ -23,7 +23,7 @@ class MockValidator:
         code: PydanticErrorCodes,
         attempt_rebuild: Callable[[], SchemaValidator | None] | None = None,
     ) -> None:
-        """Attempt rebuild."""
+        # debug(attempt_rebuild, code)
         self._error_message = error_message
         self._code: PydanticErrorCodes = code
         self._attempt_rebuild = attempt_rebuild
@@ -49,7 +49,9 @@ class MockValidator:
         return None
 
 
-def set_basemodel_mock_validator(cls: type[BaseModel], cls_name: str, undefined_name: str) -> None:
+def set_basemodel_mock_validator(
+    cls: type[BaseModel], cls_name: str, undefined_name: str = 'all referenced types'
+) -> None:
     undefined_type_error_message = (
         f'`{cls_name}` is not fully defined; you should define {undefined_name},'
         f' then call `{cls_name}.model_rebuild()`.'

--- a/pydantic/_internal/_mock_validator.py
+++ b/pydantic/_internal/_mock_validator.py
@@ -23,7 +23,6 @@ class MockValidator:
         code: PydanticErrorCodes,
         attempt_rebuild: Callable[[], SchemaValidator | None] | None = None,
     ) -> None:
-        # debug(attempt_rebuild, code)
         self._error_message = error_message
         self._code: PydanticErrorCodes = code
         self._attempt_rebuild = attempt_rebuild

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -452,6 +452,10 @@ def complete_model_class(
         ref_mode='unpack',
     )
 
+    if config_wrapper.defer_model_build:
+        set_basemodel_mock_validator(cls, cls_name)
+        return False
+
     try:
         schema = cls.__get_pydantic_core_schema__(cls, handler)
     except PydanticUndefinedAnnotation as e:
@@ -465,7 +469,7 @@ def complete_model_class(
     schema = gen_schema.collect_definitions(schema)
     schema = apply_discriminators(flatten_schema_defs(schema))
     if collect_invalid_schemas(schema):
-        set_basemodel_mock_validator(cls, cls_name, 'all referenced types')
+        set_basemodel_mock_validator(cls, cls_name)
         return False
 
     # debug(schema)

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -452,7 +452,7 @@ def complete_model_class(
         ref_mode='unpack',
     )
 
-    if config_wrapper.defer_model_build:
+    if config_wrapper.defer_build:
         set_basemodel_mock_validator(cls, cls_name)
         return False
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -100,6 +100,12 @@ class ConfigDict(TypedDict, total=False):
             _pydantic_), an error will be raised. Defaults to `()`.
         allow_inf_nan: Whether to allow infinity (`+inf` an `-inf`) and NaN values to float fields. Defaults to `True`.
         json_schema_extra: A dict or callable to provide extra JSON schema properties. Defaults to `None`.
+        json_encoders: A `dict` of custom JSON encoders for specific types. Defaults to `None`.
+
+            !!! note
+                This config option is a carryover from v1.
+                We originally planned to remove it in v2 but didn't have a 1:1 replacement so we are keeping it for now.
+                It is still deprecated and will likely be removed in the future.
         strict: If `True`, strict validation is applied to all fields on the model.
             See [Strict Mode](../usage/strict_mode.md) for details.
         revalidate_instances: When and how to revalidate models and dataclasses during validation. Accepts the string
@@ -129,12 +135,10 @@ class ConfigDict(TypedDict, total=False):
         hide_input_in_errors: Whether to hide inputs when printing errors. Defaults to `False`.
 
             See [Hide Input in Errors](../usage/model_config.md#hide-input-in-errors).
-        json_encoders: A `dict` of custom JSON encoders for specific types. Defaults to `None`.
-
-            !!! note
-                This config option is a carryover from v1.
-                We originally planned to remove it in v2 but didn't have a 1:1 replacement so we are keeping it for now.
-                It is still deprecated and will likely be removed in the future.
+        defer_model_build: Whether to defer model validator and serializer construction until the
+            first model validation. This can be useful to avoid the overhead of building models which are only
+            used nested within other models, or when you want to manually define type namespace via
+            [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild]. Defaults to False.
     """
 
     title: str | None
@@ -171,6 +175,7 @@ class ConfigDict(TypedDict, total=False):
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
+    defer_model_build: bool
 
 
 __getattr__ = getattr_migration(__name__)

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -135,7 +135,7 @@ class ConfigDict(TypedDict, total=False):
         hide_input_in_errors: Whether to hide inputs when printing errors. Defaults to `False`.
 
             See [Hide Input in Errors](../usage/model_config.md#hide-input-in-errors).
-        defer_model_build: Whether to defer model validator and serializer construction until the
+        defer_build: Whether to defer model validator and serializer construction until the
             first model validation. This can be useful to avoid the overhead of building models which are only
             used nested within other models, or when you want to manually define type namespace via
             [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild]. Defaults to False.
@@ -175,7 +175,7 @@ class ConfigDict(TypedDict, total=False):
     validate_return: bool
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
-    defer_model_build: bool
+    defer_build: bool
 
 
 __getattr__ = getattr_migration(__name__)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -452,10 +452,13 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 types_namespace = cls.__pydantic_parent_namespace__
 
                 types_namespace = _typing_extra.get_cls_types_namespace(cls, types_namespace)
+
+            # manually override defer_model_build so complete_model_class doesn't skip building the model again
+            config = {**cls.model_config, 'defer_model_build': False}
             return _model_construction.complete_model_class(
                 cls,
                 cls.__name__,
-                _config.ConfigWrapper(cls.model_config, check=False),
+                _config.ConfigWrapper(config, check=False),
                 raise_errors=raise_errors,
                 types_namespace=types_namespace,
             )

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -453,8 +453,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
                 types_namespace = _typing_extra.get_cls_types_namespace(cls, types_namespace)
 
-            # manually override defer_model_build so complete_model_class doesn't skip building the model again
-            config = {**cls.model_config, 'defer_model_build': False}
+            # manually override defer_build so complete_model_class doesn't skip building the model again
+            config = {**cls.model_config, 'defer_build': False}
             return _model_construction.complete_model_class(
                 cls,
                 cls.__name__,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -668,7 +668,7 @@ def test_json_encoders_type_adapter() -> None:
 
 
 def test_config_model_defer_build():
-    class MyModel(BaseModel, defer_model_build=True):
+    class MyModel(BaseModel, defer_build=True):
         x: int
 
     assert isinstance(MyModel.__pydantic_validator__, MockValidator)
@@ -680,7 +680,7 @@ def test_config_model_defer_build():
 
 
 def test_config_model_defer_build_nested():
-    class MyNestedModel(BaseModel, defer_model_build=True):
+    class MyNestedModel(BaseModel, defer_build=True):
         x: int
 
     class MyModel(BaseModel):


### PR DESCRIPTION
## Change Summary

This proposes a new config flag `defer_model_build`, when true this means the core schema, schema validator and schema serializer are not constructed for a model when it's defined, instead they're only built when `model_rebuild()` is called, or when the model is first called.

Two reasons this can be useful:
* so models which are only ever used nested or within `TypeAdapter`s don't need all this logic calling - see #6768 and #6748
* so that the type namespace used when constructing models can be customised, fixes #6742

## Related issue number

fix #6742

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable - **somewhat, I'm going to rewrite the docs for `ConfigDict` anyway, so I'll add more logic then**
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb