### PR TITLE
Update field annotations when building the schema

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -68,7 +68,7 @@ from ._decorators import (
 )
 from ._fields import collect_dataclass_fields, get_type_hints_infer_globalns
 from ._forward_ref import PydanticRecursiveRef
-from ._generics import get_standard_typevars_map, recursively_defined_type_refs, replace_types
+from ._generics import get_standard_typevars_map, has_instance_in_type, recursively_defined_type_refs, replace_types
 from ._schema_generation_shared import (
     CallbackGetCoreSchemaHandler,
 )
@@ -712,6 +712,18 @@ class GenerateSchema:
         )
 
     def _common_field_schema(self, name: str, field_info: FieldInfo, decorators: DecoratorInfos) -> _CommonField:
+        # Update FieldInfo annotation if appropriate:
+        if has_instance_in_type(field_info.annotation, (ForwardRef, str)):
+            types_namespace = self.types_namespace
+            if self.typevars_map:
+                types_namespace = (types_namespace or {}).copy()
+                # Ensure that typevars get mapped to their concrete types:
+                types_namespace.update({k.__name__: v for k, v in self.typevars_map.items()})
+
+            evaluated = _typing_extra.eval_type_lenient(field_info.annotation, types_namespace, None)
+            if evaluated is not field_info.annotation and not has_instance_in_type(evaluated, PydanticRecursiveRef):
+                field_info.annotation = evaluated
+
         source_type, annotations = field_info.annotation, field_info.metadata
 
         def set_discriminator(schema: CoreSchema) -> CoreSchema:

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -284,7 +284,9 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
     if origin_type is typing_extensions.Annotated:
         annotated_type, *annotations = type_args
         annotated = replace_types(annotated_type, type_map)
-        return typing_extensions.Annotated[annotated, *annotations]
+        for annotation in annotations:
+            annotated = typing_extensions.Annotated[annotated, annotation]
+        return annotated
 
     # Having type args is a good indicator that this is a typing module
     # class instantiation or a generic alias of some sort.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -439,6 +439,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         if not force and cls.__pydantic_complete__:
             return None
         else:
+            if '__pydantic_core_schema__' in cls.__dict__:
+                delattr(cls, '__pydantic_core_schema__')  # delete cached value to ensure full rebuild happens
             if _types_namespace is not None:
                 types_namespace: dict[str, Any] | None = _types_namespace.copy()
             else:

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -64,9 +64,7 @@ def test_forward_ref_auto_update_no_model(create_module):
     assert b.model_dump() == {'b': {'a': {'b': {'a': None}}}}
 
     # model_fields is complete on Foo
-    assert repr(module.Foo.model_fields['a']) == (
-        "FieldInfo(annotation=Union[ForwardRef('Bar'), NoneType], required=False)"
-    )
+    assert repr(module.Foo.model_fields['a']) == ('FieldInfo(annotation=Union[Bar, NoneType], required=False)')
 
     assert module.Foo.__pydantic_complete__ is False
     # Foo gets auto-rebuilt during the first attempt at validation
@@ -693,7 +691,7 @@ def test_pep585_recursive_generics(create_module):
 
         Team.model_rebuild()
 
-    assert repr(module.Team.model_fields['heroes']) == "FieldInfo(annotation=list[ForwardRef('Hero')], required=True)"
+    assert repr(module.Team.model_fields['heroes']) == 'FieldInfo(annotation=list[Hero], required=True)'
     assert repr(module.Hero.model_fields['teams']) == 'FieldInfo(annotation=list[Team], required=True)'
 
     h = module.Hero(name='Ivan', teams=[module.Team(name='TheBest', heroes=[])])


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6742

Currently, once you have rebuilt a model, the field annotations aren't updated from the original forward refs; as a result, when you declare subclasses in new modules, the same forward ref gets re-evaluated, even if the original model was rebuilt with a specific annotation in use.

This PR changes things so that the `FieldInfo`s in `cls.model_fields` _do_ get updated to resolve the `ForwardRef`s, ensuring that the resolved fields retain their resolved type even when new subclasses are defined in different modules.

I still need to add a test along the lines of what is described in https://github.com/pydantic/pydantic/issues/6742#issuecomment-1647856883, but I was able to confirm that files written in that way seem to work with these changes. Before I attempt to add such tests though, I was hoping to get confirmation that this approach would be accepted.

Selected Reviewer: @samuelcolvin