### PR TITLE
delegate UUID serialization to pydantic-core

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -373,19 +373,7 @@ def uuid_prepare_pydantic_annotations(
     if source_type is not UUID:
         return None
 
-    schema = core_schema.uuid_schema(
-        # TODO: this shouldn't be necessary, but avoids a UserWarning emitted
-        # when serializing a string
-        serialization=core_schema.to_string_ser_schema(),
-    )
-
-    return (
-        source_type,
-        [
-            InnerSchemaValidator(schema, js_core_schema=core_schema.str_schema(), js_schema_update={'format': 'uuid'}),
-            *annotations,
-        ],
-    )
+    return (source_type, [InnerSchemaValidator(core_schema.uuid_schema()), *annotations])
 
 
 def path_schema_prepare_pydantic_annotations(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -57,7 +57,7 @@ class MyModel(BaseModel):
 @pytest.mark.parametrize(
     'ser_type,gen_value,json_output',
     [
-        (UUID, lambda: 'ebcdab58-6eb8-46fb-a190-d07a33e9eac8', b'"ebcdab58-6eb8-46fb-a190-d07a33e9eac8"'),
+        (UUID, lambda: UUID('ebcdab58-6eb8-46fb-a190-d07a33e9eac8'), b'"ebcdab58-6eb8-46fb-a190-d07a33e9eac8"'),
         (IPv4Address, lambda: '192.168.0.1', b'"192.168.0.1"'),
         (Color, lambda: Color('#000'), b'"black"'),
         (Color, lambda: Color((1, 12, 123)), b'"#010c7b"'),


### PR DESCRIPTION
## Change Summary

Follow up to #6831.

We can simplify the `InnerSchemaValidator` built for UUID to just use `pydantic-core` directly. This has only one observable change according to the tests, which is that the serializer will now raise a warning when not serializing a UUID instance. (Hence the test change.)

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu