### PR TITLE
Update serialization doc to mention `Field.exclude` takes priority over call-time `include/exclude`

### DIFF
--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -636,6 +636,9 @@ The same holds for the `model_dump_json` method.
 In addition to the explicit arguments `exclude` and `include` passed to `model_dump` and `model_dump_json` methods,
 we can also pass the `include`/`exclude` arguments directly to the `Field` constructor:
 
+Setting `exclude` on the field constructor (`Field(..., exclude=True)`) takes priority over the
+`exclude`/`include` on `model_dump` and `model_dump_json`:
+
 ```py
 from pydantic import BaseModel, Field, SecretStr
 
@@ -662,10 +665,11 @@ print(t.model_dump())
 #> {'id': '1234567890'}
 # TODO: this is wrong! not all of "user" should be excluded
 # TODO: do we need to fix the type of the argument to Field? Or do we want to just remove that functionality?
+print(t.model_dump(include={'id': True, 'value': True}))  # (1)!
+#> {'id': '1234567890'}
 ```
 
-Explicitly setting `exclude`/`include` on `model_dump` and `model_dump_json` takes priority over the
-`exclude`/`include` from the field constructor (i.e. `Field(..., exclude=True)`):
+1. `value` excluded from the output because it excluded in `Field`.
 
 Note that while merging settings, `exclude` entries are merged by computing the "union" of keys, while `include`
 entries are merged by computing the "intersection" of keys.


### PR DESCRIPTION
closes https://github.com/pydantic/pydantic/issues/6834

Selected Reviewer: @lig