### PR TITLE
Skip FieldInfo merging when unnecessary

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -380,6 +380,10 @@ class FieldInfo(_repr.Representation):
             flattened_field_infos.extend(x for x in field_info.metadata if isinstance(x, FieldInfo))
             flattened_field_infos.append(field_info)
         field_infos = tuple(flattened_field_infos)
+        if len(field_infos) == 1:
+            # No merging necessary
+            return field_infos[0]
+
         new_kwargs: dict[str, Any] = {}
         metadata = {}
         for field_info in field_infos:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -381,8 +381,12 @@ class FieldInfo(_repr.Representation):
             flattened_field_infos.append(field_info)
         field_infos = tuple(flattened_field_infos)
         if len(field_infos) == 1:
-            # No merging necessary
-            return field_infos[0]
+            # No merging necessary, but we still need to make a copy and apply the overrides
+            field_info = copy(field_infos[0])
+            field_info._attributes_set.update(overrides)
+            for k, v in overrides.items():
+                setattr(field_info, k, v)
+            return field_info
 
         new_kwargs: dict[str, Any] = {}
         metadata = {}


### PR DESCRIPTION
This change makes it so that https://github.com/tiangolo/fastapi/pull/9943 passes all tests.

Basically, the new `FieldInfo` merging logic doesn't necessarily play nice with arbitrary subclasses of `FieldInfo`. This change makes it so that the merging logic is a essentially a no-op when not necessary, resolving the issues with new FastAPI.