### PR TITLE
Update "pipx install" setup commands into two commands on the documentation site

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,7 +66,8 @@ cd pydantic
 # https://pre-commit.com/#install
 # To get pipx itself:
 # https://pypa.github.io/pipx/
-pipx install pdm pre-commit
+pipx install pdm
+pipx install pre-commit
 
 # Install pydantic, dependencies, test dependencies and doc dependencies
 make install


### PR DESCRIPTION
## Change Summary

I was working through the [contributing section](https://docs.pydantic.dev/latest/contributing/) on the docs site and I noticed that if you run the pipx install command exactly as described, it would fail since pipx can't install multiple packages in the same call.  So I ended up breaking it into two pipx install commands.

This was a pretty minor change so I didn't create an issue, but I'm more than happy to if we want to discuss more things there.

I did run through the rest of the stuff on the contributing / setup instructions and everything else looked good. 😄

Thank you!

### Before
```
$ pipx install pdm pre-commit
usage: pipx [-h] [--version]
            {install,uninject,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions} ...
pipx: error: unrecognized arguments: pre-commit
```

### After
```
$ pipx install pdm
  installed package pdm 2.8.0, installed using Python 3.11.4
  These apps are now globally available
    - pdm
done! ✨ 🌟 ✨

$ pipx install pre-commit
  installed package pre-commit 3.3.3, installed using Python 3.11.4
  These apps are now globally available
    - pre-commit
done! ✨ 🌟 ✨
```

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
