### PR TITLE
releasing: add configuration to ignore PRs from changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release


### PR DESCRIPTION
## Change Summary

Add configuration to use an `ignore-for-release` label to exclude PRs from the release notes. Doing this will help us filter the release notes down to those which are relevant to users.

I picked `ignore-for-release` because that's what Github gives in its example at https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations, I had no reason to diverge from the suggested name.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin