### PR TITLE
Re-enable fastapi tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,10 +169,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: install
-        run: |
-          pdm install -G :all
-
       - name: test
         run: make test-fastapi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,7 @@ jobs:
       - test
       - test-memray
       - test-mypy
+      - test-fastapi
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,26 @@ jobs:
         name: coverage
         path: coverage
 
+  test-fastapi:
+    # If some tests start failing due to out-of-date schemas/validation errors/etc.,
+    # update the `tests/test_fastapi.sh` script to exclude tests that have known-acceptable failures.
+    name: test fastapi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: install
+        run: |
+          pdm install -G :all
+
+      - name: test
+        run: make test-fastapi
+
   test-mypy:
     name: mypy ${{ matrix.mypy-version }} / ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,20 +23,3 @@ jobs:
 
     - name: test
       run: make test-pydantic-extra-types
-
-  test-fastapi:
-    name: test fastapi
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
-    - name: install pydantic
-      run: pip install -e .
-
-    - name: test
-      run: make test-fastapi

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,7 @@ test-examples: .pdm
 
 .PHONY: test-fastapi  ## Run the FastAPI tests with this version of pydantic
 test-fastapi:
-	# TODO: Fetch single branch after FastAPI compatible release
-	# git clone https://github.com/tiangolo/fastapi.git --single-branch
-	git clone https://github.com/tiangolo/fastapi.git
+	git clone https://github.com/tiangolo/fastapi.git --single-branch
 	./tests/test_fastapi.sh
 
 .PHONY: test-pydantic-settings  ## Run the pydantic-settings tests with this version of pydantic

--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -6,11 +6,18 @@ set -e
 cd fastapi
 git fetch --tags
 
-# TODO: Use the proper latest tag once FastAPI stable release is compatible with Pydantic V2.
-# latest_tag=$(git describe --tags --abbrev=0)
-# git switch -d "${latest_tag}"
-git switch "main-pv2"
-
 pip install -r requirements.txt
 
-./scripts/test.sh
+# ./scripts/test.sh accepts arbitrary arguments and passes them to the pytest call.
+# This may be necessary if we make low-consequence changes to pydantic, such as minor changes the details of a JSON
+# schema or the contents of a ValidationError
+#
+# To skip a specific test, add '--deselect path/to/test.py::test_name' to the end of this command
+#
+# To update the list of deselected tests, remove all deselections, run the tests, and re-add any remaining failures
+./scripts/test.sh \
+  --deselect tests/test_filter_pydantic_sub_model_pv2.py::test_validator_is_cloned \
+  --deselect tests/test_multi_body_errors.py::test_jsonable_encoder_requiring_error \
+  --deselect tests/test_multi_body_errors.py::test_put_incorrect_body_multiple \
+
+# TODO: Update the deselections after https://github.com/tiangolo/fastapi/pull/9943 is merged

--- a/tests/test_fastapi.sh
+++ b/tests/test_fastapi.sh
@@ -7,6 +7,9 @@ cd fastapi
 git fetch --tags
 
 pip install -r requirements.txt
+# Install the version of pydantic from the current branch, not the released version used by fastapi
+pip uninstall -y pydantic
+cd .. && pip install . && cd fastapi
 
 # ./scripts/test.sh accepts arbitrary arguments and passes them to the pytest call.
 # This may be necessary if we make low-consequence changes to pydantic, such as minor changes the details of a JSON


### PR DESCRIPTION
Hopefully this helps us prevent the kinds of issues that led to us requiring the 2.1.1 release.

Selected Reviewer: @hramezani