### PR TITLE
Simplify handling of typing.Annotated in GenerateSchema

### DIFF
--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1,7 +1,7 @@
 import re
 import sys
 from enum import Enum, IntEnum
-from typing import Generic, Optional, TypeVar, Union
+from typing import Generic, Optional, Sequence, TypeVar, Union
 
 import pytest
 from dirty_equals import HasRepr, IsStr
@@ -1271,3 +1271,66 @@ def test_function_after_discriminator():
             'type': 'union_tag_invalid',
         }
     ]
+
+
+def test_sequence_discriminated_union():
+    class Cat(BaseModel):
+        pet_type: Literal['cat']
+        meows: int
+
+    class Dog(BaseModel):
+        pet_type: Literal['dog']
+        barks: float
+
+    class Lizard(BaseModel):
+        pet_type: Literal['reptile', 'lizard']
+        scales: bool
+
+    Pet = Annotated[Cat | Dog | Lizard, Field(discriminator='pet_type')]
+
+    class Model(BaseModel):
+        pet: Sequence[Pet]
+        n: int
+
+    assert Model.model_json_schema() == {
+        '$defs': {
+            'Cat': {
+                'properties': {
+                    'meows': {'title': 'Meows', 'type': 'integer'},
+                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                },
+                'required': ['pet_type', 'meows'],
+                'title': 'Cat',
+                'type': 'object',
+            },
+            'Dog': {
+                'properties': {
+                    'barks': {'title': 'Barks', 'type': 'number'},
+                    'pet_type': {'const': 'dog', 'title': 'Pet Type'},
+                },
+                'required': ['pet_type', 'barks'],
+                'title': 'Dog',
+                'type': 'object',
+            },
+            'Lizard': {
+                'properties': {
+                    'pet_type': {'enum': ['reptile', 'lizard'], 'title': 'Pet Type', 'type': 'string'},
+                    'scales': {'title': 'Scales', 'type': 'boolean'},
+                },
+                'required': ['pet_type', 'scales'],
+                'title': 'Lizard',
+                'type': 'object',
+            },
+        },
+        'properties': {
+            'n': {'title': 'N', 'type': 'integer'},
+            'pet': {
+                'items': {'anyOf': [{'$ref': '#/$defs/Cat'}, {'$ref': '#/$defs/Dog'}, {'$ref': '#/$defs/Lizard'}]},
+                'title': 'Pet',
+                'type': 'array',
+            },
+        },
+        'required': ['pet', 'n'],
+        'title': 'Model',
+        'type': 'object',
+    }

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1286,7 +1286,7 @@ def test_sequence_discriminated_union():
         pet_type: Literal['reptile', 'lizard']
         scales: bool
 
-    Pet = Annotated[Cat | Dog | Lizard, Field(discriminator='pet_type')]
+    Pet = Annotated[Union[Cat, Dog, Lizard], Field(discriminator='pet_type')]
 
     class Model(BaseModel):
         pet: Sequence[Pet]


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6884

@adriangb It seems to me some of the cruft removed in this PR might have been left around from previous fiddling that has been rendered unnecessary. But if you see issues with this we can revert some of the other changes; I'll note that an alternative diff that also closes #6884 is just:

```diff
diff --git a/pydantic/_internal/_generate_schema.py b/pydantic/_internal/_generate_schema.py
index 4b4289ac..2b2de757 100644
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1222,7 +1222,7 @@ class GenerateSchema:
         item_type = self._get_first_arg_or_any(sequence_type)
 
         def json_schema_func(_schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            items_schema = self._generate_schema(item_type)
+            items_schema = self.generate_schema(item_type)
             return handler(core_schema.list_schema(items_schema))
 
         metadata = build_metadata_dict(js_functions=[json_schema_func])
```

But looking into the code, it seemed to me this was a "safer" solution. But I think you know this code best at this point.