### PR TITLE
[FIX] model validation for instances of BaseModel with `from_attributes=True`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -493,9 +493,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
         # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
         __tracebackhide__ = True
-        return cls.__pydantic_validator__.validate_python(
-            obj, strict=strict, from_attributes=from_attributes, context=context
-        )
+        kwargs = {'strict': strict, 'from_attributes': from_attributes, 'context': context}
+        if from_attributes and isinstance(obj, BaseModel):
+            kwargs['self_instance'] = obj
+        return cls.__pydantic_validator__.validate_python(obj, **kwargs)
 
     @classmethod
     def model_validate_json(

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -205,7 +205,10 @@ class TypeAdapter(Generic[T]):
         Returns:
             The validated object.
         """
-        return self.validator.validate_python(__object, strict=strict, from_attributes=from_attributes, context=context)
+        kwargs = {'strict': strict, 'from_attributes': from_attributes, 'context': context}
+        if from_attributes and isinstance(__object, BaseModel):
+            kwargs['self_instance'] = __object
+        return self.validator.validate_python(__object, **kwargs)
 
     def validate_json(
         self, __data: str | bytes, *, strict: bool | None = None, context: dict[str, Any] | None = None

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -4,7 +4,33 @@ from typing import Any, Dict, Union, cast
 
 import pytest
 
-from pydantic import BaseModel, ValidationInfo, ValidatorFunctionWrapHandler, model_validator
+from pydantic import BaseModel, ValidationError, ValidationInfo, ValidatorFunctionWrapHandler, model_validator
+
+
+def test_model_instantiate_validate() -> None:
+    class Model(BaseModel):
+        x: str
+
+    with pytest.raises(ValidationError) as exc_info:
+        # Missing required field
+        Model()
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'missing', 'loc': ('x',), 'msg': 'Field required', 'input': {}}
+    ]
+
+
+def test_model_construct_validate() -> None:
+    class Model(BaseModel):
+        x: str
+
+    obj = Model.model_construct()
+
+    with pytest.raises(ValidationError) as exc_info:
+        # Missing required field
+        obj.model_validate(obj, from_attributes=True)
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'missing', 'loc': ('x',), 'msg': 'Field required', 'input': obj}
+    ]
 
 
 def test_model_validator_wrap() -> None:

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -98,6 +98,26 @@ def test_type_alias():
     assert res == [1, '2']
 
 
+def test_validate_missing_value() -> None:
+    class Model(BaseModel):
+        x: int
+
+    validator = TypeAdapter(Model)
+
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_python({})
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'missing', 'loc': ('x',), 'msg': 'Field required', 'input': {}}
+    ]
+
+    m = Model.model_construct()
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_python(m, from_attributes=True)
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'missing', 'loc': ('x',), 'msg': 'Field required', 'input': m}
+    ]
+
+
 def test_validate_python_strict() -> None:
     class Model(TypedDict):
         x: int


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Validating a Pydantic model directly using the model object does not work as expected when object is an instance of BaseModel and `from_attributes = True`

## Related issue number

fix #6901 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
