### PR TITLE
Correct incomplete signature of pydantic dataclass

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ vulnerability, please see our [security policy](https://github.com/pydantic/pyda
 To make it as simple as possible for us to help you, please include the output of the following call in your issue:
 
 ```bash
-python -c "import pydantic.utils; print(pydantic.utils.version_info())"
+python -c "import pydantic.version; print(pydantic.version.version_info())"
 ```
 If you're using Pydantic prior to **v1.3** (when `version_info()` was added), please manually include OS, Python
 version and pydantic version.

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -210,8 +210,8 @@ def generate_dataclass_signature(cls: type[StandardDataclass]) -> Signature:
                 name = param_default.validation_alias
 
             # Replace the field default
-            default = param_default.default
-            if default is PydanticUndefined:
+            default = param_default
+            if param_default.default is PydanticUndefined:
                 if param_default.default_factory is PydanticUndefined:
                     default = inspect.Signature.empty
                 else:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2428,7 +2428,7 @@ def test_metadata():
 
 def test_signature():
     @pydantic.dataclasses.dataclass
-    class Model:
+    class Model1:
         x: int
         y: str = 'y'
         z: float = dataclasses.field(default=1.0)
@@ -2436,8 +2436,8 @@ def test_signature():
         b: float = Field(default=1.0)
         c: float = Field(default_factory=float)
 
-    assert str(inspect.signature(Model)) == (
-        "(x: int, y: str = 'y', z: float = 1.0, a: float = <factory>, b: float = 1.0, c: float = <factory>) -> None"
+    assert str(inspect.signature(Model1)) == (
+        "(x: int, y: str = 'y', z: float = 1.0, a: float = <factory>, b: float = FieldInfo(annotation=float, required=False, default=1.0), c: float = <factory>) -> None"
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixed Pydantic dataclass signature which has `FieldInfo` in its fields correctly.
Previously(Before this PR), the `FieldInfo` signature was set as the default value for `FieldInfo`.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Close: #6907 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin