### PR TITLE
Use `get_type_hints` shim in 3.10.0 (we need bpo-45166)

### DIFF
--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -276,7 +276,7 @@ else:
     _make_forward_ref = typing.ForwardRef
 
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10, 1):
     get_type_hints = typing.get_type_hints
 
 else:


### PR DESCRIPTION
Fixes #6912.
