### PR TITLE
Fix `ForwardRef` wrapper for py 3.10.0 (shim until bpo-45166)

### DIFF
--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -253,7 +253,7 @@ def get_function_type_hints(
     return type_hints
 
 
-if sys.version_info < (3, 9, 8):
+if sys.version_info < (3, 9, 8) or (3, 10) <= sys.version_info < (3, 10, 1):
 
     def _make_forward_ref(
         arg: Any,
@@ -262,11 +262,13 @@ if sys.version_info < (3, 9, 8):
         is_class: bool = False,
     ) -> typing.ForwardRef:
         """Wrapper for ForwardRef that accounts for the `is_class` argument missing in older versions.
-        The `module` argument is omitted as it breaks <3.9.8 and isn't used in the calls below.
+        The `module` argument is omitted as it breaks <3.9.8, =3.10.0 and isn't used in the calls below.
 
         See https://github.com/python/cpython/pull/28560 for some background.
         The backport happened on 3.9.8, see:
-        https://github.com/pydantic/pydantic/discussions/6244#discussioncomment-6275458.
+        https://github.com/pydantic/pydantic/discussions/6244#discussioncomment-6275458,
+        and on 3.10.1 for the 3.10 branch, see:
+        https://github.com/pydantic/pydantic/issues/6912
 
         Implemented as EAFP with memory.
         """


### PR DESCRIPTION
Fixes #6912.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Extend a fix described [here](https://github.com/pydantic/pydantic/discussions/6244) for Python 3.9 branch to Python 3.10 branch. 3.10.1 is the first version in the 3.10 branch to include the `get_type_hints` fix [bpo-45166](https://github.com/python/cpython/pull/28561).

## Related issue number

Fixes #6912.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb