### PR TITLE
Update pip commands to install 1.10

### DIFF
--- a/changes/6930-chbndrhnns.md
+++ b/changes/6930-chbndrhnns.md
@@ -1,0 +1,1 @@
+Docs: Fix pip commands to install v1

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,7 +33,7 @@ To make contributing as easy and fast as possible, you'll want to run tests and 
 *pydantic* has few dependencies, doesn't require compiling and tests don't need access to databases, etc.
 Because of this, setting up and running the tests should be very simple.
 
-You'll need to have a version between **Python 3.7 and 3.11**, **virtualenv**, **git**, and **make** installed.
+You'll need to have a version between **Python 3.7 and 3.11**, **virtualenv**, **git**, **pdm** and **make** installed.
 
 ```bash
 # 1. clone your fork and cd into the repo directory

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 Installation is as simple as:
 
 ```bash
-pip install pydantic
+pip install 'pydantic<2'
 ```
 
 *pydantic* has no required dependencies except Python 3.7, 3.8, 3.9, 3.10 or 3.11 and
@@ -12,7 +12,7 @@ Pydantic is also available on [conda](https://www.anaconda.com) under the [conda
 channel:
 
 ```bash
-conda install pydantic -c conda-forge
+conda install 'pydantic<2' -c conda-forge
 ```
 
 ## Compiled with Cython
@@ -36,7 +36,7 @@ print('compiled:', pydantic.compiled)
 Compiled binaries can increase the size of your Python environment. If for some reason you want to reduce the size of your *pydantic* installation you can avoid installing any binaries using the [`pip --no-binary`](https://pip.pypa.io/en/stable/cli/pip_install/#install-no-binary) option. Make sure `Cython` is not in your environment, or that you have the `SKIP_CYTHON` environment variable set to avoid re-compiling *pydantic* libraries:
 
 ```bash
-SKIP_CYTHON=1 pip install --no-binary pydantic pydantic
+SKIP_CYTHON=1 pip install --no-binary pydantic pydantic<2
 ```
 !!! note
     `pydantic` is repeated here intentionally, `--no-binary pydantic` tells `pip` you want no binaries for pydantic,
@@ -47,7 +47,7 @@ Alternatively, you can re-compile *pydantic* with custom [build options](https:/
 CFLAGS="-Os -g0 -s" pip install \
   --no-binary pydantic \
   --global-option=build_ext \
-  pydantic
+  pydantic<2
 ```
 
 ## Optional dependencies
@@ -60,11 +60,11 @@ CFLAGS="-Os -g0 -s" pip install \
 
 To install these along with *pydantic*:
 ```bash
-pip install pydantic[email]
+pip install 'pydantic[email]<2'
 # or
-pip install pydantic[dotenv]
+pip install 'pydantic[dotenv]<2'
 # or just
-pip install pydantic[email,dotenv]
+pip install 'pydantic[email,dotenv]<2'
 ```
 
 Of course, you can also install these requirements manually with `pip install email-validator` and/or `pip install python-dotenv`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,7 +74,7 @@ Of course, you can also install these requirements manually with `pip install em
 
 And if you prefer to install *pydantic* directly from the repository:
 ```bash
-pip install git+git://github.com/pydantic/pydantic@main#egg=pydantic
+pip install git+https://github.com/pydantic/pydantic@main#egg=pydantic
 # or with extras
-pip install git+git://github.com/pydantic/pydantic@main#egg=pydantic[email,dotenv]
+pip install git+https;://github.com/pydantic/pydantic@main#egg=pydantic[email,dotenv]
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,7 +74,7 @@ Of course, you can also install these requirements manually with `pip install em
 
 And if you prefer to install *pydantic* directly from the repository:
 ```bash
-pip install git+https://github.com/pydantic/pydantic@main#egg=pydantic
+pip install git+https://github.com/pydantic/pydantic@1.10.X-fixes#egg=pydantic
 # or with extras
-pip install git+https;://github.com/pydantic/pydantic@main#egg=pydantic[email,dotenv]
+pip install git+https;://github.com/pydantic/pydantic@1.10.X-fixes#egg=pydantic[email,dotenv]
 ```


### PR DESCRIPTION
## Change Summary

The installation instructions are incomplete for v1:
- the pip command installs v2
- pdm is not mentioned as a dependency
- the links to the Github repo should be `git+https`, not `git+git`


## Related issue number

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani