### PR TITLE
Remove xfail for discriminated union with alias

### DIFF
--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -3893,7 +3893,6 @@ def test_discriminated_annotated_union_literal_enum():
     }
 
 
-@pytest.mark.xfail(reason='json schema generation for tagged unions is fundamentally incompatible with references')
 def test_alias_same():
     class Cat(BaseModel):
         pet_type: Literal['cat'] = Field(alias='typeOfPet')
@@ -3934,7 +3933,7 @@ def test_alias_same():
             'pet': {
                 'oneOf': [{'$ref': '#/$defs/Cat'}, {'$ref': '#/$defs/Dog'}],
                 'title': 'Pet',
-                'discriminator': 'something',
+                'discriminator': {'mapping': {'cat': '#/$defs/Cat', 'dog': '#/$defs/Dog'}, 'propertyName': 'typeOfPet'},
             },
         },
         'required': ['pet', 'number'],


### PR DESCRIPTION
@adriangb I think you were the one that made this test xfail before. I'm thinking it got updated but just not .. fully updated, and it seems to be behaving as desired now, so I figured I'd just fix it up and drop the xfail. But if I'm missing something and this is actually misbehaving, we can leave it alone.