### PR TITLE
Clarify validate_default and _Unset handling in usage docs and migration guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -238,6 +238,10 @@ See [Model Config](usage/model_config.md) for more details.
         for the annotated type will _also_ be applied even to defaults, not just the custom validators. For
         example, despite the fact that the validator below will never error, the following code raises a `ValidationError`:
 
+!!! note
+    To avoid this, you can use the `validate_default` argument in the `Field` function. When set to `True`, it mimics the behavior of `always=True` in pydantic v1. However, the new way of using `validate_default` is encouraged as it provides more flexibility and control.
+
+
 ```python test="skip"
 from pydantic import BaseModel, validator
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -239,7 +239,7 @@ See [Model Config](usage/model_config.md) for more details.
         example, despite the fact that the validator below will never error, the following code raises a `ValidationError`:
 
 !!! note
-    To avoid this, you can use the `validate_default` argument in the `Field` function. When set to `True`, it mimics the behavior of `always=True` in pydantic v1. However, the new way of using `validate_default` is encouraged as it provides more flexibility and control.
+    To avoid this, you can use the `validate_default` argument in the `Field` function. When set to `True`, it mimics the behavior of `always=True` in Pydantic v1. However, the new way of using `validate_default` is encouraged as it provides more flexibility and control.
 
 
 ```python test="skip"

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -266,7 +266,7 @@ print(context['logs'])
 
 Validators won't run when the default value is used.
 This applies both to `@field_validator` validators and `Annotated` validators.
-You can force them to run with `Field(validate_defaults=True)`. Setting `validate_default` to `True` has the closest behavior to using `always=True` in `validator` in pydantic v1. However, you are generally better off using a `@model_validator(mode='before')` where the function is called before the inner validator is called.
+You can force them to run with `Field(validate_defaults=True)`. Setting `validate_default` to `True` has the closest behavior to using `always=True` in `validator` in Pydantic v1. However, you are generally better off using a `@model_validator(mode='before')` where the function is called before the inner validator is called.
 
 
 ```py

--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -266,7 +266,8 @@ print(context['logs'])
 
 Validators won't run when the default value is used.
 This applies both to `@field_validator` validators and `Annotated` validators.
-You can force them to run with `Field(validate_defaults=True)`, but you are generally better off using a `@model_validator(mode='before')`.
+You can force them to run with `Field(validate_defaults=True)`. Setting `validate_default` to `True` has the closest behavior to using `always=True` in `validator` in pydantic v1. However, you are generally better off using a `@model_validator(mode='before')` where the function is called before the inner validator is called.
+
 
 ```py
 from typing_extensions import Annotated

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -701,6 +701,9 @@ def Field(  # noqa: C901
     Used to provide extra information about a field, either for the model schema or complex validation. Some arguments
     apply only to number fields (`int`, `float`, `Decimal`) and some apply only to `str`.
 
+    Note:
+        - Any `_Unset` objects will be replaced by the corresponding value defined in the `_DefaultValues` dictionary. If a key for the `_Unset` object is not found in the `_DefaultValues` dictionary, it will default to `None`
+
     Args:
         default: Default value if the field is not set.
         default_factory: A callable to generate the default value, such as :func:`~datetime.utcnow`.
@@ -717,7 +720,7 @@ def Field(  # noqa: C901
         discriminator: Field name for discriminating the type in a tagged union.
         json_schema_extra: Any additional JSON schema data for the schema property.
         frozen: Whether the field is frozen.
-        validate_default: Run validation that isn't only checking existence of defaults. `True` by default.
+        validate_default: Run validation that isn't only checking existence of defaults. This can be set to `True` or `False`. If not set, it defaults to `None`.
         repr: A boolean indicating whether to include the field in the `__repr__` output.
         init_var: Whether the field should be included in the constructor of the dataclass.
         kw_only: Whether the field should be a keyword-only argument in the constructor of the dataclass.


### PR DESCRIPTION
## Change Summary
Clarify 'validate_default' and '_Unset' handling in usage docs and migration guide.

## Description:
This PR aims to improve the clarity and understanding of Pydantic v2 documentation in the following ways:

- `validate_default` default value clarification: The documentation for the `validate_default` parameter in the Field function is updated to specify that its default value is `None`.
- `Validator` usage: The documentation about the usage of validators, specifically with the default values, is updated. Added emphasis on how to mimic the `always=True` behavior from Pydantic v1 using `validate_default=True`. In migration guide: The migration guide is updated to include information about the `validate_default` parameter for that migrating from Pydantic v1 to v2.
- Explain the handling of `_Unset` objects: Added a note to the documentation to clarify that `_Unset` objects will be replaced by the corresponding value defined in the `_DefaultValues` dictionary or default to None if no specific value is provided.

These updates aim to make it easier for users to understand the changes in Pydantic v2 and how to effectively use the Field function and validators.

## Related issue number
fix #6812 


## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu