### PR TITLE
Handle constraints being applied to schemas that don't accept it

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1516,11 +1516,6 @@ class GenerateSchema:
         # expand annotations before we start processing them so that `__prepare_pydantic_annotations` can consume
         # individual items from GroupedMetadata
         annotations = list(_known_annotated_metadata.expand_grouped_metadata(annotations))
-        non_field_infos, field_infos = [a for a in annotations if not isinstance(a, FieldInfo)], [
-            a for a in annotations if isinstance(a, FieldInfo)
-        ]
-        if field_infos:
-            annotations = [*non_field_infos, FieldInfo.merge_field_infos(*field_infos)]
         idx = -1
         prepare = getattr(source_type, '__prepare_pydantic_annotations__', None)
         if prepare:

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from collections import defaultdict
 from copy import copy
 from functools import partial
 from typing import Any, Iterable
@@ -17,7 +18,7 @@ SEQUENCE_CONSTRAINTS = {'min_length', 'max_length'}
 INEQUALITY = {'le', 'ge', 'lt', 'gt'}
 NUMERIC_CONSTRAINTS = {'multiple_of', 'allow_inf_nan', *INEQUALITY}
 
-STR_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT, 'strip_whitespace', 'to_lower', 'to_upper'}
+STR_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT, 'strip_whitespace', 'to_lower', 'to_upper', 'pattern'}
 BYTES_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
 
 LIST_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
@@ -28,14 +29,56 @@ GENERATOR_CONSTRAINTS = {*SEQUENCE_CONSTRAINTS, *STRICT}
 
 FLOAT_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
 INT_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
+BOOL_CONSTRAINTS = STRICT
 
 DATE_TIME_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
 TIMEDELTA_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
 TIME_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *STRICT}
 
+URL_CONSTRAINTS = {
+    'max_length',
+    'allowed_schemes',
+    'host_required',
+    'default_host',
+    'default_port',
+    'default_path',
+}
+
 TEXT_SCHEMA_TYPES = ('str', 'bytes', 'url', 'multi-host-url')
 SEQUENCE_SCHEMA_TYPES = ('list', 'tuple', 'set', 'frozenset', 'generator', *TEXT_SCHEMA_TYPES)
 NUMERIC_SCHEMA_TYPES = ('float', 'int', 'date', 'time', 'timedelta', 'datetime')
+
+CONSTRAINTS_TO_ALLOWED_SCHEMAS: dict[str, set[str]] = defaultdict(set)
+for constraint in STR_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(TEXT_SCHEMA_TYPES)
+for constraint in BYTES_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('bytes',))
+for constraint in LIST_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('list',))
+for constraint in TUPLE_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('tuple',))
+for constraint in SET_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('set', 'frozenset'))
+for constraint in DICT_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('dict',))
+for constraint in GENERATOR_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('generator',))
+for constraint in FLOAT_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('float',))
+for constraint in INT_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('int',))
+for constraint in DATE_TIME_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('date', 'time', 'datetime'))
+for constraint in TIMEDELTA_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('timedelta',))
+for constraint in TIME_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('time',))
+for schema_type in (*TEXT_SCHEMA_TYPES, *SEQUENCE_SCHEMA_TYPES, NUMERIC_SCHEMA_TYPES):
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS['strict'].update(schema_type)
+for constraint in URL_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('url', 'multi-host-url'))
+for constraint in BOOL_CONSTRAINTS:
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('bool',))
 
 
 def expand_grouped_metadata(annotations: Iterable[Any]) -> Iterable[Any]:
@@ -96,82 +139,150 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         PydanticCustomError: If `Predicate` fails.
     """
     schema = schema.copy()
-    schema_update, _ = collect_known_metadata([annotation])
-    if isinstance(annotation, at.Gt):
-        if schema['type'] in NUMERIC_SCHEMA_TYPES:
-            schema.update(schema_update)  # type: ignore
-        else:
+    schema_update, other_metadata = collect_known_metadata([annotation])
+    schema_type = schema['type']
+    for constraint, value in schema_update.items():
+        if constraint not in CONSTRAINTS_TO_ALLOWED_SCHEMAS:
+            raise ValueError(f'Unknown constraint {constraint}')
+        allowed_schemas = CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint]
+
+        if schema_type in allowed_schemas:
+            schema[constraint] = value
+            continue
+
+        if constraint == 'allow_inf_nan' and value is False:
             return cs.no_info_after_validator_function(
-                partial(_validators.greater_than_validator, gt=annotation.gt),
+                _validators.forbid_inf_nan_check,
                 schema,
             )
-    elif isinstance(annotation, at.Ge):
-        if schema['type'] in NUMERIC_SCHEMA_TYPES:
-            schema.update(schema_update)  # type: ignore
-        else:
+        elif constraint == 'pattern':
+            # insert a str schema to make sure the regex engine matches
+            return cs.chain_schema(
+                [
+                    schema,
+                    cs.str_schema(pattern=value),
+                ]
+            )
+        elif constraint == 'gt':
             return cs.no_info_after_validator_function(
-                partial(_validators.greater_than_or_equal_validator, ge=annotation.ge),
+                partial(_validators.greater_than_validator, gt=value),
                 schema,
             )
-    elif isinstance(annotation, at.Lt):
-        if schema['type'] in NUMERIC_SCHEMA_TYPES:
-            schema.update(schema_update)  # type: ignore
-        else:
+        elif constraint == 'ge':
             return cs.no_info_after_validator_function(
-                partial(_validators.less_than_validator, lt=annotation.lt),
+                partial(_validators.greater_than_or_equal_validator, ge=value),
                 schema,
             )
-    elif isinstance(annotation, at.Le):
-        if schema['type'] in NUMERIC_SCHEMA_TYPES:
-            schema.update(schema_update)  # type: ignore
-        else:
+        elif constraint == 'lt':
             return cs.no_info_after_validator_function(
-                partial(_validators.less_than_or_equal_validator, le=annotation.le),
+                partial(_validators.less_than_validator, lt=value),
                 schema,
             )
-    elif isinstance(annotation, at.MultipleOf):
-        if schema['type'] in NUMERIC_SCHEMA_TYPES:
-            schema.update(schema_update)  # type: ignore
-        else:
+        elif constraint == 'le':
             return cs.no_info_after_validator_function(
-                partial(_validators.multiple_of_validator, multiple_of=annotation.multiple_of),
+                partial(_validators.less_than_or_equal_validator, le=value),
                 schema,
             )
-    elif isinstance(annotation, at.MinLen):
-        if schema['type'] in SEQUENCE_SCHEMA_TYPES:
-            schema.update(schema_update)  # type: ignore
-        else:
+        elif constraint == 'multiple_of':
+            return cs.no_info_after_validator_function(
+                partial(_validators.multiple_of_validator, multiple_of=value),
+                schema,
+            )
+        elif constraint == 'min_length':
+            return cs.no_info_after_validator_function(
+                partial(_validators.min_length_validator, min_length=value),
+                schema,
+            )
+        elif constraint == 'max_length':
+            return cs.no_info_after_validator_function(
+                partial(_validators.max_length_validator, max_length=value),
+                schema,
+            )
+        elif constraint == 'strip_whitespace':
+            return cs.chain_schema(
+                [
+                    schema,
+                    cs.str_schema(strip_whitespace=True),
+                ]
+            )
+        elif constraint == 'to_lower':
+            return cs.chain_schema(
+                [
+                    schema,
+                    cs.str_schema(to_lower=True),
+                ]
+            )
+        elif constraint == 'to_upper':
+            return cs.chain_schema(
+                [
+                    schema,
+                    cs.str_schema(to_upper=True),
+                ]
+            )
+        elif constraint == 'min_length':
             return cs.no_info_after_validator_function(
                 partial(_validators.min_length_validator, min_length=annotation.min_length),
                 schema,
             )
-    elif isinstance(annotation, at.MaxLen):
-        if schema['type'] in SEQUENCE_SCHEMA_TYPES:
-            schema.update(schema_update)  # type: ignore
-        else:
+        elif constraint == 'max_length':
             return cs.no_info_after_validator_function(
                 partial(_validators.max_length_validator, max_length=annotation.max_length),
                 schema,
             )
-    elif isinstance(annotation, at.Predicate):
-        predicate_name = f'{annotation.func.__qualname__} ' if hasattr(annotation.func, '__qualname__') else ''
+        else:
+            raise RuntimeError(f'Unable to apply constraint {constraint} to schema {schema_type}')
 
-        def val_func(v: Any) -> Any:
-            # annotation.func may also raise an exception, let it pass through
-            if not annotation.func(v):
-                raise PydanticCustomError(
-                    'predicate_failed',
-                    f'Predicate {predicate_name}failed',  # type: ignore
-                    {},
-                )
-            return v
+    for annotation in other_metadata:
+        if isinstance(annotation, at.Gt):
+            return cs.no_info_after_validator_function(
+                partial(_validators.greater_than_validator, gt=annotation.gt),
+                schema,
+            )
+        elif isinstance(annotation, at.Ge):
+            return cs.no_info_after_validator_function(
+                partial(_validators.greater_than_or_equal_validator, ge=annotation.ge),
+                schema,
+            )
+        elif isinstance(annotation, at.Lt):
+            return cs.no_info_after_validator_function(
+                partial(_validators.less_than_validator, lt=annotation.lt),
+                schema,
+            )
+        elif isinstance(annotation, at.Le):
+            return cs.no_info_after_validator_function(
+                partial(_validators.less_than_or_equal_validator, le=annotation.le),
+                schema,
+            )
+        elif isinstance(annotation, at.MultipleOf):
+            return cs.no_info_after_validator_function(
+                partial(_validators.multiple_of_validator, multiple_of=annotation.multiple_of),
+                schema,
+            )
+        elif isinstance(annotation, at.MinLen):
+            return cs.no_info_after_validator_function(
+                partial(_validators.min_length_validator, min_length=annotation.min_length),
+                schema,
+            )
+        elif isinstance(annotation, at.MaxLen):
+            return cs.no_info_after_validator_function(
+                partial(_validators.max_length_validator, max_length=annotation.max_length),
+                schema,
+            )
+        elif isinstance(annotation, at.Predicate):
+            predicate_name = f'{annotation.func.__qualname__} ' if hasattr(annotation.func, '__qualname__') else ''
 
-        return cs.no_info_after_validator_function(val_func, schema)
-    elif schema_update:
-        # for all other annotations just update the schema
-        # this includes things like `strict` which apply to pretty much every schema
-        schema.update(schema_update)  # type: ignore
-    else:
+            def val_func(v: Any) -> Any:
+                # annotation.func may also raise an exception, let it pass through
+                if not annotation.func(v):
+                    raise PydanticCustomError(
+                        'predicate_failed',
+                        f'Predicate {predicate_name}failed',  # type: ignore
+                        {},
+                    )
+                return v
+
+            return cs.no_info_after_validator_function(val_func, schema)
+        # ignore any other unknown metadata
         return None
 
     return schema

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -276,7 +276,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
                 if not annotation.func(v):
                     raise PydanticCustomError(
                         'predicate_failed',
-                        f'Predicate {predicate_name} failed',  # type: ignore
+                        f'Predicate {predicate_name}failed',  # type: ignore
                     )
                 return v
 

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -277,7 +277,6 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
                     raise PydanticCustomError(
                         'predicate_failed',
                         f'Predicate {predicate_name} failed',  # type: ignore
-                        {},
                     )
                 return v
 

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -276,7 +276,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
                 if not annotation.func(v):
                     raise PydanticCustomError(
                         'predicate_failed',
-                        f'Predicate {predicate_name}failed',  # type: ignore
+                        f'Predicate {predicate_name} failed',  # type: ignore
                         {},
                     )
                 return v

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -73,8 +73,8 @@ for constraint in TIMEDELTA_CONSTRAINTS:
     CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('timedelta',))
 for constraint in TIME_CONSTRAINTS:
     CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('time',))
-for schema_type in (*TEXT_SCHEMA_TYPES, *SEQUENCE_SCHEMA_TYPES, NUMERIC_SCHEMA_TYPES):
-    CONSTRAINTS_TO_ALLOWED_SCHEMAS['strict'].update(schema_type)
+for schema_type in (*TEXT_SCHEMA_TYPES, *SEQUENCE_SCHEMA_TYPES, *NUMERIC_SCHEMA_TYPES, 'typed-dict', 'model'):
+    CONSTRAINTS_TO_ALLOWED_SCHEMAS['strict'].add(schema_type)
 for constraint in URL_CONSTRAINTS:
     CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint].update(('url', 'multi-host-url'))
 for constraint in BOOL_CONSTRAINTS:
@@ -317,7 +317,9 @@ def collect_known_metadata(annotations: Iterable[Any]) -> tuple[dict[str, Any], 
         # But it seems dangerous!
         if isinstance(annotation, PydanticGeneralMetadata):
             res.update(annotation.__dict__)
-        elif isinstance(annotation, (at.BaseMetadata, PydanticMetadata)):
+        elif isinstance(annotation, PydanticMetadata):
+            res.update(dataclasses.asdict(annotation))  # type: ignore[call-overload]
+        elif isinstance(annotation, (at.MinLen, at.MaxLen, at.Gt, at.Ge, at.Lt, at.Le, at.MultipleOf)):
             res.update(dataclasses.asdict(annotation))  # type: ignore[call-overload]
         elif isinstance(annotation, type) and issubclass(annotation, PydanticMetadata):
             # also support PydanticMetadata classes being used without initialisation,

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -5,6 +5,7 @@ Import of this module is deferred since it contains imports of many standard lib
 
 from __future__ import annotations as _annotations
 
+import math
 import re
 import typing
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
@@ -267,5 +268,14 @@ def max_length_validator(x: Any, max_length: Any) -> Any:
         raise PydanticKnownError(
             'too_long',
             {'field_type': 'Value', 'max_length': max_length, 'actual_length': len(x)},
+        )
+    return x
+
+
+def forbid_inf_nan_check(x: Any) -> Any:
+    if not math.isfinite(x):
+        raise PydanticKnownError(
+            'finite_number',
+            {},
         )
     return x

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -274,8 +274,5 @@ def max_length_validator(x: Any, max_length: Any) -> Any:
 
 def forbid_inf_nan_check(x: Any) -> Any:
     if not math.isfinite(x):
-        raise PydanticKnownError(
-            'finite_number',
-            {},
-        )
+        raise PydanticKnownError('finite_number')
     return x

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -285,7 +285,13 @@ class FieldInfo(_repr.Representation):
                 new_field_info = copy(field_info)
                 new_field_info.annotation = first_arg
                 new_field_info.frozen = final or field_info.frozen
-                new_field_info.metadata += [a for a in extra_args if not isinstance(a, FieldInfo)]
+                metadata: list[Any] = []
+                for a in extra_args:
+                    if not isinstance(a, FieldInfo):
+                        metadata.append(a)
+                    else:
+                        metadata.extend(a.metadata)
+                new_field_info.metadata = metadata
                 return new_field_info
 
         return cls(annotation=annotation, frozen=final or None)
@@ -356,7 +362,7 @@ class FieldInfo(_repr.Representation):
                 first_arg, *extra_args = typing_extensions.get_args(annotation)
                 field_infos = [a for a in extra_args if isinstance(a, FieldInfo)]
                 field_info = cls.merge_field_infos(*field_infos, annotation=first_arg, default=default)
-                field_info.metadata += [a for a in extra_args if not isinstance(a, FieldInfo)]
+                field_info.metadata = list(extra_args)
                 return field_info
 
             return cls(annotation=annotation, default=default, frozen=final or None)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -362,7 +362,13 @@ class FieldInfo(_repr.Representation):
                 first_arg, *extra_args = typing_extensions.get_args(annotation)
                 field_infos = [a for a in extra_args if isinstance(a, FieldInfo)]
                 field_info = cls.merge_field_infos(*field_infos, annotation=first_arg, default=default)
-                field_info.metadata = list(extra_args)
+                metadata: list[Any] = []
+                for a in extra_args:
+                    if not isinstance(a, FieldInfo):
+                        metadata.append(a)
+                    else:
+                        metadata.extend(a.metadata)
+                field_info.metadata = metadata
                 return field_info
 
             return cls(annotation=annotation, default=default, frozen=final or None)

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -165,9 +165,8 @@ def test_annotated_alias() -> None:
         e: Nested
 
     fields_repr = {k: repr(v) for k, v in MyModel.model_fields.items()}
-    # insert_assert(fields_repr)
     assert fields_repr == {
-        'a': "FieldInfo(annotation=str, required=False, default='abc', metadata=[FieldInfo(annotation=NoneType, required=True, metadata=[MaxLen(max_length=3)])])",
+        'a': "FieldInfo(annotation=str, required=False, default='abc', metadata=[MaxLen(max_length=3)])",
         'b': 'FieldInfo(annotation=str, required=True, metadata=[MaxLen(max_length=3)])',
         'c': 'FieldInfo(annotation=int, required=False, default_factory=<lambda>)',
         'd': 'FieldInfo(annotation=int, required=False, default_factory=<lambda>)',

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -371,6 +371,5 @@ def test_predicate_error_python() -> None:
             'loc': (),
             'msg': 'Predicate test_predicate_error_python.<locals>.<lambda> failed',
             'input': -1,
-            'ctx': {},
         }
     ]

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -24,7 +24,7 @@ NO_VALUE = object()
         (
             lambda: Annotated[int, Field(gt=0)],
             5,
-            'FieldInfo(annotation=int, required=False, default=5, metadata=[FieldInfo(annotation=NoneType, required=True, metadata=[Gt(gt=0)])])',
+            'FieldInfo(annotation=int, required=False, default=5, metadata=[Gt(gt=0)])',
         ),
         (
             lambda: int,
@@ -64,7 +64,7 @@ NO_VALUE = object()
         (
             lambda: Annotated[int, Field(gt=0), Lt(2)],
             5,
-            'FieldInfo(annotation=int, required=False, default=5, metadata=[FieldInfo(annotation=NoneType, required=True, metadata=[Gt(gt=0)]), Lt(lt=2)])',
+            'FieldInfo(annotation=int, required=False, default=5, metadata=[Gt(gt=0), Lt(lt=2)])',
         ),
         (
             lambda: Annotated[int, Field(alias='foobar')],

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5037,7 +5037,7 @@ def test_skip_json_schema_annotation() -> None:
 
 def test_skip_json_schema_exclude_default():
     class Model(BaseModel):
-        x: Annotated[Union[int, SkipJsonSchema[None]], Field(json_schema_extra=lambda s: s.pop('default'))] = None
+        x: Union[int, SkipJsonSchema[None]] = Field(default=None, json_schema_extra=lambda s: s.pop('default'))
 
     assert Model().x is None
     # insert_assert(Model.model_json_schema())
@@ -5333,24 +5333,18 @@ def test_callable_json_schema_extra():
 
     class Model(BaseModel):
         a: int = Field(default=1, json_schema_extra=pop_default)
-        b: Annotated[int, Field(json_schema_extra=pop_default)] = 2
-        c: Annotated[int, Field(json_schema_extra=pop_default), Field(default=3)]
-        d: Annotated[int, Field(default=4), Field(json_schema_extra=pop_default)]
-        e: Annotated[int, Field(json_schema_extra=pop_default)] = Field(default=5)
-        f: Annotated[int, Field(default=6)] = Field(json_schema_extra=pop_default)
+        b: Annotated[int, Field(default=2), Field(json_schema_extra=pop_default)]
+        c: Annotated[int, Field(default=3)] = Field(json_schema_extra=pop_default)
 
-    assert Model().model_dump() == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5, 'f': 6}
-    assert Model(a=11, b=12, c=13, d=14, e=15, f=16).model_dump() == {
+    assert Model().model_dump() == {'a': 1, 'b': 2, 'c': 3}
+    assert Model(a=11, b=12, c=13).model_dump() == {
         'a': 11,
         'b': 12,
         'c': 13,
-        'd': 14,
-        'e': 15,
-        'f': 16,
     }
 
     json_schema = Model.model_json_schema()
-    for key in 'abcdef':
+    for key in 'abc':
         assert json_schema['properties'][key] == {'title': key.upper(), 'type': 'integer'}  # default is not present
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,6 +44,7 @@ from pydantic import (
     field_validator,
 )
 from pydantic.type_adapter import TypeAdapter
+from pydantic.types import StringConstraints
 
 
 def test_success():
@@ -2807,3 +2808,60 @@ def test_schema_generator_customize_type() -> None:
         model_config = ConfigDict(schema_generator=LaxStrGenerator)
 
     assert Model(x=1).x == '1'
+
+
+def test_schema_generator_customize_type_constraints() -> None:
+    class LaxStrGenerator(GenerateSchema):
+        def str_schema(self) -> CoreSchema:
+            return core_schema.no_info_plain_validator_function(str)
+
+    class Model(BaseModel):
+        x: Annotated[str, Field(pattern='^\\d+$')]
+        y: Annotated[float, Field(gt=0)]
+        z: Annotated[list[int], Field(min_length=1)]
+        model_config = ConfigDict(schema_generator=LaxStrGenerator)
+
+    # insert_assert(Model(x='123', y=1, z=[-1]).model_dump())
+    assert Model(x='123', y=1, z=[-1]).model_dump() == {'x': '123', 'y': 1.0, 'z': [-1]}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(x='abc', y=-1, z=[])
+
+    # insert_assert(exc_info.value.errors(include_url=False))
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'string_pattern_mismatch',
+            'loc': ('x',),
+            'msg': "String should match pattern '^\\d+$'",
+            'input': 'abc',
+            'ctx': {'pattern': '^\\d+$'},
+        },
+        {
+            'type': 'greater_than',
+            'loc': ('y',),
+            'msg': 'Input should be greater than 0',
+            'input': -1,
+            'ctx': {'gt': 0.0},
+        },
+        {
+            'type': 'too_short',
+            'loc': ('z',),
+            'msg': 'List should have at least 1 item after validation, not 0',
+            'input': [],
+            'ctx': {'field_type': 'List', 'min_length': 1, 'actual_length': 0},
+        },
+    ]
+
+
+@pytest.mark.xfail(reason='Order of constraints is not preserved')
+def test_schema_generator_customize_type_constraints_order() -> None:
+    class Model(BaseModel):
+        # whitespace will be stripped first, then max length will be checked, should pass on ' 1 '
+        x: Annotated[str, StringConstraints(strip_whitespace=True), StringConstraints(max_length=1)]
+        # max length will be checked first, then whitespace will be stripped, should fail on ' 1 '
+        y: Annotated[str, StringConstraints(max_length=1), StringConstraints(strip_whitespace=True)]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(x=' 1 ', y=' 1 ')
+
+    assert exc_info.value.errors(include_url=False) == []  # TODO: add errors when fixing

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,6 +28,7 @@ from pydantic_core import CoreSchema, core_schema
 from typing_extensions import Annotated, Final, Literal
 
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
@@ -38,14 +39,13 @@ from pydantic import (
     PydanticUndefinedAnnotation,
     PydanticUserError,
     SecretStr,
+    StringConstraints,
+    TypeAdapter,
     ValidationError,
     ValidationInfo,
     constr,
     field_validator,
 )
-from pydantic.functional_validators import AfterValidator
-from pydantic.type_adapter import TypeAdapter
-from pydantic.types import StringConstraints
 
 
 def test_success():
@@ -2819,7 +2819,7 @@ def test_schema_generator_customize_type_constraints() -> None:
     class Model(BaseModel):
         x: Annotated[str, Field(pattern='^\\d+$')]
         y: Annotated[float, Field(gt=0)]
-        z: Annotated[list[int], Field(min_length=1)]
+        z: Annotated[List[int], Field(min_length=1)]
         model_config = ConfigDict(schema_generator=LaxStrGenerator)
 
     # insert_assert(Model(x='123', y=1, z=[-1]).model_dump())

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -896,7 +896,7 @@ def test_serialize_as_any() -> None:
         password: SecretStr
 
     class OuterModel(BaseModel):
-        maybe_as_any: Optional[SerializeAsAny[User]]
+        maybe_as_any: Optional[SerializeAsAny[User]] = None
         as_any: SerializeAsAny[User]
         without: User
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5501,7 +5501,6 @@ def test_constraints_arbitrary_type() -> None:
             'loc': ('predicate',),
             'msg': 'Predicate test_constraints_arbitrary_type.<locals>.Model.<lambda> failed',
             'input': CustomType(-1),
-            'ctx': {},
         },
     ]
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -39,7 +39,7 @@ import annotated_types
 import dirty_equals
 import pytest
 from dirty_equals import HasRepr, IsOneOf, IsStr
-from pydantic_core import CoreSchema, PydanticCustomError, SchemaError, core_schema
+from pydantic_core import CoreSchema, PydanticCustomError, core_schema
 from typing_extensions import Annotated, Literal, TypedDict, get_args
 
 from pydantic import (
@@ -1673,25 +1673,6 @@ def test_enum_from_json(enum_base, strict):
                 'type': 'enum',
             }
         ]
-
-
-@pytest.mark.parametrize(
-    'kwargs,type_',
-    [
-        ({'pattern': '^foo$'}, int),
-        ({'gt': 0}, conlist(int, min_length=4)),
-        ({'gt': 0}, conset(int, min_length=4)),
-        ({'gt': 0}, confrozenset(int, min_length=4)),
-    ],
-)
-def test_invalid_schema_constraints(kwargs, type_):
-    match = (
-        r'(:?Invalid Schema:\n.*\n  Extra inputs are not permitted)|(:?The following constraints cannot be applied to)'
-    )
-    with pytest.raises((SchemaError, TypeError), match=match):
-
-        class Foo(BaseModel):
-            a: type_ = Field('foo', title='A title', description='A description', **kwargs)
 
 
 def test_invalid_decimal_constraint():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -39,7 +39,7 @@ import annotated_types
 import dirty_equals
 import pytest
 from dirty_equals import HasRepr, IsOneOf, IsStr
-from pydantic_core import CoreSchema, PydanticCustomError, core_schema
+from pydantic_core import CoreSchema, PydanticCustomError, SchemaError, core_schema
 from typing_extensions import Annotated, Literal, TypedDict, get_args
 
 from pydantic import (
@@ -1673,6 +1673,31 @@ def test_enum_from_json(enum_base, strict):
                 'type': 'enum',
             }
         ]
+
+
+@pytest.mark.parametrize(
+    'kwargs,type_',
+    [
+        pytest.param(
+            {'pattern': '^foo$'},
+            int,
+            marks=pytest.mark.xfail(
+                reason='int cannot be used with pattern but we do not currently validate that at schema build time'
+            ),
+        ),
+        ({'gt': 0}, conlist(int, min_length=4)),
+        ({'gt': 0}, conset(int, min_length=4)),
+        ({'gt': 0}, confrozenset(int, min_length=4)),
+    ],
+)
+def test_invalid_schema_constraints(kwargs, type_):
+    match = (
+        r'(:?Invalid Schema:\n.*\n  Extra inputs are not permitted)|(:?The following constraints cannot be applied to)'
+    )
+    with pytest.raises((SchemaError, TypeError), match=match):
+
+        class Foo(BaseModel):
+            a: type_ = Field('foo', title='A title', description='A description', **kwargs)
 
 
 def test_invalid_decimal_constraint():


### PR DESCRIPTION
This handles the particular case of `pattern` not working when using a custom `GenerateSchema` (reported in https://github.com/pydantic/pydantic/issues/6045#issuecomment-1652440886) but also tries to be more general to handle other similar issues.

Selected Reviewer: @samuelcolvin