### PR TITLE
Feat: BaseModel default __hash__ method.

### DIFF
--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -121,6 +121,19 @@ Models possess the following methods and attributes:
     See [Changes to `pydantic.BaseModel`](../migration.md#changes-to-pydanticbasemodel) in the
     [Migration Guide](../migration.md) for details on changes from Pydantic V1.
 
+### Hash
+
+`BaseModel` hash is the sum of the class hash and instance identity:
+```py
+def __hash__(self: BaseModel) -> int:
+    return hash(self.__class__) + id(self)
+```
+When `frozen` the hash method is overridden by the sum of the class hash and the tuple of all model field values:
+```py
+def hash_func(self: BaseModel) -> int:
+    return hash(self.__class__) + hash(tuple(self.__dict__.values()))
+```
+
 ## Nested models
 
 More complex hierarchical data structures can be defined using models themselves as types in annotations.

--- a/docs/usage/models.md
+++ b/docs/usage/models.md
@@ -125,12 +125,12 @@ Models possess the following methods and attributes:
 
 `BaseModel` hash is the sum of the class hash and instance identity:
 ```py
-def __hash__(self: BaseModel) -> int:
+def __hash__(self) -> int:
     return hash(self.__class__) + id(self)
 ```
 When `frozen` the hash method is overridden by the sum of the class hash and the tuple of all model field values:
 ```py
-def hash_func(self: BaseModel) -> int:
+def __hash__(self) -> int:
     return hash(self.__class__) + hash(tuple(self.__dict__.values()))
 ```
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
-from functools import lru_cache
 from typing import (
     Any,
     Callable,
@@ -495,12 +494,14 @@ def test_hashable():
 
 
 def test_cached_method():
+    from functools import lru_cache
+
     should_never_be_more_than_one = 0
 
     class TestModel(BaseModel):
         a: int = 95
 
-        @lru_cache
+        @lru_cache(maxsize=None)
         def my_cached_method(self) -> int:
             nonlocal should_never_be_more_than_one
 


### PR DESCRIPTION
Refactor: Removed test_not_frozen_are_not_hashable; the predicate the test is False.
Doc: Entry for BaseModel being hashable

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Make sure models are hashable, by providing a default to models that are not `frozen`: `hash(self.__class__) + id(self)`.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
Fixes #3376

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
