### PR TITLE
Fix generic computed fields

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1427,6 +1427,7 @@ class GenerateSchema:
                 code='model-field-missing-annotation',
             )
 
+        return_type = replace_types(return_type, self._typevars_map)
         return_type_schema = self.generate_schema(return_type)
         # Apply serializers to computed field if there exist
         return_type_schema = self._apply_field_serializers(

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -1,7 +1,7 @@
 import random
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, Callable, ClassVar, List, Tuple
+from typing import Any, Callable, ClassVar, Generic, List, Tuple, TypeVar
 
 import pytest
 from pydantic_core import ValidationError, core_schema
@@ -717,3 +717,18 @@ def test_multiple_references_to_schema(model_factory: Callable[[], Any]) -> None
         'title': 'Model',
         'type': 'object',
     }
+
+
+def test_generic_computed_field():
+    T = TypeVar('T')
+
+    class A(BaseModel, Generic[T]):
+        x: T
+
+        @computed_field
+        @property
+        def double_x(self) -> T:
+            return self.x * 2
+
+    assert A[int](x=1).model_dump() == {'x': 1, 'double_x': 2}
+    assert A[str](x='abc').model_dump() == {'x': 'abc', 'double_x': 'abcabc'}


### PR DESCRIPTION
Fix an issue where computed fields with a generic return type would not reflect the parametrized value of the generic parameter.