### PR TITLE
Handle non-json native enum values

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -676,6 +676,8 @@ class GenerateJsonSchema:
             The generated JSON schema.
         """
         expected = [v.value if isinstance(v, Enum) else v for v in schema['expected']]
+        # jsonify the expected values
+        expected = [to_jsonable_python(v) for v in expected]
 
         if len(expected) == 1:
             return {'const': expected[0]}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5384,3 +5384,16 @@ def test_callable_json_schema_extra_dataclass():
     json_schema = adapter.json_schema()
     for key in 'abcdef':
         assert json_schema['properties'][key] == {'title': key.upper(), 'type': 'integer'}  # default is not present
+
+
+def test_enum_complex_value() -> None:
+    """https://github.com/pydantic/pydantic/issues/7045"""
+
+    class MyEnum(Enum):
+        foo = (1, 2)
+        bar = (2, 3)
+
+    ta = TypeAdapter(MyEnum)
+
+    # insert_assert(ta.json_schema())
+    assert ta.json_schema() == {'enum': [[1, 2], [2, 3]], 'title': 'MyEnum', 'type': 'array'}


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/7045

This isn't perfect, e.g. ideally if the value is always a two tuple of ints it would be reflected in the generated schema. But this is better than invalid json.