### PR TITLE
Remove useless cast to int

### DIFF
--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -443,11 +443,8 @@ def float_to_255(c: float) -> int:
 
     Returns:
         The integer equivalent of the given float value rounded to the nearest whole number.
-
-    Raises:
-        ValueError: If the given float value is outside the acceptable range of 0 to 1 (inclusive).
     """
-    return int(round(c * 255))
+    return round(c * 255)
 
 
 COLORS_BY_NAME = {


### PR DESCRIPTION
## Change Summary

Remove a useless `int()` cast of a `round()` method. In Python 2 it was necessary (`round()` returned `float`), but not in Python 3.

Also removed the `Raises` part of the docs. `round(c * 255)` does not raise anything for values outside of the `0…1` range.

No need to add it to changelog.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex