### PR TITLE
Use explicit math methods to check inf/nan

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -577,7 +577,7 @@ class GenerateJsonSchema:
         """
         json_schema: dict[str, Any] = {'type': 'integer'}
         self.update_with_validations(json_schema, schema, self.ValidationsMapping.numeric)
-        json_schema = {k: v for k, v in json_schema.items() if v not in {math.inf, -math.inf}}
+        json_schema = {k: v for k, v in json_schema.items() if not math.isinf(v)}
         return json_schema
 
     def float_schema(self, schema: core_schema.FloatSchema) -> JsonSchemaValue:
@@ -591,7 +591,7 @@ class GenerateJsonSchema:
         """
         json_schema: dict[str, Any] = {'type': 'number'}
         self.update_with_validations(json_schema, schema, self.ValidationsMapping.numeric)
-        json_schema = {k: v for k, v in json_schema.items() if v not in {math.inf, -math.inf}}
+        json_schema = {k: v for k, v in json_schema.items() if not math.isinf(v)}
         return json_schema
 
     def str_schema(self, schema: core_schema.StringSchema) -> JsonSchemaValue:

--- a/pydantic/v1/validators.py
+++ b/pydantic/v1/validators.py
@@ -170,7 +170,7 @@ def float_finite_validator(v: 'Number', field: 'ModelField', config: 'BaseConfig
     if allow_inf_nan is None:
         allow_inf_nan = config.allow_inf_nan
 
-    if allow_inf_nan is False and (math.isnan(v) or math.isinf(v)):
+    if allow_inf_nan is False and not math.isfinite(v):
         raise errors.NumberNotFiniteError()
     return v
 


### PR DESCRIPTION
## Change Summary

Use explicit `math.isinf` and `math.isfinite` methods to check on ±inf and NaN values.

No need to add to Changelog.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
