### PR TITLE
Replace almost_equal_floats with math.isclose

### DIFF
--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -114,11 +114,6 @@ def update_not_none(mapping: dict[Any, Any], **update: Any) -> None:
     mapping.update({k: v for k, v in update.items() if v is not None})
 
 
-def almost_equal_floats(value_1: float, value_2: float, *, delta: float = 1e-8) -> bool:
-    """Return True if two floats are almost equal."""
-    return abs(value_1 - value_2) <= delta
-
-
 T = TypeVar('T')
 
 

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Optional, Tuple, Type, Union, cast
 from pydantic_core import CoreSchema, PydanticCustomError, core_schema
 from typing_extensions import deprecated
 
-from ._internal import _repr, _utils
+from ._internal import _repr
 from ._internal._schema_generation_shared import GetJsonSchemaHandler as _GetJsonSchemaHandler
 from .json_schema import JsonSchemaValue
 from .warnings import PydanticDeprecatedSince20
@@ -399,7 +399,7 @@ def parse_float_alpha(value: Union[None, str, float, int]) -> Optional[float]:
     except ValueError:
         raise PydanticCustomError('color_error', 'value is not a valid color: alpha values must be a valid float')
 
-    if _utils.almost_equal_floats(alpha, 1):
+    if math.isclose(alpha, 1):
         return None
     elif 0 <= alpha <= 1:
         return alpha


### PR DESCRIPTION
## Change Summary

Replace the own method `almost_equal_floats` with stdlib's `math.isclose`.

No need to add to changelog.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt