### PR TITLE
Tweak documentation of `Field.exclude`

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -92,7 +92,7 @@ class FieldInfo(_repr.Representation):
         title: The title of the field.
         description: The description of the field.
         examples: List of examples of the field.
-        exclude: Whether to exclude the field from the model schema.
+        exclude: Whether to exclude the field from the model serialization.
         discriminator: Field name for discriminating the type in a tagged union.
         json_schema_extra: Dictionary of extra JSON schema properties.
         frozen: Whether the field is frozen.
@@ -713,7 +713,7 @@ def Field(  # noqa: C901
         title: Human-readable title.
         description: Human-readable description.
         examples: Example values for this field.
-        exclude: Whether to exclude the field from the model schema.
+        exclude: Whether to exclude the field from the model serialization.
         discriminator: Field name for discriminating the type in a tagged union.
         json_schema_extra: Any additional JSON schema data for the schema property.
         frozen: Whether the field is frozen.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I don't know if this is expected, but doing the following:

```python
from typing import Annotated, TypeVar

from pydantic import BaseModel, Field

T = TypeVar("T")

ExcludedField = Annotated[T, Field(exclude=True)]


class Model(BaseModel):
    run_path: ExcludedField[str | None] = None

Model.model_json_schema()
#> {'properties': {'run_path': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'default': None, 'title': 'Run Path'}}, 'title': 'Model', 'type': 'object'}
Model(run_path="a").model_dump()
#> {}
```

The field is still included in the JSON Schema. So either the docstring is incorrect or it should not be included in the JSON Schema as well?

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb