### PR TITLE
Do not require `validate_assignment` to use `Field.frozen`

### DIFF
--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -609,7 +609,7 @@ except ValidationError as exc:
 This error is raised when you attempt to assign a value to a field with `frozen=True`:
 
 ```py
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 
 class Model(BaseModel):

--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -606,8 +606,7 @@ except ValidationError as exc:
 
 ## `frozen_field`
 
-This error is raised when `model_config['validate_assignment'] == True` and you attempt to assign
-a value to a field with `frozen=True`:
+This error is raised when you attempt to assign a value to a field with `frozen=True`:
 
 ```py
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -615,8 +614,6 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 class Model(BaseModel):
     x: str = Field('test', frozen=True)
-
-    model_config = ConfigDict(validate_assignment=True)
 
 
 model = Model()

--- a/docs/usage/fields.md
+++ b/docs/usage/fields.md
@@ -627,8 +627,6 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
 class User(BaseModel):
-    model_config = ConfigDict(validate_assignment=True)  # (1)!
-
     name: str = Field(frozen=True)
     age: int
 
@@ -636,7 +634,7 @@ class User(BaseModel):
 user = User(name='John', age=42)
 
 try:
-    user.name = 'Jane'  # (2)!
+    user.name = 'Jane'  # (1)!
 except ValidationError as e:
     print(e)
     """
@@ -646,11 +644,7 @@ except ValidationError as e:
     """
 ```
 
-1. The `model_config` field is used to enable the validation of assignments.
-
-    See the [Validate Assignment] section for more details.
-
-2. Since `validate_assignment` is enabled, and the `name` field is frozen, the assignment is not allowed.
+1. Since `name` field is frozen, the assignment is not allowed.
 
 ## Exclude
 

--- a/docs/usage/fields.md
+++ b/docs/usage/fields.md
@@ -623,7 +623,7 @@ assigned a new value after the model is created (immutability).
 See the [frozen dataclass documentation] for more details.
 
 ```py
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 
 class User(BaseModel):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -748,7 +748,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 'input': value,
             }
             raise pydantic_core.ValidationError.from_exception_data(self.__class__.__name__, [error])
-        elif name in self.model_fields and self.model_fields[name].frozen:
+        elif getattr(self.model_fields.get(name), "frozen", False)
             error: pydantic_core.InitErrorDetails = {
                 'type': 'frozen_field',
                 'loc': (name,),

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -748,7 +748,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 'input': value,
             }
             raise pydantic_core.ValidationError.from_exception_data(self.__class__.__name__, [error])
-        elif getattr(self.model_fields.get(name), "frozen", False)
+        elif getattr(self.model_fields.get(name), 'frozen', False):
             error: pydantic_core.InitErrorDetails = {
                 'type': 'frozen_field',
                 'loc': (name,),

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -748,6 +748,13 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 'input': value,
             }
             raise pydantic_core.ValidationError.from_exception_data(self.__class__.__name__, [error])
+        elif name in self.model_fields and self.model_fields[name].frozen:
+            error: pydantic_core.InitErrorDetails = {
+                'type': 'frozen_field',
+                'loc': (name,),
+                'input': value,
+            }
+            raise pydantic_core.ValidationError.from_exception_data(self.__class__.__name__, [error])
 
         attr = getattr(self.__class__, name, None)
         if isinstance(attr, property):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -503,6 +503,18 @@ def test_frozen_model():
     ]
 
 
+def test_frozen_field():
+    class FrozenModel(BaseModel):
+        a: int = 10
+
+    m = FrozenModel()
+
+    with pytest.raises(ValidationError) as exc_info:
+        m.a = 11
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'frozen_field', 'loc': ('a',), 'msg': 'Field is frozen', 'input': 11}
+    ]
+
 def test_not_frozen_are_not_hashable():
     class TestModel(BaseModel):
         a: int = 10
@@ -1660,7 +1672,7 @@ def test_base_config_type_hinting():
     get_type_hints(type(M.model_config))
 
 
-def test_frozen_field():
+def test_frozen_field_with_validate_assignment():
     """assigning a frozen=True field should raise a TypeError"""
 
     class Entry(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -505,7 +505,7 @@ def test_frozen_model():
 
 def test_frozen_field():
     class FrozenModel(BaseModel):
-        a: int = 10 = Field(frozen=True)
+        a: int = Field(10, frozen=True)
 
     m = FrozenModel()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -505,7 +505,7 @@ def test_frozen_model():
 
 def test_frozen_field():
     class FrozenModel(BaseModel):
-        a: int = 10
+        a: int = 10 = Field(frozen=True)
 
     m = FrozenModel()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -515,6 +515,7 @@ def test_frozen_field():
         {'type': 'frozen_field', 'loc': ('a',), 'msg': 'Field is frozen', 'input': 11}
     ]
 
+
 def test_not_frozen_are_not_hashable():
     class TestModel(BaseModel):
         a: int = 10


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I find it a bit unusual to have the following working:

```python
from pydantic import BaseModel, Field

class Model(BaseModel):
    a: int = 1
    model_config = {"frozen": True}

m = Model()
m.a = 2
#> Raises ValidationError
```

But not the following:

```python
from pydantic import BaseModel, Field

class Model(BaseModel):
    a: int = Field(frozen=True)

m = Model(a=1)
m.a = 2
#> No ValidationError, unless model_config.validate_assignment is set to True
```

If you think the current behavior is as designed, I can revert my commit but I think a note on the `Field.frozen` docstring would be required.
## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin