### PR TITLE
Revert "Fix default port for mongosrv DSNs (#6827)"

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -4,7 +4,7 @@ from __future__ import annotations as _annotations
 import dataclasses as _dataclasses
 import re
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, TypeAlias
@@ -124,10 +124,7 @@ RedisDsn = Annotated[
     UrlConstraints(allowed_schemes=['redis', 'rediss'], default_host='localhost', default_port=6379, default_path='/0'),
 ]
 """A type that will accept any Redis DSN."""
-MongoDsn = Union[
-    Annotated[MultiHostUrl, UrlConstraints(allowed_schemes=['mongodb'], default_port=27017)],
-    Annotated[MultiHostUrl, UrlConstraints(allowed_schemes=['mongodb+srv'])],
-]
+MongoDsn = Annotated[MultiHostUrl, UrlConstraints(allowed_schemes=['mongodb', 'mongodb+srv'], default_port=27017)]
 """A type that will accept any MongoDB DSN."""
 KafkaDsn = Annotated[Url, UrlConstraints(allowed_schemes=['kafka'], default_host='localhost', default_port=9092)]
 """A type that will accept any Kafka DSN."""

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -615,16 +615,6 @@ def test_mongodb_dsns():
     assert m.a.hosts() == [{'username': None, 'password': None, 'host': 'localhost', 'port': 27017}]
 
 
-def test_mongodsn_default_ports():
-    class Model(BaseModel):
-        a: MongoDsn
-
-    m1 = Model(a='mongodb://user:pass@localhost/app')
-    m2 = Model(a='mongodb+srv://user:pass@localhost/app')
-    assert str(m1.a) == 'mongodb://user:pass@localhost:27017/app'
-    assert str(m2.a) == 'mongodb+srv://user:pass@localhost/app'
-
-
 def test_kafka_dsns():
     class Model(BaseModel):
         a: KafkaDsn

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -615,6 +615,30 @@ def test_mongodb_dsns():
     assert m.a.hosts() == [{'username': None, 'password': None, 'host': 'localhost', 'port': 27017}]
 
 
+@pytest.mark.parametrize(
+    ('dsn', 'expected'),
+    [
+        ('mongodb://user:pass@localhost/app', 'mongodb://user:pass@localhost:27017/app'),
+        pytest.param(
+            'mongodb+srv://user:pass@localhost/app',
+            'mongodb+srv://user:pass@localhost/app',
+            marks=pytest.mark.xfail(
+                reason=(
+                    'This case is not supported. '
+                    'Check https://github.com/pydantic/pydantic/pull/7116 for more details.'
+                )
+            ),
+        ),
+    ],
+)
+def test_mongodsn_default_ports(dsn: str, expected: str):
+    class Model(BaseModel):
+        dsn: MongoDsn
+
+    m = Model(dsn=dsn)
+    assert str(m.dsn) == expected
+
+
 def test_kafka_dsns():
     class Model(BaseModel):
         a: KafkaDsn


### PR DESCRIPTION
- This reverts https://github.com/pydantic/pydantic/pull/6827.

Since we are reverting that PR, the idea is that we recommend doing the following for https://github.com/pydantic/pydantic/issues/6774:

```py
from typing import Annotated

from pydantic.networks import UrlConstraints
from pydantic_core import MultiHostUrl

MongoSRVDsn = Annotated[MultiHostUrl, UrlConstraints(allowed_schemes=['mongodb+srv'])]
```

## Related issue number

- Closes #6945

## Notes

@dmontagu mentioned that we should keep the tests that were added. ~So I'll add on the next commit...~ Added.

Selected Reviewer: @davidhewitt