### PR TITLE
Don't always require typing.Generic as a base for partially parametrized models

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -133,8 +133,8 @@ class ModelMetaclass(ABCMeta):
             if __pydantic_generic_metadata__:
                 cls.__pydantic_generic_metadata__ = __pydantic_generic_metadata__
             else:
-                parameters = getattr(cls, '__parameters__', ())
                 parent_parameters = getattr(cls, '__pydantic_generic_metadata__', {}).get('parameters', ())
+                parameters = getattr(cls, '__parameters__', None) or parent_parameters
                 if parameters and parent_parameters and not all(x in parameters for x in parent_parameters):
                     combined_parameters = parent_parameters + tuple(x for x in parameters if x not in parent_parameters)
                     parameters_str = ', '.join([str(x) for x in combined_parameters])

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -2561,3 +2561,34 @@ def test_parametrize_with_basemodel():
 
     class Concrete(SimpleGenericModel[BaseModel]):
         pass
+
+
+def test_no_generic_base():
+    T = TypeVar('T')
+
+    class A(BaseModel, Generic[T]):
+        a: T
+
+    class B(A[T]):
+        b: T
+
+    class C(B[int]):
+        pass
+
+    assert C(a='1', b='2').model_dump() == {'a': 1, 'b': 2}
+    with pytest.raises(ValidationError) as exc_info:
+        C(a='a', b='b')
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'input': 'a',
+            'loc': ('a',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'type': 'int_parsing',
+        },
+        {
+            'input': 'b',
+            'loc': ('b',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'type': 'int_parsing',
+        },
+    ]


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/6980

I won't be surprised if there are still cases that aren't properly handled by this change, but this resolves the reported issue, and given the complexity of the generics stuff I think our best bet in the long run is to just rely on converting reported issues into tests, and making sure all tests pass.

Selected Reviewer: @adriangb