### PR TITLE
classify error `loc` as allowed breakage

### DIFF
--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -18,10 +18,12 @@ Of course some apparently safe changes and bug fixes will inevitably break some 
 The following changes will **NOT** be considered breaking changes, and may occur in minor releases:
 
 * Changing the format of `ref` as used in JSON Schema.
-* Changing the `message` and `context` fields of `ValidationError` errors, `type` will not change &mdash; if you're programmatically parsing error messages, you should use `type`.
+* Changing the `msg`, `ctx`, and `loc` fields of `ValidationError` errors. `type` will not change &mdash; if you're programmatically parsing error messages, you should use `type`.
 * Adding new keys to `ValidationError` errors &mdash; e.g. we intend to add `line_number` and `column_number` to errors when validating JSON once we migrate to a new JSON parser.
 * Adding new `ValidationError` errors.
 * Changing `repr` even of public classes.
+
+In all cases we will aim to minimize churn and do so only when justified by the increase of quality of `pydantic` for users.
 
 ## Pydantic V3 and beyond
 


### PR DESCRIPTION
## Change Summary

I noticed that `loc` was missing from the text classifying allowed / disallowed breakage for errors. In conversation with @samuelcolvin and @dmontagu we agreed that it would be acceptable to change loc to improve readability.

(In particular we envisage improving `union` case locs in the future.)

I also renamed these fields to match the `msg`, `cix`, and `loc` names used in the error dictionaries.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin