### PR TITLE
document `round_trip` in Json type documentation 

### DIFF
--- a/docs/usage/types/json.md
+++ b/docs/usage/types/json.md
@@ -1,12 +1,10 @@
 `Json`
 : a special type wrapper which loads JSON before parsing
 
-You can use `Json` data type to make Pydantic first load a raw JSON string. 
-Use `round_trip=True` when dumping the model to get the original JSON back. 
-It can also optionally be used to parse the loaded object into another type base on
-the type `Json` is parameterised with:
+You can use the `Json` data type to make Pydantic first load a raw JSON string before
+validating the loaded data into the parametrized type:
 
-```py
+```py group='json'
 from typing import Any, List
 
 from pydantic import BaseModel, Json, ValidationError
@@ -24,12 +22,6 @@ print(AnyJsonModel(json_obj='{"b": 1}'))
 #> json_obj={'b': 1}
 print(ConstrainedJsonModel(json_obj='[1, 2, 3]'))
 #> json_obj=[1, 2, 3]
-
-print(ConstrainedJsonModel(json_obj="[1, 2, 3]").model_dump_json())
-#> {"json_obj":[1,2,3]}
-print(ConstrainedJsonModel(json_obj="[1, 2, 3]").model_dump_json(round_trip=True))
-#> {"json_obj":"[1,2,3]"} 
-
 
 try:
     ConstrainedJsonModel(json_obj=12)
@@ -62,4 +54,16 @@ except ValidationError as e:
     json_obj.1
       Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='b', input_type=str]
     """
+```
+
+When you dump the model using `model_dump` or `model_dump_json`, the dumped value will be the result of validation,
+not the original JSON string. However, you can use the argument `round_trip=True` to get the original JSON string back:
+
+```py group='json'
+print(ConstrainedJsonModel(json_obj='[1, 2, 3]').model_dump_json())
+#> {"json_obj":[1,2,3]}
+print(
+    ConstrainedJsonModel(json_obj='[1, 2, 3]').model_dump_json(round_trip=True)
+)
+#> {"json_obj":"[1,2,3]"}
 ```

--- a/docs/usage/types/json.md
+++ b/docs/usage/types/json.md
@@ -1,7 +1,9 @@
 `Json`
 : a special type wrapper which loads JSON before parsing
 
-You can use `Json` data type to make Pydantic first load a raw JSON string. Use `round_trip=True` when dumping the model to get the original JSON back. It can also optionally be used to parse the loaded object into another type base on
+You can use `Json` data type to make Pydantic first load a raw JSON string. 
+Use `round_trip=True` when dumping the model to get the original JSON back. 
+It can also optionally be used to parse the loaded object into another type base on
 the type `Json` is parameterised with: 
 
 ```py

--- a/docs/usage/types/json.md
+++ b/docs/usage/types/json.md
@@ -1,9 +1,8 @@
 `Json`
 : a special type wrapper which loads JSON before parsing
 
-You can use `Json` data type to make Pydantic first load a raw JSON string.
-It can also optionally be used to parse the loaded object into another type base on
-the type `Json` is parameterised with:
+You can use `Json` data type to make Pydantic first load a raw JSON string. Use `round_trip=True` when dumping the model to get the original JSON back. It can also optionally be used to parse the loaded object into another type base on
+the type `Json` is parameterised with: 
 
 ```py
 from typing import Any, List
@@ -23,6 +22,13 @@ print(AnyJsonModel(json_obj='{"b": 1}'))
 #> json_obj={'b': 1}
 print(ConstrainedJsonModel(json_obj='[1, 2, 3]'))
 #> json_obj=[1, 2, 3]
+
+print(ConstrainedJsonModel(json_obj="[1, 2, 3]").model_dump_json())
+#> {"json_obj":[1,2,3]}
+print(ConstrainedJsonModel(json_obj="[1, 2, 3]").model_dump_json(round_trip=True))
+#> {"json_obj":"[1,2,3]"} 
+
+
 try:
     ConstrainedJsonModel(json_obj=12)
 except ValidationError as e:

--- a/docs/usage/types/json.md
+++ b/docs/usage/types/json.md
@@ -4,7 +4,7 @@
 You can use `Json` data type to make Pydantic first load a raw JSON string. 
 Use `round_trip=True` when dumping the model to get the original JSON back. 
 It can also optionally be used to parse the loaded object into another type base on
-the type `Json` is parameterised with: 
+the type `Json` is parameterised with:
 
 ```py
 from typing import Any, List


### PR DESCRIPTION
Add documentation of the `round_trip` option on the Json type documentation page.