### PR TITLE
Add ability to get namespace from module in TypeAdapter

### DIFF
--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1019,3 +1019,22 @@ def test_forward_ref_in_generic_separate_modules(create_module: Any) -> None:
     Bar = module_2.Bar
     Foo.model_rebuild(_types_namespace={'tp': typing, 'Bar': Bar})
     assert Foo(x={Bar: Bar}).x[Bar] is Bar
+
+
+def test_future_annotations_namespace(create_module):
+    forward = create_module(
+        """
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+@dataclass
+class Item:
+    id: UUID
+    """
+    )
+
+    from pydantic import TypeAdapter
+
+    TypeAdapter(forward.Item)


### PR DESCRIPTION
Related to https://github.com/pydantic/pydantic/issues/7111, but in its current form this PR cannot/should not be merged.

The problem with this approach is that the input to the `TypeAdapter` may be in a different module. The most obvious case of that is something like:
```python
from typing import List

TypeAdapter(List[forward.Model])
```

I do think it's a good idea to add the ability to provide a types namespace when creating a type adapter, which would at least make it _possible_ to resolve the issue in fastapi (e.g., by having fastapi capture the namespace in the initial call to the decorator). But I think, unlike what this PR currently does, we should probably not try to infer the module automatically, and should require it be explicitly specified.

@adriangb is well aware of this issue and may have opinions about how to proceed.