### PR TITLE
Optimize recursion detection by stopping on the second visit for the …

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -467,8 +467,12 @@ def _simplify_schema_references(schema: core_schema.CoreSchema, inline: bool) ->
             return recurse(s, count_refs)
         ref = s['schema_ref']
         ref_counts[ref] += 1
-        if current_recursion_ref_count[ref] != 0:
-            involved_in_recursion[ref] = True
+
+        if ref_counts[ref] >= 2:
+            # If this model is involved in a recursion this should be detected
+            # on its second encounter, we can safely stop the walk here.
+            if current_recursion_ref_count[ref] != 0:
+                involved_in_recursion[ref] = True
             return s
 
         current_recursion_ref_count[ref] += 1


### PR DESCRIPTION
…same object.

It's guaranteed to be enough since after we start walking into types reachable from an initial type we either can reach again our initial type or the type is not recursive.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
