### PR TITLE
fix link in docs

### DIFF
--- a/docs/integrations/visual_studio_code.md
+++ b/docs/integrations/visual_studio_code.md
@@ -283,7 +283,7 @@ This is a limitation of dataclass transforms and cannot be fixed in pydantic.
 
     These details are only useful for other library authors, etc.
 
-This additional editor support works by implementing the proposed draft standard for [Dataclass Transform](https://github.com/microsoft/pyright/blob/master/specs/dataclass_transforms.md).
+This additional editor support works by implementing the proposed draft standard for [Dataclass Transform (PEP 681)](https://peps.python.org/pep-0681/).
 
 The proposed draft standard is written by Eric Traut, from the Microsoft team, the same author of the open source package Pyright (used by Pylance to provide Python support in VS Code).
 


### PR DESCRIPTION
Fixes a broken link in the docs.  [microsoft/pyright](https://github.com/microsoft/pyright/) no longer has a `specs/` folder, so this links to PEP681 instead