### PR TITLE
fix: move getattr warning in deprecated BaseConfig

### DIFF
--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -18,7 +18,6 @@ __all__ = 'BaseConfig', 'Extra'
 
 class _ConfigMetaclass(type):
     def __getattr__(self, item: str) -> Any:
-
         try:
             obj = _config.config_defaults[item]
             warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -18,10 +18,11 @@ __all__ = 'BaseConfig', 'Extra'
 
 class _ConfigMetaclass(type):
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
 
         try:
-            return _config.config_defaults[item]
+            obj = _config.config_defaults[item]
+            warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+            return obj
         except KeyError as exc:
             raise AttributeError(f"type object '{self.__name__}' has no attribute {exc}") from exc
 
@@ -35,9 +36,10 @@ class BaseConfig(metaclass=_ConfigMetaclass):
     """
 
     def __getattr__(self, item: str) -> Any:
-        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
         try:
-            return super().__getattribute__(item)
+            obj = super().__getattribute__(item)
+            warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+            return obj
         except AttributeError as exc:
             try:
                 return getattr(type(self), item)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I wonder if you'd consider this small change to the warnings emitted by `_ConfigMetaclass.__getattr__`.
This warning popped up for me in a situation where pydantic was imported, but not being used, (i.e. I wasn't creating a model with a deprecated config) because another library was calling `hasattr()` on basically any object it could find (all subclasses of `object`).  

I know that's a bit unusual, but since `__getattr__` is called when checking `hasattr`, I thought it does seem reasonable to let the AttributeError go through in cases of `KeyError`, and only emit the warning when you're actually *getting* an attribute.

To give a simple example:

```python
In [1]: import warnings

In [2]: warnings.simplefilter("default")

In [3]: from pydantic.deprecated.config import BaseConfig

In [4]: b = BaseConfig()  # warning makes total sense here
<ipython-input-4-74b49e0b3948>:1: PydanticDeprecatedSince20: BaseConfig is deprecated. Use the `pydantic.ConfigDict` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.2/migration/
  b = BaseConfig()

In [5]: hasattr(b, 'asdfsdf')  # I would expect this to simply return False
/Users/talley/micromamba/envs/ome-types/lib/python3.11/site-packages/pydantic/deprecated/config.py:38: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.2/migration/
  warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
/Users/talley/micromamba/envs/ome-types/lib/python3.11/site-packages/pydantic/deprecated/config.py:21: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.2/migration/
  warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
Out[5]: False
```
## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
