### PR TITLE
Add copy button on documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
   features:
     - content.tabs.link
     - content.code.annotate
+    - content.code.copy
     - announce.dismiss
     - navigation.tabs
   logo: 'logo-white.svg'


### PR DESCRIPTION
Adds this: https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button 🙏 

Selected Reviewer: @lig