### PR TITLE
Make shadowing attributes a warning instead of an error

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -151,9 +151,9 @@ def collect_model_fields(  # noqa: C901
                 if base is generic_origin:
                     # Don't error when "shadowing" of attributes in parametrized generics
                     continue
-                raise NameError(
-                    f'Field name "{ann_name}" shadows an attribute in parent "{base.__qualname__}"; '
-                    f'you might want to use a different field name with "alias=\'{ann_name}\'".'
+                warnings.warn(
+                    f'Field name "{ann_name}" shadows an attribute in parent "{base.__qualname__}"; ',
+                    UserWarning,
                 )
 
         try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2890,7 +2890,7 @@ def test_schema_generator_customize_type_constraints_order() -> None:
 
 
 def test_shadow_attribute() -> None:
-    """_summary_"""
+    """https://github.com/pydantic/pydantic/issues/7108"""
 
     class Model(BaseModel):
         foo: str

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2887,3 +2887,38 @@ def test_schema_generator_customize_type_constraints_order() -> None:
             'ctx': {'max_length': 1},
         }
     ]
+
+
+def test_shadow_attribute() -> None:
+    """_summary_"""
+
+    class Model(BaseModel):
+        foo: str
+
+        @classmethod
+        def __pydantic_init_subclass__(cls, **kwargs: Any):
+            super().__pydantic_init_subclass__(**kwargs)
+            for key in cls.model_fields.keys():
+                setattr(cls, key, getattr(cls, key, '') + ' edited!')
+
+    class One(Model):
+        foo: str = 'abc'
+
+    with pytest.warns(UserWarning, match=r'"foo" shadows an attribute in parent ".*One"'):
+
+        class Two(One):
+            foo: str
+
+    with pytest.warns(UserWarning, match=r'"foo" shadows an attribute in parent ".*One"'):
+
+        class Three(One):
+            foo: str = 'xyz'
+
+    # unlike dataclasses BaseModel does not preserve the value of defaults
+    # so when we access the attribute in `Model.__pydantic_init_subclass__` there is no default
+    # and hence we append `edited!` to an empty string
+    # we've talked about changing this but this is the current behavior as of this test
+    assert getattr(Model, 'foo', None) is None
+    assert getattr(One, 'foo', None) == ' edited!'
+    assert getattr(Two, 'foo', None) == ' edited! edited!'
+    assert getattr(Three, 'foo', None) == ' edited! edited!'


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/7108

Selected Reviewer: @samuelcolvin