### PR TITLE
fix #7228 (typo): docs in `validators.md` to correct `validate_default` kwarg

### DIFF
--- a/docs/usage/validators.md
+++ b/docs/usage/validators.md
@@ -266,7 +266,7 @@ print(context['logs'])
 
 Validators won't run when the default value is used.
 This applies both to `@field_validator` validators and `Annotated` validators.
-You can force them to run with `Field(validate_defaults=True)`. Setting `validate_default` to `True` has the closest behavior to using `always=True` in `validator` in Pydantic v1. However, you are generally better off using a `@model_validator(mode='before')` where the function is called before the inner validator is called.
+You can force them to run with `Field(validate_default=True)`. Setting `validate_default` to `True` has the closest behavior to using `always=True` in `validator` in Pydantic v1. However, you are generally better off using a `@model_validator(mode='before')` where the function is called before the inner validator is called.
 
 
 ```py


### PR DESCRIPTION
Docs typo referencing a nonexistent `Field` kwarg which should be `validate_default`.

## Change Summary

Trivial typo fix, confirmed only instance in the repo.

## Related issue number

- #7228

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review