### PR TITLE
Update description for string type in Standard Library Types documentation section

### DIFF
--- a/docs/usage/types/standard_types.md
+++ b/docs/usage/types/standard_types.md
@@ -11,7 +11,7 @@ Pydantic supports many common types from the Python standard library. If you nee
 | `bool` | See [Booleans](booleans.md) for details on how bools are validated and what values are permitted. |
 | `int` | Pydantic uses `int(v)` to coerce types to an `int`. See [Number Types](number_types.md) for more details. See the [Data Conversion](../models.md#data-conversion) warning on loss of information during data conversion. |
 | `float` | `float(v)` is used to coerce values to floats. See [Number Types](number_types.md) for more details. |
-| `str` | Strings are accepted as-is. `int`, `float`, and `Decimal` are coerced using `str(v)`. `bytes` and `bytearray` are converted using `v.decode()`. `Enum`s inheriting from `str` are converted using `v.value`. All other types cause an error. See [String Types](string_types.md) for more details. |
+| `str` | Strings are accepted as-is. `bytes` and `bytearray` are converted using `v.decode()`. `Enum`s inheriting from `str` are converted using `v.value`. All other types cause an error. See [String Types](string_types.md) for more details. |
 | `bytes` | `bytes` are accepted as-is. `bytearray` is converted using `bytes(v)`. `str` are converted using `v.encode()`. `int`, `float`, and `Decimal` are coerced using `str(v).encode()`. See [ByteSize](bytesize.md) for more details. |
 | `list` | Allows `list`, `tuple`, `set`, `frozenset`, `deque`, or generators and casts to a list. See [`typing.List`](list_types.md) for sub-type constraints. |
 | `tuple` | Allows `list`, `tuple`, `set`, `frozenset`, `deque`, or generators and casts to a tuple. See [`typing.Tuple`](list_types.md) for sub-type constraints. |


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Remove sentence about coercion of numeric types to `str`.

According to #6045, coercion int->str is not supported in v2, yet https://docs.pydantic.dev/latest/usage/types/standard_types/ states:
> Strings are accepted as-is. `int`, `float`, and `Decimal` are coerced using `str(v)`. `bytes` and `bytearray` are converted using `v.decode()`. `Enum`s inheriting from `str` are converted using `v.value`. All other types cause an error. See [String Types](string_types.md) for more details.

`String types` section (https://docs.pydantic.dev/latest/usage/types/string_types/) it links to seems to be correct in this regard.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
