### PR TITLE
✅ Enforce behavior of private attributes having double leading underscore

### DIFF
--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -27,6 +27,29 @@ def test_private_attribute():
     assert m.__dict__ == {}
 
 
+def test_private_attribute_double_leading_underscore():
+    default = {'a': {}}
+
+    class Model(BaseModel):
+        __foo = PrivateAttr(default)
+
+    assert set(Model.__private_attributes__) == {'_Model__foo'}
+
+    m = Model()
+
+    with pytest.raises(AttributeError, match='__foo'):
+        m.__foo
+    assert m._Model__foo == default
+    assert m._Model__foo is not default
+    assert m._Model__foo['a'] is not default['a']
+
+    m._Model__foo = None
+    assert m._Model__foo is None
+
+    assert m.model_dump() == {}
+    assert m.__dict__ == {}
+
+
 def test_private_attribute_nested():
     class SubModel(BaseModel):
         _foo = PrivateAttr(42)


### PR DESCRIPTION
## Change Summary

Enforce behavior of private attributes having double leading underscore using a test

## Related issue number

Fix #4833 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin