### PR TITLE
Fix hash function generation for frozen models with unusual MRO

### DIFF
--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -2613,3 +2613,15 @@ def test_no_generic_base():
             'type': 'int_parsing',
         },
     ]
+
+
+def test_reverse_order_generic_hashability():
+    T = TypeVar('T')
+
+    class Model(Generic[T], BaseModel):
+        x: T
+        model_config = dict(frozen=True)
+
+    m1 = Model[int](x=1)
+    m2 = Model[int](x=1)
+    assert len({m1, m2}) == 1

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -21,6 +21,7 @@ from pydantic import (
     PydanticUserError,
     ValidationError,
 )
+from pydantic._internal._decorators import get_attribute_from_bases
 from pydantic.functional_serializers import field_serializer, model_serializer
 from pydantic.functional_validators import field_validator, model_validator
 from pydantic.type_adapter import TypeAdapter
@@ -890,3 +891,16 @@ def test_schema_generator() -> None:
     ta = TypeAdapter(Model)
 
     assert ta.validate_python(dict(x=1))['x'] == '1'
+
+
+def test_typeddict_mro():
+    class A(TypedDict):
+        x = 1
+
+    class B(A):
+        x = 2
+
+    class C(B):
+        pass
+
+    assert get_attribute_from_bases(C, 'x') == 2


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/7236

Also fixes a bug with the way attributes were read from nested typeddicts (mro was being iterated over in reverse order), and adds a related test.

Selected Reviewer: @hramezani