### PR TITLE
Make fields with defaults not required in the serialization schema by default

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -76,6 +76,10 @@ class ConfigWrapper:
     hide_input_in_errors: bool
     defer_build: bool
     schema_generator: type[GenerateSchema] | None
+    json_schema_serialization_defaults_required: bool
+    json_schema_mode_override: Literal['validation', 'serialization', None]
+    json_schema_validation_suffix: str
+    json_schema_serialization_suffix: str
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -239,6 +243,10 @@ config_defaults = ConfigDict(
     json_encoders=None,
     defer_build=False,
     schema_generator=None,
+    json_schema_serialization_defaults_required=False,
+    json_schema_mode_override=None,
+    json_schema_validation_suffix='-Input',
+    json_schema_serialization_suffix='-Output',
 )
 
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -207,5 +207,47 @@ class ConfigDict(TypedDict, total=False):
     Defaults to `None`.
     """
 
+    json_schema_serialization_defaults_required: bool
+    """
+    Whether fields with default values should be marked as required in the serialization schema.
+
+    This ensures that the serialization schema will reflect the fact a field with a default will always be present
+    when serializing the model, even though it is not required for validation.
+
+    However, there are scenarios where this may be undesirable — in particular, if you want to share the schema
+    between validation and serialization, and don't mind fields with defaults being marked as not required during
+    serialization. See [#7209](https://github.com/pydantic/pydantic/issues/7209) for more details.
+
+    Defaults to `False`.
+    """
+
+    json_schema_mode_override: Literal['validation', 'serialization', None]
+    """
+    If not `None`, the specified mode will be used to generate the JSON schema regardless of what `mode` was passed to
+    the function call.
+
+    This provides a way to force the JSON schema generation to reflect a specific mode, e.g., to always use the
+    validation schema, even if a framework (like FastAPI) might be indicating to use the serialization schema in some
+    places.
+
+    Defaults to `None`.
+    """
+
+    json_schema_validation_suffix: str
+    """
+    When the validation and serialization schemas for a single model are different, and both schemas must be referenced
+    in a single generated JSON schema, this suffix will be added to the schema for `mode='validation'`.
+
+    Defaults to `'-Input'`.
+    """
+
+    json_schema_serialization_suffix: str
+    """
+    When the validation and serialization schemas for a single model are different, and both schemas must be referenced
+    in a single generated JSON schema, this suffix will be added to the schema for `mode='serialization'`.
+
+    Defaults to `'-Output'`.
+    """
+
 
 __getattr__ = getattr_migration(__name__)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -521,7 +521,6 @@ def test_decimal_json_schema():
             'a': {'default': 'foobar', 'format': 'binary', 'title': 'A', 'type': 'string'},
             'b': {'default': '12.34', 'title': 'B', 'type': 'string'},
         },
-        'required': ['a', 'b'],
         'title': 'Model',
         'type': 'object',
     }
@@ -1695,7 +1694,6 @@ def test_model_default_timedelta(ser_json_timedelta: Literal['float', 'iso8601']
     # insert_assert(Model.model_json_schema(mode='serialization'))
     assert Model.model_json_schema(mode='serialization') == {
         'properties': properties,
-        'required': ['duration'],
         'title': 'Model',
         'type': 'object',
     }
@@ -1717,7 +1715,6 @@ def test_model_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], properti
     # insert_assert(Model.model_json_schema(mode='serialization'))
     assert Model.model_json_schema(mode='serialization') == {
         'properties': properties,
-        'required': ['data'],
         'title': 'Model',
         'type': 'object',
     }
@@ -1740,7 +1737,6 @@ def test_dataclass_default_timedelta(
     # insert_assert(TypeAdapter(Dataclass).json_schema(mode='serialization'))
     assert TypeAdapter(Dataclass).json_schema(mode='serialization') == {
         'properties': properties,
-        'required': ['duration'],
         'title': 'Dataclass',
         'type': 'object',
     }
@@ -1761,7 +1757,6 @@ def test_dataclass_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], prop
     # insert_assert(TypeAdapter(Dataclass).json_schema(mode='serialization'))
     assert TypeAdapter(Dataclass).json_schema(mode='serialization') == {
         'properties': properties,
-        'required': ['data'],
         'title': 'Dataclass',
         'type': 'object',
     }
@@ -1785,7 +1780,6 @@ def test_typeddict_default_timedelta(
     # insert_assert(TypeAdapter(MyTypedDict).json_schema(mode='serialization'))
     assert TypeAdapter(MyTypedDict).json_schema(mode='serialization') == {
         'properties': properties,
-        'required': ['duration'],
         'title': 'MyTypedDict',
         'type': 'object',
     }
@@ -1807,7 +1801,6 @@ def test_typeddict_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], prop
     # insert_assert(TypeAdapter(MyTypedDict).json_schema(mode='serialization'))
     assert TypeAdapter(MyTypedDict).json_schema(mode='serialization') == {
         'properties': properties,
-        'required': ['data'],
         'title': 'MyTypedDict',
         'type': 'object',
     }
@@ -1928,7 +1921,6 @@ def test_constraints_schema_serialization(kwargs, type_, expected_extra):
         'title': 'Foo',
         'type': 'object',
         'properties': {'a': {'title': 'A title', 'description': 'A description', 'default': 'foo'}},
-        'required': ['a'],
     }
 
     expected_schema['properties']['a'].update(expected_extra)
@@ -4755,7 +4747,7 @@ def test_serialization_schema_with_exclude():
     }
     assert Model.model_json_schema(mode='serialization', schema_generator=MyGenerateJsonSchema) == {
         'properties': {'x': {'title': 'X', 'type': 'integer'}, 'y': {'title': 'Y', 'type': 'integer'}},
-        'required': ['x'],
+        'required': ['x', 'y'],
         'title': 'Model',
         'type': 'object',
     }


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/7209

Note this is not against main, but against @Kludex's branch for supporting ser json stuff.

This should have tests added before being merged, but I wanted to open now to get some initial review. Reading the discussion in the issue linked above may be helpful for understanding the motivation for this change.