### PR TITLE
Fixes for `install` and `docs` targets when contributing on Windows

### DIFF
--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -61,15 +61,15 @@ def on_page_markdown(markdown: str, page: Page, config: Config, files: Files) ->
 
 
 def add_changelog() -> None:
-    history = (PROJECT_ROOT / 'HISTORY.md').read_text()
+    history = (PROJECT_ROOT / 'HISTORY.md').read_text(encoding='utf-8')
     history = re.sub(r'(\s)@([\w\-]+)', r'\1[@\2](https://github.com/\2)', history, flags=re.I)
     history = re.sub(r'\[GitHub release]\(', r'[:simple-github: GitHub release](', history)
     history = re.sub('@@', '@', history)
     new_file = DOCS_DIR / 'changelog.md'
 
     # avoid writing file unless the content has changed to avoid infinite build loop
-    if not new_file.is_file() or new_file.read_text() != history:
-        new_file.write_text(history)
+    if not new_file.is_file() or new_file.read_text(encoding='utf-8') != history:
+        new_file.write_text(history, encoding='utf-8')
 
 
 MIN_MINOR_VERSION = 7

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "t
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:d207d0ea189f3fbf1c45b945839a8414703b7bef4a44671031efefb72d478e96"
+content_hash = "sha256:627e50210e085b981c7b60ee693c0989cf5ab9b07a1b85396a6c42f2efd89413"
 
 [[package]]
 name = "annotated-types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ mypy = [
     "pydantic-settings>=2.0.0",
 ]
 memray = [
-    "pytest-memray",
+    "pytest-memray; platform_system != 'Windows'",
 ]
 
 [tool.pdm.resolution.overrides]


### PR DESCRIPTION
## Change Summary
Tweaks `pyproject.toml` and `docs/plugins/main.py` so that no errors occur when performing common dev tasks like installing, running tests, and building docs on Windows.

Install:

```
> pip install pipx
> pipx install pdm
> pipx install pre-commit
> make install
  ...
  ✔ Install ruff 0.0.285 successful
  ✔ Install mkdocs-material 9.2.3 successful
  ✔ Install sqlalchemy 1.4.0 successful
Retry failed jobs
  ✖ Install memray 1.9.1 failed

ERRORS:
add memray failed:
Traceback (most recent call last):
  ...
  File "<string>", line 276, in <module>
RuntimeError: memray does not support this platform (win32)
```

Building tests then of course fail because of the missing import:

```
> make
...
File ".\Python\pydantic\env\lib\site-packages\pytest_memray\plugin.py", line 22, in <module>
    from memray import AllocationRecord
ModuleNotFoundError: No module named 'memray'
.\Python\pydantic\env\lib\site-packages\coverage\control.py:860: CoverageWarning: No data was collected. (no-data-collected)
  self._warn("No data was collected.", slug="no-data-collected")
make: *** [test] Error 1
```

This can be fixed by simply excluding memray's installation if the installers platform is Windows. This means no memory profiling on Windows, but I would argue that's less important for minimal changes and can always be tested in CI. Not much Pydantic can do about it, in any case.

Making docs also breaks, but for a different reason:

```
> make docs
...
  File ".\Python\pydantic\docs\plugins\main.py", line 64, in add_changelog
    history = (PROJECT_ROOT / 'HISTORY.md').read_text()
  File ".\AppData\Local\Programs\Python\Python310\lib\pathlib.py", line 1135, in read_text
    return f.read()
  File ".\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 7310: character maps to <undefined>
make: *** [docs] Error 1
```

Windows python seems to not want to read the text in "utf-8" by default, which is somewhat bizarre even for Windows. I changed the `read_text()` and `write_text()` functions to specify `encoding="utf-8"`, which should probably be done for consistency anyway.

After these changes, installing, formatting, linting, typechecking, testing, coverage, and building docs all work out of the box on Windows. There are still a few commands that fail (like `test-examples`), but this is less a total conversion PR (and would be much more complex if it was), but instead a pair of fixes so that somebody on Windows who's willing to install `make` could follow along with [the contribution page.](https://docs.pydantic.dev/latest/contributing/) 

Maybe the documentation page could now recommend to install `make` if you're on Windows? All the remaining documentation would be unchanged.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist (N/A)
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review


Selected Reviewer: @davidhewitt