### PR TITLE
Fix pydantic-settings to underscore in docs

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -795,7 +795,7 @@ For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringCons
 
 | Pydantic V1 | Pydantic V2 |
 | --- | --- |
-| `pydantic.BaseSettings` | [`pydantic-settings.BaseSettings`](#basesettings-has-moved-to-pydantic-settings) |
+| `pydantic.BaseSettings` | [`pydantic_settings.BaseSettings`](#basesettings-has-moved-to-pydantic-settings) |
 | `pydantic.color` | `pydantic_extra_types.color` |
 | `pydantic.types.PaymentCardBrand` | [`pydantic_extra_types.PaymentCardBrand`](#color-and-payment-card-numbers-moved-to-pydantic-extra-types) |
 | `pydantic.types.PaymentCardNumber` | [`pydantic_extra_types.PaymentCardNumber`](#color-and-payment-card-numbers-moved-to-pydantic-extra-types) |


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
In this [migration docs](https://docs.pydantic.dev/2.3/migration/#moved-in-pydantic-v2), it seems desirable to change **"pydantic-settings" to "pydantic_settings"** with underscores.
Even though the package repo name is "pydantic-settings", In Python, we still need to use underscores as shown below.
```
from pydantic_settings import BaseSettings
```
I believe this change will be helpful for users.

Thanks! ☺️
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb