### PR TITLE
Docs: fix link to `model_dump`

### DIFF
--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -97,7 +97,7 @@ print(Model(x=['{"a": 1}', '[1, 2]']).model_dump(round_trip=True))
     [`pydantic.main.BaseModel.model_dump_json`][pydantic.main.BaseModel.model_dump_json]<br>
 
 The `.model_dump_json()` method serializes a model directly to a JSON-encoded string
-that is equivalent to the result produced by [`.model_dump()`](#modelmodeldump).
+that is equivalent to the result produced by [`.model_dump()`](#modelmodel_dump).
 
 See [arguments][pydantic.main.BaseModel.model_dump_json] for more information.
 


### PR DESCRIPTION
## Change Summary

I noticed that the documentation for `model_dump_json()` has a link to `model_dump()` but it was missing an underscore.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
