### PR TITLE
Mark `Extra` as deprecated

### DIFF
--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,15 +1,12 @@
 """Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union
 
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 from ._migration import getattr_migration
-from .deprecated.config import BaseConfig
-from .deprecated.config import Extra as _Extra
-from .warnings import PydanticDeprecatedSince20
+from .deprecated.config import BaseConfig, Extra
 
 if TYPE_CHECKING:
     from ._internal._generate_schema import GenerateSchema as _GenerateSchema
@@ -23,13 +20,6 @@ JsonSchemaExtraCallable: TypeAlias = Union[
     Callable[[Dict[str, Any]], None],
     Callable[[Dict[str, Any], Type[Any]], None],
 ]
-
-with warnings.catch_warnings():
-    # The relevant deprecation warning is still raised on attribute access,
-    # so it is okay to suppress the one coming from the @deprecated decorator here.
-    warnings.filterwarnings('ignore', category=PydanticDeprecatedSince20)
-
-    Extra = _Extra()
 
 ExtraValues = Literal['allow', 'ignore', 'forbid']
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 from ._migration import getattr_migration
-from .deprecated.config import BaseConfig, Extra
+from .deprecated.config import BaseConfig
+from .deprecated.config import Extra as _Extra
 from .warnings import PydanticDeprecatedSince20
 
 if TYPE_CHECKING:
@@ -22,6 +23,13 @@ JsonSchemaExtraCallable: TypeAlias = Union[
     Callable[[Dict[str, Any]], None],
     Callable[[Dict[str, Any], Type[Any]], None],
 ]
+
+with warnings.catch_warnings():
+    # The relevant deprecation warning is still raised on attribute access,
+    # so it is okay to suppress the one coming from the @deprecated decorator here.
+    warnings.filterwarnings('ignore', category=PydanticDeprecatedSince20)
+
+    Extra = _Extra()
 
 ExtraValues = Literal['allow', 'ignore', 'forbid']
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 from ._migration import getattr_migration
-from .deprecated.config import BaseConfig
-from .deprecated.config import Extra as _Extra
+from .deprecated.config import BaseConfig, Extra
 from .warnings import PydanticDeprecatedSince20
 
 if TYPE_CHECKING:
@@ -23,13 +22,6 @@ JsonSchemaExtraCallable: TypeAlias = Union[
     Callable[[Dict[str, Any]], None],
     Callable[[Dict[str, Any], Type[Any]], None],
 ]
-
-with warnings.catch_warnings():
-    # The relevant deprecation warning is still raised on attribute access,
-    # so it is okay to suppress the one coming from the @deprecated decorator here.
-    warnings.filterwarnings('ignore', category=PydanticDeprecatedSince20)
-
-    Extra = _Extra()
 
 ExtraValues = Literal['allow', 'ignore', 'forbid']
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,6 +1,7 @@
 """Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union
 
 from typing_extensions import Literal, TypeAlias, TypedDict
@@ -8,6 +9,7 @@ from typing_extensions import Literal, TypeAlias, TypedDict
 from ._migration import getattr_migration
 from .deprecated.config import BaseConfig
 from .deprecated.config import Extra as _Extra
+from .warnings import PydanticDeprecatedSince20
 
 if TYPE_CHECKING:
     from ._internal._generate_schema import GenerateSchema as _GenerateSchema
@@ -22,7 +24,12 @@ JsonSchemaExtraCallable: TypeAlias = Union[
     Callable[[Dict[str, Any], Type[Any]], None],
 ]
 
-Extra = _Extra()
+with warnings.catch_warnings():
+    # The relevant deprecation warning is still raised on attribute access,
+    # so it is okay to suppress the one coming from the @deprecated decorator here.
+    warnings.filterwarnings('ignore', category=PydanticDeprecatedSince20)
+
+    Extra = _Extra()
 
 ExtraValues = Literal['allow', 'ignore', 'forbid']
 

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -50,7 +50,9 @@ class BaseConfig(metaclass=_ConfigMetaclass):
         return super().__init_subclass__(**kwargs)
 
 
-@deprecated('Extra is deprecated. Use literal values instead (e.g. `extra=\'allow\'`)', category=PydanticDeprecatedSince20)
+@deprecated(
+    "Extra is deprecated. Use literal values instead (e.g. `extra='allow'`)", category=PydanticDeprecatedSince20
+)
 class Extra:
     allow: Literal['allow'] = 'allow'
     ignore: Literal['ignore'] = 'ignore'

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -50,18 +50,22 @@ class BaseConfig(metaclass=_ConfigMetaclass):
         return super().__init_subclass__(**kwargs)
 
 
+class _ExtraMeta(type):
+    def __getattribute__(self, __name: str) -> Any:
+        # The @deprecated decorator accesses other attributes, so we only emit a warning for the expected ones
+        if __name in {'allow', 'ignore', 'forbid'}:
+            warnings.warn(
+                "`pydantic.config.Extra` is deprecated, use literal values instead (e.g. `extra='allow'`)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return super().__getattribute__(__name)
+
+
 @deprecated(
     "Extra is deprecated. Use literal values instead (e.g. `extra='allow'`)", category=PydanticDeprecatedSince20
 )
-class Extra:
+class Extra(metaclass=_ExtraMeta):
     allow: Literal['allow'] = 'allow'
     ignore: Literal['ignore'] = 'ignore'
     forbid: Literal['forbid'] = 'forbid'
-
-    def __getattribute__(self, __name: str) -> Any:
-        warnings.warn(
-            "`pydantic.config.Extra` is deprecated, use literal values instead (e.g. `extra='allow'`)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return super().__getattribute__(__name)

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -50,6 +50,7 @@ class BaseConfig(metaclass=_ConfigMetaclass):
         return super().__init_subclass__(**kwargs)
 
 
+@deprecated('Extra is deprecated. use literal values instead (e.g. `extra=\'allow\'`)', category=PydanticDeprecatedSince20)
 class Extra:
     allow: Literal['allow'] = 'allow'
     ignore: Literal['ignore'] = 'ignore'

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -50,7 +50,7 @@ class BaseConfig(metaclass=_ConfigMetaclass):
         return super().__init_subclass__(**kwargs)
 
 
-@deprecated('Extra is deprecated. use literal values instead (e.g. `extra=\'allow\'`)', category=PydanticDeprecatedSince20)
+@deprecated('Extra is deprecated. Use literal values instead (e.g. `extra=\'allow\'`)', category=PydanticDeprecatedSince20)
 class Extra:
     allow: Literal['allow'] = 'allow'
     ignore: Literal['ignore'] = 'ignore'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Similary to the `BaseConfig`, `Extra` is now marked using the `@deprecated` decorator for IDE support to advise against its usage.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu