### PR TITLE
fix: adding a check that alias is validated as an identifier for Python

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -204,10 +204,12 @@ def generate_dataclass_signature(cls: type[StandardDataclass]) -> Signature:
 
             # Replace the field name with the alias if present
             name = param.name
-            if param_default.validation_alias is None and isinstance(param_default.alias, str):
-                name = param_default.alias
-            elif isinstance(param_default.validation_alias, str):
-                name = param_default.validation_alias
+            alias = param_default.alias
+            validation_alias = param_default.validation_alias
+            if validation_alias is None and isinstance(alias, str) and alias.isidentifier():
+                name = alias
+            elif isinstance(validation_alias, str) and validation_alias.isidentifier():
+                name = validation_alias
 
             # Replace the field default
             default = param_default.default

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -22,6 +22,7 @@ from ._generate_schema import GenerateSchema
 from ._generics import get_standard_typevars_map
 from ._mock_val_ser import set_dataclass_mock_validator
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
+from ._utils import is_valid_identifier
 
 if typing.TYPE_CHECKING:
     from ..config import ConfigDict
@@ -206,9 +207,9 @@ def generate_dataclass_signature(cls: type[StandardDataclass]) -> Signature:
             name = param.name
             alias = param_default.alias
             validation_alias = param_default.validation_alias
-            if validation_alias is None and isinstance(alias, str) and alias.isidentifier():
+            if validation_alias is None and isinstance(alias, str) and is_valid_identifier(alias):
                 name = alias
-            elif isinstance(validation_alias, str) and validation_alias.isidentifier():
+            elif isinstance(validation_alias, str) and is_valid_identifier(validation_alias):
                 name = validation_alias
 
             # Replace the field default

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2554,8 +2554,8 @@ def test_alias_with_dashes():
     data = {'some-var': 'some_value'}
 
     @pydantic.dataclasses.dataclass
-    class Example:
+    class Foo:
         some_var: str = Field(..., alias='some-var')
 
-    obj = Example(**data)
+    obj = Foo(**data)
     assert obj.some_var == data['some-var']

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2551,11 +2551,9 @@ def test_can_inherit_stdlib_dataclasses_with_dataclass_fields():
 
 def test_alias_with_dashes():
     """Test for fix issue #7226."""
-    data = {'some-var': 'some_value'}
-
     @pydantic.dataclasses.dataclass
     class Foo:
-        some_var: str = Field(..., alias='some-var')
+        some_var: str = Field(alias='some-var')
 
-    obj = Foo(**data)
-    assert obj.some_var == data['some-var']
+    obj = Foo(**{'some-var': 'some_value'})
+    assert obj.some_var == 'some_value'

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2551,6 +2551,7 @@ def test_can_inherit_stdlib_dataclasses_with_dataclass_fields():
 
 def test_alias_with_dashes():
     """Test for fix issue #7226."""
+
     @pydantic.dataclasses.dataclass
     class Foo:
         some_var: str = Field(alias='some-var')

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -5,7 +5,7 @@ import re
 import sys
 import traceback
 from collections.abc import Hashable
-from dataclasses import FrozenInstanceError, InitVar
+from dataclasses import InitVar
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, List, Optional, Set, TypeVar, Union
@@ -2551,24 +2551,11 @@ def test_can_inherit_stdlib_dataclasses_with_dataclass_fields():
 
 def test_alias_with_dashes():
     """Test for fix issue #7226."""
-    # WITH
     data = {'some-var': 'some_value'}
 
     @pydantic.dataclasses.dataclass
     class Example:
         some_var: str = Field(..., alias='some-var')
 
-    @pydantic.dataclasses.dataclass(frozen=True)
-    class FrozenExample:
-        some_frozen_var: str = Field(..., alias='some-var')
-
-    # WHEN
     obj = Example(**data)
-    frozen_obj = FrozenExample(**data)
-    with pytest.raises(FrozenInstanceError) as exc_info:
-        frozen_obj.some_frozen_var = 'some_other_value'
-    # THEN
     assert obj.some_var == data['some-var']
-    assert obj.some_var == data['some-var']
-    assert frozen_obj.some_frozen_var == data['some-var']
-    assert exc_info.value.args[0] == "cannot assign to field 'some_frozen_var'"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Changes in `generate_dataclass_signature` function. I used `is_valid_identifier` function from `_utils.py` for `alias` and `validation_alias` as new statement when `name` parameter is replaced by the alias or the validation alias.

I didn't want to use `:=` (walrus operator) in if statement because it isn't support for Python 3.7, so I assigned variables first to make the code more readable.

<!-- Please give a short summary of the changes. -->

## Related issue number

Fix: #7226 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
