### PR TITLE
Raise an Error When Computed Field Overrides Field

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from ..fields import FieldInfo
     from ..main import BaseModel
     from ._dataclasses import StandardDataclass
+    from ._decorators import DecoratorInfos
 
 
 def get_type_hints_infer_globalns(

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -196,6 +196,11 @@ def collect_model_fields(  # noqa: C901
             except AttributeError:
                 pass  # indicates the attribute was on a parent class
 
+        # Use cls.__dict__['__pydantic_decorators__'] instead of cls.__pydantic_decorators__
+        # to make sure the decorators have already been built for this exact class
+        decorators: DecoratorInfos = cls.__dict__['__pydantic_decorators__']
+        if ann_name in decorators.computed_fields:
+            raise ValueError("you can't override a field with a computed field")
         fields[ann_name] = field_info
 
     if typevars_map:

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -741,3 +741,18 @@ def test_generic_computed_field():
 
     with pytest.warns(UserWarning, match='Expected `int` but got `str` - serialized value may not be as expected'):
         B[int]().model_dump()
+
+
+def test_computed_field_override_raises():
+    class Model(BaseModel):
+        name: str = 'foo'
+
+    with pytest.raises(ValueError) as e:
+
+        class SubModel(Model):
+            @computed_field
+            @property
+            def name(self) -> str:
+                return 'bar'
+
+    assert e.value.args == ("you can't override a field with a computed field",)

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -747,7 +747,7 @@ def test_computed_field_override_raises():
     class Model(BaseModel):
         name: str = 'foo'
 
-    with pytest.raises(ValueError, match='you can't override a field with a computed field') as e:
+    with pytest.raises(ValueError, match="you can't override a field with a computed field"):
 
         class SubModel(Model):
             @computed_field

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -747,12 +747,10 @@ def test_computed_field_override_raises():
     class Model(BaseModel):
         name: str = 'foo'
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='you can't override a field with a computed field') as e:
 
         class SubModel(Model):
             @computed_field
             @property
             def name(self) -> str:
                 return 'bar'
-
-    assert e.value.args == ("you can't override a field with a computed field",)


### PR DESCRIPTION
## Change Summary
* If a `computed_field` is defined in a subclass such that it overrides a field from a super class, a `ValueError` is raised.

## Related issue number

fix #7250 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
