### PR TITLE
Fixed a regular expression denial of service issue by limiting whites…

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -421,7 +421,7 @@ def _build_pretty_email_regex() -> re.Pattern:
     unquoted_name_group = fr'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
     # altered regex to no longer be susceptible to denial of service
-    email_group = r'<\s{0,5}(.+)\s{0,5}>'
+    email_group = r'<\s{0,5}(.{0,3000})\s{0,5}>'
     return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -421,7 +421,7 @@ def _build_pretty_email_regex() -> re.Pattern:
     unquoted_name_group = fr'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
     # altered regex to no longer be susceptible to denial of service
-    email_group = r'<\s{0,5}.\s{0,5}>'
+    email_group = r'<\s{0,5}(.+)\s{0,5}>'
     return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -420,7 +420,8 @@ def _build_pretty_email_regex() -> re.Pattern:
     name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'
     unquoted_name_group = fr'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
-    email_group = r'<\s*(.+)\s*>'
+    # altered regex to no longer be susceptible to denial of service
+    email_group = r'<\s{0,5}.\s{0,5}>'
     return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -416,16 +416,20 @@ class IPvAnyNetwork:
         return cls(__input_value)  # type: ignore[return-value]
 
 
-def _build_pretty_email_regex() -> re.Pattern:
+def _build_pretty_email_regex() -> re.Pattern[str]:
     name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'
     unquoted_name_group = fr'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
-    # altered regex to no longer be susceptible to denial of service
-    email_group = r'<\s{0,5}(.{0,3000})\s{0,5}>'
+    email_group = r'<\s*(.{0,254})\s*>'
     return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
 
 
 pretty_email_regex = _build_pretty_email_regex()
+
+MAX_EMAIL_LENGTH = 2048
+"""Maximum length for an email.
+A somewhat arbitrary but very generous number compared to what is allowed by most implementations.
+"""
 
 
 def validate_email(value: str) -> tuple[str, str]:
@@ -440,6 +444,13 @@ def validate_email(value: str) -> tuple[str, str]:
     """
     if email_validator is None:
         import_email_validator()
+
+    if len(value) > MAX_EMAIL_LENGTH:
+        raise PydanticCustomError(
+            'value_error',
+            'value is not a valid email address: {reason}',
+            {'reason': f'Length must not exceed {MAX_EMAIL_LENGTH} characters'},
+        )
 
     m = pretty_email_regex.fullmatch(value)
     name: str | None = None

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Union
 
 import pytest
 from pydantic_core import PydanticCustomError, Url
@@ -277,7 +277,7 @@ def test_http_url_success(value, expected):
 
 def test_nullable_http_url():
     class Model(BaseModel):
-        v: HttpUrl | None
+        v: Union[HttpUrl, None]
 
     assert Model(v=None).v is None
     assert str(Model(v='http://example.org').v) == 'http://example.org/'
@@ -815,7 +815,7 @@ def test_address_valid(value, name, email):
         pytest.param('foobar <' + 'a' * 4096 + '@example.com>', 'Length must not exceed 2048 characters', id='long'),
     ],
 )
-def test_address_invalid(value: str, reason: str | None):
+def test_address_invalid(value: str, reason: Union[str, None]):
     with pytest.raises(PydanticCustomError, match=f'value is not a valid email address: {reason or ""}'):
         validate_email(value)
 

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,4 +1,4 @@
-from typing import Union
+from __future__ import annotations
 
 import pytest
 from pydantic_core import PydanticCustomError, Url
@@ -277,7 +277,7 @@ def test_http_url_success(value, expected):
 
 def test_nullable_http_url():
     class Model(BaseModel):
-        v: Union[HttpUrl, None]
+        v: HttpUrl | None
 
     assert Model(v=None).v is None
     assert str(Model(v='http://example.org').v) == 'http://example.org/'
@@ -812,9 +812,10 @@ def test_address_valid(value, name, email):
         ('foobar <<foobar<@example.com>', None),
         ('foobar <>', None),
         ('first.last <first.last@example.com>', None),
+        pytest.param('foobar <' + 'a' * 4096 + '@example.com>', 'Length must not exceed 2048 characters', id='long'),
     ],
 )
-def test_address_invalid(value, reason):
+def test_address_invalid(value: str, reason: str | None):
     with pytest.raises(PydanticCustomError, match=f'value is not a valid email address: {reason or ""}'):
         validate_email(value)
 


### PR DESCRIPTION
…paces

## Change Summary

As discussed over email, this fixes a security issue where a regular expression denial of service can be performed. 

Exploit code is below:
```python
import time
from pydantic import networks
from pydantic.networks import validate_email

start = time.time()

try:
    exploit_string = '<' + ' ' * 3000
    validate_email(exploit_string)
except:
    pass

print(f"Time elapsed: {time.time() - start}")
```

## Related issue number

NA

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ x My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin