### PR TITLE
Update dataclass docs to indicate support for `extra` config

### DIFF
--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -140,7 +140,8 @@ class MyDataclass2:
 !!! note
     Pydantic dataclasses support [`extra`](model_config.md#extra-attributes) configuration to `ignore`, `forbid`, or
     `allow` extra fields passed to the initializer. However, some default behavior of stdlib dataclasses may prevail.
-    For example, extra fields are omitted when `print`ing a Pydantic dataclass with allowed extra fields.
+    For example, any extra fields present on a Pydantic dataclass using `extra='allow'` are omitted when the dataclass
+    is `print`ed.
 
 ## Nested dataclasses
 

--- a/docs/usage/dataclasses.md
+++ b/docs/usage/dataclasses.md
@@ -138,11 +138,9 @@ class MyDataclass2:
 1. You can read more about `validate_assignment` in [model_config](model_config.md#validate-assignment).
 
 !!! note
-    Pydantic dataclasses do not support [`extra='allow'`](model_config.md#extra-attributes), where extra fields passed
-    to the initializer would be stored as extra attributes on the dataclass.
-
-    `extra='ignore'` is still supported for the purpose of ignoring
-    unexpected fields while parsing data; they just won't be stored on the instance.
+    Pydantic dataclasses support [`extra`](model_config.md#extra-attributes) configuration to `ignore`, `forbid`, or
+    `allow` extra fields passed to the initializer. However, some default behavior of stdlib dataclasses may prevail.
+    For example, extra fields are omitted when `print`ing a Pydantic dataclass with allowed extra fields.
 
 ## Nested dataclasses
 


### PR DESCRIPTION
Fixing documentation ambiguity noted in #7362.

## Change Summary

This PR updates the dataclasses documentation to indicate support for `extra` configuration. Currently, the documentation states that this configuration is not supported, when in fact it is supported (with caveats).

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
