### PR TITLE
Document Via Tables Expected `exclude` at `Field` and `model_dump` level

### DIFF
--- a/docs/plugins/conversion_table.py
+++ b/docs/plugins/conversion_table.py
@@ -17,6 +17,8 @@ from typing_extensions import TypedDict
 
 from pydantic import ByteSize, InstanceOf
 
+from .utils import generate_table_heading, generate_table_row
+
 
 @dataclass
 class Row:
@@ -77,15 +79,9 @@ class ConversionTable:
             row.condition if row.condition else '',
         ]
 
-    @staticmethod
-    def row_as_markdown(cols: list[str]) -> str:
-        return f'| {" | ".join(cols)} |'
-
     def as_markdown(self) -> str:
-        lines = [self.row_as_markdown(self.col_names), self.row_as_markdown(['-'] * len(self.col_names))]
-        for row in self.rows:
-            lines.append(self.row_as_markdown(self.col_values(row)))
-        return '\n'.join(lines)
+        table_heading = generate_table_heading(self.col_names)
+        return ''.join([table_heading, *[generate_table_row(row) for row in self.rows]])
 
     @staticmethod
     def row_sort_key(row: Row) -> Any:

--- a/docs/plugins/conversion_table.py
+++ b/docs/plugins/conversion_table.py
@@ -81,7 +81,7 @@ class ConversionTable:
 
     def as_markdown(self) -> str:
         table_heading = generate_table_heading(self.col_names)
-        return ''.join([table_heading, *[generate_table_row(row) for row in self.rows]])
+        return ''.join([table_heading, *[generate_table_row(self.col_values(row)) for row in self.rows]])
 
     @staticmethod
     def row_sort_key(row: Row) -> Any:

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -10,6 +10,7 @@ from .utils import generate_table_heading, generate_table_row
 class ExcludeSetting:
     name: str
     value: Union[bool, set]
+
     open_nowrap_span: str = '<span style="white-space: nowrap;">'
     close_nowrap_span: str = '</span>'
 
@@ -37,7 +38,7 @@ model_dump_exclude_settings: List[ExcludeSetting] = [
 ]
 model_dump_exclude_x_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude_none', value=True),
-    ExcludeSetting(name='exclude_none', value=False),
+    ExcludeSetting(name='exclude_none', value={}),
     ExcludeSetting(name='exclude_defaults', value=True),
     ExcludeSetting(name='exclude_defaults', value=False),
     ExcludeSetting(name='exclude_unset', value=True),
@@ -46,13 +47,13 @@ model_dump_exclude_x_settings: List[ExcludeSetting] = [
 
 
 def build_exclude_priority_table(
-    field_settings: List[ExcludeSetting], model_dump_settings: List[ExcludeSetting], constructor_kwargs: Dict[str, Any]
+        field_settings: List[ExcludeSetting], model_dump_settings: List[ExcludeSetting],
+        constructor_kwargs: Dict[str, Any]
 ) -> str:
     rows = []
-    for field_setting in field_settings:
+    for model_dump_setting in model_dump_settings:
         col_values = []
-        for model_dump_setting in model_dump_settings:
-
+        for field_setting in field_settings:
             class Dog(BaseModel):
                 """Example class for explanation of `exclude` priority."""
 
@@ -62,9 +63,15 @@ def build_exclude_priority_table(
             result = my_dog.model_dump(**model_dump_setting.kwargs_dict)
             col_values.append(result)
 
-        rows.append(generate_table_row(col_values=[field_setting.markdown_str, *[f'`{x}`' for x in col_values]]))
+        rows.append(generate_table_row(col_values=[model_dump_setting.markdown_str, *[f'`{x}`' for x in col_values]]))
 
-    table_heading = generate_table_heading(col_names=['Field Setting', *[x.markdown_str for x in model_dump_settings]])
+    table_heading = generate_table_heading(
+        col_names=[
+            f'<br></br>`model_dump` **Setting**',
+            f'`Field` **Setting**<br></br>{field_settings[0].markdown_str}',
+            *[f'<br></br>{x.markdown_str}' for x in field_settings[1:]]
+        ]
+    )
     table = ''.join([table_heading, *rows])
 
     return table

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -50,7 +50,7 @@ def build_exclude_priority_table(
 ) -> str:
     rows = []
     for field_setting in field_settings:
-        col_values = [field_setting.markdown_str]
+        col_values = []
         for model_dump_setting in model_dump_settings:
 
             class Dog(BaseModel):
@@ -62,7 +62,7 @@ def build_exclude_priority_table(
             result = my_dog.model_dump(**model_dump_setting.kwargs_dict)
             col_values.append(result)
 
-        rows.append(generate_table_row(col_values=[f'`{x}`' for x in col_values]))
+        rows.append(generate_table_row(col_values=[field_setting.markdown_str, *[f'`{x}`' for x in col_values]]))
 
     table_heading = generate_table_heading(col_names=['Field Setting', *[x.markdown_str for x in model_dump_settings]])
     table = ''.join([table_heading, *rows])

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -10,27 +10,32 @@ from .utils import generate_table_heading, generate_table_row
 class ExcludeSetting:
     name: str
     value: Union[bool, set]
+    open_nowrap_span: str = '<span style="white-space: nowrap;">'
+    close_nowrap_span: str = '</span>'
 
     @property
     def markdown_str(self) -> str:
-        return f'`{self.name}={self.value}`'
+        o = self.open_nowrap_span
+        c = self.close_nowrap_span
+
+        return f'{o}`{self.name}={self.value}`{c}'
 
     @property
-    def kwargs_dict(self) -> dict[str, Union[str, bool, set]]:
+    def kwargs_dict(self) -> Dict[str, Union[str, bool, set]]:
         return {self.name: self.value}
 
 
-field_exclude_settings: list[ExcludeSetting] = [
+field_exclude_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude', value=True),
     ExcludeSetting(name='exclude', value=False),
 ]
-model_dump_exclude_settings: list[ExcludeSetting] = [
+model_dump_exclude_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude', value={'name'}),
     ExcludeSetting(name='exclude', value={}),
     ExcludeSetting(name='include', value={'name'}),
     ExcludeSetting(name='include', value={}),
 ]
-model_dump_exclude_x_settings: list[ExcludeSetting] = [
+model_dump_exclude_x_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude_none', value=True),
     ExcludeSetting(name='exclude_none', value=False),
     ExcludeSetting(name='exclude_defaults', value=True),
@@ -41,7 +46,7 @@ model_dump_exclude_x_settings: list[ExcludeSetting] = [
 
 
 def build_exclude_priority_table(
-    field_settings: list[ExcludeSetting], model_dump_settings: list[ExcludeSetting], constructor_kwargs: dict[str, Any]
+    field_settings: List[ExcludeSetting], model_dump_settings: List[ExcludeSetting], constructor_kwargs: Dict[str, Any]
 ) -> str:
     rows = []
     for field_setting in field_settings:

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from .utils import generate_table_heading, generate_table_row
+
+
+@dataclass
+class ExcludeSetting:
+    name: str
+    value: Union[bool, set]
+
+    @property
+    def markdown_str(self) -> str:
+        return f'`{self.name}={self.value}`'
+
+    @property
+    def kwargs_dict(self) -> dict[str, Union[str, bool, set]]:
+        return {self.name: self.value}
+
+
+field_exclude_settings: list[ExcludeSetting] = [
+    ExcludeSetting(name='exclude', value=True),
+    ExcludeSetting(name='exclude', value=False),
+]
+model_dump_exclude_settings: list[ExcludeSetting] = [
+    ExcludeSetting(name='exclude', value={'name'}),
+    ExcludeSetting(name='exclude', value={}),
+    ExcludeSetting(name='include', value={'name'}),
+    ExcludeSetting(name='include', value={}),
+]
+model_dump_exclude_x_settings: list[ExcludeSetting] = [
+    ExcludeSetting(name='exclude_none', value=True),
+    ExcludeSetting(name='exclude_none', value=False),
+    ExcludeSetting(name='exclude_defaults', value=True),
+    ExcludeSetting(name='exclude_defaults', value=False),
+    ExcludeSetting(name='exclude_unset', value=True),
+    ExcludeSetting(name='exclude_unset', value=False),
+]
+
+
+def build_exclude_priority_table(
+    field_settings: list[ExcludeSetting], model_dump_settings: list[ExcludeSetting], constructor_kwargs: dict[str, Any]
+) -> str:
+    rows = []
+    for field_setting in field_settings:
+        col_values = [field_setting.markdown_str]
+        for model_dump_setting in model_dump_settings:
+
+            class Dog(BaseModel):
+                """Example class for explanation of `exclude` priority."""
+
+                name: Optional[str] = Field(default=None, **field_setting.kwargs_dict)
+
+            my_dog = Dog(**constructor_kwargs)
+            result = my_dog.model_dump(**model_dump_setting.kwargs_dict)
+            col_values.append(result)
+
+        rows.append(generate_table_row(col_values=[f'`{x}`' for x in col_values]))
+
+    table_heading = generate_table_heading(col_names=['Field Setting', *[x.markdown_str for x in model_dump_settings]])
+    table = ''.join([table_heading, *rows])
+
+    return table
+
+
+exclude_table = build_exclude_priority_table(
+    field_settings=field_exclude_settings,
+    model_dump_settings=model_dump_exclude_settings,
+    constructor_kwargs={'name': 'Ralph'},
+)
+exclude_x_table = build_exclude_priority_table(
+    field_settings=field_exclude_settings, model_dump_settings=model_dump_exclude_x_settings, constructor_kwargs={}
+)

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -1,100 +1,63 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
-
-from .utils import generate_table_heading, generate_table_row
-
-
-def _no_wrap(s: str) -> str:
-    open_nowrap_span: str = '<span style="white-space: nowrap;">'
-    close_nowrap_span: str = '</span>'
-
-    return f'{open_nowrap_span}{s}{close_nowrap_span}'
 
 
 @dataclass
 class ExcludeSetting:
     name: str
     value: Union[bool, set]
-    md_str: Optional[str] = None
 
     @property
     def markdown_str(self) -> str:
-        return self.md_str or f'{self.name}={self.value}'
+        return f'{self.name}={self.value}'
 
     @property
     def kwargs_dict(self) -> Dict[str, Union[str, bool, set]]:
         return {} if self.name == 'not_specified' else {self.name: self.value}
 
 
-field_exclude_settings: List[ExcludeSetting] = [
-    ExcludeSetting(name='exclude', value=False),
-    ExcludeSetting(name='exclude', value=True),
-]
-model_dump_exclude_overrides_settings: List[ExcludeSetting] = [
-    ExcludeSetting(name='exclude', value={'name'}),
-    ExcludeSetting(name='exclude', value={}),
-    ExcludeSetting(name='include', value={'name'}),
-    ExcludeSetting(name='include', value={}),
-]
 model_dump_exclude_variants_settings: List[ExcludeSetting] = [
-    ExcludeSetting(name='not_specified', value={}, md_str='`<not specified>`'),  # special case
+    ExcludeSetting(name='exclude', value={'name'}),
+    ExcludeSetting(name='include', value={}),
     ExcludeSetting(name='exclude_none', value=True),
     ExcludeSetting(name='exclude_defaults', value=True),
     ExcludeSetting(name='exclude_unset', value=True),
 ]
 
 
-def build_exclude_priority_table(
-    field_settings: List[ExcludeSetting],
-    model_dump_settings: List[ExcludeSetting],
-    constructor_kwargs: List[Dict[str, Any]],
-) -> str:
-    rows = []
-    for kwargs_ in constructor_kwargs:
-        for idx, model_dump_setting in enumerate(model_dump_settings):
-            col_values = []
-            for field_setting in field_settings:
+base_markdown = """
+```py
+from typing import Optional
 
-                class Dog(BaseModel):
-                    """Example class for explanation of `exclude` priority."""
+from pydantic import BaseModel, Field
 
-                    name: Optional[str] = Field(default='Unspecified', **field_setting.kwargs_dict)
+class Dog(BaseModel):
+    name: Optional[str] = Field(default='Unspecified', exclude=False)
 
-                my_dog = Dog(**kwargs_)
-                result = my_dog.model_dump(**model_dump_setting.kwargs_dict)
-                col_values.append(result)
-
-            rows.append(
-                generate_table_row(
-                    col_values=[
-                        _no_wrap(f'`{kwargs_}`') if idx == 0 else '',
-                        _no_wrap(f'`{str(model_dump_setting.kwargs_dict)}`'),
-                        *[_no_wrap(f'`{str(x)}`') for x in col_values],
-                    ]
-                )
-            )
-
-    table_heading = generate_table_heading(
-        col_names=[
-            '`init_kws`',
-            '`model_dump_kws`',
-            *[f'`model_dump` with {_no_wrap(f"`Field({x.markdown_str})`")}' for x in field_settings],
-        ]
-    )
-    table = ''.join([table_heading, *rows])
-
-    return table
+"""
 
 
-exclude_overrides_table = build_exclude_priority_table(
-    field_settings=field_exclude_settings,
-    model_dump_settings=model_dump_exclude_overrides_settings,
-    constructor_kwargs=[{'name': 'Ralph'}],
-)
-exclude_variants_table = build_exclude_priority_table(
-    field_settings=field_exclude_settings,
-    model_dump_settings=model_dump_exclude_variants_settings,
-    constructor_kwargs=[{'name': 'Ralph'}, {'name': 'Unspecified'}, {'name': None}, {}],
-)
+class Dog(BaseModel):
+    name: Optional[str] = Field(default='Unspecified', exclude=False)
+
+
+def _build_exclude_example_markdown(exclude_setting: ExcludeSetting) -> str:
+    modified_markdown = base_markdown
+    for init_kws in [{'name': 'Ralph'}, {'name': 'Unspecified'}, {'name': None}, {}]:
+        my_dog = Dog(**init_kws)
+
+        modified_markdown += f'my_dog = Dog(**{init_kws})\n'
+        modified_markdown += f'print(my_dog.model_dump({exclude_setting.markdown_str}))\n'
+        modified_markdown += f'#> {my_dog.model_dump(**exclude_setting.kwargs_dict)}\n'
+
+    modified_markdown += '```'
+
+    return modified_markdown
+
+
+exclude_variations_code_examples = {
+    setting.name: _build_exclude_example_markdown(exclude_setting=setting)
+    for setting in model_dump_exclude_variants_settings
+}

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -27,8 +27,8 @@ class ExcludeSetting:
 
 
 field_exclude_settings: List[ExcludeSetting] = [
-    ExcludeSetting(name='exclude', value=True),
     ExcludeSetting(name='exclude', value=False),
+    ExcludeSetting(name='exclude', value=True),
 ]
 model_dump_exclude_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude', value={'name'}),
@@ -38,38 +38,47 @@ model_dump_exclude_settings: List[ExcludeSetting] = [
 ]
 model_dump_exclude_x_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude_none', value=True),
-    ExcludeSetting(name='exclude_none', value={}),
     ExcludeSetting(name='exclude_defaults', value=True),
-    ExcludeSetting(name='exclude_defaults', value=False),
     ExcludeSetting(name='exclude_unset', value=True),
-    ExcludeSetting(name='exclude_unset', value=False),
 ]
 
 
 def build_exclude_priority_table(
-        field_settings: List[ExcludeSetting], model_dump_settings: List[ExcludeSetting],
-        constructor_kwargs: Dict[str, Any]
+    field_settings: List[ExcludeSetting],
+    model_dump_settings: List[ExcludeSetting],
+    constructor_kwargs: List[Dict[str, Any]],
 ) -> str:
     rows = []
-    for model_dump_setting in model_dump_settings:
-        col_values = []
-        for field_setting in field_settings:
-            class Dog(BaseModel):
-                """Example class for explanation of `exclude` priority."""
+    for kwargs_ in constructor_kwargs:
+        for idx, model_dump_setting in enumerate(model_dump_settings):
+            col_values = []
+            for field_setting in field_settings:
 
-                name: Optional[str] = Field(default=None, **field_setting.kwargs_dict)
+                class Dog(BaseModel):
+                    """Example class for explanation of `exclude` priority."""
 
-            my_dog = Dog(**constructor_kwargs)
-            result = my_dog.model_dump(**model_dump_setting.kwargs_dict)
-            col_values.append(result)
+                    name: Optional[str] = Field(default='Unspecified', **field_setting.kwargs_dict)
 
-        rows.append(generate_table_row(col_values=[model_dump_setting.markdown_str, *[f'`{x}`' for x in col_values]]))
+                my_dog = Dog(**kwargs_)
+                result = my_dog.model_dump(**model_dump_setting.kwargs_dict)
+                col_values.append(result)
+
+            rows.append(
+                generate_table_row(
+                    col_values=[
+                        f'`{kwargs_}`' if idx == 0 else '',
+                        model_dump_setting.markdown_str,
+                        *[f'`{x}`' for x in col_values],
+                    ]
+                )
+            )
 
     table_heading = generate_table_heading(
         col_names=[
-            f'<br></br>`model_dump` **Setting**',
+            '<br></br>`__init__` **kwargs**',
+            '<br></br>`model_dump` **Setting**',
             f'`Field` **Setting**<br></br>{field_settings[0].markdown_str}',
-            *[f'<br></br>{x.markdown_str}' for x in field_settings[1:]]
+            *[f'<br></br>{x.markdown_str}' for x in field_settings[1:]],
         ]
     )
     table = ''.join([table_heading, *rows])
@@ -80,8 +89,10 @@ def build_exclude_priority_table(
 exclude_table = build_exclude_priority_table(
     field_settings=field_exclude_settings,
     model_dump_settings=model_dump_exclude_settings,
-    constructor_kwargs={'name': 'Ralph'},
+    constructor_kwargs=[{'name': 'Ralph'}],
 )
 exclude_x_table = build_exclude_priority_table(
-    field_settings=field_exclude_settings, model_dump_settings=model_dump_exclude_x_settings, constructor_kwargs={}
+    field_settings=field_exclude_settings,
+    model_dump_settings=model_dump_exclude_x_settings,
+    constructor_kwargs=[{'name': 'Ralph'}, {'name': 'Unspecified'}, {'name': None}, {}],
 )

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -6,21 +6,22 @@ from pydantic import BaseModel, Field
 from .utils import generate_table_heading, generate_table_row
 
 
+def _no_wrap(s: str) -> str:
+    open_nowrap_span: str = '<span style="white-space: nowrap;">'
+    close_nowrap_span: str = '</span>'
+
+    return f'{open_nowrap_span}{s}{close_nowrap_span}'
+
+
 @dataclass
 class ExcludeSetting:
     name: str
     value: Union[bool, set]
     md_str: Optional[str] = None
 
-    open_nowrap_span: str = '<span style="white-space: nowrap;">'
-    close_nowrap_span: str = '</span>'
-
     @property
     def markdown_str(self) -> str:
-        o = self.open_nowrap_span
-        c = self.close_nowrap_span
-
-        return self.md_str or f'{o}`{self.name}={self.value}`{c}'
+        return self.md_str or f'{self.name}={self.value}'
 
     @property
     def kwargs_dict(self) -> Dict[str, Union[str, bool, set]]:
@@ -68,19 +69,18 @@ def build_exclude_priority_table(
             rows.append(
                 generate_table_row(
                     col_values=[
-                        f'`{kwargs_}`' if idx == 0 else '',
-                        model_dump_setting.markdown_str,
-                        *[f'`{x}`' for x in col_values],
+                        _no_wrap(f'`{kwargs_}`') if idx == 0 else '',
+                        _no_wrap(f'`{str(model_dump_setting.kwargs_dict)}`'),
+                        *[_no_wrap(f'`{str(x)}`') for x in col_values],
                     ]
                 )
             )
 
     table_heading = generate_table_heading(
         col_names=[
-            '<br></br>`__init__` **kwargs**',
-            '<br></br>`model_dump` **Setting**',
-            f'`Field` **Setting**<br></br>{field_settings[0].markdown_str}',
-            *[f'<br></br>{x.markdown_str}' for x in field_settings[1:]],
+            '`init_kws`',
+            '`model_dump_kws`',
+            *[f'`model_dump` with {_no_wrap(f"`Field({x.markdown_str})`")}' for x in field_settings],
         ]
     )
     table = ''.join([table_heading, *rows])

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -24,7 +24,7 @@ class ExcludeSetting:
 
     @property
     def kwargs_dict(self) -> Dict[str, Union[str, bool, set]]:
-        return {self.name: self.value} if self.name != 'not_specified' else {}
+        return {} if self.name == 'not_specified' else {self.name: self.value}
 
 
 field_exclude_settings: List[ExcludeSetting] = [
@@ -38,7 +38,7 @@ model_dump_exclude_overrides_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='include', value={}),
 ]
 model_dump_exclude_variants_settings: List[ExcludeSetting] = [
-    ExcludeSetting(name='not_specified', value={}, md_str='<not specified>'),
+    ExcludeSetting(name='not_specified', value={}, md_str='`<not specified>`'),  # special case
     ExcludeSetting(name='exclude_none', value=True),
     ExcludeSetting(name='exclude_defaults', value=True),
     ExcludeSetting(name='exclude_unset', value=True),

--- a/docs/plugins/exclude_priority_table.py
+++ b/docs/plugins/exclude_priority_table.py
@@ -10,6 +10,7 @@ from .utils import generate_table_heading, generate_table_row
 class ExcludeSetting:
     name: str
     value: Union[bool, set]
+    md_str: Optional[str] = None
 
     open_nowrap_span: str = '<span style="white-space: nowrap;">'
     close_nowrap_span: str = '</span>'
@@ -19,24 +20,25 @@ class ExcludeSetting:
         o = self.open_nowrap_span
         c = self.close_nowrap_span
 
-        return f'{o}`{self.name}={self.value}`{c}'
+        return self.md_str or f'{o}`{self.name}={self.value}`{c}'
 
     @property
     def kwargs_dict(self) -> Dict[str, Union[str, bool, set]]:
-        return {self.name: self.value}
+        return {self.name: self.value} if self.name != 'not_specified' else {}
 
 
 field_exclude_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude', value=False),
     ExcludeSetting(name='exclude', value=True),
 ]
-model_dump_exclude_settings: List[ExcludeSetting] = [
+model_dump_exclude_overrides_settings: List[ExcludeSetting] = [
     ExcludeSetting(name='exclude', value={'name'}),
     ExcludeSetting(name='exclude', value={}),
     ExcludeSetting(name='include', value={'name'}),
     ExcludeSetting(name='include', value={}),
 ]
-model_dump_exclude_x_settings: List[ExcludeSetting] = [
+model_dump_exclude_variants_settings: List[ExcludeSetting] = [
+    ExcludeSetting(name='not_specified', value={}, md_str='<not specified>'),
     ExcludeSetting(name='exclude_none', value=True),
     ExcludeSetting(name='exclude_defaults', value=True),
     ExcludeSetting(name='exclude_unset', value=True),
@@ -86,13 +88,13 @@ def build_exclude_priority_table(
     return table
 
 
-exclude_table = build_exclude_priority_table(
+exclude_overrides_table = build_exclude_priority_table(
     field_settings=field_exclude_settings,
-    model_dump_settings=model_dump_exclude_settings,
+    model_dump_settings=model_dump_exclude_overrides_settings,
     constructor_kwargs=[{'name': 'Ralph'}],
 )
-exclude_x_table = build_exclude_priority_table(
+exclude_variants_table = build_exclude_priority_table(
     field_settings=field_exclude_settings,
-    model_dump_settings=model_dump_exclude_x_settings,
+    model_dump_settings=model_dump_exclude_variants_settings,
     constructor_kwargs=[{'name': 'Ralph'}, {'name': 'Unspecified'}, {'name': None}, {}],
 )

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -16,7 +16,7 @@ from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 
 from .conversion_table import conversion_table
-from .exclude_priority_table import exclude_table, exclude_x_table
+from .exclude_priority_table import exclude_overrides_table, exclude_variants_table
 from .utils import generate_table_heading, generate_table_row
 
 logger = logging.getLogger('mkdocs.plugin')
@@ -283,8 +283,8 @@ def build_exclude_priority_table(markdown: str, page: Page) -> str | None:
     if page.file.src_uri != 'usage/serialization.md':
         return None
 
-    markdown = re.sub(r'{{ *exclude_table *}}', exclude_table, markdown)
-    markdown = re.sub(r'{{ *exclude_x_table *}}', exclude_x_table, markdown)
+    markdown = re.sub(r'{{ *exclude_overrides_table *}}', exclude_overrides_table, markdown)
+    markdown = re.sub(r'{{ *exclude_variants_table *}}', exclude_variants_table, markdown)
 
     return markdown
 

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -16,7 +16,7 @@ from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 
 from .conversion_table import conversion_table
-from .exclude_priority_table import exclude_overrides_table, exclude_variants_table
+from .exclude_priority_table import exclude_variations_code_examples
 from .utils import generate_table_heading, generate_table_row
 
 logger = logging.getLogger('mkdocs.plugin')
@@ -283,8 +283,9 @@ def build_exclude_priority_table(markdown: str, page: Page) -> str | None:
     if page.file.src_uri != 'usage/serialization.md':
         return None
 
-    markdown = re.sub(r'{{ *exclude_overrides_table *}}', exclude_overrides_table, markdown)
-    markdown = re.sub(r'{{ *exclude_variants_table *}}', exclude_variants_table, markdown)
+    for example_name, md_example in exclude_variations_code_examples.items():
+        md_example = textwrap.indent(md_example, '    ')
+        markdown = re.sub(rf'{{{{ *{example_name}_example *}}}}', md_example, markdown)
 
     return markdown
 

--- a/docs/plugins/utils.py
+++ b/docs/plugins/utils.py
@@ -1,9 +1,10 @@
 """Shared utility functions for docs plugins."""
+from typing import List
 
 
-def generate_table_row(col_values: list[str]) -> str:
+def generate_table_row(col_values: List[str]) -> str:
     return f'| {" | ".join(col_values)} |\n'
 
 
-def generate_table_heading(col_names: list[str]) -> str:
+def generate_table_heading(col_names: List[str]) -> str:
     return generate_table_row(col_names) + generate_table_row(['-'] * len(col_names))

--- a/docs/plugins/utils.py
+++ b/docs/plugins/utils.py
@@ -1,0 +1,9 @@
+"""Shared utility functions for docs plugins."""
+
+
+def generate_table_row(col_values: list[str]) -> str:
+    return f'| {" | ".join(col_values)} |\n'
+
+
+def generate_table_heading(col_names: list[str]) -> str:
+    return generate_table_row(col_names) + generate_table_row(['-'] * len(col_names))

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -646,18 +646,18 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-# differ by table row / col
-init_kwargs = {}
-field_settings = {}
-model_dump_settings = {}
+# differs by table row / col
+init_kws = {}
+field_kws = {}
+model_dump_kws = {}
 
 
 class Dog(BaseModel):
-    name: Optional[str] = Field(default='Unspecified', **field_settings)
+    name: Optional[str] = Field(default='Unspecified', **field_kws)
 
 
-my_dog = Dog(**init_kwargs)
-my_dog.model_dump(**model_dump_settings)
+my_dog = Dog(**init_kws)
+my_dog.model_dump(**model_dump_kws)
 ```
 
 {{ exclude_overrides_table }}

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -634,39 +634,24 @@ The same holds for the `model_dump_json` method.
 ### Model- and field-level include and exclude
 
 In addition to the explicit arguments `exclude` and `include` passed to `model_dump` and `model_dump_json` methods,
-we can also pass the `exclude: bool` arguments directly to the `Field` constructor.
+we can also pass the `exclude: bool` argument directly to the `Field` constructor.
+The tabs below show the expected behavior when using combinations of `exclude` at the `Field` constructor level
+and `exclude`, `include`, `exclude_none`, `exclude_defaults`, and `exclude_unset` for the `model_dump` and `model_dump_json` methods.
 
-The table below shows the expected behavior when using combinations of `exclude` at the `Field` constructor level
-and `exclude` and `include` for the `model_dump` and `model_dump_json` methods.
+=== "exclude"
+{{ exclude_example }}
 
-Imagine a case where we have the following class definition + instance creation:
+=== "include"
+{{ include_example }}
 
-```py
-from typing import Optional
+=== "exclude_none"
+{{ exclude_none_example }}
 
-from pydantic import BaseModel, Field
+=== "exclude_defaults"
+{{ exclude_defaults_example }}
 
-# differs by table row / col
-init_kws = {}
-field_kws = {}
-model_dump_kws = {}
-
-
-class Dog(BaseModel):
-    name: Optional[str] = Field(default='Unspecified', **field_kws)
-
-
-my_dog = Dog(**init_kws)
-my_dog.model_dump(**model_dump_kws)
-```
-
-{{ exclude_overrides_table }}
-
-Using the same case with the `Dog` class defined above, this table shows the expected behavior when using combinations
-of `exclude` at the `Field` constructor level and `exclude_none`, `exclude_defaults`, and `exclude_unset` for the
-`model_dump` and `model_dump_json` methods.
-
-{{ exclude_variants_table }}
+=== "exclude_unset"
+{{ exclude_unset_example }}
 
 
 ## `model_copy(...)`

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -730,6 +730,7 @@ from pydantic import BaseModel, Field
 class Dog(BaseModel):
     name: Optional[str] = Field(default=None)
 
+
 my_dog = Dog()
 ```
 

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -660,13 +660,13 @@ my_dog = Dog(**init_kwargs)
 my_dog.model_dump(**model_dump_settings)
 ```
 
-{{ exclude_table }}
+{{ exclude_overrides_table }}
 
 Using the same case with the `Dog` class defined above, this table shows the expected behavior when using combinations 
 of `exclude` at the `Field` constructor level and `exclude_none`, `exclude_defaults`, and `exclude_unset` for the 
 `model_dump` and `model_dump_json` methods.
 
-{{ exclude_x_table }}
+{{ exclude_variants_table }}
 
 
 ## `model_copy(...)`

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -662,8 +662,8 @@ my_dog.model_dump(**model_dump_settings)
 
 {{ exclude_overrides_table }}
 
-Using the same case with the `Dog` class defined above, this table shows the expected behavior when using combinations 
-of `exclude` at the `Field` constructor level and `exclude_none`, `exclude_defaults`, and `exclude_unset` for the 
+Using the same case with the `Dog` class defined above, this table shows the expected behavior when using combinations
+of `exclude` at the `Field` constructor level and `exclude_none`, `exclude_defaults`, and `exclude_unset` for the
 `model_dump` and `model_dump_json` methods.
 
 {{ exclude_variants_table }}

--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -698,6 +698,44 @@ print(person.model_dump(exclude_defaults=True))  # (3)!
 3. `age` excluded from the output because `exclude_defaults` was set to `True`, and `age` takes the default value of `None`.
 
 
+See the tables below regarding expected behavior for `Field` and `model_dump()` level `include` and `exclude`.
+
+First, imagine a case where we have the following class definition:
+
+```py
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class Dog(BaseModel):
+    name: Optional[str] = Field(default=None)
+
+
+my_dog = Dog(name='Ralph')
+```
+
+Assuming we specify the `Field` level `exclude` setting as specified by the row in the table
+and a `model_dump` setting specified by the column in the table, the result of `my_dog.model_dump(<<settings>>)` is shown in the intersecting cell.
+
+{{ exclude_table }}
+
+In this more complex case, we revise our constructor call to the following, without the `name` argument.
+```py
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class Dog(BaseModel):
+    name: Optional[str] = Field(default=None)
+
+my_dog = Dog()
+```
+
+{{ exclude_x_table }}
+
+
 ## `model_copy(...)`
 
 ??? api "API Documentation"


### PR DESCRIPTION
## Change Summary

Adding a tabbed display to the Usage/Serialization section of the documentation explaining the expected behavior when `exclude` params are specified at both the `Field` and `model_dump` level.

## Related issue number

fix #7361

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
