### PR TITLE
experiment with reducing import time

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -19,10 +19,10 @@ from ._internal._annotated_handlers import (
 )
 from ._internal._generate_schema import GenerateSchema as GenerateSchema
 from ._migration import getattr_migration
-from .config import ConfigDict, Extra
-from .deprecated.class_validators import root_validator, validator
-from .deprecated.config import BaseConfig
-from .deprecated.tools import *
+from .config import ConfigDict
+# from .deprecated.class_validators import root_validator, validator
+# from .deprecated.config import BaseConfig
+# from .deprecated.tools import *
 from .errors import *
 from .fields import AliasChoices, AliasPath, Field, PrivateAttr, computed_field
 from .functional_serializers import PlainSerializer, SerializeAsAny, WrapSerializer, field_serializer, model_serializer
@@ -40,7 +40,7 @@ from .json_schema import WithJsonSchema
 from .main import *
 from .networks import *
 from .type_adapter import TypeAdapter
-from .types import *
+# from .types import *
 from .validate_call import validate_call
 from .version import VERSION
 from .warnings import *
@@ -66,8 +66,8 @@ __all__ = [
     'PlainValidator',
     'WrapValidator',
     # deprecated V1 functional validators
-    'root_validator',
-    'validator',
+    # 'root_validator',
+    # 'validator',
     # functional serializers
     'field_serializer',
     'model_serializer',
@@ -78,9 +78,8 @@ __all__ = [
     'SerializationInfo',
     'SerializerFunctionWrapHandler',
     # config
-    'BaseConfig',
+    # 'BaseConfig',
     'ConfigDict',
-    'Extra',
     # validate_call
     'validate_call',
     # pydantic_core errors
@@ -123,9 +122,9 @@ __all__ = [
     # root_model
     'RootModel',
     # tools
-    'parse_obj_as',
-    'schema_of',
-    'schema_json_of',
+    # 'parse_obj_as',
+    # 'schema_of',
+    # 'schema_json_of',
     # types
     'Strict',
     'StrictStr',

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -1,7 +1,6 @@
 """Private logic for creating pydantic dataclasses."""
 from __future__ import annotations as _annotations
 
-import dataclasses
 import inspect
 import typing
 import warnings
@@ -190,6 +189,8 @@ def generate_dataclass_signature(cls: type[StandardDataclass]) -> Signature:
     Returns:
         The signature.
     """
+    import dataclasses
+
     sig = signature(cls)
     final_params: dict[str, Parameter] = {}
 

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -1,7 +1,6 @@
 """Private logic related to fields (the `Field()` function and `FieldInfo` class), and arguments to `Annotated`."""
 from __future__ import annotations as _annotations
 
-import dataclasses
 import sys
 import warnings
 from copy import copy
@@ -94,6 +93,7 @@ def collect_model_fields(  # noqa: C901
             - If there is a field other than `root` in `RootModel`.
             - If a field shadows an attribute in the parent model.
     """
+    import dataclasses
     from ..fields import FieldInfo
 
     type_hints = get_cls_type_hints_lenient(cls, types_namespace)
@@ -237,6 +237,7 @@ def collect_dataclass_fields(
     Returns:
         The dataclass fields.
     """
+    import dataclasses
     from ..fields import FieldInfo
 
     fields: dict[str, FieldInfo] = {}

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2,7 +2,6 @@
 from __future__ import annotations as _annotations
 
 import collections.abc
-import dataclasses
 import inspect
 import re
 import sys
@@ -86,19 +85,19 @@ if TYPE_CHECKING:
     from ._dataclasses import StandardDataclass
     from ._schema_generation_shared import GetJsonSchemaFunction
 
+    FieldDecoratorInfo = Union[ValidatorDecoratorInfo, FieldValidatorDecoratorInfo, FieldSerializerDecoratorInfo]
+    FieldDecoratorInfoType = TypeVar('FieldDecoratorInfoType', bound=FieldDecoratorInfo)
+    AnyFieldDecorator = Union[
+        Decorator[ValidatorDecoratorInfo],
+        Decorator[FieldValidatorDecoratorInfo],
+        Decorator[FieldSerializerDecoratorInfo],
+    ]
+
+    ModifyCoreSchemaWrapHandler = GetCoreSchemaHandler
+    GetCoreSchemaFunction = Callable[[Any, ModifyCoreSchemaWrapHandler], core_schema.CoreSchema]
+
 _SUPPORTS_TYPEDDICT = sys.version_info >= (3, 12)
 _AnnotatedType = type(Annotated[int, 123])
-
-FieldDecoratorInfo = Union[ValidatorDecoratorInfo, FieldValidatorDecoratorInfo, FieldSerializerDecoratorInfo]
-FieldDecoratorInfoType = TypeVar('FieldDecoratorInfoType', bound=FieldDecoratorInfo)
-AnyFieldDecorator = Union[
-    Decorator[ValidatorDecoratorInfo],
-    Decorator[FieldValidatorDecoratorInfo],
-    Decorator[FieldSerializerDecoratorInfo],
-]
-
-ModifyCoreSchemaWrapHandler = GetCoreSchemaHandler
-GetCoreSchemaFunction = Callable[[Any, ModifyCoreSchemaWrapHandler], core_schema.CoreSchema]
 
 
 TUPLE_TYPES: list[type] = [tuple, typing.Tuple]
@@ -1258,6 +1257,8 @@ class GenerateSchema:
         self, dataclass: type[StandardDataclass], origin: type[StandardDataclass] | None
     ) -> core_schema.CoreSchema:
         """Generate schema for a dataclass."""
+        import dataclasses
+
         with self.defs.get_schema_or_ref(dataclass) as (dataclass_ref, maybe_schema):
             if maybe_schema is not None:
                 return maybe_schema

--- a/pydantic/_internal/_internal_dataclass.py
+++ b/pydantic/_internal/_internal_dataclass.py
@@ -1,10 +1,76 @@
 import sys
-from typing import Any, Dict
+from typing import Any
 
-dataclass_kwargs: Dict[str, Any]
 
-# `slots` is available on Python >= 3.10
-if sys.version_info >= (3, 10):
-    slots_true = {'slots': True}
-else:
-    slots_true = {}
+class DeferredDataclassMeta(type):
+    def __new__(mcs, *args, **kwargs):
+        original_cls = kwargs.pop('original_cls')
+        frozen = kwargs.pop('frozen', False)
+        slots = kwargs.pop('slots', True)
+        cls = super().__new__(mcs, *args, **kwargs)
+        cls._original_cls = original_cls
+        cls._frozen = frozen
+        cls._slots = slots
+        cls._dc = None
+        return cls
+
+    def _create_dc(self):
+        if self._dc is None:
+            import dataclasses
+
+            if sys.version_info >= (3, 10):
+                dc_func = dataclasses.dataclass(slots=self._slots, frozen=self._frozen)
+            else:
+                dc_func = dataclasses.dataclass(frozen=self._frozen)
+            self._dc = dc_func(self._original_cls)
+            print(f'This should not be called {self._dc}')
+        return self._dc
+
+    @property
+    def __dataclass_fields__(cls):
+        dc = cls._create_dc()
+        return dc.__dataclass_fields__
+
+    @property
+    def __dataclass_params__(self):
+        dc = self._create_dc()
+        return dc.__dataclass_params__
+
+    def __getitem__(self, item):
+        dc = self._create_dc()
+        return dc.__class_getitem__(item)
+
+    def __getattr__(self, item):
+        dc = self._create_dc()
+        return getattr(dc, item)
+
+    def __instancecheck__(self, instance):
+        dc = self._create_dc()
+        return isinstance(instance, dc)
+
+    @property
+    def __name__(self):
+        print('name', id(self))
+        dc = self._create_dc()
+        return dc.__name__
+
+
+def deferred_dataclass(__cls: type[Any] = None, *, slots=True, frozen=False):
+    """
+    A decorator that creates a class that looks and smells very like a dataclass, but defers import of
+    `dataclasses`.
+
+    For internal use only.
+    """
+    if __cls is None:
+        return lambda __cls: deferred_dataclass(__cls, frozen=frozen)
+    else:
+        class DeferredDataclass(metaclass=DeferredDataclassMeta, original_cls=__cls):
+            def __new__(cls, *args, **kwargs):
+                dc = cls._create_dc()
+                # debug(cls, args, kwargs, dc)
+                return dc(*args, **kwargs)
+
+            def __init_subclass__(cls, **kwargs):
+                raise TypeError('Inheritance of deferred dataclasses is not supported')
+        return DeferredDataclass

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -6,7 +6,6 @@ from __future__ import annotations as _annotations
 
 import collections
 import collections.abc
-import dataclasses
 import decimal
 import inspect
 import os
@@ -35,7 +34,7 @@ from ..config import ConfigDict
 from ..json_schema import JsonSchemaValue, update_json_schema
 from . import _known_annotated_metadata, _typing_extra, _validators
 from ._core_utils import get_type_ref
-from ._internal_dataclass import slots_true
+from ._internal_dataclass import deferred_dataclass
 from ._schema_generation_shared import GetCoreSchemaHandler, GetJsonSchemaHandler
 
 if typing.TYPE_CHECKING:
@@ -44,7 +43,7 @@ if typing.TYPE_CHECKING:
     StdSchemaFunction = Callable[[GenerateSchema, type[Any]], core_schema.CoreSchema]
 
 
-@dataclasses.dataclass(**slots_true)
+@deferred_dataclass
 class SchemaTransformer:
     get_core_schema: Callable[[Any, GetCoreSchemaHandler], CoreSchema]
     get_json_schema: Callable[[CoreSchema, GetJsonSchemaHandler], JsonSchemaValue]
@@ -136,7 +135,7 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
     )
 
 
-@dataclasses.dataclass(**slots_true)
+@deferred_dataclass
 class InnerSchemaValidator:
     """Use a fixed CoreSchema, avoiding interference from outward annotations."""
 
@@ -283,7 +282,7 @@ def dequeue_validator(
         return collections.deque(handler(input_value), maxlen=maxlen)
 
 
-@dataclasses.dataclass(**slots_true)
+@deferred_dataclass
 class SequenceValidator:
     mapped_origin: type[Any]
     item_source_type: type[Any]
@@ -409,7 +408,7 @@ def sequence_like_prepare_pydantic_annotations(
     metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
     _known_annotated_metadata.check_metadata(metadata, _known_annotated_metadata.SEQUENCE_CONSTRAINTS, source_type)
 
-    return (source_type, [SequenceValidator(mapped_origin, item_source_type, **metadata), *remaining_annotations])
+    return source_type, [SequenceValidator(mapped_origin, item_source_type, **metadata), *remaining_annotations]
 
 
 MAPPING_ORIGIN_MAP: dict[Any, Any] = {
@@ -497,7 +496,7 @@ def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable
     return default_default_factory
 
 
-@dataclasses.dataclass(**slots_true)
+@deferred_dataclass
 class MappingValidator:
     mapped_origin: type[Any]
     keys_source_type: type[Any]

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -1,7 +1,6 @@
 """Logic for interacting with type annotations, mostly extensions, shims and hacks to wrap python's typing module."""
 from __future__ import annotations as _annotations
 
-import dataclasses
 import sys
 import types
 import typing
@@ -428,6 +427,8 @@ else:
 def is_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
     # The dataclasses.is_dataclass function doesn't seem to provide TypeGuard functionality,
     # so I created this convenience function
+    import dataclasses
+
     return dataclasses.is_dataclass(_cls)
 
 

--- a/pydantic/_migration.py
+++ b/pydantic/_migration.py
@@ -270,6 +270,9 @@ def getattr_migration(module: str) -> Callable[[str], Any]:
         Returns:
             The object.
         """
+        if name == '__path__':
+            raise AttributeError('no "__path__" attribute')
+
         import_path = f'{module}:{name}'
         if import_path in MOVED_IN_V2.keys():
             new_location = MOVED_IN_V2[import_path]

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 from ._migration import getattr_migration
-from .deprecated.config import BaseConfig
-from .deprecated.config import Extra as _Extra
+# from .deprecated.config import BaseConfig
+# from .deprecated.config import Extra as _Extra
 
 if TYPE_CHECKING:
     from ._internal._generate_schema import GenerateSchema as _GenerateSchema
 
-__all__ = 'BaseConfig', 'ConfigDict', 'Extra'
+__all__ = ('ConfigDict',)
 
 
 JsonEncoder = Callable[[Any], Any]
@@ -22,7 +22,7 @@ JsonSchemaExtraCallable: TypeAlias = Union[
     Callable[[Dict[str, Any], Type[Any]], None],
 ]
 
-Extra = _Extra()
+# Extra = _Extra()
 
 ExtraValues = Literal['allow', 'ignore', 'forbid']
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -1,7 +1,7 @@
 """Provide an enhanced dataclass that performs validation."""
 from __future__ import annotations as _annotations
 
-import dataclasses
+# import dataclasses
 import sys
 import types
 from typing import TYPE_CHECKING, Any, Callable, Generic, NoReturn, TypeVar, overload
@@ -23,7 +23,7 @@ _T = TypeVar('_T')
 
 if sys.version_info >= (3, 10):
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    # @dataclass_transform(field_specifiers=(dataclasses.field, Field))
     @overload
     def dataclass(
         *,
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 10):
     ) -> Callable[[type[_T]], type[PydanticDataclass]]:  # type: ignore
         ...
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    # @dataclass_transform(field_specifiers=(dataclasses.field, Field))
     @overload
     def dataclass(
         _cls: type[_T],  # type: ignore
@@ -60,7 +60,7 @@ if sys.version_info >= (3, 10):
 
 else:
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    # @dataclass_transform(field_specifiers=(dataclasses.field, Field))
     @overload
     def dataclass(
         *,
@@ -75,7 +75,7 @@ else:
     ) -> Callable[[type[_T]], type[PydanticDataclass]]:  # type: ignore
         ...
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    # @dataclass_transform(field_specifiers=(dataclasses.field, Field))
     @overload
     def dataclass(
         _cls: type[_T],  # type: ignore
@@ -92,7 +92,7 @@ else:
         ...
 
 
-@dataclass_transform(field_specifiers=(dataclasses.field, Field))
+# @dataclass_transform(field_specifiers=(dataclasses.field, Field))
 def dataclass(
     _cls: type[_T] | None = None,
     *,
@@ -155,6 +155,8 @@ def dataclass(
         Returns:
             A Pydantic dataclass.
         """
+        import dataclasses
+
         original_cls = cls
 
         config_dict = config
@@ -215,18 +217,18 @@ def dataclass(
 
 __getattr__ = getattr_migration(__name__)
 
-if (3, 8) <= sys.version_info < (3, 11):
-    # Monkeypatch dataclasses.InitVar so that typing doesn't error if it occurs as a type when evaluating type hints
-    # Starting in 3.11, typing.get_type_hints will not raise an error if the retrieved type hints are not callable.
-
-    def _call_initvar(*args: Any, **kwargs: Any) -> NoReturn:
-        """This function does nothing but raise an error that is as similar as possible to what you'd get
-        if you were to try calling `InitVar[int]()` without this monkeypatch. The whole purpose is just
-        to ensure typing._type_check does not error if the type hint evaluates to `InitVar[<parameter>]`.
-        """
-        raise TypeError("'InitVar' object is not callable")
-
-    dataclasses.InitVar.__call__ = _call_initvar
+# if (3, 8) <= sys.version_info < (3, 11):
+#     # Monkeypatch dataclasses.InitVar so that typing doesn't error if it occurs as a type when evaluating type hints
+#     # Starting in 3.11, typing.get_type_hints will not raise an error if the retrieved type hints are not callable.
+#
+#     def _call_initvar(*args: Any, **kwargs: Any) -> NoReturn:
+#         """This function does nothing but raise an error that is as similar as possible to what you'd get
+#         if you were to try calling `InitVar[int]()` without this monkeypatch. The whole purpose is just
+#         to ensure typing._type_check does not error if the type hint evaluates to `InitVar[<parameter>]`.
+#         """
+#         raise TypeError("'InitVar' object is not callable")
+#
+#     dataclasses.InitVar.__call__ = _call_initvar
 
 
 def rebuild_dataclass(
@@ -287,4 +289,6 @@ def is_pydantic_dataclass(__cls: type[Any]) -> TypeGuard[type[PydanticDataclass]
     Returns:
         `True` if the class is a pydantic dataclass, `False` otherwise.
     """
+    import dataclasses
+
     return dataclasses.is_dataclass(__cls) and '__pydantic_validator__' in __cls.__dict__

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1,12 +1,10 @@
 """Defining fields on models."""
 from __future__ import annotations as _annotations
 
-import dataclasses
 import inspect
 import sys
 import typing
 from copy import copy
-from dataclasses import Field as DataclassField
 from typing import Any, ClassVar
 from warnings import warn
 
@@ -15,13 +13,14 @@ import typing_extensions
 from pydantic_core import PydanticUndefined
 from typing_extensions import Literal, Unpack
 
-from . import types
+# from . import types
 from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra, _utils
 from .errors import PydanticUserError
 from .warnings import PydanticDeprecatedSince20
 
 if typing.TYPE_CHECKING:
     from ._internal._repr import ReprArgs
+    from dataclasses import Field as DataclassField
 else:
     # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
     # and https://youtrack.jetbrains.com/issue/PY-51428
@@ -150,7 +149,7 @@ class FieldInfo(_repr.Representation):
     # used to convert kwargs to metadata/constraints,
     # None has a special meaning - these items are collected into a `PydanticGeneralMetadata`
     metadata_lookup: ClassVar[dict[str, typing.Callable[[Any], Any] | None]] = {
-        'strict': types.Strict,
+        # 'strict': types.Strict,
         'gt': annotated_types.Gt,
         'ge': annotated_types.Ge,
         'lt': annotated_types.Lt,
@@ -322,6 +321,8 @@ class FieldInfo(_repr.Representation):
                 spam: Annotated[int, pydantic.Field(gt=4)] = 4  # <-- or this
             ```
         """
+        import dataclasses
+
         final = False
         if _typing_extra.is_finalvar(annotation):
             final = True
@@ -422,6 +423,8 @@ class FieldInfo(_repr.Representation):
         Raises:
             TypeError: If any of the `FieldInfo` kwargs does not match the `dataclass.Field` kwargs.
         """
+        import dataclasses
+
         default = dc_field.default
         if default is dataclasses.MISSING:
             default = PydanticUndefined
@@ -572,7 +575,7 @@ class FieldInfo(_repr.Representation):
                     yield s, value
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass
 class AliasPath:
     """Usage docs: https://docs.pydantic.dev/2.3/usage/fields#aliaspath-and-aliaschoices
 
@@ -596,7 +599,7 @@ class AliasPath:
         return self.path
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass
 class AliasChoices:
     """Usage docs: https://docs.pydantic.dev/2.3/usage/fields#aliaspath-and-aliaschoices
 
@@ -943,7 +946,7 @@ def PrivateAttr(
     )
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass
 class ComputedFieldInfo:
     """A container for data from `@computed_field` so that we can access it while building the pydantic-core schema.
 

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -1,7 +1,6 @@
 """This module contains related classes and functions for serialization."""
 from __future__ import annotations
 
-import dataclasses
 from functools import partialmethod
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, overload
 
@@ -13,7 +12,7 @@ from . import PydanticUndefinedAnnotation
 from ._internal import _annotated_handlers, _decorators, _internal_dataclass
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true, frozen=True)
+@_internal_dataclass.deferred_dataclass(frozen=True)
 class PlainSerializer:
     """Plain serializers use a function to modify the output of serialization.
 
@@ -57,7 +56,7 @@ class PlainSerializer:
         return schema
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true, frozen=True)
+@_internal_dataclass.deferred_dataclass(frozen=True)
 class WrapSerializer:
     """Wrap serializers receive the raw inputs along with a handler function that applies the standard serialization
     logic, and can modify the resulting value before returning it as the final output of serialization.
@@ -258,7 +257,7 @@ if TYPE_CHECKING:
     """
 else:
 
-    @dataclasses.dataclass(**_internal_dataclass.slots_true)
+    @_internal_dataclass.deferred_dataclass
     class SerializeAsAny:  # noqa: D101
         def __class_getitem__(cls, item: Any) -> Any:
             return Annotated[item, SerializeAsAny()]

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations as _annotations
 
-import dataclasses
 import sys
 from functools import partialmethod
 from types import FunctionType
@@ -30,7 +29,7 @@ else:
 _inspect_validator = _decorators.inspect_validator
 
 
-@dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass(frozen=True)
 class AfterValidator:
     '''Usage docs: https://docs.pydantic.dev/2.2/usage/validators/#annotated-validators
 
@@ -85,7 +84,7 @@ class AfterValidator:
             return core_schema.no_info_after_validator_function(self.func, schema=schema)  # type: ignore
 
 
-@dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass(frozen=True)
 class BeforeValidator:
     """Usage docs: https://docs.pydantic.dev/2.3/usage/validators/#annotated-validators
 
@@ -127,7 +126,7 @@ class BeforeValidator:
             return core_schema.no_info_before_validator_function(self.func, schema=schema)  # type: ignore
 
 
-@dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass(frozen=True)
 class PlainValidator:
     """Usage docs: https://docs.pydantic.dev/2.3/usage/validators/#annotated-validators
 
@@ -162,7 +161,7 @@ class PlainValidator:
             return core_schema.no_info_plain_validator_function(self.func)  # type: ignore
 
 
-@dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass(frozen=True)
 class WrapValidator:
     """Usage docs: https://docs.pydantic.dev/2.3/usage/validators/#annotated-validators
 
@@ -486,7 +485,7 @@ if TYPE_CHECKING:
 
 else:
 
-    @dataclasses.dataclass(**_internal_dataclass.slots_true)
+    @_internal_dataclass.deferred_dataclass
     class InstanceOf:
         '''Generic type for annotating a type that is an instance of a given class.
 
@@ -553,7 +552,7 @@ if TYPE_CHECKING:
     SkipValidation = Annotated[AnyType, ...]  # SkipValidation[list[str]] will be treated by type checkers as list[str]
 else:
 
-    @dataclasses.dataclass(**_internal_dataclass.slots_true)
+    @_internal_dataclass.deferred_dataclass
     class SkipValidation:
         """If this is applied as an annotation (e.g., via `x: Annotated[int, SkipValidation]`), validation will be
             skipped. You can also use `SkipValidation[int]` as a shorthand for `Annotated[int, SkipValidation]`.

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -8,14 +8,12 @@ In general you shouldn't need to use this module directly; instead, you can
 """
 from __future__ import annotations as _annotations
 
-import dataclasses
 import inspect
 import math
 import re
 import warnings
 from collections import defaultdict
 from copy import deepcopy
-from dataclasses import is_dataclass
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -139,7 +137,7 @@ CoreModeRef = Tuple[CoreRef, JsonSchemaMode]
 JsonSchemaKeyT = TypeVar('JsonSchemaKeyT', bound=Hashable)
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass
 class _DefinitionsRemapping:
     defs_remapping: dict[DefsRef, DefsRef]
     json_remapping: dict[JsonRef, JsonRef]
@@ -1479,6 +1477,8 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
+        import dataclasses
+
         cls = schema['cls']
         config: ConfigDict = getattr(cls, '__pydantic_config__', cast('ConfigDict', {}))
         title = config.get('title') or cls.__name__
@@ -1490,7 +1490,7 @@ class GenerateJsonSchema:
         json_schema = self._update_class_schema(json_schema, title, config.get('extra', None), cls, json_schema_extra)
 
         # Dataclass-specific handling of description
-        if is_dataclass(cls) and not hasattr(cls, '__pydantic_validator__'):
+        if dataclasses.is_dataclass(cls) and not hasattr(cls, '__pydantic_validator__'):
             # vanilla dataclass; don't use cls.__doc__ as it will contain the class signature by default
             description = None
         else:
@@ -2229,7 +2229,7 @@ def _sort_json_schema(value: JsonSchemaValue, parent_key: str | None = None) -> 
         return value
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass
 class WithJsonSchema:
     """Add this as an annotation on a field to override the (base) JSON schema that would be generated for that field.
     This provides a way to set a JSON schema for types that would otherwise raise errors when producing a JSON schema,
@@ -2261,7 +2261,7 @@ class WithJsonSchema:
         return hash(type(self.mode))
 
 
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
+@_internal_dataclass.deferred_dataclass
 class Examples:
     """Add examples to a JSON schema.
 
@@ -2316,7 +2316,7 @@ if TYPE_CHECKING:
     SkipJsonSchema = Annotated[AnyType, ...]
 else:
 
-    @dataclasses.dataclass(**_internal_dataclass.slots_true)
+    @_internal_dataclass.deferred_dataclass
     class SkipJsonSchema:
         """Add this as an annotation on a field to skip generating a JSON schema for that field.
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -26,8 +26,8 @@ from ._internal import (
 )
 from ._migration import getattr_migration
 from .config import ConfigDict
-from .deprecated import copy_internals as _deprecated_copy_internals
-from .deprecated import parse as _deprecated_parse
+# from .deprecated import copy_internals as _deprecated_copy_internals
+# from .deprecated import parse as _deprecated_parse
 from .errors import PydanticUndefinedAnnotation, PydanticUserError
 from .fields import ComputedFieldInfo, FieldInfo, ModelPrivateAttr
 from .json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMode, JsonSchemaValue, model_json_schema

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1,7 +1,6 @@
 """The networks module contains types for common network-related fields."""
 from __future__ import annotations as _annotations
 
-import dataclasses as _dataclasses
 import re
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import TYPE_CHECKING, Any
@@ -9,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, TypeAlias
 
-from ._internal import _annotated_handlers, _fields, _repr, _schema_generation_shared
+from ._internal import _annotated_handlers, _fields, _repr, _schema_generation_shared, _internal_dataclass
 from ._migration import getattr_migration
 from .json_schema import JsonSchemaValue
 
@@ -45,7 +44,6 @@ __all__ = [
 ]
 
 
-@_dataclasses.dataclass
 class UrlConstraints(_fields.PydanticMetadata):
     """Url constraints.
 
@@ -57,13 +55,31 @@ class UrlConstraints(_fields.PydanticMetadata):
         default_port: The default port. Defaults to `None`.
         default_path: The default path. Defaults to `None`.
     """
+    __slots__ = 'max_length', 'allowed_schemes', 'host_required', 'default_host', 'default_port', 'default_path'
 
-    max_length: int | None = None
-    allowed_schemes: list[str] | None = None
-    host_required: bool | None = None
-    default_host: str | None = None
-    default_port: int | None = None
-    default_path: str | None = None
+    max_length: int | None
+    allowed_schemes: list[str] | None
+    host_required: bool | None
+    default_host: str | None
+    default_port: int | None
+    default_path: str | None
+
+    def __init__(
+        self,
+        max_length: int | None = None,
+        allowed_schemes: list[str] | None = None,
+        host_required: bool | None = None,
+        default_host: str | None = None,
+        default_port: int | None = None,
+        default_path: str | None = None,
+    ):
+        self.max_length = max_length
+        self.allowed_schemes = allowed_schemes
+        self.host_required = host_required
+        self.default_host = default_host
+        self.default_port = default_port
+        self.default_path = default_path
+
 
     def __hash__(self) -> int:
         return hash(

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -8,9 +8,8 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Set, TypeVar, Un
 from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator, Some
 from typing_extensions import Literal, is_typeddict
 
-from pydantic.errors import PydanticUserError
-from pydantic.main import BaseModel
-
+from .errors import PydanticUserError
+from .main import BaseModel
 from ._internal import _config, _core_utils, _discriminated_union, _generate_schema, _typing_extra
 from .config import ConfigDict
 from .json_schema import (


### PR DESCRIPTION
ref #7409

Experiment with reducing import time.

Removing dataclasses is pretty hard since:
1. it's used by `annotated-types`, I think persuading @adriangb to remove dataclasses from there and using a proxy/hack like we do here is pretty unlike
2. it's used in dataclass transform like `@dataclass_transform(field_specifiers=(dataclasses.field, Field))`, while this is only required by type checkers, I think it would be quite to remove them and keep `dataclass_transform` behaviour the same, maybe it's possible
3. We have a lot of dataclasses with pydantic, I've got rid of or deferred most of them here, but the remainders are hard

From my experience here the low hanging fruit to improve performance times are:
* defer everything related to `deprecated`, using a mixture of local imports and `pydantic.__init__.__getattr__`
* defer importing `pydantic.types`, and add it all it's exports to `pydantic.__init__.__getattr__`
* defer import of `pydantic_core.core_schema`
* hard to tell, but perhaps the `deferred_dataclasses` provides some improvements even through it doesn't yet avoid dataclasses being imported