### PR TITLE
Generate a schema for Required/NotRequired

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -33,6 +33,7 @@ from typing import (
 )
 from warnings import warn
 
+import typing_extensions
 from pydantic_core import CoreSchema, PydanticUndefined, core_schema
 from typing_extensions import Annotated, Final, Literal, TypeAliasType, TypedDict, get_args, get_origin, is_typeddict
 
@@ -773,6 +774,8 @@ class GenerateSchema:
             return self._iterable_schema(obj)
         elif origin in (re.Pattern, typing.Pattern):
             return self._pattern_schema(obj)
+        elif origin in (typing_extensions.Required, typing_extensions.NotRequired):
+            return self.generate_schema(get_args(obj)[0])
 
         if self._arbitrary_types:
             return self._arbitrary_type_schema(origin)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -39,7 +39,7 @@ import dirty_equals
 import pytest
 from dirty_equals import HasRepr, IsOneOf, IsStr
 from pydantic_core import CoreSchema, PydanticCustomError, SchemaError, core_schema
-from typing_extensions import Annotated, Literal, TypedDict, get_args
+from typing_extensions import Annotated, Literal, NotRequired, Required, TypedDict, get_args
 
 from pydantic import (
     UUID1,
@@ -5847,3 +5847,10 @@ def test_decimal_float_precision() -> None:
     assert ta.validate_python('1.1') == Decimal('1.1')
     assert ta.validate_json('1') == Decimal('1')
     assert ta.validate_python(1) == Decimal('1')
+
+
+def test_typeddict_required() -> None:
+    # Required and NotRequired are just ignored; handling them like this makes it safe to pass a
+    # field annotation of a TypedDict directly into a TypeAdapter.
+    assert TypeAdapter(Required[int]).core_schema == TypeAdapter(int).core_schema
+    assert TypeAdapter(NotRequired[int]).core_schema == TypeAdapter(int).core_schema


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/7437

If there are good objections to handling (and ignoring) the `Required`/`NotRequired` things, we can close this. I think it's reasonable to ignore them though; admittedly it is an edge case but I think it's nice if it works, in particular for the use case described in #7437.

@baderdean if this PR gets rejected or you aren't patient enough to wait for a new pydantic release, you should be able to take a similar approach to this PR to pass your annotation into a function that will "strip off" the `Required`/`NotRequired` to achieve the same thing in your own code without needing the changes here.