### PR TITLE
fix: type-error on model_validator in wrap mode

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -432,7 +432,9 @@ _AnyModelAfterValidator = Union[ModelAfterValidator[_ModelType], ModelAfterValid
 def model_validator(
     *,
     mode: Literal['wrap'],
-) -> Callable[[_AnyModelWrapValidator[_ModelType]], _decorators.PydanticDescriptorProxy[_decorators.ModelValidatorDecoratorInfo]]:
+) -> Callable[
+    [_AnyModelWrapValidator[_ModelType]], _decorators.PydanticDescriptorProxy[_decorators.ModelValidatorDecoratorInfo]
+]:
     ...
 
 

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -432,7 +432,7 @@ _AnyModelAfterValidator = Union[ModelAfterValidator[_ModelType], ModelAfterValid
 def model_validator(
     *,
     mode: Literal['wrap'],
-) -> Callable[[_AnyModelWrapValidator], _decorators.PydanticDescriptorProxy[_decorators.ModelValidatorDecoratorInfo]]:
+) -> Callable[[_AnyModelWrapValidator[_ModelType]], _decorators.PydanticDescriptorProxy[_decorators.ModelValidatorDecoratorInfo]]:
     ...
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Since #7154, `ModelWrapValidator` is generic, and if `reportUnknownVariableType` is enabled in Pyright the import will be a type-error. I think it was an oversight to not add the type-parameter here as the other generic model validator type (`ModelAfterValidator`) consumes the type-parameter - and adding it indeed fixes the issue.

I think this doesn't need a new test as it's purely a type-level change.

## Related issue number

Prior PR - #7154

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt