### PR TITLE
Allow @validate_call on methods in class with __slots__

### DIFF
--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -725,3 +725,19 @@ def test_async_func() -> None:
             'input': 'x',
         }
     ]
+
+
+def test_with_slots() -> None:
+    class ClassWithSlots:
+        __slots__ = {'counter'}
+
+        def __init__(self) -> None:
+            self.counter = 0
+
+        @validate_call
+        def some_instance_method(self, increment: int) -> None:
+            self.counter += increment
+
+    c = ClassWithSlots()
+    c.some_instance_method(increment=5)
+    assert c.counter == 5


### PR DESCRIPTION
## Change Summary

Adding in a `BoundValidateCallWrapper` so that we're not mutating methods decorated with the `@validate_call` wrapper

## Related issue number

Fix #7466

## Still To Do

* Fix / investigate breaking tests
* Benchmark testing (make sure performance vs `main` isn't hindered)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
