### PR TITLE
try to move self-schema validation into pydantic

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -16,7 +16,7 @@ from ..errors import PydanticUndefinedAnnotation
 from ..fields import FieldInfo
 from ..warnings import PydanticDeprecatedSince20
 from . import _config, _decorators, _discriminated_union, _typing_extra
-from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs
+from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs, validate_core_schema
 from ._fields import collect_dataclass_fields
 from ._generate_schema import GenerateSchema
 from ._generics import get_standard_typevars_map
@@ -163,6 +163,7 @@ def complete_dataclass(
     # debug(schema)
     cls.__pydantic_core_schema__ = schema = _discriminated_union.apply_discriminators(flatten_schema_defs(schema))
     simplified_core_schema = inline_schema_defs(schema)
+    simplified_core_schema = validate_core_schema(simplified_core_schema)
     cls.__pydantic_validator__ = validator = SchemaValidator(simplified_core_schema, core_config)
     cls.__pydantic_serializer__ = SchemaSerializer(simplified_core_schema, core_config)
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -16,7 +16,7 @@ from ..errors import PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import Field, FieldInfo, ModelPrivateAttr, PrivateAttr
 from ..warnings import PydanticDeprecatedSince20
 from ._config import ConfigWrapper
-from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs
+from ._core_utils import collect_invalid_schemas, flatten_schema_defs, inline_schema_defs, validate_core_schema
 from ._decorators import (
     ComputedFieldInfo,
     DecoratorInfos,
@@ -491,6 +491,8 @@ def complete_model_class(
     if collect_invalid_schemas(schema):
         set_model_mocks(cls, cls_name)
         return False
+
+    schema = validate_core_schema(schema)
 
     # debug(schema)
     cls.__pydantic_core_schema__ = schema

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from inspect import signature
 from typing import Any, ContextManager, Iterable, NamedTuple, Optional, Type, Union, get_type_hints
 
 from dirty_equals import HasRepr, IsPartialDict
-from pydantic_core import SchemaError, SchemaSerializer, SchemaValidator
+from pydantic_core import SchemaSerializer, SchemaValidator
 
 from pydantic import (
     BaseConfig,
@@ -470,15 +470,15 @@ def test_invalid_extra():
     )
     config_dict = {'extra': 'invalid-value'}
 
-    with pytest.raises(SchemaError, match=extra_error):
+    with pytest.raises(ValidationError, match=extra_error):
 
         class MyModel(BaseModel):
             model_config = config_dict
 
-    with pytest.raises(SchemaError, match=extra_error):
+    with pytest.raises(ValidationError, match=extra_error):
         create_model('MyCreatedModel', __config__=config_dict)
 
-    with pytest.raises(SchemaError, match=extra_error):
+    with pytest.raises(ValidationError, match=extra_error):
 
         @pydantic_dataclass(config=config_dict)
         class MyDataclass:


### PR DESCRIPTION
## Change Summary

... to allow getting rid of `generate_self_schema` in `pydantic-core`, and to give more control over when schemas get validated.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
