### PR TITLE
generate release notes via github api

### DIFF
--- a/release/make_history.py
+++ b/release/make_history.py
@@ -1,9 +1,9 @@
 from __future__ import annotations as _annotations
 
+import json
 import re
 import subprocess
 import sys
-from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
@@ -23,14 +23,12 @@ def main():
         print(f'WARNING: v{new_version} already in history, stopping')
         sys.exit(1)
 
-    commits = get_commits()
-    commits_bullets = '\n'.join(f'* {c}' for c in commits)
-
     title = f'v{new_version} ({date.today():%Y-%m-%d})'
+    notes = get_notes(new_version)
     new_chunk = (
         f'## {title}\n\n'
         f'[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v{new_version})\n\n'
-        f'{commits_bullets}\n\n'
+        f'{notes}\n\n'
     )
     history = new_chunk + history_content
 
@@ -38,67 +36,48 @@ def main():
     print(f'\nSUCCESS: added "{title}" section to {history_path.relative_to(root_dir)}')
 
 
-def get_commits() -> list[Commit]:
+def get_notes(new_version: str) -> str:
     last_tag = get_last_tag()
-    raw_commits = run('git', 'log', f'{last_tag}..main', '--oneline')
-    commits = [Commit.from_line(line) for line in raw_commits.splitlines()]
-    commits = [c for c in commits if c]
-    print(f'found {len(commits)} commits since {last_tag}')
-    add_author(commits)
-    return commits
+    auth_token = get_gh_auth_token()
 
+    data = {'target_committish': 'main', 'previous_tag_name': last_tag, 'tag_name': f'v{new_version}'}
+    response = requests.post(
+        'https://api.github.com/repos/pydantic/pydantic/releases/generate-notes',
+        headers={
+            'Accept': 'application/vnd.github+json',
+            'Authorization': f'Bearer {auth_token}',
+            'x-github-api-version': '2022-11-28',
+        },
+        data=json.dumps(data),
+    )
+    response.raise_for_status()
 
-@dataclass
-class Commit:
-    short_sha: str
-    message: str
-    pr: int
-    author: str | None = None
+    body = response.json()['body']
+    body = body.removeprefix('<!-- Release notes generated using configuration in .github/release.yml at main -->\n\n')
+    body = body.removeprefix("## What's Changed\n")
 
-    @classmethod
-    def from_line(cls, line: str) -> Commit | None:
-        short_sha, message = line.split(' ', 1)
-        message, last_word = message.rsplit(' ', 1)
-        m = re.fullmatch(r'\(#(\d+)\)', last_word)
-        if m:
-            pr = int(m.group(1))
-            return cls(short_sha, message, pr)
+    body = re.sub(
+        pattern='https://github.com/pydantic/pydantic/pull/(\\d+)',
+        repl=r'[#\1](https://github.com/pydantic/pydantic/pull/\1)',
+        string=body,
+    )
 
-    def __str__(self):
-        return f'{self.message} by @{self.author} in [#{self.pr}](https://github.com/pydantic/pydantic/pull/{self.pr})'
+    # Remove "full changelog" link
+    body = re.sub(
+        pattern=r'\*\*Full Changelog\*\*: https://.*$',
+        repl='',
+        string=body,
+    )
 
-
-def add_author(commits: list[Commit]) -> None:
-    print('Getting PR authors from GitHub...')
-    session = requests.Session()
-    headers = {
-        'Accept': 'application/vnd.github+json',
-        'x-github-api-version': '2022-11-28',
-    }
-    missing = {c.pr for c in commits}
-    for page in range(1, 10):
-        print(f'getting GH pulls page {page}, looking for {len(missing)} missing authors...')
-        params = {'per_page': 100, 'page': page, 'direction': 'desc', 'sort': 'updated', 'state': 'closed'}
-        r = session.get('https://api.github.com/repos/pydantic/pydantic/pulls', headers=headers, params=params)
-        r.raise_for_status()
-        for pr in r.json():
-            pr_number = pr['number']
-            # debug(pr_number, missing, pr_number in missing)
-            if pr_number in missing:
-                for c in commits:
-                    if c.pr == pr_number:
-                        missing.remove(pr_number)
-                        c.author = pr['user']['login']
-                        break
-        if not missing:
-            print(f'all authors found after page {page}')
-            return
-        else:
-            print(f'{len(missing)} authors still missing after page {page}')
+    return body.strip()
 
 
 def get_last_tag():
     return run('git', 'describe', '--tags', '--abbrev=0')
+
+
+def get_gh_auth_token():
+    return run('gh', 'auth', 'token')
 
 
 def run(*args: str) -> str:


### PR DESCRIPTION
## Change Summary

Use the Github API to autogenerate release notes. I'll push some config and apply labels in a followup PR.

Here's what gets generated off main at the moment:

```
## v2.4.0 (2023-09-20)

[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.4.0)

* Fix PR links in HISTORY.md for v2.3.0 by @adriangb in [#7233](https://github.com/pydantic/pydantic/pull/7233)
* Update description for string type in Standard Library Types documentation section by @15498th in [#7238](https://github.com/pydantic/pydantic/pull/7238)
* Move function is_pydantic_dataclass from pydantic._internal._dataclasses to pydantic.dataclasses by @GabrielCappelli in [#7213](https://github.com/pydantic/pydantic/pull/7213)
* Release improvements by @samuelcolvin in [#7244](https://github.com/pydantic/pydantic/pull/7244)
* fix: Allow inheriting dataclasses with defaults by @tobni in [#7184](https://github.com/pydantic/pydantic/pull/7184)
* Fix config detection for TypedDict from grandparent classes by @dmontagu in [#7272](https://github.com/pydantic/pydantic/pull/7272)
* Fix hash function generation for frozen models with unusual MRO by @dmontagu in [#7274](https://github.com/pydantic/pydantic/pull/7274)
* Fixes for `install` and `docs` targets when contributing on Windows by @redruin1 in [#7282](https://github.com/pydantic/pydantic/pull/7282)
* Make strict config overridable in field for Path by @hramezani in [#7281](https://github.com/pydantic/pydantic/pull/7281)
* Update pydantic-core to latest version by @adriangb in [#7277](https://github.com/pydantic/pydantic/pull/7277)
* Add Base64Url types by @dmontagu in [#7286](https://github.com/pydantic/pydantic/pull/7286)
* Use `ser_json_<timedelta|bytes>` on default in `GenerateJsonSchema` by @Kludex in [#7269](https://github.com/pydantic/pydantic/pull/7269)
* Fix pydantic-settings to underscore in docs by @FacerAin in [#7288](https://github.com/pydantic/pydantic/pull/7288)
* Docs: fix link to `model_dump` by @acdha in [#7297](https://github.com/pydantic/pydantic/pull/7297)
* Add section about `Annotated` in `Field` usage by @Viicos in [#7311](https://github.com/pydantic/pydantic/pull/7311)
* fix: adding a check that alias is validated as an identifier for Python by @andree0 in [#7319](https://github.com/pydantic/pydantic/pull/7319)
* Raise an Error When Computed Field Overrides Field by @sydney-runkle in [#7346](https://github.com/pydantic/pydantic/pull/7346)
* Get rid of `__prepare_pydantic_annotations__` by @adriangb in [#7347](https://github.com/pydantic/pydantic/pull/7347)
* Fix sublists rendering in datetime docs by @slafs in [#7356](https://github.com/pydantic/pydantic/pull/7356)
* Adding Docs For Exclude Prioritization by @sydney-runkle in [#7358](https://github.com/pydantic/pydantic/pull/7358)
* tweak docs and add "run" button to run examples in the browser. by @samuelcolvin in [#7330](https://github.com/pydantic/pydantic/pull/7330)
* Attempt to fix docs deploy job by @dmontagu in [#7363](https://github.com/pydantic/pydantic/pull/7363)
* Attempt to fix docs deploy job again by @dmontagu in [#7365](https://github.com/pydantic/pydantic/pull/7365)
* 📝 Remove `string_types.md` page by @Kludex in [#7370](https://github.com/pydantic/pydantic/pull/7370)
* Delete .github/SECURITY.md by @Kludex in [#7369](https://github.com/pydantic/pydantic/pull/7369)
* 📝 Remove `secrets.md` page by @Kludex in [#7374](https://github.com/pydantic/pydantic/pull/7374)
* Update CI to not use secrets for required jobs for forks by @dmontagu in [#7378](https://github.com/pydantic/pydantic/pull/7378)
* 📝 Remove `file_types.md` page by @Kludex in [#7377](https://github.com/pydantic/pydantic/pull/7377)
* Update dataclass docs to indicate support for `extra` config by @gordonhart in [#7375](https://github.com/pydantic/pydantic/pull/7375)
* Fix applying SkipValidation to referenced schemas by @adriangb in [#7381](https://github.com/pydantic/pydantic/pull/7381)
* ✅ Enforce behavior of private attributes having double leading underscore by @lig in [#7265](https://github.com/pydantic/pydantic/pull/7265)
* 📝 Remove `encoded.md` page by @Kludex in [#7397](https://github.com/pydantic/pydantic/pull/7397)
* Remove `computed_fields.md` page by @hramezani in [#7406](https://github.com/pydantic/pydantic/pull/7406)
* Do not override `model_post_init` in subclass with private attrs by @Viicos in [#7302](https://github.com/pydantic/pydantic/pull/7302)
* Remove `bytesize.md` page by @hramezani in [#7414](https://github.com/pydantic/pydantic/pull/7414)
* Standardize `__get_pydantic_core_schema__` signature by @hramezani in [#7415](https://github.com/pydantic/pydantic/pull/7415)
* Fix `model_validate` doc by @hramezani in [#7419](https://github.com/pydantic/pydantic/pull/7419)
* Fix Generic Dataclass Fields Mutation Bug (when using TypeAdapter) by @sydney-runkle in [#7435](https://github.com/pydantic/pydantic/pull/7435)
* Update Issue Assignees + Add Sydney to Reviewers List by @sydney-runkle in [#7460](https://github.com/pydantic/pydantic/pull/7460)
* Document `decimal.Decimal` serialization logic by @sydney-runkle in [#7465](https://github.com/pydantic/pydantic/pull/7465)
* Make fields with defaults not required in the serialization schema by default by @dmontagu in [#7275](https://github.com/pydantic/pydantic/pull/7275)
* Adding docs to explain behavior when overriding a field with `computed_field` by @sydney-runkle in [#7489](https://github.com/pydantic/pydantic/pull/7489)
* Add simple FastAPI startup benchmark by @adriangb in [#7469](https://github.com/pydantic/pydantic/pull/7469)
* Add debug helper function to pretty print core schemas by @adriangb in [#7492](https://github.com/pydantic/pydantic/pull/7492)
* fix: type-error on model_validator in wrap mode by @pmmmwh in [#7496](https://github.com/pydantic/pydantic/pull/7496)
* Improve enum error message by @hramezani in [#7506](https://github.com/pydantic/pydantic/pull/7506)
* Mark `Extra` as deprecated by @disrupted in [#7299](https://github.com/pydantic/pydantic/pull/7299)
* Make `repr` work for instances that failed initialization when handling `ValidationError`s by @dmontagu in [#7439](https://github.com/pydantic/pydantic/pull/7439)
* Fixed a regular expression denial of service issue by limiting whites… by @prodigysml in [#7360](https://github.com/pydantic/pydantic/pull/7360)
* 🐛 Make `EncodedStr` a dataclass by @Kludex in [#7396](https://github.com/pydantic/pydantic/pull/7396)
* Update pydantic-core to 2.8.0 by @adriangb in [#7522](https://github.com/pydantic/pydantic/pull/7522)
* Move cProfile output of benchmark tests to root directory of repo by @adriangb in [#7524](https://github.com/pydantic/pydantic/pull/7524)
* Simplify flatteining and inlining of Coreschema by @adriangb in [#7523](https://github.com/pydantic/pydantic/pull/7523)
* Remove unused copies in CoreSchema walking by @adriangb in [#7528](https://github.com/pydantic/pydantic/pull/7528)

## New Contributors
* @15498th made their first contribution in [#7238](https://github.com/pydantic/pydantic/pull/7238)
* @GabrielCappelli made their first contribution in [#7213](https://github.com/pydantic/pydantic/pull/7213)
* @tobni made their first contribution in [#7184](https://github.com/pydantic/pydantic/pull/7184)
* @redruin1 made their first contribution in [#7282](https://github.com/pydantic/pydantic/pull/7282)
* @FacerAin made their first contribution in [#7288](https://github.com/pydantic/pydantic/pull/7288)
* @acdha made their first contribution in [#7297](https://github.com/pydantic/pydantic/pull/7297)
* @andree0 made their first contribution in [#7319](https://github.com/pydantic/pydantic/pull/7319)
* @gordonhart made their first contribution in [#7375](https://github.com/pydantic/pydantic/pull/7375)
* @pmmmwh made their first contribution in [#7496](https://github.com/pydantic/pydantic/pull/7496)
* @disrupted made their first contribution in [#7299](https://github.com/pydantic/pydantic/pull/7299)
* @prodigysml made their first contribution in [#7360](https://github.com/pydantic/pydantic/pull/7360)
```

## Related issue number

Closes #7467 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig