### PR TITLE
make documentation an acceptable label to ignore release changes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,8 @@
 changelog:
   exclude:
     labels:
-      - ignore-for-release
+      - relnotes-ignore
+      - documentation
   categories:
     - title: Packaging
       labels:

--- a/release/check_relnotes.py
+++ b/release/check_relnotes.py
@@ -12,15 +12,22 @@ if __name__ == '__main__':
     with open(event_path) as event_file:
         event = json.load(event_file)
 
-    labels = [label['name'] for label in event['pull_request']['labels'] if label['name'].startswith('relnotes-')]
+    labels = [
+        label['name']
+        for label in event['pull_request']['labels']
+        if label['name'].startswith('relnotes-') or label['name'] == 'documentation'
+    ]
 
     if not labels:
-        print('No relnotes label found', file=sys.stderr)
+        print(
+            'No suitable label found, please add either one of the `relnotes-` or `documentation` labels.',
+            file=sys.stderr,
+        )
         exit(1)
 
     if len(labels) > 1:
         print(f'Multiple relnotes labels found: `{"`, `".join(labels)}`', file=sys.stderr)
         exit(1)
 
-    print('Found relnotes label:', labels[0])
+    print('Found suitable label:', labels[0])
     exit(0)

--- a/release/make_history.py
+++ b/release/make_history.py
@@ -54,7 +54,6 @@ def get_notes(new_version: str) -> str:
 
     body = response.json()['body']
     body = body.removeprefix('<!-- Release notes generated using configuration in .github/release.yml at main -->\n\n')
-    body = body.removeprefix("## What's Changed\n")
 
     body = re.sub(
         pattern='https://github.com/pydantic/pydantic/pull/(\\d+)',


### PR DESCRIPTION
## Change Summary

Makes `documentation` an acceptable label to ignore release changes. I think docs changes are not interesting to put in history; documentation goes live at different intervals..

This is what will currently get generated off the contents of `main` since v2.3:

```
## v2.4.0 (2023-09-21)

[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.4.0)

## What's Changed
### Packaging
* Update pydantic-core to latest version by @adriangb in [#7277](https://github.com/pydantic/pydantic/pull/7277)
* Update pydantic-core to 2.8.0 by @adriangb in [#7522](https://github.com/pydantic/pydantic/pull/7522)
### New Features
* Add Base64Url types by @dmontagu in [#7286](https://github.com/pydantic/pydantic/pull/7286)
* ✨ Implement optional `number` to `str` coercion by @lig in [#7508](https://github.com/pydantic/pydantic/pull/7508)
### Changes
* Do not override `model_post_init` in subclass with private attrs by @Viicos in [#7302](https://github.com/pydantic/pydantic/pull/7302)
* Make fields with defaults not required in the serialization schema by default by @dmontagu in [#7275](https://github.com/pydantic/pydantic/pull/7275)
* Mark `Extra` as deprecated by @disrupted in [#7299](https://github.com/pydantic/pydantic/pull/7299)
* 🐛 Make `EncodedStr` a dataclass by @Kludex in [#7396](https://github.com/pydantic/pydantic/pull/7396)
### Performance
* Simplify flatteining and inlining of Coreschema by @adriangb in [#7523](https://github.com/pydantic/pydantic/pull/7523)
* Remove unused copies in CoreSchema walking by @adriangb in [#7528](https://github.com/pydantic/pydantic/pull/7528)
* Add caches for collecting definitions and invalid schemas from a CoreSchema by @adriangb in [#7527](https://github.com/pydantic/pydantic/pull/7527)
* Eagerly resolve discriminated unions and cache cases where we can't by @adriangb in [#7529](https://github.com/pydantic/pydantic/pull/7529)
* Replace dict.get and dict.setdefault with more verbose versions in CoreSchema building hot paths by @adriangb in [#7536](https://github.com/pydantic/pydantic/pull/7536)
* Cache invalid CoreSchema discovery by @adriangb in [#7535](https://github.com/pydantic/pydantic/pull/7535)
### Fixes
* Fix config detection for TypedDict from grandparent classes by @dmontagu in [#7272](https://github.com/pydantic/pydantic/pull/7272)
* Fix hash function generation for frozen models with unusual MRO by @dmontagu in [#7274](https://github.com/pydantic/pydantic/pull/7274)
* Make strict config overridable in field for Path by @hramezani in [#7281](https://github.com/pydantic/pydantic/pull/7281)
* Use `ser_json_<timedelta|bytes>` on default in `GenerateJsonSchema` by @Kludex in [#7269](https://github.com/pydantic/pydantic/pull/7269)
* fix: adding a check that alias is validated as an identifier for Python by @andree0 in [#7319](https://github.com/pydantic/pydantic/pull/7319)
* Raise an Error When Computed Field Overrides Field by @sydney-runkle in [#7346](https://github.com/pydantic/pydantic/pull/7346)
* Fix applying SkipValidation to referenced schemas by @adriangb in [#7381](https://github.com/pydantic/pydantic/pull/7381)
* ✅ Enforce behavior of private attributes having double leading underscore by @lig in [#7265](https://github.com/pydantic/pydantic/pull/7265)
* Standardize `__get_pydantic_core_schema__` signature by @hramezani in [#7415](https://github.com/pydantic/pydantic/pull/7415)
* Fix Generic Dataclass Fields Mutation Bug (when using TypeAdapter) by @sydney-runkle in [#7435](https://github.com/pydantic/pydantic/pull/7435)
* fix: type-error on model_validator in wrap mode by @pmmmwh in [#7496](https://github.com/pydantic/pydantic/pull/7496)
* Improve enum error message by @hramezani in [#7506](https://github.com/pydantic/pydantic/pull/7506)
* Make `repr` work for instances that failed initialization when handling `ValidationError`s by @dmontagu in [#7439](https://github.com/pydantic/pydantic/pull/7439)
* Fixed a regular expression denial of service issue by limiting whites… by @prodigysml in [#7360](https://github.com/pydantic/pydantic/pull/7360)

## New Contributors
* @15498th made their first contribution in [#7238](https://github.com/pydantic/pydantic/pull/7238)
* @GabrielCappelli made their first contribution in [#7213](https://github.com/pydantic/pydantic/pull/7213)
* @tobni made their first contribution in [#7184](https://github.com/pydantic/pydantic/pull/7184)
* @redruin1 made their first contribution in [#7282](https://github.com/pydantic/pydantic/pull/7282)
* @FacerAin made their first contribution in [#7288](https://github.com/pydantic/pydantic/pull/7288)
* @acdha made their first contribution in [#7297](https://github.com/pydantic/pydantic/pull/7297)
* @andree0 made their first contribution in [#7319](https://github.com/pydantic/pydantic/pull/7319)
* @gordonhart made their first contribution in [#7375](https://github.com/pydantic/pydantic/pull/7375)
* @pmmmwh made their first contribution in [#7496](https://github.com/pydantic/pydantic/pull/7496)
* @disrupted made their first contribution in [#7299](https://github.com/pydantic/pydantic/pull/7299)
* @prodigysml made their first contribution in [#7360](https://github.com/pydantic/pydantic/pull/7360)
```

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin