### PR TITLE
Add `BaseModel.model_validate_strings` and `TypeAdapter.validate_strings`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -531,6 +531,28 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return cls.__pydantic_validator__.validate_json(json_data, strict=strict, context=context)
 
     @classmethod
+    def model_validate_strings(
+        cls: type[Model],
+        obj: Any,
+        *,
+        strict: bool | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> Model:
+        """Validate the given object contains string data against the Pydantic model.
+
+        Args:
+            obj: The object contains string data to validate.
+            strict: Whether to enforce types strictly.
+            context: Extra variables to pass to the validator.
+
+        Returns:
+            The validated Pydantic model.
+        """
+        # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
+        __tracebackhide__ = True
+        return cls.__pydantic_validator__.validate_strings(obj, strict=strict, context=context)
+
+    @classmethod
     def __get_pydantic_core_schema__(
         cls, __source: type[BaseModel], __handler: _annotated_handlers.GetCoreSchemaHandler
     ) -> CoreSchema:

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -221,6 +221,19 @@ class TypeAdapter(Generic[T]):
         """
         return self.validator.validate_json(__data, strict=strict, context=context)
 
+    def validate_strings(self, __obj: Any, *, strict: bool | None = None, context: dict[str, Any] | None = None) -> T:
+        """Validate object contains string data against the model.
+
+        Args:
+            __obj: The object contains string data to validate.
+            strict: Whether to strictly check types.
+            context: Additional context to use during validation.
+
+        Returns:
+            The validated object.
+        """
+        return self.validator.validate_strings(__obj, strict=strict, context=context)
+
     def get_default_value(self, *, strict: bool | None = None, context: dict[str, Any] | None = None) -> Some[T] | None:
         """Get the default value for the wrapped type.
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 from collections.abc import Hashable
 from dataclasses import InitVar
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, List, Optional, Set, TypeVar, Union
 
@@ -2593,3 +2593,14 @@ def test_alias_with_dashes():
 
     obj = Foo(**{'some-var': 'some_value'})
     assert obj.some_var == 'some_value'
+
+
+def test_validate_strings():
+    @pydantic.dataclasses.dataclass
+    class Nested:
+        d: date
+
+    class Model(BaseModel):
+        n: Nested
+
+    assert Model.model_validate_strings({'n': {'d': '2017-01-01'}}).n.d == date(2017, 1, 1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2577,7 +2577,7 @@ def test_model_validate_strings(field_type, input_value, expected, raises_match,
         with pytest.raises(expected, match=raises_match):
             Model.model_validate_strings({'x': input_value}, strict=strict)
     else:
-        Model.model_validate_strings({'x': input_value}, strict=strict).x == expected
+        assert Model.model_validate_strings({'x': input_value}, strict=strict).x == expected
 
 
 @pytest.mark.parametrize('strict', [True, False])

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -1,4 +1,5 @@
 import pickle
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 
 import pytest
@@ -616,3 +617,38 @@ def test_copy_preserves_equality():
 
     deepcopied = model.__deepcopy__()
     assert model == deepcopied
+
+
+@pytest.mark.parametrize(
+    'root_type,input_value,expected,raises_match,strict',
+    [
+        (bool, 'true', True, None, False),
+        (bool, 'true', True, None, True),
+        (bool, 'false', False, None, False),
+        (bool, 'e', ValidationError, 'type=bool_parsing', False),
+        (int, '1', 1, None, False),
+        (int, '1', 1, None, True),
+        (int, 'xxx', ValidationError, 'type=int_parsing', True),
+        (float, '1.1', 1.1, None, False),
+        (float, '1.10', 1.1, None, False),
+        (float, '1.1', 1.1, None, True),
+        (float, '1.10', 1.1, None, True),
+        (date, '2017-01-01', date(2017, 1, 1), None, False),
+        (date, '2017-01-01', date(2017, 1, 1), None, True),
+        (date, '2017-01-01T12:13:14.567', ValidationError, 'type=date_from_datetime_inexact', False),
+        (date, '2017-01-01T12:13:14.567', ValidationError, 'type=date_parsing', True),
+        (date, '2017-01-01T00:00:00', date(2017, 1, 1), None, False),
+        (date, '2017-01-01T00:00:00', ValidationError, 'type=date_parsing', True),
+        (datetime, '2017-01-01T12:13:14.567', datetime(2017, 1, 1, 12, 13, 14, 567_000), None, False),
+        (datetime, '2017-01-01T12:13:14.567', datetime(2017, 1, 1, 12, 13, 14, 567_000), None, True),
+    ],
+    ids=repr,
+)
+def test_model_validate_strings(root_type, input_value, expected, raises_match, strict):
+    Model = RootModel[root_type]
+
+    if raises_match is not None:
+        with pytest.raises(expected, match=raises_match):
+            Model.model_validate_strings(input_value, strict=strict)
+    else:
+        assert Model.model_validate_strings(input_value, strict=strict).root == expected

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -295,12 +295,12 @@ def test_validate_python_from_attributes() -> None:
     ids=repr,
 )
 def test_validate_strings(field_type, input_value, expected, raises_match, strict):
+    ta = TypeAdapter(field_type)
     if raises_match is not None:
-        print(TypeAdapter(field_type).core_schema)
         with pytest.raises(expected, match=raises_match):
-            TypeAdapter(field_type).validate_strings(input_value, strict=strict)
+            ta.validate_strings(input_value, strict=strict)
     else:
-        TypeAdapter(field_type).validate_strings(input_value, strict=strict) == expected
+        assert ta.validate_strings(input_value, strict=strict) == expected
 
 
 @pytest.mark.parametrize('strict', [True, False])

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from dataclasses import dataclass
+from datetime import date, datetime
 from typing import Any, Dict, ForwardRef, Generic, List, NamedTuple, Tuple, TypeVar, Union
 
 import pytest
@@ -266,3 +267,45 @@ def test_validate_python_from_attributes() -> None:
 
     res = ta.validate_python(UnrelatedClass(), from_attributes=True)
     assert res == ModelFromAttributesFalse(x=1)
+
+
+@pytest.mark.parametrize(
+    'field_type,input_value,expected,raises_match,strict',
+    [
+        (bool, 'true', True, None, False),
+        (bool, 'true', True, None, True),
+        (bool, 'false', False, None, False),
+        (bool, 'e', ValidationError, 'type=bool_parsing', False),
+        (int, '1', 1, None, False),
+        (int, '1', 1, None, True),
+        (int, 'xxx', ValidationError, 'type=int_parsing', True),
+        (float, '1.1', 1.1, None, False),
+        (float, '1.10', 1.1, None, False),
+        (float, '1.1', 1.1, None, True),
+        (float, '1.10', 1.1, None, True),
+        (date, '2017-01-01', date(2017, 1, 1), None, False),
+        (date, '2017-01-01', date(2017, 1, 1), None, True),
+        (date, '2017-01-01T12:13:14.567', ValidationError, 'type=date_from_datetime_inexact', False),
+        (date, '2017-01-01T12:13:14.567', ValidationError, 'type=date_parsing', True),
+        (date, '2017-01-01T00:00:00', date(2017, 1, 1), None, False),
+        (date, '2017-01-01T00:00:00', ValidationError, 'type=date_parsing', True),
+        (datetime, '2017-01-01T12:13:14.567', datetime(2017, 1, 1, 12, 13, 14, 567_000), None, False),
+        (datetime, '2017-01-01T12:13:14.567', datetime(2017, 1, 1, 12, 13, 14, 567_000), None, True),
+    ],
+    ids=repr,
+)
+def test_validate_strings(field_type, input_value, expected, raises_match, strict):
+    if raises_match is not None:
+        print(TypeAdapter(field_type).core_schema)
+        with pytest.raises(expected, match=raises_match):
+            TypeAdapter(field_type).validate_strings(input_value, strict=strict)
+    else:
+        TypeAdapter(field_type).validate_strings(input_value, strict=strict) == expected
+
+
+@pytest.mark.parametrize('strict', [True, False])
+def test_validate_strings_dict(strict):
+    assert TypeAdapter(Dict[int, date]).validate_strings({'1': '2017-01-01', '2': '2017-01-02'}, strict=strict) == {
+        1: date(2017, 1, 1),
+        2: date(2017, 1, 2),
+    }


### PR DESCRIPTION
`validate_strings` was implemented in `pydantic-core` in https://github.com/pydantic/pydantic-core/pull/883.

closes #7549
closes #7065

Selected Reviewer: @adriangb