### PR TITLE
move `annoated_handlers` to be public

### DIFF
--- a/docs/api/annotated_handlers.md
+++ b/docs/api/annotated_handlers.md
@@ -1,0 +1,1 @@
+::: pydantic.annotated_handlers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - 'Functional Serializers': api/functional_serializers.md
     - 'Pydantic Types': api/types.md
     - 'Network Types': api/networks.md
+    - 'Annotated Handlers': api/annotated_handlers.md
     - 'Version Information': api/version.md
   - Pydantic Core:
     - 'pydantic_core': api/pydantic_core.md

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -10,14 +10,9 @@ from pydantic_core.core_schema import (
 )
 
 from . import dataclasses
-from ._internal._annotated_handlers import (
-    GetCoreSchemaHandler as GetCoreSchemaHandler,
-)
-from ._internal._annotated_handlers import (
-    GetJsonSchemaHandler as GetJsonSchemaHandler,
-)
 from ._internal._generate_schema import GenerateSchema as GenerateSchema
 from ._migration import getattr_migration
+from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from .config import ConfigDict, Extra
 from .deprecated.class_validators import root_validator, validator
 from .deprecated.config import BaseConfig

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -36,6 +36,7 @@ from warnings import warn
 from pydantic_core import CoreSchema, PydanticUndefined, core_schema
 from typing_extensions import Annotated, Final, Literal, TypeAliasType, TypedDict, get_args, get_origin, is_typeddict
 
+from ..annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ..config import ConfigDict, JsonEncoder
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
 from ..fields import AliasChoices, AliasPath, FieldInfo
@@ -43,7 +44,6 @@ from ..json_schema import JsonSchemaValue
 from ..version import version_short
 from ..warnings import PydanticDeprecatedSince20
 from . import _decorators, _discriminated_union, _known_annotated_metadata, _typing_extra
-from ._annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ._config import ConfigWrapper, ConfigWrapperStack
 from ._core_metadata import (
     CoreMetadataHandler,

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -13,7 +13,7 @@ from . import _validators
 from ._fields import PydanticGeneralMetadata, PydanticMetadata
 
 if TYPE_CHECKING:
-    from ._annotated_handlers import GetJsonSchemaHandler
+    from ..annotated_handlers import GetJsonSchemaHandler
 
 
 STRICT = {'strict'}

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from pydantic_core import core_schema
 from typing_extensions import Literal
 
-from ._annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
+from ..annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 
 if TYPE_CHECKING:
     from ..json_schema import GenerateJsonSchema, JsonSchemaValue

--- a/pydantic/annotated_handlers.py
+++ b/pydantic/annotated_handlers.py
@@ -1,3 +1,4 @@
+"""Type annotations to use with `__get_pydantic_core_schema__` and `__get_pydantic_json_schema__`."""
 from __future__ import annotations as _annotations
 
 from typing import TYPE_CHECKING, Any, Union
@@ -5,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Union
 from pydantic_core import core_schema
 
 if TYPE_CHECKING:
-    from ..json_schema import JsonSchemaMode, JsonSchemaValue
+    from .json_schema import JsonSchemaMode, JsonSchemaValue
 
     CoreSchemaOrField = Union[
         core_schema.CoreSchema,

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -10,7 +10,8 @@ from pydantic_core import core_schema as _core_schema
 from typing_extensions import Annotated, Literal, TypeAlias
 
 from . import PydanticUndefinedAnnotation
-from ._internal import _annotated_handlers, _decorators, _internal_dataclass
+from ._internal import _decorators, _internal_dataclass
+from .annotated_handlers import GetCoreSchemaHandler
 
 
 @dataclasses.dataclass(**_internal_dataclass.slots_true, frozen=True)
@@ -28,9 +29,7 @@ class PlainSerializer:
     return_type: Any = PydanticUndefined
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
-    def __get_pydantic_core_schema__(
-        self, source_type: Any, handler: _annotated_handlers.GetCoreSchemaHandler
-    ) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         """Gets the Pydantic core schema.
 
         Args:
@@ -73,9 +72,7 @@ class WrapSerializer:
     return_type: Any = PydanticUndefined
     when_used: Literal['always', 'unless-none', 'json', 'json-unless-none'] = 'always'
 
-    def __get_pydantic_core_schema__(
-        self, source_type: Any, handler: _annotated_handlers.GetCoreSchemaHandler
-    ) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         """This method is used to get the Pydantic core schema of the class.
 
         Args:
@@ -264,7 +261,7 @@ else:
             return Annotated[item, SerializeAsAny()]
 
         def __get_pydantic_core_schema__(
-            self, source_type: Any, handler: _annotated_handlers.GetCoreSchemaHandler
+            self, source_type: Any, handler: GetCoreSchemaHandler
         ) -> core_schema.CoreSchema:
             schema = handler(source_type)
             schema_to_update = schema

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -13,13 +13,8 @@ from pydantic_core import core_schema as _core_schema
 from typing_extensions import Annotated, Literal, TypeAlias
 
 from . import GetCoreSchemaHandler as _GetCoreSchemaHandler
-from ._internal import (
-    _annotated_handlers,
-    _core_metadata,
-    _decorators,
-    _generics,
-    _internal_dataclass,
-)
+from ._internal import _core_metadata, _decorators, _generics, _internal_dataclass
+from .annotated_handlers import GetCoreSchemaHandler
 from .errors import PydanticUserError
 
 if sys.version_info < (3, 11):
@@ -530,9 +525,7 @@ else:
             return Annotated[item, cls()]
 
         @classmethod
-        def __get_pydantic_core_schema__(
-            cls, source: Any, handler: _annotated_handlers.GetCoreSchemaHandler
-        ) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
             from pydantic import PydanticSchemaGenerationError
 
             # use the generic _origin_ as the second argument to isinstance when appropriate
@@ -575,9 +568,7 @@ else:
             return Annotated[item, SkipValidation()]
 
         @classmethod
-        def __get_pydantic_core_schema__(
-            cls, source: Any, handler: _annotated_handlers.GetCoreSchemaHandler
-        ) -> core_schema.CoreSchema:
+        def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
             original_schema = handler(source)
             metadata = _core_metadata.build_metadata_dict(js_annotation_functions=[lambda _c, h: h(original_schema)])
             return core_schema.any_schema(

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -40,7 +40,6 @@ from pydantic_core.core_schema import ComputedField
 from typing_extensions import Annotated, Literal, assert_never
 
 from ._internal import (
-    _annotated_handlers,
     _config,
     _core_metadata,
     _core_utils,
@@ -50,6 +49,7 @@ from ._internal import (
     _schema_generation_shared,
     _typing_extra,
 )
+from .annotated_handlers import GetJsonSchemaHandler
 from .config import JsonSchemaExtraCallable
 from .errors import PydanticInvalidForJsonSchema, PydanticUserError
 
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from . import ConfigDict
     from ._internal._core_utils import CoreSchemaField, CoreSchemaOrField
     from ._internal._dataclasses import PydanticDataclass
-    from ._internal._schema_generation_shared import GetJsonSchemaFunction, GetJsonSchemaHandler
+    from ._internal._schema_generation_shared import GetJsonSchemaFunction
     from .main import BaseModel
 
 
@@ -2251,7 +2251,7 @@ class WithJsonSchema:
     mode: Literal['validation', 'serialization'] | None = None
 
     def __get_pydantic_json_schema__(
-        self, core_schema: core_schema.CoreSchema, handler: _annotated_handlers.GetJsonSchemaHandler
+        self, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
         mode = self.mode or handler.mode
         if mode != handler.mode:
@@ -2281,7 +2281,7 @@ class Examples:
     mode: Literal['validation', 'serialization'] | None = None
 
     def __get_pydantic_json_schema__(
-        self, core_schema: core_schema.CoreSchema, handler: _annotated_handlers.GetJsonSchemaHandler
+        self, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
         mode = self.mode or handler.mode
         json_schema = handler(core_schema)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -12,7 +12,6 @@ import typing_extensions
 from pydantic_core import PydanticUndefined
 
 from ._internal import (
-    _annotated_handlers,
     _config,
     _decorators,
     _fields,
@@ -25,6 +24,7 @@ from ._internal import (
     _utils,
 )
 from ._migration import getattr_migration
+from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from .config import ConfigDict
 from .deprecated import copy_internals as _deprecated_copy_internals
 from .deprecated import parse as _deprecated_parse
@@ -553,9 +553,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return cls.__pydantic_validator__.validate_strings(obj, strict=strict, context=context)
 
     @classmethod
-    def __get_pydantic_core_schema__(
-        cls, __source: type[BaseModel], __handler: _annotated_handlers.GetCoreSchemaHandler
-    ) -> CoreSchema:
+    def __get_pydantic_core_schema__(cls, __source: type[BaseModel], __handler: GetCoreSchemaHandler) -> CoreSchema:
         """Hook into generating the model's CoreSchema.
 
         Args:
@@ -582,7 +580,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     def __get_pydantic_json_schema__(
         cls,
         __core_schema: CoreSchema,
-        __handler: _annotated_handlers.GetJsonSchemaHandler,
+        __handler: GetJsonSchemaHandler,
     ) -> JsonSchemaValue:
         """Hook into generating the model's JSON schema.
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -9,8 +9,9 @@ from typing import TYPE_CHECKING, Any
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, TypeAlias
 
-from ._internal import _annotated_handlers, _fields, _repr, _schema_generation_shared
+from ._internal import _fields, _repr, _schema_generation_shared
 from ._migration import getattr_migration
+from .annotated_handlers import GetCoreSchemaHandler
 from .json_schema import JsonSchemaValue
 
 if TYPE_CHECKING:
@@ -194,7 +195,7 @@ else:
         def __get_pydantic_core_schema__(
             cls,
             _source: type[Any],
-            _handler: _annotated_handlers.GetCoreSchemaHandler,
+            _handler: GetCoreSchemaHandler,
         ) -> core_schema.CoreSchema:
             import_email_validator()
             return core_schema.no_info_after_validator_function(cls._validate, core_schema.str_schema())
@@ -269,7 +270,7 @@ class NameEmail(_repr.Representation):
     def __get_pydantic_core_schema__(
         cls,
         _source: type[Any],
-        _handler: _annotated_handlers.GetCoreSchemaHandler,
+        _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         import_email_validator()
         return core_schema.no_info_after_validator_function(
@@ -323,7 +324,7 @@ class IPvAnyAddress:
     def __get_pydantic_core_schema__(
         cls,
         _source: type[Any],
-        _handler: _annotated_handlers.GetCoreSchemaHandler,
+        _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         return core_schema.no_info_plain_validator_function(
             cls._validate, serialization=core_schema.to_string_ser_schema()
@@ -363,7 +364,7 @@ class IPvAnyInterface:
     def __get_pydantic_core_schema__(
         cls,
         _source: type[Any],
-        _handler: _annotated_handlers.GetCoreSchemaHandler,
+        _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         return core_schema.no_info_plain_validator_function(
             cls._validate, serialization=core_schema.to_string_ser_schema()
@@ -405,7 +406,7 @@ class IPvAnyNetwork:
     def __get_pydantic_core_schema__(
         cls,
         _source: type[Any],
-        _handler: _annotated_handlers.GetCoreSchemaHandler,
+        _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         return core_schema.no_info_plain_validator_function(
             cls._validate, serialization=core_schema.to_string_ser_schema()


### PR DESCRIPTION
Since they're public alread, and so we can add the attributes to API documentation.

Selected Reviewer: @davidhewitt