### PR TITLE
Fixing `__iter__` returning private `cached_property` info

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -7,7 +7,12 @@ import sys
 import typing
 from copy import copy
 from dataclasses import Field as DataclassField
-from functools import cached_property
+
+try:
+    from functools import cached_property  # type: ignore
+except ImportError:
+    # python 3.7
+    cached_property = None
 from typing import Any, ClassVar
 from warnings import warn
 
@@ -992,14 +997,14 @@ def computed_field(__func: PropertyT) -> PropertyT:
     ...
 
 
-def _wrapped_property_is_private(property_: cached_property | property) -> bool:
+def _wrapped_property_is_private(property_: cached_property | property) -> bool:  # type: ignore
     """Returns true if provided property is private, False otherwise."""
     wrapped_name: str = ''
 
     if isinstance(property_, property):
         wrapped_name = getattr(property_.fget, '__name__', '')
-    elif isinstance(property_, cached_property):
-        wrapped_name = getattr(property_.func, '__name__', '')
+    elif isinstance(property_, cached_property):  # type: ignore
+        wrapped_name = getattr(property_.func, '__name__', '')  # type: ignore
 
     return wrapped_name.startswith('_') and not wrapped_name.startswith('__')
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -887,7 +887,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     def __iter__(self) -> TupleGenerator:
         """So `dict(model)` works."""
-        yield from self.__dict__.items()
+        yield from [(k, v) for (k, v) in self.__dict__.items() if not k.startswith('_')]
         extra = self.__pydantic_extra__
         if extra:
             yield from extra.items()

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -402,7 +402,7 @@ def test_private_computed_field():
     class MyModel(BaseModel):
         x: int
 
-        @computed_field
+        @computed_field(repr=True)
         def _double(self) -> int:
             return self.x * 2
 

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -395,7 +395,8 @@ class BaseConfig(BaseModel):
     assert module.BaseConfig._FIELD_UPDATE_STRATEGY == {}
 
 
-def test_private_properties_not_included_in_iter() -> None:
+@pytest.mark.skipif(not hasattr(functools, 'cached_property'), reason='cached_property is not available')
+def test_private_properties_not_included_in_iter_cached_property() -> None:
     class Model(BaseModel):
         foo: int
 
@@ -405,17 +406,25 @@ def test_private_properties_not_included_in_iter() -> None:
             return -self.foo
 
     m = Model(foo=1)
-    assert '_foo' not in list(k for k, v in m)
+    assert '_foo' not in list(k for k, _ in m)
 
 
-def test_private_properties_not_included_in_repr_by_default() -> None:
+def test_private_properties_not_included_in_iter_property() -> None:
     class Model(BaseModel):
         foo: int
 
         @computed_field
         @functools.cached_property
-        def _private_cached_property(self) -> int:
+        def _foo(self) -> int:
             return -self.foo
+
+    m = Model(foo=1)
+    assert '_foo' not in list(k for k, _ in m)
+
+
+def test_private_properties_not_included_in_repr_by_default_property() -> None:
+    class Model(BaseModel):
+        foo: int
 
         @computed_field
         @property
@@ -424,5 +433,19 @@ def test_private_properties_not_included_in_repr_by_default() -> None:
 
     m = Model(foo=1)
     m_repr = repr(m)
-    assert '_private_cached_property' not in m_repr
     assert '_private_property' not in m_repr
+
+
+@pytest.mark.skipif(not hasattr(functools, 'cached_property'), reason='cached_property is not available')
+def test_private_properties_not_included_in_repr_by_default_cached_property() -> None:
+    class Model(BaseModel):
+        foo: int
+
+        @computed_field
+        @functools.cached_property
+        def _private_cached_property(self) -> int:
+            return -self.foo
+
+    m = Model(foo=1)
+    m_repr = repr(m)
+    assert '_private_cached_property' not in m_repr

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -414,7 +414,7 @@ def test_private_properties_not_included_in_iter_property() -> None:
         foo: int
 
         @computed_field
-        @functools.cached_property
+        @property
         def _foo(self) -> int:
             return -self.foo
 


### PR DESCRIPTION
## Change Summary
* Fixing `__iter__` returning private `cached_property` info
* By default, private `computed_field`s have `repr` set to False

<!-- Please give a short summary of the changes. -->

Fix #7499

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin