### PR TITLE
Added `is_set` function to check whether a model field is set on an instance

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -53,7 +53,7 @@ else:
     # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
 
-__all__ = 'BaseModel', 'create_model'
+__all__ = 'BaseModel', 'create_model', 'is_set'
 
 _object_setattr = _model_construction.object_setattr
 
@@ -1399,3 +1399,20 @@ def create_model(
 
 
 __getattr__ = getattr_migration(__name__)
+
+
+def is_set(field: Any, obj: Any) -> bool:
+    """Check whether a field is set on a particular model instance.
+
+    Args:
+        field: The reference to a model field
+        obj: The model instance to check
+
+    Raises:
+        TypeError: If the object is not a model instance
+        TypeError: If the model class does not define the field.
+
+    Returns:
+        bool: Whether the field was set or not
+    """
+    raise NotImplementedError()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I've added a function to check whether a model field was set on a particular model instance.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

fix #7578

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
