### PR TITLE
revert plugin performance regression

### DIFF
--- a/pydantic/plugin/_loader.py
+++ b/pydantic/plugin/_loader.py
@@ -35,8 +35,8 @@ def get_plugins() -> Iterable[PydanticPluginProtocol]:
         # this happens when plugins themselves use pydantic, we return no plugins
         return ()
     elif _plugins is None:
-        # plugins already loaded
         _plugins = {}
+        # set _loading_plugins so any plugins that use pydantic don't themselves use plugins
         _loading_plugins = True
         try:
             for dist in importlib_metadata.distributions():

--- a/pydantic/plugin/_loader.py
+++ b/pydantic/plugin/_loader.py
@@ -33,7 +33,7 @@ def get_plugins() -> Iterable[PydanticPluginProtocol]:
     global _plugins, _loading_plugins
     if _loading_plugins:
         # this happens when plugins themselves use pydantic, we return no plugins
-        return {}.values()
+        return ()
     elif _plugins is None:
         # plugins already loaded
         _plugins = {}

--- a/tests/plugin/example_plugin.py
+++ b/tests/plugin/example_plugin.py
@@ -5,6 +5,10 @@ class MyModel(BaseModel):
     x: int
 
 
+m = MyModel(x='10')
+if m.x != 10:
+    raise Exception('m.x should be 10')
+
 log = []
 
 

--- a/tests/plugin/example_plugin.py
+++ b/tests/plugin/example_plugin.py
@@ -7,7 +7,7 @@ class MyModel(BaseModel):
 
 m = MyModel(x='10')
 if m.x != 10:
-    raise Exception('m.x should be 10')
+    raise ValueError('m.x should be 10')
 
 log = []
 

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -8,11 +8,9 @@ pytestmark = pytest.mark.skipif(not os.getenv('TEST_PLUGIN'), reason='Test only 
 def test_plugin_usage():
     from pydantic import BaseModel
 
-    with pytest.warns(UserWarning, match='AttributeError while loading the `my_plugin` Pydantic plugin.*'):
-
-        class MyModel(BaseModel):
-            x: int
-            y: str
+    class MyModel(BaseModel):
+        x: int
+        y: str
 
     m = MyModel(x='10', y='hello')
     assert m.x == 10


### PR DESCRIPTION
Avoid loading plugins, and thereby iterating over `importlib_metadata.distributions()` ever time a model is created.

Instead we only look for plugins is we haven't looked before, or loading plugins previously failed.

Selected Reviewer: @lig