### PR TITLE
Revert unecessary regex change from e4393ae

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -638,7 +638,7 @@ def _build_pretty_email_regex() -> re.Pattern[str]:
     name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'
     unquoted_name_group = fr'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
-    email_group = r'<\s*(.{0,254})\s*>'
+    email_group = r'<\s*(.+)\s*>'
     return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
 
 


### PR DESCRIPTION
See https://github.com/pydantic/pydantic/pull/7360#discussion_r1335792440. No regex changes were necessary in the end because we ended up just restricting the overall length