### PR TITLE
fix unintentional drop of character in HISTORY

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,11 +2,13 @@
 
 [GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.4.0)
 
-### Packaging
+### What's Changed
+
+#### Packaging
 
 * Update pydantic-core to 2.10.0 by @samuelcolvin in [#7542](https://github.com/pydantic/pydantic/pull/7542)
 
-### New Features
+#### New Features
 
 * Add `Base64Url` types by @dmontagu in [#7286](https://github.com/pydantic/pydantic/pull/7286)
 * Implement optional `number` to `str` coercion by @lig in [#7508](https://github.com/pydantic/pydantic/pull/7508)
@@ -14,7 +16,7 @@
 * Add `BaseModel.model_validate_strings` and `TypeAdapter.validate_strings` by @hramezani in [#7552](https://github.com/pydantic/pydantic/pull/7552)
 * Add Pydantic `plugins` experimental implementation by @lig @samuelcolvin and @Kludex in [#6820](https://github.com/pydantic/pydantic/pull/6820)
 
-### Changes
+#### Changes
 
 * Do not override `model_post_init` in subclass with private attrs by @Viicos in [#7302](https://github.com/pydantic/pydantic/pull/7302)
 * Make fields with defaults not required in the serialization schema by default by @dmontagu in [#7275](https://github.com/pydantic/pydantic/pull/7275)
@@ -22,7 +24,7 @@
 * Make `EncodedStr` a dataclass by @Kludex in [#7396](https://github.com/pydantic/pydantic/pull/7396)
 * Move `annotated_handlers` to be public by @samuelcolvin in [#7569](https://github.com/pydantic/pydantic/pull/7569)
 
-### Performance
+#### Performance
 
 * Simplify flattening and inlining of `CoreSchema` by @adriangb in [#7523](https://github.com/pydantic/pydantic/pull/7523)
 * Remove unused copies in `CoreSchema` walking by @adriangb in [#7528](https://github.com/pydantic/pydantic/pull/7528)
@@ -32,7 +34,7 @@
 * Cache invalid `CoreSchema` discovery by @adriangb in [#7535](https://github.com/pydantic/pydantic/pull/7535)
 * Allow disabling `CoreSchema` validation for faster startup times by @adriangb in [#7565](https://github.com/pydantic/pydantic/pull/7565)
 
-### Fixes
+#### Fixes
 
 * Fix config detection for `TypedDict` from grandparent classes by @dmontagu in [#7272](https://github.com/pydantic/pydantic/pull/7272)
 * Fix hash function generation for frozen models with unusual MRO by @dmontagu in [#7274](https://github.com/pydantic/pydantic/pull/7274)

--- a/release/make_history.py
+++ b/release/make_history.py
@@ -67,17 +67,11 @@ def get_notes(new_version: str) -> str:
     body = response.json()['body']
     body = body.removeprefix('<!-- Release notes generated using configuration in .github/release.yml at main -->\n\n')
 
-    # We don't use the "What's Changed" header, the subgroups are already at `###` which is the correct level
-    body = body.removeprefix("## What's Changed\n")
+    # Add one level to all headers so they match HISTORY.md, and add trailing newline
+    body = re.sub(pattern='^(#+ .+?)$', repl=r'#\1\n', string=body, flags=re.MULTILINE)
 
-    # Correct "New Contributors" header level
-    body = re.sub(pattern='\n## New Contributors', repl='\n### New Contributors', string=body)
-
-    # Add newline after all ### headers as Github doesn't add spacing
-    body = re.sub(pattern='((^|\n)### .+?\n)', repl=r'\1\n', string=body)
-
-    # Ensure a blank line before ### headers
-    body = re.sub(pattern='([^\n])(\n### .+?\n)', repl=r'\1\n\2', string=body)
+    # Ensure a blank line before headers
+    body = re.sub(pattern='([^\n])(\n#+ .+?\n)', repl=r'\1\n\2', string=body)
 
     # Render PR links nicely
     body = re.sub(

--- a/release/make_history.py
+++ b/release/make_history.py
@@ -77,7 +77,7 @@ def get_notes(new_version: str) -> str:
     body = re.sub(pattern='((^|\n)### .+?\n)', repl=r'\1\n', string=body)
 
     # Ensure a blank line before ### headers
-    body = re.sub(pattern='[^\n](\n### .+?\n)', repl=r'\n\1', string=body)
+    body = re.sub(pattern='([^\n])(\n### .+?\n)', repl=r'\1\n\2', string=body)
 
     # Render PR links nicely
     body = re.sub(


### PR DESCRIPTION
## Change Summary

The `[^\n]` leading character in the regex to add newlines was being unintentionally thrown away, this PR adjusts the `re.sub` call to re-emit that character.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle