### PR TITLE
Correct allowed formats for `datetime.timedelta` parsing in docs

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -133,8 +133,8 @@ print(m.model_dump())
     * `timedelta`; an existing `timedelta` object
     * `int` or `float`; assumed to be seconds
     * `str`; the following formats are accepted:
-        * `[-][DD]D[ ][HH:MM]SS[.ffffff]`
-            * Ex: `'1D 01:02:03.000004'` or `'1D01:02:03.000004'` or `'01:02:03'`
+        * `[-][DD]D[,][HH:MM]SS[.ffffff]`
+            * Ex: `'1d,01:02:03.000004'` or `'1D01:02:03.000004'` or `'01:02:03'`
         * `[±]P[DD]DT[HH]H[MM]M[SS]S` ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format for timedelta)
 
 ```py

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -133,7 +133,8 @@ print(m.model_dump())
     * `timedelta`; an existing `timedelta` object
     * `int` or `float`; assumed to be seconds
     * `str`; the following formats are accepted:
-        * `[-][DD ][HH:MM]SS[.ffffff]`
+        * `[-][DD]D[ ][HH:MM]SS[.ffffff]`
+            * Ex: `'1D 01:02:03.000004'` or `'1D01:02:03.000004'` or `'01:02:03'`
         * `[±]P[DD]DT[HH]H[MM]M[SS]S` ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format for timedelta)
 
 ```py

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -133,7 +133,7 @@ print(m.model_dump())
     * `timedelta`; an existing `timedelta` object
     * `int` or `float`; assumed to be seconds
     * `str`; the following formats are accepted:
-        * `[-][DD]D[,][HH:MM]SS[.ffffff]`
+        * `[-][DD]D[,][HH:MM:]SS[.ffffff]`
             * Ex: `'1d,01:02:03.000004'` or `'1D01:02:03.000004'` or `'01:02:03'`
         * `[±]P[DD]DT[HH]H[MM]M[SS]S` ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format for timedelta)
 


### PR DESCRIPTION
## Change Summary

Correct format for `datetime.timedelta` parsing

## Related issue number

Fix #7650

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex