### PR TITLE
docs: Mixing of V1/V2 models is not supported in generics

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -134,6 +134,9 @@ The `pydantic.generics.GenericModel` class is no longer necessary, and has been 
 create generic `BaseModel` subclasses by just adding `Generic` as a parent class on a `BaseModel` subclass directly.
 This looks like `class MyGenericModel(BaseModel, Generic[T]): ...`.
 
+Mixing of V1 and V2 models is not supported which means that type parameters of such generic `BaseModel` (V2)
+cannot be V1 models.
+
 While it may not raise an error, we strongly advise against using _parametrized_ generics in `isinstance` checks.
 
   * For example, you should not do `isinstance(my_model, MyGenericModel[int])`.


### PR DESCRIPTION
## Change Summary

Explain that v1/v2 models cannot be mixed

## Related issue number

Fix #7637 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin