### PR TITLE
Change unconfirmed label to 'pending' for hooky issue labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ addopts = [
 assignees = []
 reviewers = ['samuelcolvin', 'adriangb', 'dmontagu', 'hramezani', 'lig', 'Kludex', 'davidhewitt', 'sydney-runkle']
 require_change_file = false
+unconfirmed_label = 'pending'
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Change Summary

When `hooky` assigns labels to a newly created issue, `pending` is added instead of `unconfirmed`.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb