### PR TITLE
Fix `mypy` issue with subclasses of `RootModel`

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -607,8 +607,9 @@ class PydanticModelTransformer:
                 lhs = stmt.lvalues[0]
                 if is_root_model and lhs.name != 'root':
                     error_extra_fields_on_root_model(self._api, stmt)
-                current_field_names.add(lhs.name)
-                found_fields[lhs.name] = maybe_field
+                else:
+                    current_field_names.add(lhs.name)
+                    found_fields[lhs.name] = maybe_field
 
         return list(found_fields.values())
 

--- a/tests/mypy/modules/root_models.py
+++ b/tests/mypy/modules/root_models.py
@@ -17,3 +17,7 @@ class Pets3(RootModel):
 pets1 = Pets1(['dog', 'cat'])
 pets2 = Pets2(['dog', 'cat'])
 pets3 = Pets3(['dog', 'cat'])
+
+
+class Pets4(RootModel[List[str]]):
+    pets: List[str]

--- a/tests/mypy/modules/root_models.py
+++ b/tests/mypy/modules/root_models.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from pydantic import RootModel
+
+
+class Pets1(RootModel[List[str]]):
+    pass
+
+
+Pets2 = RootModel[List[str]]
+
+
+class Pets3(RootModel):
+    root: List[str]
+
+
+pets1 = Pets1(['dog', 'cat'])
+pets2 = Pets2(['dog', 'cat'])
+pets3 = Pets3(['dog', 'cat'])

--- a/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
@@ -18,3 +18,8 @@ class Pets3(RootModel):
 pets1 = Pets1(['dog', 'cat'])
 pets2 = Pets2(['dog', 'cat'])
 pets3 = Pets3(['dog', 'cat'])
+
+
+class Pets4(RootModel[List[str]]):
+    pets: List[str]
+    # MYPY: error: Extra field on RootModel subclass  [pydantic-field]

--- a/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from pydantic import RootModel
+
+
+class Pets1(RootModel[List[str]]):
+    pass
+
+
+Pets2 = RootModel[List[str]]
+
+
+class Pets3(RootModel):
+# MYPY: error: Missing type parameters for generic type "RootModel"  [type-arg]
+    root: List[str]
+
+
+pets1 = Pets1(['dog', 'cat'])
+pets2 = Pets2(['dog', 'cat'])
+pets3 = Pets3(['dog', 'cat'])

--- a/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
@@ -22,4 +22,4 @@ pets3 = Pets3(['dog', 'cat'])
 
 class Pets4(RootModel[List[str]]):
     pets: List[str]
-    # MYPY: error: Extra field on RootModel subclass  [pydantic-field]
+# MYPY: error: Only `root` is allowed as a field of a `RootModel`  [pydantic-field]

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -98,6 +98,7 @@ cases = (
     + [
         ('mypy-plugin.ini', 'custom_constructor.py'),
         ('mypy-plugin.ini', 'generics.py'),
+        ('mypy-plugin.ini', 'root_models.py'),
         ('mypy-plugin-strict.ini', 'plugin_default_factory.py'),
         ('mypy-plugin-strict-no-any.ini', 'dataclass_no_any.py'),
         ('mypy-plugin-very-strict.ini', 'metaclass_args.py'),


### PR DESCRIPTION
## Change Summary

`mypy` no longer errors when a subclass of `RootModel` is instantiated without a `root` keyword argument. See issue for details/

## Related issue number

Fix #7463

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig