### PR TITLE
Add support for instance method reassignment when `extra='allow'`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -801,11 +801,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             if self.model_extra and name in self.model_extra:
                 self.__pydantic_extra__[name] = value  # type: ignore
             else:
-                attr_exists_on_instance: Any = getattr(self, name, None)
-                if attr_exists_on_instance:
-                    _object_setattr(self, name, value)
-                else:
+                try:
+                    getattr(self, name)
+                except AttributeError:
+                    # attribute does not already exist on instance, so put it in extra
                     self.__pydantic_extra__[name] = value  # type: ignore
+                else:
+                    # attribute _does_ already exist on instance, and was not in extra, so update it
+                    _object_setattr(self, name, value)
         else:
             self.__dict__[name] = value
             self.__pydantic_fields_set__.add(name)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -798,8 +798,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # TODO - matching error
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
         elif self.model_config.get('extra') == 'allow' and name not in self.model_fields:
-            # SAFETY: __pydantic_extra__ is not None when extra = 'allow'
-            self.__pydantic_extra__[name] = value  # type: ignore
+            if getattr(self, name, None) and name not in self.model_extra and callable(value):  # type: ignore
+                self.__dict__[name] = value.__get__(self, type(self))
+            else:
+                # SAFETY: __pydantic_extra__ is not None when extra = 'allow'
+                self.__pydantic_extra__[name] = value  # type: ignore
         else:
             self.__dict__[name] = value
             self.__pydantic_fields_set__.add(name)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -798,14 +798,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # TODO - matching error
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
         elif self.model_config.get('extra') == 'allow' and name not in self.model_fields:
-            reassigning_existing_method: bool = (
-                getattr(self, name, None) and name not in self.model_extra and callable(value)  # type: ignore
-            )
-            if reassigning_existing_method:
-                self.__dict__[name] = value.__get__(self, type(self))
-            else:
-                # SAFETY: __pydantic_extra__ is not None when extra = 'allow'
+            if self.model_extra and name in self.model_extra:
                 self.__pydantic_extra__[name] = value  # type: ignore
+            else:
+                attr_exists_on_instance: Any = getattr(self, name, None)
+                if attr_exists_on_instance:
+                    _object_setattr(self, name, value)
+                else:
+                    self.__pydantic_extra__[name] = value  # type: ignore
         else:
             self.__dict__[name] = value
             self.__pydantic_fields_set__.add(name)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -798,7 +798,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # TODO - matching error
             raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
         elif self.model_config.get('extra') == 'allow' and name not in self.model_fields:
-            if getattr(self, name, None) and name not in self.model_extra and callable(value):  # type: ignore
+            reassigning_existing_method: bool = (
+                getattr(self, name, None) and name not in self.model_extra and callable(value)  # type: ignore
+            )
+            if reassigning_existing_method:
                 self.__dict__[name] = value.__get__(self, type(self))
             else:
                 # SAFETY: __pydantic_extra__ is not None when extra = 'allow'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -342,22 +342,22 @@ def test_extra_allowed():
     assert model.c == 1
 
 
-def test_reassign_instance_method_with_extra_allow():
+def test_reassign_static_method_with_extra_allow():
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow')
-        name: str
 
-        def not_extra_func(self) -> str:
-            return f'hello {self.name}'
+        @staticmethod
+        def not_extra_func(name: str) -> str:
+            return f'hello {name}'
 
-    def not_extra_func_replacement(self_sub: Model) -> str:
-        return f'hi {self_sub.name}'
+    def not_extra_func_replacement(name: str) -> str:
+        return f'hi {name}'
 
-    m = Model(name='james')
-    assert m.not_extra_func() == 'hello james'
+    m = Model()
+    assert m.not_extra_func(name='james') == 'hello james'
 
     m.not_extra_func = not_extra_func_replacement
-    assert m.not_extra_func() == 'hi james'
+    assert m.not_extra_func(name='james') == 'hi james'
     assert 'not_extra_func' in m.__dict__
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
+from functools import partial
 from typing import (
     Any,
     Callable,
@@ -342,6 +343,30 @@ def test_extra_allowed():
     assert model.c == 1
 
 
+def test_reassign_instance_method_with_extra_allow():
+    class Model(BaseModel):
+        model_config = ConfigDict(extra='allow')
+        name: str
+
+        def not_extra_func(self) -> str:
+            return f'hello {self.name}'
+
+    def not_extra_func_replacement(self_sub: Model) -> str:
+        return f'hi {self_sub.name}'
+
+    m = Model(name='james')
+    assert m.not_extra_func() == 'hello james'
+
+    m.not_extra_func = partial(not_extra_func_replacement, m)
+    assert m.not_extra_func() == 'hi james'
+    assert 'not_extra_func' in m.__dict__
+
+    m1 = Model(name='jeffrey')
+    m1.not_extra_func = lambda: not_extra_func_replacement(m1)
+    assert m1.not_extra_func() == 'hi jeffrey'
+    assert 'not_extra_func' in m.__dict__
+
+
 def test_reassign_static_method_with_extra_allow():
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow')
@@ -359,24 +384,6 @@ def test_reassign_static_method_with_extra_allow():
     m.not_extra_func = not_extra_func_replacement
     assert m.not_extra_func(name='james') == 'hi james'
     assert 'not_extra_func' in m.__dict__
-
-
-def test_reassign_class_method_with_extra_allow():
-    class Model(BaseModel):
-        model_config = ConfigDict(extra='allow')
-        name: ClassVar[str] = 'julia'
-
-        @classmethod
-        def not_extra_func(cls) -> str:
-            return f'hello {cls.name}'
-
-    def not_extra_func_replacement(cls_sub: Type[Model] = Model) -> str:
-        return f'hi {cls_sub.name}'
-
-    assert Model.not_extra_func() == 'hello julia'
-
-    Model.not_extra_func = not_extra_func_replacement
-    assert Model.not_extra_func() == 'hi julia'
 
 
 def test_extra_ignored():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -342,6 +342,43 @@ def test_extra_allowed():
     assert model.c == 1
 
 
+def test_reassign_instance_method_with_extra_allow():
+    class Model(BaseModel):
+        model_config = ConfigDict(extra='allow')
+        name: str
+
+        def not_extra_func(self) -> str:
+            return f'hello {self.name}'
+
+    def not_extra_func_replacement(self_sub: Model) -> str:
+        return f'hi {self_sub.name}'
+
+    m = Model(name='james')
+    assert m.not_extra_func() == 'hello james'
+
+    m.not_extra_func = not_extra_func_replacement
+    assert m.not_extra_func() == 'hi james'
+    assert 'not_extra_func' in m.__dict__
+
+
+def test_reassign_class_method_with_extra_allow():
+    class Model(BaseModel):
+        model_config = ConfigDict(extra='allow')
+        name: ClassVar[str] = 'julia'
+
+        @classmethod
+        def not_extra_func(cls) -> str:
+            return f'hello {cls.name}'
+
+    def not_extra_func_replacement(cls_sub: Type[Model] = Model) -> str:
+        return f'hi {cls_sub.name}'
+
+    assert Model.not_extra_func() == 'hello julia'
+
+    Model.not_extra_func = not_extra_func_replacement
+    assert Model.not_extra_func() == 'hi julia'
+
+
 def test_extra_ignored():
     class Model(BaseModel):
         model_config = ConfigDict(extra='ignore')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -361,29 +361,6 @@ def test_reassign_instance_method_with_extra_allow():
     assert m.not_extra_func() == 'hi james'
     assert 'not_extra_func' in m.__dict__
 
-    m1 = Model(name='jeffrey')
-    m1.not_extra_func = lambda: not_extra_func_replacement(m1)
-    assert m1.not_extra_func() == 'hi jeffrey'
-    assert 'not_extra_func' in m.__dict__
-
-
-def test_reassign_static_method_with_extra_allow():
-    class Model(BaseModel):
-        model_config = ConfigDict(extra='allow')
-
-        @staticmethod
-        def not_extra_func(name: str) -> str:
-            return f'hello {name}'
-
-    def not_extra_func_replacement(name: str) -> str:
-        return f'hi {name}'
-
-    m = Model()
-    assert m.not_extra_func(name='james') == 'hello james'
-
-    m.not_extra_func = not_extra_func_replacement
-    assert m.not_extra_func(name='james') == 'hi james'
-    assert 'not_extra_func' in m.__dict__
 
 
 def test_extra_ignored():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -362,7 +362,6 @@ def test_reassign_instance_method_with_extra_allow():
     assert 'not_extra_func' in m.__dict__
 
 
-
 def test_extra_ignored():
     class Model(BaseModel):
         model_config = ConfigDict(extra='ignore')


### PR DESCRIPTION
## Change Summary

Adding aligning the logic of `__setattr__` and `__getattr__` when `extra=True` on a model's config.

## Related issue number

Fix #7631

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex