### PR TITLE
Properly rebuild the FieldInfo when a forward ref gets evaluated

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -897,7 +897,9 @@ class GenerateSchema:
             metadata=common_field['metadata'],
         )
 
-    def _common_field_schema(self, name: str, field_info: FieldInfo, decorators: DecoratorInfos) -> _CommonField:
+    def _common_field_schema(  # noqa C901
+        self, name: str, field_info: FieldInfo, decorators: DecoratorInfos
+    ) -> _CommonField:
         # Update FieldInfo annotation if appropriate:
         if has_instance_in_type(field_info.annotation, (ForwardRef, str)):
             types_namespace = self._types_namespace
@@ -908,7 +910,9 @@ class GenerateSchema:
 
             evaluated = _typing_extra.eval_type_lenient(field_info.annotation, types_namespace, None)
             if evaluated is not field_info.annotation and not has_instance_in_type(evaluated, PydanticRecursiveRef):
-                field_info.annotation = evaluated
+                new_field_info = FieldInfo.from_annotation(evaluated)
+                for k, v in new_field_info._attributes_set.items():
+                    setattr(field_info, k, v)
 
         source_type, annotations = field_info.annotation, field_info.metadata
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -373,3 +373,16 @@ def test_predicate_error_python() -> None:
             'input': -1,
         }
     ]
+
+
+def test_annotated_field_info_not_lost_from_forwardref():
+    from pydantic import BaseModel
+
+    class ForwardRefAnnotatedFieldModel(BaseModel):
+        foo: 'Annotated[Integer, Field(alias="bar")]'
+
+    Integer = int
+
+    ForwardRefAnnotatedFieldModel.model_rebuild()
+
+    assert ForwardRefAnnotatedFieldModel(bar=1).foo == 1

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -379,10 +379,24 @@ def test_annotated_field_info_not_lost_from_forwardref():
     from pydantic import BaseModel
 
     class ForwardRefAnnotatedFieldModel(BaseModel):
-        foo: 'Annotated[Integer, Field(alias="bar")]'
+        foo: 'Annotated[Integer, Field(alias="bar", default=1)]' = 2
+        foo2: 'Annotated[Integer, Field(alias="bar2", default=1)]' = Field(default=2, alias='baz')
 
     Integer = int
 
     ForwardRefAnnotatedFieldModel.model_rebuild()
 
-    assert ForwardRefAnnotatedFieldModel(bar=1).foo == 1
+    assert ForwardRefAnnotatedFieldModel(bar=3).foo == 3
+    assert ForwardRefAnnotatedFieldModel(baz=3).foo2 == 3
+
+    with pytest.raises(ValidationError) as exc_info:
+        ForwardRefAnnotatedFieldModel(bar='bar')
+    assert exc_info.value.errors() == [
+        {
+            'input': 'bar',
+            'loc': ('bar',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'type': 'int_parsing',
+            'url': 'https://errors.pydantic.dev/2.4/v/int_parsing',
+        }
+    ]


### PR DESCRIPTION
Closes #3282.

@adriangb can you imagine any problems with this? Also, do you object to the access to the "private" attribute `_attributes_set`? If so, we could add a "public" method to the `FieldInfo` for updating one from another like this.