### PR TITLE
Fix populate_by_name migration note about old name

### DIFF
--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -131,7 +131,7 @@ class ConfigDict(TypedDict, total=False):
 
     Note:
         The name of this configuration setting was changed in **v2.0** from
-        `allow_population_by_alias` to `populate_by_name`.
+        `allow_population_by_field_name` to `populate_by_name`.
 
     ```py
     from pydantic import BaseModel, ConfigDict, Field


### PR DESCRIPTION
## Change Summary
Docs change only: Changed note about name of `populate_by_name` config field before pydantic v2.x.

## Related issue number
No issue created for trivial doc change.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist **(no code changes)**
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb