### PR TITLE
fix: update typevar handling when default is not set

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1449,17 +1449,14 @@ class GenerateSchema:
 
         bound = typevar.__bound__
         constraints = typevar.__constraints__
-        not_set = object()
-        default = getattr(typevar, '__default__', not_set)
-        if default is None:
-            default = not_set
+        default = getattr(typevar, '__default__', None)
 
-        if (bound is not None) + (len(constraints) != 0) + (default is not not_set) > 1:
+        if (bound is not None) + (len(constraints) != 0) + (default is not None) > 1:
             raise NotImplementedError(
                 'Pydantic does not support mixing more than one of TypeVar bounds, constraints and defaults'
             )
 
-        if default is not not_set:
+        if default is not None:
             return self.generate_schema(default)
         elif constraints:
             return self._union_schema(typing.Union[constraints])  # type: ignore

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1451,8 +1451,10 @@ class GenerateSchema:
         constraints = typevar.__constraints__
         not_set = object()
         default = getattr(typevar, '__default__', not_set)
+        if default is None:
+            default = not_set
 
-        if (bound is not None) + (len(constraints) != 0) + (default is not not_set and default is not None) > 1:
+        if (bound is not None) + (len(constraints) != 0) + (default is not not_set) > 1:
             raise NotImplementedError(
                 'Pydantic does not support mixing more than one of TypeVar bounds, constraints and defaults'
             )

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1452,7 +1452,7 @@ class GenerateSchema:
         not_set = object()
         default = getattr(typevar, '__default__', not_set)
 
-        if (bound is not None) + (len(constraints) != 0) + (default is not not_set) > 1:
+        if (bound is not None) + (len(constraints) != 0) + (default is not not_set and default is not None) > 1:
             raise NotImplementedError(
                 'Pydantic does not support mixing more than one of TypeVar bounds, constraints and defaults'
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I believe the behaviour change in #7606 is raising false positives when the `default` argument is supported but not specified.

Ref: https://peps.python.org/pep-0696/#implementation

## Related issue number

#7606

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex