### PR TITLE
Fix `defer_build` behavior with `TypeAdapter`

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -27,7 +27,7 @@ from ._core_utils import collect_invalid_schemas, simplify_schema_references, va
 from ._fields import collect_dataclass_fields
 from ._generate_schema import GenerateSchema
 from ._generics import get_standard_typevars_map
-from ._mock_val_ser import set_dataclass_mock_validator
+from ._mock_val_ser import set_dataclass_mocks
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._utils import is_valid_identifier
 
@@ -153,14 +153,14 @@ def complete_dataclass(
     except PydanticUndefinedAnnotation as e:
         if raise_errors:
             raise
-        set_dataclass_mock_validator(cls, cls.__name__, f'`{e.name}`')
+        set_dataclass_mocks(cls, cls.__name__, f'`{e.name}`')
         return False
 
     core_config = config_wrapper.core_config(cls)
 
     schema = gen_schema.collect_definitions(schema)
     if collect_invalid_schemas(schema):
-        set_dataclass_mock_validator(cls, cls.__name__, 'all referenced types')
+        set_dataclass_mocks(cls, cls.__name__, 'all referenced types')
         return False
 
     schema = _discriminated_union.apply_discriminators(simplify_schema_references(schema))

--- a/pydantic/_internal/_mock_val_ser.py
+++ b/pydantic/_internal/_mock_val_ser.py
@@ -96,15 +96,24 @@ def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = '
     )
 
 
-def set_dataclass_mocks(cls: type[PydanticDataclass], cls_name: str, undefined_name: str) -> None:
+def set_dataclass_mocks(
+    cls: type[PydanticDataclass], cls_name: str, undefined_name: str = 'all referenced types'
+) -> None:
+    """Set `__pydantic_validator__` and `__pydantic_serializer__` to `MockValSer`s on a dataclass.
+
+    Args:
+        cls: The model class to set the mocks on
+        cls_name: Name of the model class, used in error messages
+        undefined_name: Name of the undefined thing, used in error messages
+    """
+    from ..dataclasses import rebuild_dataclass
+
     undefined_type_error_message = (
         f'`{cls_name}` is not fully defined; you should define {undefined_name},'
         f' then call `pydantic.dataclasses.rebuild_dataclass({cls_name})`.'
     )
 
     def attempt_rebuild_validator() -> SchemaValidator | None:
-        from ..dataclasses import rebuild_dataclass
-
         if rebuild_dataclass(cls, raise_errors=False, _parent_namespace_depth=5) is not False:
             return cls.__pydantic_validator__
         else:
@@ -118,8 +127,6 @@ def set_dataclass_mocks(cls: type[PydanticDataclass], cls_name: str, undefined_n
     )
 
     def attempt_rebuild_serializer() -> SchemaSerializer | None:
-        from ..dataclasses import rebuild_dataclass
-
         if rebuild_dataclass(cls, raise_errors=False, _parent_namespace_depth=5) is not False:
             return cls.__pydantic_serializer__
         else:

--- a/pydantic/_internal/_mock_val_ser.py
+++ b/pydantic/_internal/_mock_val_ser.py
@@ -70,7 +70,7 @@ def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = '
     )
 
     def attempt_rebuild_validator() -> SchemaValidator | None:
-        if cls.model_rebuild(raise_errors=False, _parent_namespace_depth=5):
+        if cls.model_rebuild(raise_errors=False, _parent_namespace_depth=5) is not False:
             return cls.__pydantic_validator__
         else:
             return None
@@ -83,7 +83,7 @@ def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = '
     )
 
     def attempt_rebuild_serializer() -> SchemaSerializer | None:
-        if cls.model_rebuild(raise_errors=False, _parent_namespace_depth=5):
+        if cls.model_rebuild(raise_errors=False, _parent_namespace_depth=5) is not False:
             return cls.__pydantic_serializer__
         else:
             return None
@@ -96,16 +96,16 @@ def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = '
     )
 
 
-def set_dataclass_mock_validator(cls: type[PydanticDataclass], cls_name: str, undefined_name: str) -> None:
+def set_dataclass_mocks(cls: type[PydanticDataclass], cls_name: str, undefined_name: str) -> None:
     undefined_type_error_message = (
         f'`{cls_name}` is not fully defined; you should define {undefined_name},'
         f' then call `pydantic.dataclasses.rebuild_dataclass({cls_name})`.'
     )
 
-    def attempt_rebuild() -> SchemaValidator | None:
+    def attempt_rebuild_validator() -> SchemaValidator | None:
         from ..dataclasses import rebuild_dataclass
 
-        if rebuild_dataclass(cls, raise_errors=False, _parent_namespace_depth=5):
+        if rebuild_dataclass(cls, raise_errors=False, _parent_namespace_depth=5) is not False:
             return cls.__pydantic_validator__
         else:
             return None
@@ -114,5 +114,20 @@ def set_dataclass_mock_validator(cls: type[PydanticDataclass], cls_name: str, un
         undefined_type_error_message,
         code='class-not-fully-defined',
         val_or_ser='validator',
-        attempt_rebuild=attempt_rebuild,
+        attempt_rebuild=attempt_rebuild_validator,
+    )
+
+    def attempt_rebuild_serializer() -> SchemaSerializer | None:
+        from ..dataclasses import rebuild_dataclass
+
+        if rebuild_dataclass(cls, raise_errors=False, _parent_namespace_depth=5) is not False:
+            return cls.__pydantic_serializer__
+        else:
+            return None
+
+    cls.__pydantic_serializer__ = MockValSer(  # type: ignore[assignment]
+        undefined_type_error_message,
+        code='class-not-fully-defined',
+        val_or_ser='validator',
+        attempt_rebuild=attempt_rebuild_serializer,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -701,18 +701,7 @@ def test_config_type_adapter_defer_build():
     m2 = ta.validate_python({'x': 2})
     assert m2.x == 2
 
-
-def test_config_dataclass_defer_build():
-    @pydantic_dataclass(config={'defer_build': True})
-    class MyModel:
-        x: int
-
-    assert isinstance(MyModel.__pydantic_validator__, MockValSer)
-    assert isinstance(MyModel.__pydantic_serializer__, MockValSer)
-
-    m = MyModel(x=1)
-    assert m.x == 1
-
+    # in the future, can reassign said validators to the TypeAdapter
     assert isinstance(MyModel.__pydantic_validator__, SchemaValidator)
     assert isinstance(MyModel.__pydantic_serializer__, SchemaSerializer)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -687,6 +687,36 @@ def test_config_model_defer_build():
     assert isinstance(MyModel.__pydantic_serializer__, SchemaSerializer)
 
 
+def test_config_type_adapter_defer_build():
+    class MyModel(BaseModel, defer_build=True):
+        x: int
+
+    ta = TypeAdapter(MyModel)
+
+    assert isinstance(ta.validator, MockValSer)
+    assert isinstance(ta.serializer, MockValSer)
+
+    m = ta.validate_python({'x': 1})
+    assert m.x == 1
+    m2 = ta.validate_python({'x': 2})
+    assert m2.x == 2
+
+
+def test_config_dataclass_defer_build():
+    @pydantic_dataclass(config={'defer_build': True})
+    class MyModel:
+        x: int
+
+    assert isinstance(MyModel.__pydantic_validator__, MockValSer)
+    assert isinstance(MyModel.__pydantic_serializer__, MockValSer)
+
+    m = MyModel(x=1)
+    assert m.x == 1
+
+    assert isinstance(MyModel.__pydantic_validator__, SchemaValidator)
+    assert isinstance(MyModel.__pydantic_serializer__, SchemaSerializer)
+
+
 def test_config_model_defer_build_nested():
     class MyNestedModel(BaseModel, defer_build=True):
         x: int


### PR DESCRIPTION
## Change Summary

Fix `defer_build` behavior with `TypeAdapter`, see #7727 for details on bug.

## Related issue number

Fix #7727

## Other Notes
* Can implement support for `defer_build` for `dataclasses` in the future
* Can reassign `serializer` and `validator` attributes of the `TypeAdapter` in the future

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb