### PR TITLE
Updated migration.md to add description of how to push down Field constraints to generics

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -166,6 +166,8 @@ The following properties have been removed from or changed in `Field`:
 - `regex` (use `pattern` instead)
 - `final` (use the `typing.Final` type hint instead)
 
+Field constraints are no longer automatically pushed down to the parameters of generics.  For example, you can no longer validate every element of a list matches a regex by providing `my_list: list[str] = Field(pattern=".*")`.  Instead, use `typing.Annotated` to provide an annotation on the `str` itself: `my_list: list[Annotated[str, Field(pattern=".*")]]`
+
 * [TODO: Need to document any other backwards-incompatible changes to `pydantic.Field`]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Added a section to the migration.md to describe the backwards-compatibility breaking change that Field constraints are not automatically pushed down, which based on https://github.com/pydantic/pydantic/issues/6409 is an intended break.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani