### PR TITLE
Extract sequence-like class from class hierarchy

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -388,12 +388,24 @@ def identity(s: CoreSchema) -> CoreSchema:
     return s
 
 
+def get_sequence_origin_from_subclass(source_type: Any):
+    mro = source_type.mro()[1:]
+    for item in mro:
+        mapped_origin = SEQUENCE_ORIGIN_MAP.get(item)
+        if mapped_origin:
+            return mapped_origin
+
+
 def sequence_like_prepare_pydantic_annotations(
     source_type: Any, annotations: Iterable[Any], _config: ConfigDict
 ) -> tuple[Any, list[Any]] | None:
     origin: Any = get_origin(source_type)
 
     mapped_origin = SEQUENCE_ORIGIN_MAP.get(origin, None) if origin else SEQUENCE_ORIGIN_MAP.get(source_type, None)
+
+    if mapped_origin is None:
+        mapped_origin = get_sequence_origin_from_subclass(origin or source_type)
+
     if mapped_origin is None:
         return None
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4297,6 +4297,32 @@ def test_literal_multiple():
     ]
 
 
+def test_mutable_set_subclass():
+    class MySet(typing.MutableSet):
+        def __init__(self):
+            self._data = set()
+
+        def add(self, value):
+            self._data.add(value)
+
+        def discard(self, value):
+            self._data.discard(value)
+
+        def __contains__(self, x):
+            return x in self._data
+
+        def __len__(self):
+            return len(self._data)
+
+        def __iter__(self):
+            return iter(self._data)
+
+    class Model(BaseModel):
+        data: MySet
+
+    assert Model(data=MySet())
+
+
 def test_typing_mutable_set():
     s1 = TypeAdapter(Set[int]).core_schema
     s1.pop('metadata', None)


### PR DESCRIPTION
## Change Summary

Supports subclasses of `typing.MutableSet` as type annotations

## Related issue number

fix #7752 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
