### PR TITLE
Add option to output unsorted schema

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -748,8 +748,10 @@ from pydantic.json_schema import GenerateJsonSchema
 
 
 class MyGenerateJsonSchema(GenerateJsonSchema):
-    def generate(self, schema, mode='validation'):
-        json_schema = super().generate(schema, mode=mode)
+    def generate(self, schema, mode='validation', sort_schema=True):
+        json_schema = super().generate(
+            schema, mode=mode, sort_schema=sort_schema
+        )
         json_schema['title'] = 'Customize title'
         json_schema['$schema'] = self.schema_dialect
         return json_schema

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -386,12 +386,15 @@ class GenerateJsonSchema:
         self._used = True
         return json_schemas_map, _sort_json_schema(json_schema['$defs'])  # type: ignore
 
-    def generate(self, schema: CoreSchema, mode: JsonSchemaMode = 'validation') -> JsonSchemaValue:
+    def generate(
+        self, schema: CoreSchema, mode: JsonSchemaMode = 'validation', sort_schema: bool = True
+    ) -> JsonSchemaValue:
         """Generates a JSON schema for a specified schema in a specified mode.
 
         Args:
             schema: A Pydantic model.
             mode: The mode in which to generate the schema. Defaults to 'validation'.
+            sort_schema: Toggle sorting of the output schema. Defaults to `True`
 
         Returns:
             A JSON schema representing the specified schema.
@@ -436,7 +439,10 @@ class GenerateJsonSchema:
         # json_schema['$schema'] = self.schema_dialect
 
         self._used = True
-        return _sort_json_schema(json_schema)
+        if sort_schema:
+            return _sort_json_schema(json_schema)
+        else:
+            return json_schema
 
     def generate_inner(self, schema: CoreSchemaOrField) -> JsonSchemaValue:  # noqa: C901
         """Generates a JSON schema for a given core schema.
@@ -2129,6 +2135,7 @@ def model_json_schema(
     ref_template: str = DEFAULT_REF_TEMPLATE,
     schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
     mode: JsonSchemaMode = 'validation',
+    sort_schema: bool = True,
 ) -> dict[str, Any]:
     """Utility function to generate a JSON Schema for a model.
 
@@ -2142,6 +2149,7 @@ def model_json_schema(
 
             - 'validation': Generate a JSON Schema for validating data.
             - 'serialization': Generate a JSON Schema for serializing data.
+        sort_schema: Toggle sorting of the output schema. Defaults to `True`
 
     Returns:
         The generated JSON Schema.
@@ -2150,7 +2158,7 @@ def model_json_schema(
     if isinstance(cls.__pydantic_validator__, _mock_val_ser.MockValSer):
         cls.__pydantic_validator__.rebuild()
     assert '__pydantic_core_schema__' in cls.__dict__, 'this is a bug! please report it'
-    return schema_generator_instance.generate(cls.__pydantic_core_schema__, mode=mode)
+    return schema_generator_instance.generate(cls.__pydantic_core_schema__, mode=mode, sort_schema=sort_schema)
 
 
 def models_json_schema(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -369,6 +369,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         ref_template: str = DEFAULT_REF_TEMPLATE,
         schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
         mode: JsonSchemaMode = 'validation',
+        sort_schema: bool = True,
     ) -> dict[str, Any]:
         """Generates a JSON schema for a model class.
 
@@ -378,12 +379,18 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             schema_generator: To override the logic used to generate the JSON schema, as a subclass of
                 `GenerateJsonSchema` with your desired modifications
             mode: The mode in which to generate the schema.
+            sort_schema: Toggle sorting of the output schema. Defaults to `True`
 
         Returns:
             The JSON schema for the given model class.
         """
         return model_json_schema(
-            cls, by_alias=by_alias, ref_template=ref_template, schema_generator=schema_generator, mode=mode
+            cls,
+            by_alias=by_alias,
+            ref_template=ref_template,
+            schema_generator=schema_generator,
+            mode=mode,
+            sort_schema=sort_schema,
         )
 
     @classmethod

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -417,6 +417,7 @@ class TypeAdapter(Generic[T]):
         ref_template: str = DEFAULT_REF_TEMPLATE,
         schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
         mode: JsonSchemaMode = 'validation',
+        sort_schema: bool = True,
     ) -> dict[str, Any]:
         """Generate a JSON schema for the adapted type.
 
@@ -425,12 +426,13 @@ class TypeAdapter(Generic[T]):
             ref_template: The format string used for generating $ref strings.
             schema_generator: The generator class used for creating the schema.
             mode: The mode to use for schema generation.
+            sort_schema: Toggle sorting of the output schema. Defaults to `True`
 
         Returns:
             The JSON schema for the model as a dictionary.
         """
         schema_generator_instance = schema_generator(by_alias=by_alias, ref_template=ref_template)
-        return schema_generator_instance.generate(self.core_schema, mode=mode)
+        return schema_generator_instance.generate(self.core_schema, mode=mode, sort_schema=sort_schema)
 
     @staticmethod
     def json_schemas(


### PR DESCRIPTION
## Change Summary

Add toggle so that the schema output `model_dump`  can be sorted or unsorted. The sorting was added in https://github.com/pydantic/pydantic/pull/6043. 

## Related issue number

#7580

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt