### PR TITLE
Keep values of private attributes set within `model_post_init` in subclasses

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -259,11 +259,11 @@ def init_private_attributes(self: BaseModel, __context: Any) -> None:
         self: The BaseModel instance.
         __context: The context.
     """
-    pydantic_private = {}
+    pydantic_private = getattr(self, '__pydantic_private__', None) or {}
     for name, private_attr in self.__private_attributes__.items():
         default = private_attr.get_default()
         if default is not PydanticUndefined:
-            pydantic_private[name] = default
+            pydantic_private.setdefault(name, default)
     object_setattr(self, '__pydantic_private__', pydantic_private)
 
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -259,14 +259,13 @@ def init_private_attributes(self: BaseModel, __context: Any) -> None:
         self: The BaseModel instance.
         __context: The context.
     """
-    if getattr(self, '__pydantic_private__', None) is not None:
-        return
-    pydantic_private = {}
-    for name, private_attr in self.__private_attributes__.items():
-        default = private_attr.get_default()
-        if default is not PydanticUndefined:
-            pydantic_private[name] = default
-    object_setattr(self, '__pydantic_private__', pydantic_private)
+    if getattr(self, '__pydantic_private__', None) is None:
+        pydantic_private = {}
+        for name, private_attr in self.__private_attributes__.items():
+            default = private_attr.get_default()
+            if default is not PydanticUndefined:
+                pydantic_private[name] = default
+        object_setattr(self, '__pydantic_private__', pydantic_private)
 
 
 def get_model_post_init(namespace: dict[str, Any], bases: tuple[type[Any], ...]) -> Callable[..., Any] | None:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -259,11 +259,13 @@ def init_private_attributes(self: BaseModel, __context: Any) -> None:
         self: The BaseModel instance.
         __context: The context.
     """
-    pydantic_private = getattr(self, '__pydantic_private__', None) or {}
+    if getattr(self, '__pydantic_private__', None) is not None:
+        return
+    pydantic_private = {}
     for name, private_attr in self.__private_attributes__.items():
         default = private_attr.get_default()
         if default is not PydanticUndefined:
-            pydantic_private.setdefault(name, default)
+            pydantic_private[name] = default
     object_setattr(self, '__pydantic_private__', pydantic_private)
 
 


### PR DESCRIPTION
## Change Summary

Check for an existing `__pydantic_private__` dict in `init_private_attributes` and account for values within, rather than always replacing with a new dict.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/7091

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle