### PR TITLE
Wrap `weakref.ref` instead of subclassing to fix `cloudpickle` serialization

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -611,7 +611,7 @@ class _PydanticWeakRef:
             return self._wr()
 
     def __reduce__(self) -> Tuple[Callable, Tuple[Optional[weakref.ReferenceType]]]:
-        return _PydanticWeakRef, (self._wr if self._wr is None else self._wr(),)
+        return _PydanticWeakRef, (self(),)
 
 
 def build_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -592,7 +592,7 @@ class _PydanticWeakRef:
 
     Cloudpickle fails to serialize `weakref.ref` objects due to an arcane error related
     to abstract base classes (`abc.ABC`). This class works around the issue by wrapping
-    `weakref.ref` instead of subclassing.
+    `weakref.ref` instead of subclassing it.
 
     See https://github.com/pydantic/pydantic/issues/6763 for context.
     """

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -596,6 +596,7 @@ class _PydanticWeakRef:
 
     See https://github.com/pydantic/pydantic/issues/6763 for context.
     """
+
     def __init__(self, obj: Any):
         if obj is None:
             # The object will be `None` upon deserialization if the serialized weakref

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -611,7 +611,7 @@ class _PydanticWeakRef:
             return self._wr()
 
     def __reduce__(self) -> Tuple[Callable, Tuple[Optional[weakref.ReferenceType]]]:
-        return _PydanticWeakRef, (self._wr if self._wr is None else self._wr())
+        return _PydanticWeakRef, (self._wr if self._wr is None else self._wr(),)
 
 
 def build_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -597,10 +597,10 @@ class _PydanticWeakRef:
     See https://github.com/pydantic/pydantic/issues/6763 for context.
 
     Semantics:
-        - If not pickled, `__call__` behaves the same as a `weakref.ref`.
-        - If pickled along with the underlying reference, the same `weakref.ref`
-          behavior will be maintained between them after unpickling.
-        - If pickled without the underlying reference, after unpickling the underlying
+        - If not pickled, behaves the same as a `weakref.ref`.
+        - If pickled along with the referenced object, the same `weakref.ref` behavior
+          will be maintained between them after unpickling.
+        - If pickled without the referenced object, after unpickling the underlying
           reference will be cleared (`__call__` will always return `None`).
     """
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -7,7 +7,7 @@ import weakref
 from abc import ABCMeta
 from functools import partial
 from types import FunctionType
-from typing import Any, Callable, Generic, Mapping
+from typing import Any, Callable, Generic, Mapping, Optional, Tuple
 
 from pydantic_core import PydanticUndefined, SchemaSerializer
 from typing_extensions import dataclass_transform, deprecated

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -588,7 +588,7 @@ def generate_model_signature(
 
 
 class _PydanticWeakRef:
-    """Wrapper for `weakref.ref` that enables cloudpickle serialization.
+    """Wrapper for `weakref.ref` that enables `pickle` serialization.
 
     Cloudpickle fails to serialize `weakref.ref` objects due to an arcane error related
     to abstract base classes (`abc.ABC`). This class works around the issue by wrapping

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -595,6 +595,13 @@ class _PydanticWeakRef:
     `weakref.ref` instead of subclassing it.
 
     See https://github.com/pydantic/pydantic/issues/6763 for context.
+
+    Semantics:
+        - If not pickled, `__call__` behaves the same as a `weakref.ref`.
+        - If pickled along with the underlying reference, the same `weakref.ref`
+          behavior will be maintained between them after unpickling.
+        - If pickled without the underlying reference, after unpickling the underlying
+          reference will be cleared (`__call__` will always return `None`).
     """
 
     def __init__(self, obj: Any):

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -593,6 +593,8 @@ class _PydanticWeakRef:
     Cloudpickle fails to serialize `weakref.ref` objects due to an arcane error related
     to abstract base classes (`abc.ABC`). This class works around the issue by wrapping
     `weakref.ref` instead of subclassing.
+
+    See https://github.com/pydantic/pydantic/issues/6763 for context.
     """
     def __init__(self, obj: Any):
         if obj is None:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -7,7 +7,7 @@ import weakref
 from abc import ABCMeta
 from functools import partial
 from types import FunctionType
-from typing import Any, Callable, Generic, Mapping, Optional, Tuple
+from typing import Any, Callable, Generic, Mapping
 
 from pydantic_core import PydanticUndefined, SchemaSerializer
 from typing_extensions import dataclass_transform, deprecated
@@ -610,7 +610,7 @@ class _PydanticWeakRef:
         else:
             return self._wr()
 
-    def __reduce__(self) -> Tuple[Callable, Tuple[Optional[weakref.ReferenceType]]]:
+    def __reduce__(self) -> tuple[Callable, tuple[weakref.ReferenceType | None]]:
         return _PydanticWeakRef, (self(),)
 
 

--- a/tests/test_pickle_pydantic_weakref.py
+++ b/tests/test_pickle_pydantic_weakref.py
@@ -13,6 +13,7 @@ class IntWrapper:
     def __eq__(self, other: 'IntWrapper') -> bool:
         return self.get() == other.get()
 
+
 def test_pickle_pydantic_weakref():
     obj1 = IntWrapper(1)
     ref1 = _PydanticWeakRef(obj1)

--- a/tests/test_pickle_pydantic_weakref.py
+++ b/tests/test_pickle_pydantic_weakref.py
@@ -1,0 +1,47 @@
+import pickle
+
+from pydantic._internal._model_construction import _PydanticWeakRef
+
+class IntWrapper:
+    def __init__(self, v: int):
+        self._v = v
+
+    def get(self) -> int:
+        return self._v
+
+    def __eq__(self, other: "IntWrapper") -> bool:
+        return self.get() == other.get()
+
+def test_pickle_pydantic_weakref():
+    obj1 = IntWrapper(1)
+    ref1 = _PydanticWeakRef(obj1)
+    assert ref1() is obj1
+
+    obj2 = IntWrapper(2)
+    ref2 = _PydanticWeakRef(obj2)
+    assert ref2() is obj2
+
+    ref3 = _PydanticWeakRef(IntWrapper(3))
+    assert ref3() is None
+
+    d = {
+        # Hold a hard reference to the underlying object for ref1 that will also
+        # be pickled.
+        "hard_ref": obj1,
+        # ref1's underlying object has a hard reference in the pickled object so it
+        # should maintain the reference after deserialization.
+        "has_hard_ref": ref1,
+        # ref2's underlying object has no hard reference in the pickled object so it
+        # should be `None` after deserialization.
+        "has_no_hard_ref": ref2,
+        # ref3's underlying object had already gone out of scope before pickling so it
+        # should be `None` after deserialization.
+        "ref_out_of_scope": ref3,
+    }
+
+    loaded = pickle.loads(pickle.dumps(d))
+
+    assert loaded["hard_ref"] == IntWrapper(1)
+    assert loaded["has_hard_ref"]() is loaded["hard_ref"]
+    assert loaded["has_no_hard_ref"]() is None
+    assert loaded["ref_out_of_scope"]() is None

--- a/tests/test_pickle_pydantic_weakref.py
+++ b/tests/test_pickle_pydantic_weakref.py
@@ -2,6 +2,7 @@ import pickle
 
 from pydantic._internal._model_construction import _PydanticWeakRef
 
+
 class IntWrapper:
     def __init__(self, v: int):
         self._v = v
@@ -9,7 +10,7 @@ class IntWrapper:
     def get(self) -> int:
         return self._v
 
-    def __eq__(self, other: "IntWrapper") -> bool:
+    def __eq__(self, other: 'IntWrapper') -> bool:
         return self.get() == other.get()
 
 def test_pickle_pydantic_weakref():
@@ -27,21 +28,21 @@ def test_pickle_pydantic_weakref():
     d = {
         # Hold a hard reference to the underlying object for ref1 that will also
         # be pickled.
-        "hard_ref": obj1,
+        'hard_ref': obj1,
         # ref1's underlying object has a hard reference in the pickled object so it
         # should maintain the reference after deserialization.
-        "has_hard_ref": ref1,
+        'has_hard_ref': ref1,
         # ref2's underlying object has no hard reference in the pickled object so it
         # should be `None` after deserialization.
-        "has_no_hard_ref": ref2,
+        'has_no_hard_ref': ref2,
         # ref3's underlying object had already gone out of scope before pickling so it
         # should be `None` after deserialization.
-        "ref_out_of_scope": ref3,
+        'ref_out_of_scope': ref3,
     }
 
     loaded = pickle.loads(pickle.dumps(d))
 
-    assert loaded["hard_ref"] == IntWrapper(1)
-    assert loaded["has_hard_ref"]() is loaded["hard_ref"]
-    assert loaded["has_no_hard_ref"]() is None
-    assert loaded["ref_out_of_scope"]() is None
+    assert loaded['hard_ref'] == IntWrapper(1)
+    assert loaded['has_hard_ref']() is loaded['hard_ref']
+    assert loaded['has_no_hard_ref']() is None
+    assert loaded['ref_out_of_scope']() is None

--- a/tests/test_pickle_pydantic_weakref.py
+++ b/tests/test_pickle_pydantic_weakref.py
@@ -25,7 +25,7 @@ def test_pickle_pydantic_weakref():
     assert ref2() is obj2
 
     ref3 = _PydanticWeakRef(IntWrapper(3))
-    gc.collect() # PyPy does not use reference counting and always relies on GC.
+    gc.collect()  # PyPy does not use reference counting and always relies on GC.
     assert ref3() is None
 
     d = {
@@ -44,7 +44,7 @@ def test_pickle_pydantic_weakref():
     }
 
     loaded = pickle.loads(pickle.dumps(d))
-    gc.collect() # PyPy does not use reference counting and always relies on GC.
+    gc.collect()  # PyPy does not use reference counting and always relies on GC.
 
     assert loaded['hard_ref'] == IntWrapper(1)
     assert loaded['has_hard_ref']() is loaded['hard_ref']

--- a/tests/test_pickle_pydantic_weakref.py
+++ b/tests/test_pickle_pydantic_weakref.py
@@ -1,3 +1,4 @@
+import gc
 import pickle
 
 from pydantic._internal._model_construction import _PydanticWeakRef
@@ -24,6 +25,7 @@ def test_pickle_pydantic_weakref():
     assert ref2() is obj2
 
     ref3 = _PydanticWeakRef(IntWrapper(3))
+    gc.collect() # PyPy does not use reference counting and always relies on GC.
     assert ref3() is None
 
     d = {
@@ -42,6 +44,7 @@ def test_pickle_pydantic_weakref():
     }
 
     loaded = pickle.loads(pickle.dumps(d))
+    gc.collect() # PyPy does not use reference counting and always relies on GC.
 
     assert loaded['hard_ref'] == IntWrapper(1)
     assert loaded['has_hard_ref']() is loaded['hard_ref']


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

See context in https://github.com/pydantic/pydantic/issues/6763.

The existing `_PydanticWeakref` cannot be serialized due to a [known issue](https://github.com/uqfoundation/dill/issues/332) serializing `weakref.ref` objects.

This change works around the issue by updating `_PydanticWeakref` to be a wrapper instead of a subclass.

Along with https://github.com/pydantic/pydantic-core/pull/1006, this should enable pydantic model definitions to be cloudpickled.

## Related issue number

https://github.com/pydantic/pydantic/issues/6763

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
