### PR TITLE
Only hash model_fields, not whole __dict__

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2252,7 +2252,7 @@ def test_model_parametrized_name_not_generic():
 def test_model_equality_generics():
     T = TypeVar('T')
 
-    class GenericModel(BaseModel, Generic[T]):
+    class GenericModel(BaseModel, Generic[T], frozen=True):
         x: T
 
     class ConcreteModel(BaseModel):
@@ -2265,20 +2265,22 @@ def test_model_equality_generics():
     assert GenericModel(x=1) != GenericModel(x=2)
 
     S = TypeVar('S')
-    assert GenericModel(x=1) == GenericModel(x=1)
-    assert GenericModel(x=1) == GenericModel[S](x=1)
-    assert GenericModel(x=1) == GenericModel[Any](x=1)
-    assert GenericModel(x=1) == GenericModel[float](x=1)
-
-    assert GenericModel[int](x=1) == GenericModel[int](x=1)
-    assert GenericModel[int](x=1) == GenericModel[S](x=1)
-    assert GenericModel[int](x=1) == GenericModel[Any](x=1)
-    assert GenericModel[int](x=1) == GenericModel[float](x=1)
-
-    # Test that it works with nesting as well
-    nested_any = GenericModel[GenericModel[Any]](x=GenericModel[Any](x=1))
-    nested_int = GenericModel[GenericModel[int]](x=GenericModel[int](x=1))
-    assert nested_any == nested_int
+    models = [
+        GenericModel(x=1),
+        GenericModel[S](x=1),
+        GenericModel[Any](x=1),
+        GenericModel[int](x=1),
+        GenericModel[float](x=1),
+    ]
+    for m1 in models:
+        for m2 in models:
+            # Test that it works with nesting as well
+            m3 = GenericModel[type(m1)](x=m1)
+            m4 = GenericModel[type(m2)](x=m2)
+            assert m1 == m2
+            assert m3 == m4
+            assert hash(m1) == hash(m2)
+            assert hash(m3) == hash(m4)
 
 
 def test_model_validate_strict() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -590,6 +590,16 @@ def test_frozen_with_unhashable_fields_are_not_hashable():
     assert "unhashable type: 'list'" in exc_info.value.args[0]
 
 
+def test_hash_function_empty_model():
+    class TestModel(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+    m = TestModel()
+    m2 = TestModel()
+    assert m == m2
+    assert hash(m) == hash(m2)
+
+
 def test_hash_function_give_different_result_for_different_object():
     class TestModel(BaseModel):
         model_config = ConfigDict(frozen=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -628,6 +628,21 @@ def test_hash_function_works_when_instance_dict_modified():
     assert h != hash(m)
 
 
+def test_default_hash_function_overrides_default_hash_function():
+    class A(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        x: int
+
+    class B(A):
+        model_config = ConfigDict(frozen=True)
+
+        y: int
+
+    assert A.__hash__ != B.__hash__
+    assert hash(A(x=1)) != hash(B(x=1, y=2)) != hash(B(x=1, y=3))
+
+
 def test_hash_method_is_inherited_for_frozen_models():
     from functools import lru_cache
 


### PR DESCRIPTION
## Change Summary

This deals with just the `__hash__` part of https://github.com/pydantic/pydantic/issues/7444, because initially I was worried that it would be hard to fix without a significant hit to performance. With this timing code:

```python
import timeit

setup = """
import pydantic

A = pydantic.create_model("A", __config__=dict(frozen=True), **{f'x{i}': (int, i) for i in range(100)})

a = A()
"""

stmt = """
hash(a)
"""

print(timeit.timeit(setup=setup, stmt=stmt, number=1000000))
```

the previous approach is slightly *slower* for 5 fields, but about 60-70% faster for 100 fields. So this PR may slow down some programs a little, but in the larger scheme of things it's hard to imagine it making a real difference since it can still hash a million times in about 2 seconds.

Closes https://github.com/pydantic/pydantic/issues/7785

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
