### PR TITLE
Raise an error when deleting frozen (model) fields

### DIFF
--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -715,7 +715,7 @@ except ValidationError as exc:
 
 ## `frozen_field`
 
-This error is raised when you attempt to assign a value to a field with `frozen=True`:
+This error is raised when you attempt to assign a value to a field with `frozen=True`, or to delete such a field:
 
 ```py
 from pydantic import BaseModel, Field, ValidationError
@@ -726,8 +726,15 @@ class Model(BaseModel):
 
 
 model = Model()
+
 try:
     model.x = 'test1'
+except ValidationError as exc:
+    print(repr(exc.errors()[0]['type']))
+    #> 'frozen_field'
+
+try:
+    del model.x
 except ValidationError as exc:
     print(repr(exc.errors()[0]['type']))
     #> 'frozen_field'
@@ -735,7 +742,7 @@ except ValidationError as exc:
 
 ## `frozen_instance`
 
-This error is raised when `model_config['frozen] == True` and you attempt to assign a new value to
+This error is raised when `model_config['frozen] == True` and you attempt to delete or assign a new value to
 any of the fields:
 
 ```py
@@ -749,8 +756,15 @@ class Model(BaseModel):
 
 
 m = Model(x=1)
+
 try:
     m.x = 2
+except ValidationError as exc:
+    print(repr(exc.errors()[0]['type']))
+    #> 'frozen_instance'
+
+try:
+    del m.x
 except ValidationError as exc:
     print(repr(exc.errors()[0]['type']))
     #> 'frozen_instance'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -515,13 +515,21 @@ def test_frozen_model():
         a: int = 10
 
     m = FrozenModel()
-
     assert m.a == 10
+
     with pytest.raises(ValidationError) as exc_info:
         m.a = 11
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'frozen_instance', 'loc': ('a',), 'msg': 'Instance is frozen', 'input': 11}
     ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        del m.a
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'frozen_instance', 'loc': ('a',), 'msg': 'Instance is frozen', 'input': None}
+    ]
+
+    assert m.a == 10
 
 
 def test_frozen_field():
@@ -529,12 +537,21 @@ def test_frozen_field():
         a: int = Field(10, frozen=True)
 
     m = FrozenModel()
+    assert m.a == 10
 
     with pytest.raises(ValidationError) as exc_info:
         m.a = 11
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'frozen_field', 'loc': ('a',), 'msg': 'Field is frozen', 'input': 11}
     ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        del m.a
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'frozen_field', 'loc': ('a',), 'msg': 'Field is frozen', 'input': None}
+    ]
+
+    assert m.a == 10
 
 
 def test_not_frozen_are_not_hashable():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Extracted the validation logic for frozen fields/models in `__setattr__` into a new method `_check_frozen`, deduplicated it a bit, and called it in `__delattr__` which was previously incorrectly not checking this.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7784

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu