### PR TITLE
Use generated alias for aliases that are not specified otherwise

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -997,21 +997,20 @@ class GenerateSchema:
         # apply alias generator
         alias_generator = self._config_wrapper.alias_generator
         if alias_generator:
-            if field_info.alias_priority is None or field_info.alias_priority <= 1:
+            if field_info.alias_priority is None or field_info.alias_priority <= 1 or field_info.alias is None:
                 alias = alias_generator(name)
                 if not isinstance(alias, str):
                     raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
+                if field_info.alias is None:
+                    if field_info.serialization_alias is None:
+                        field_info.serialization_alias = alias
+                    if field_info.validation_alias is None:
+                        field_info.validation_alias = alias
+                else:
+                    field_info.serialization_alias = alias
+                    field_info.validation_alias = alias
+                    field_info.alias_priority = 1
                 field_info.alias = alias
-                field_info.validation_alias = alias
-                field_info.serialization_alias = alias
-                field_info.alias_priority = 1
-            elif field_info.alias is None:
-                alias = alias_generator(name)
-                if not isinstance(alias, str):
-                    raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
-                field_info.alias = alias
-                field_info.serialization_alias = field_info.serialization_alias or alias
-                field_info.validation_alias = field_info.validation_alias or alias
 
         if isinstance(field_info.validation_alias, (AliasChoices, AliasPath)):
             validation_alias = field_info.validation_alias.convert_to_aliases()

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -996,14 +996,22 @@ class GenerateSchema:
 
         # apply alias generator
         alias_generator = self._config_wrapper.alias_generator
-        if alias_generator and (field_info.alias_priority is None or field_info.alias_priority <= 1):
-            alias = alias_generator(name)
-            if not isinstance(alias, str):
-                raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
-            field_info.alias = alias
-            field_info.validation_alias = alias
-            field_info.serialization_alias = alias
-            field_info.alias_priority = 1
+        if alias_generator:
+            if field_info.alias_priority is None or field_info.alias_priority <= 1:
+                alias = alias_generator(name)
+                if not isinstance(alias, str):
+                    raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
+                field_info.alias = alias
+                field_info.validation_alias = alias
+                field_info.serialization_alias = alias
+                field_info.alias_priority = 1
+            elif field_info.alias is None:
+                alias = alias_generator(name)
+                if not isinstance(alias, str):
+                    raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
+                field_info.alias = alias
+                field_info.serialization_alias = field_info.serialization_alias or alias
+                field_info.validation_alias = field_info.validation_alias or alias
 
         if isinstance(field_info.validation_alias, (AliasChoices, AliasPath)):
             validation_alias = field_info.validation_alias.convert_to_aliases()

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -996,21 +996,22 @@ class GenerateSchema:
 
         # apply alias generator
         alias_generator = self._config_wrapper.alias_generator
-        if alias_generator:
-            if field_info.alias_priority is None or field_info.alias_priority <= 1 or field_info.alias is None:
-                alias = alias_generator(name)
-                if not isinstance(alias, str):
-                    raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
-                if field_info.alias is None:
-                    if field_info.serialization_alias is None:
-                        field_info.serialization_alias = alias
-                    if field_info.validation_alias is None:
-                        field_info.validation_alias = alias
-                else:
+        if alias_generator and (
+            field_info.alias_priority is None or field_info.alias_priority <= 1 or field_info.alias is None
+        ):
+            alias = alias_generator(name)
+            if not isinstance(alias, str):
+                raise TypeError(f'alias_generator {alias_generator} must return str, not {alias.__class__}')
+            if field_info.alias is None:
+                if field_info.serialization_alias is None:
                     field_info.serialization_alias = alias
+                if field_info.validation_alias is None:
                     field_info.validation_alias = alias
-                    field_info.alias_priority = 1
-                field_info.alias = alias
+            else:
+                field_info.serialization_alias = alias
+                field_info.validation_alias = alias
+                field_info.alias_priority = 1
+            field_info.alias = alias
 
         if isinstance(field_info.validation_alias, (AliasChoices, AliasPath)):
             validation_alias = field_info.validation_alias.convert_to_aliases()

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -216,6 +216,64 @@ def test_alias_generator_on_child():
     assert [f.alias for f in Child.model_fields.values()] == ['abc', 'Y', 'Z']
 
 
+def test_alias_generator_used_by_default():
+    class Model(BaseModel):
+        model_config = ConfigDict(alias_generator=lambda x: x.upper())
+
+        a: str
+        b: str = Field(..., alias='b_alias')
+        c: str = Field(..., validation_alias='c_val_alias')
+        d: str = Field(..., serialization_alias='d_ser_alias')
+        e: str = Field(..., alias='e_alias', validation_alias='e_val_alias')
+        f: str = Field(..., alias='f_alias', serialization_alias='f_ser_alias')
+        g: str = Field(..., alias='g_alias', validation_alias='g_val_alias', serialization_alias='g_ser_alias')
+
+    assert {
+        name: {k: getattr(f, k) for k in ('alias', 'validation_alias', 'serialization_alias')}
+        for name, f in Model.model_fields.items()
+    } == {
+        # Validation/serialization aliases should be:
+        # 1. The specific alias, if specified, or
+        # 2. The alias, if specified, or
+        # 3. The generated alias (i.e. the field name in upper case)
+        'a': {
+            'alias': 'A',
+            'validation_alias': 'A',
+            'serialization_alias': 'A',
+        },
+        'b': {
+            'alias': 'b_alias',
+            'validation_alias': 'b_alias',
+            'serialization_alias': 'b_alias',
+        },
+        'c': {
+            'alias': 'C',
+            'validation_alias': 'c_val_alias',
+            'serialization_alias': 'C',
+        },
+        'd': {
+            'alias': 'D',
+            'validation_alias': 'D',
+            'serialization_alias': 'd_ser_alias',
+        },
+        'e': {
+            'alias': 'e_alias',
+            'validation_alias': 'e_val_alias',
+            'serialization_alias': 'e_alias',
+        },
+        'f': {
+            'alias': 'f_alias',
+            'validation_alias': 'f_alias',
+            'serialization_alias': 'f_ser_alias',
+        },
+        'g': {
+            'alias': 'g_alias',
+            'validation_alias': 'g_val_alias',
+            'serialization_alias': 'g_ser_alias',
+        },
+    }
+
+
 def test_low_priority_alias():
     class Parent(BaseModel):
         w: bool = Field(..., alias='w_', validation_alias='w_val_alias', serialization_alias='w_ser_alias')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

All three aliases now fallback to the alias generator if there is one and no other value was specified for that alias.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7781

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani