### PR TITLE
Minor docs updates based on issues with docs flags

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -2,7 +2,7 @@ Pydantic allows automatic creation of JSON schemas from models.
 
 Using Pydantic, there are several ways to generate JSON schemas or JSON representations from fields or models:
 
-* [`BaseModel.model_json_schema`][pydantic.main.BaseModel.model_json_schema] returns a dict of the schema.
+* [`BaseModel.model_json_schema`][pydantic.main.BaseModel.model_json_schema] returns a jsonable dict of the schema.
 * [`BaseModel.model_dump_json`][pydantic.main.BaseModel.model_dump_json] returns a JSON string representation of the
     dict of the schema.
 * [`TypeAdapter.dump_json`][pydantic.type_adapter.TypeAdapter.dump_json] serializes an instance of the adapted type to
@@ -146,6 +146,11 @@ print(json.dumps(MainModel.model_json_schema(), indent=2))
     argument.
 * The format of `$ref`s can be altered by calling `model_json_schema()` or `model_dump_json()`
     with the `ref_template` keyword argument.
+
+!!! note
+    Regarding the "jsonable" nature of the `model_json_schema()` results, if you call `json.dumps(m.model_json_schema())`
+    for some `BaseModel` `m`, you'll get a valid JSON string.
+
 
 ## Getting schema of a specified type
 

--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -148,8 +148,8 @@ print(json.dumps(MainModel.model_json_schema(), indent=2))
     with the `ref_template` keyword argument.
 
 !!! note
-    Regarding the "jsonable" nature of the `model_json_schema()` results, if you call `json.dumps(m.model_json_schema())`
-    for some `BaseModel` `m`, you'll get a valid JSON string.
+    Regarding the "jsonable" nature of the `model_json_schema()` results, calling `json.dumps(m.model_json_schema())`
+    on some `BaseModel` `m` returns a valid JSON string.
 
 
 ## Getting schema of a specified type

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -102,7 +102,7 @@ Models possess the following methods and attributes:
     [Serialization](serialization.md#modeldumpjson).
 * `model_extra`: get extra fields set during validation.
 * `model_fields_set`: set of fields which were set when the model instance was initialized.
-* `model_json_schema()`: returns a dictionary representing the model as JSON Schema. See [JSON Schema](json_schema.md).
+* `model_json_schema()`: returns a jsonable dictionary representing the model as JSON Schema. See [JSON Schema](json_schema.md).
 * `model_modify_json_schema()`: a method for how the "generic" properties of the JSON schema are populated.
     See [JSON Schema](json_schema.md).
 * `model_parametrized_name()`: compute the class name for parametrizations of generic classes.

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -886,9 +886,8 @@ from typing_extensions import TypeVar
 
 from pydantic import BaseModel
 
-
-TBound = TypeVar("TBound", bound=BaseModel)
-TNoBound = TypeVar("TNoBound")
+TBound = TypeVar('TBound', bound=BaseModel)
+TNoBound = TypeVar('TNoBound')
 
 
 class IntValue(BaseModel):
@@ -901,6 +900,7 @@ class ItemBound(BaseModel, Generic[TBound]):
 
 class ItemNoBound(BaseModel, Generic[TNoBound]):
     item: TNoBound
+
 
 item_bound_inferred = ItemBound(item=IntValue(value=3))
 item_bound_explicit = ItemBound[IntValue](item=IntValue(value=3))
@@ -978,12 +978,12 @@ assert error.model_dump() == {
 
 ```py
 from typing import Generic
-from pydantic import BaseModel
 
 from typing_extensions import TypeVar
 
+from pydantic import BaseModel
 
-TItem = TypeVar("TItem", bound="ItemBase")
+TItem = TypeVar('TItem', bound='ItemBase')
 
 
 class ItemBase(BaseModel):
@@ -998,7 +998,7 @@ class ItemHolder(BaseModel, Generic[TItem]):
     item: TItem
 
 
-loaded_data = {"item": {"value": 1}}
+loaded_data = {'item': {'value': 1}}
 
 
 print(ItemHolder(**loaded_data).model_dump())  # (1)!

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -777,16 +777,10 @@ except ValidationError as e:
 When using bound type parameters, and when leaving type parameters unspecified, Pydantic treats generic models
 similarly to how it treats built-in generic types like `List` and `Dict`:
 
-* If you don't specify parameters before instantiating the generic model, they are treated as the bound of the `TypeVar`.
+* If you don't specify parameters before instantiating the generic model, they are validated as the bound of the `TypeVar`.
 * If the `TypeVar`s involved have no bounds, they are treated as `Any`.
 
-Also, like `List` and `Dict`, any parameters specified using a `TypeVar` can later be substituted with concrete types.
-
-!!! note
-    For serialization this means: when a `TypeVar` is constrained or bound using a parent model `ParentModel`
-    and a child model `ChildModel` is used as a concrete value, Pydantic will serialize `ChildModel` as `ParentModel`.
-    `TypeVar` needs to be wrapped inside [`SerializeAsAny`](serialization.md#serializing-with-duck-typing)
-    for Pydantic to serialize `ChildModel` as `ChildModel`.
+Also, like `List` and `Dict`, any parameters specified using a `TypeVar` can later be substituted with concrete types:
 
 ```py requires="3.12"
 from typing import Generic, TypeVar
@@ -900,11 +894,11 @@ TNoBound = TypeVar("TNoBound")
 class IntValue(BaseModel):
     value: int
 
-    
+
 class ItemBound(BaseModel, Generic[TBound]):
     item: TBound
 
-    
+
 class ItemNoBound(BaseModel, Generic[TNoBound]):
     item: TNoBound
 
@@ -917,7 +911,10 @@ item_no_bound_explicit = ItemNoBound[IntValue](item=IntValue(value=3))
 #> {'item': {'value': 3}}
 ```
 
-If you use a `default=...` (available in Python >= 3.13 or via `typing-extensions`) or constraints (`TypeVar('T', str, int)`; note that you rarely want to use this form of a `TypeVar`) then the default value or constraints will be used for both validation and serialization if the type variable is not parametrized. You can override this behavior using `pydantic.SerializeAsAny`:
+If you use a `default=...` (available in Python >= 3.13 or via `typing-extensions`) or constraints (`TypeVar('T', str, int)`;
+note that you rarely want to use this form of a `TypeVar`) then the default value or constraints will be used for both
+validation and serialization if the type variable is not parametrized.
+You can override this behavior using `pydantic.SerializeAsAny`:
 
 ```py
 from typing import Generic, Optional
@@ -977,7 +974,7 @@ assert error.model_dump() == {
 
 !!! note
     Note, you may run into a bit of trouble if you don't parametrize a generic when the case of validating against the generic's bound
-    could cause data loss. Thus, it's safer to lean on the side of parametrization to prevent data loss during validation. See the example below:
+    could cause data loss. See the example below:
 
 ```py
 from typing import Generic
@@ -1011,10 +1008,10 @@ print(ItemHolder[IntItem](**loaded_data).model_dump())  # (2)!
 #> {'item': {'value': 1}}
 ```
 
-1. When the generic isn't parametrized, the input data is validated against the generic bound. 
+1. When the generic isn't parametrized, the input data is validated against the generic bound.
    Given that `ItemBase` has no fields, the `item` field information is lost.
-2. In this case, the runtime type information is provided explicitly, so the input data is validated against the 
-   `IntItem` class and the serialization output matches what's expected.
+2. In this case, the runtime type information is provided explicitly via the generic parametrization,
+   so the input data is validated against the `IntItem` class and the serialization output matches what's expected.
 
 ## Dynamic model creation
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -164,6 +164,40 @@ class ConfigDict(TypedDict, total=False):
     """
     Whether to populate models with the `value` property of enums, rather than the raw enum.
     This may be useful if you want to serialize `model.model_dump()` later. Defaults to `False`.
+
+    !!! note
+        If you have an `Optional[Enum]` value that you set a default for, you need to use `validate_default=True`
+        for said Field to ensure that the `use_enum_values` flag takes effect on the default, as extracting an
+        enum's value occurs during validation, not serialization.
+
+    ```py
+    from enum import Enum
+    from typing import Optional
+
+    from pydantic import BaseModel, ConfigDict, Field
+
+
+    class SomeEnum(Enum):
+        FOO = 'foo'
+        BAR = 'bar'
+        BAZ = 'baz'
+
+
+    class SomeModel(BaseModel):
+        model_config = ConfigDict(use_enum_values=True)
+
+        some_enum: SomeEnum
+        another_enum: Optional[SomeEnum] = Field(default=SomeEnum.FOO, validate_default=True)
+
+
+    model1 = SomeModel(some_enum=SomeEnum.BAR)
+    print(model1.model_dump())
+    # {'some_enum': 'bar', 'another_enum': 'foo'}
+
+    model2 = SomeModel(some_enum=SomeEnum.BAR, another_enum=SomeEnum.BAZ)
+    print(model2.model_dump())
+    #> {'some_enum': 'bar', 'another_enum': 'baz'}
+    ```
     """
 
     validate_assignment: bool

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -273,6 +273,10 @@ class TypeAdapter(Generic[T]):
             from_attributes: Whether to extract data from object attributes.
             context: Additional context to pass to the validator.
 
+        !!! note
+            When using `TypeAdapter` with a Pydantic `dataclass`, the use of the `from_attributes`
+            argument is not supported.
+
         Returns:
             The validated object.
         """


### PR DESCRIPTION
## Change Summary

Fix a few issues needing docs updates:
* #7774 - adding more examples to docs for using `Generic` with `BaseModel`
* #7772 - clarifying the nature of `model_json_schema()` return value as a jsonable `dict`
* #7757 - adding example to docs re use of `use_enum_values` and `validate_default=True` on a field
* #7805 - documenting the fact that `from_attributes` is not supported when using `TypeAdapter` with a Pydantic dataclass

## Related issue number

Fix #7774
Fix #7772
#7757 was already closed, but following up with a docs update
Fix #7805

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin