### PR TITLE
Only compare pydantic fields in `BaseModel.__eq__` instead of whole `__dict__`

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -25,7 +25,7 @@ from ._generics import PydanticGenericMetadata, get_model_typevars_map
 from ._mock_val_ser import MockValSer, set_model_mocks
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._typing_extra import get_cls_types_namespace, is_annotated, is_classvar, parent_frame_namespace
-from ._utils import ClassAttribute
+from ._utils import ClassAttribute, SafeGetItemProxy
 from ._validate_call import ValidateCallWrapper
 
 if typing.TYPE_CHECKING:
@@ -422,17 +422,9 @@ def make_hash_func(cls: type[BaseModel]) -> Any:
             # all model fields, which is how we can get here.
             # getter(self.__dict__) is much faster than any 'safe' method that accounts for missing keys,
             # and wrapping it in a `try` doesn't slow things down much in the common case.
-            return hash(getter(FallbackDict(self.__dict__)))  # type: ignore
+            return hash(getter(SafeGetItemProxy(self.__dict__)))
 
     return hash_func
-
-
-class FallbackDict:
-    def __init__(self, inner):
-        self.inner = inner
-
-    def __getitem__(self, key):
-        return self.inner.get(key)
 
 
 def set_model_fields(

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -347,9 +347,9 @@ class SafeGetItemProxy:
     # @dataclasses.dataclass() only support slots=True in python>=3.10
     __slots__ = ('wrapped', )
 
-    wrapped: Mapping
+    wrapped: Mapping[str, Any]
 
-    def __getitem__(self, __key: Any) -> Any:
+    def __getitem__(self, __key: str) -> Any:
         return self.wrapped.get(__key, _SENTINEL)
 
     # required to pass the object to operator.itemgetter() instances due to a quirk of typeshed
@@ -358,5 +358,5 @@ class SafeGetItemProxy:
     # Since this is typing-only, hide it in a typing.TYPE_CHECKING block
     if typing.TYPE_CHECKING:
 
-        def __contains__(self, __key: Any) -> bool:
+        def __contains__(self, __key: str) -> bool:
             return self.wrapped.__contains__(__key)

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -336,16 +336,16 @@ def all_identical(left: typing.Iterable[Any], right: typing.Iterable[Any]) -> bo
     return True
 
 
-
 @dataclasses.dataclass(frozen=True)
 class SafeGetItemProxy:
     """Wrapper redirecting `__getitem__` to `get` with a sentinel value as default
 
     This makes is safe to use in `operator.itemgetter` when some keys may be missing
     """
+
     # Define __slots__manually for performances
     # @dataclasses.dataclass() only support slots=True in python>=3.10
-    __slots__ = ('wrapped', )
+    __slots__ = ('wrapped',)
 
     wrapped: Mapping[str, Any]
 

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -341,16 +341,18 @@ _KeyType = TypeVar('_KeyType')
 _ValueType = TypeVar('_ValueType')
 
 
-# We need a sentinel value for missing fields when comparing models
-# Models are equals if-and-only-if they miss the same fields, and since None is a legitimate value
-# we can't default to None
-# We use the single-value enum trick to allow correct typing when using a sentinel
+# We need a sentinel value for missing keys that cannot be None, since None is a legitimate value
+# This sentinel must be hashable, compare equal only to itself, and properly typeable in type annotations
+# We use the single-value enum trick to allow correct typing when using a sentinel, from the MyPy suggestion:
 # https://github.com/python/typing/issues/689#issuecomment-561568944
 class SentinelType(enum.Enum):
+    """Class for a sentinel value so that sentinel usage can written and type-checked in type annotations"""
+
     SENTINEL = enum.auto()
 
 
 SENTINEL = SentinelType.SENTINEL
+"""Sentinel value that can be properly typed in type annotations"""
 
 
 @dataclasses.dataclass(frozen=True)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -932,7 +932,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # If we reach here, there are non-pydantic-fields keys, mapped to unequal values, that we need to ignore
             # Resort to costly filtering of the __dict__ objects
             # We use operator.itemgetter because it is much faster than dict comprehensions
-            # NOTE: Contratry to standard python class and instances, when the Model class has default value for an
+            # NOTE: Contrary to standard python class and instances, when the Model class has a default value for an
             # attribute  and the model instance doesn't have a corresponding attribute, accessing the missing attribute
             # raises an error in BaseModel.__getattr__ instead of returning the class attribute
             # So we can use operator.itemgetter() instead of operator.attrgetter()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -915,7 +915,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 return False
 
             # We only want to compare pydantic fields but ignoring fields is costly.
-            # We'll performance fast check first, and fallback only when need
+            # We'll perform a fast check first, and fallback only when needed
             # See GH-7444 and GH-7825 for rationale and a performance benchmark
 
             # First, do the fast (and sometimes faulty) __dict__ comparison

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -930,7 +930,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 return False
 
             # If we reach here, there are non-pydantic-fields keys, mapped to unequal values, that we need to ignore
-            # Resort to coslty filtering of the __dict__ objects
+            # Resort to costly filtering of the __dict__ objects
             # We use operator.itemgetter because it is much faster than dict comprehensions
             # NOTE: Contratry to standard python class and instances, when the Model class has default value for an
             # attribute  and the model instance doesn't have a corresponding attribute, accessing the missing attribute

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -933,7 +933,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # Resort to costly filtering of the __dict__ objects
             # We use operator.itemgetter because it is much faster than dict comprehensions
             # NOTE: Contrary to standard python class and instances, when the Model class has a default value for an
-            # attribute  and the model instance doesn't have a corresponding attribute, accessing the missing attribute
+            # attribute and the model instance doesn't have a corresponding attribute, accessing the missing attribute
             # raises an error in BaseModel.__getattr__ instead of returning the class attribute
             # So we can use operator.itemgetter() instead of operator.attrgetter()
             getter = operator.itemgetter(*model_fields) if model_fields else lambda _: _SENTINEL

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -899,7 +899,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # attribute and the model instance doesn't have a corresponding attribute, accessing the missing attribute
             # raises an error in BaseModel.__getattr__ instead of returning the class attribute
             # So we can use operator.itemgetter() instead of operator.attrgetter()
-            getter = operator.itemgetter(*model_fields) if model_fields else lambda _: _utils.SENTINEL
+            getter = operator.itemgetter(*model_fields) if model_fields else lambda _: _utils._SENTINEL
             try:
                 return getter(self.__dict__) == getter(other.__dict__)
             except KeyError:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -923,7 +923,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 # If the check above passes, then pydantic fields are equal, we can return early
                 return True
 
-            # We don't want to trigger unnecessary coslty filtering of __dict__ on all unequal objects, so we return
+            # We don't want to trigger unnecessary costly filtering of __dict__ on all unequal objects, so we return
             # early if there are no keys to ignore (we would just return False later on anyway)
             model_fields = type(self).model_fields.keys()
             if self.__dict__.keys() <= model_fields and other.__dict__.keys() <= model_fields:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1,12 +1,14 @@
 """Logic for creating models."""
 from __future__ import annotations as _annotations
 
+import enum
+import operator
 import sys
 import types
 import typing
 import warnings
 from copy import copy, deepcopy
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Generic, Mapping, TypeVar
 
 import pydantic_core
 import typing_extensions
@@ -55,6 +57,42 @@ else:
 __all__ = 'BaseModel', 'create_model'
 
 _object_setattr = _model_construction.object_setattr
+
+_K = TypeVar('_K')
+_V = TypeVar('_V')
+
+
+# We need a sentinel value for missing fields when comparing models
+# Models are equals if-and-only-if they miss the same fields, and since None is a legitimate value
+# we can't default to None
+# We use the single-value enum trick to allow correct typing when using a sentinel
+class _SentinelType(enum.Enum):
+    SENTINEL = enum.auto()
+
+
+_SENTINEL = _SentinelType.SENTINEL
+
+
+class _SafeGetItemProxy(Generic[_K, _V]):
+    """Wrapper redirecting `__getitem__` to `get` with a sentinel value as default
+
+    This makes is safe to use in `operator.itemgetter` when some keys may be missing
+    """
+
+    wrapped: Mapping[_K, _V]
+
+    def __init__(self, __mapping: Mapping[_K, _V]) -> None:
+        self.wrapped = __mapping
+
+    def __getitem__(self, __key: _K) -> _SentinelType | _V:
+        return self.wrapped.get(__key, _SENTINEL)
+
+    # required to pass the proxy to operator.itemgetter instances
+    def __contains__(self, __key: _K) -> bool:
+        return self.wrapped.__contains__(__key)
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}({self.wrapped!r})'
 
 
 class BaseModel(metaclass=_model_construction.ModelMetaclass):
@@ -868,12 +906,41 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             self_type = self.__pydantic_generic_metadata__['origin'] or self.__class__
             other_type = other.__pydantic_generic_metadata__['origin'] or other.__class__
 
-            return (
+            # Perform common checks first
+            if not (
                 self_type == other_type
-                and self.__dict__ == other.__dict__
                 and self.__pydantic_private__ == other.__pydantic_private__
                 and self.__pydantic_extra__ == other.__pydantic_extra__
-            )
+            ):
+                return False
+
+            # Fix GH-7444 by comparing only pydantic fields
+            # We provide a fast-path for performance: __dict__ comparison is *much* faster
+            # See tests/benchmarks/test_basemodel_eq_performances.py and GH-7825 for benchmarks
+            if self.__dict__ == other.__dict__:
+                # If the check above passes, then pydantic fields are equal, we can return early
+                return True
+            else:
+                # Else, we need to perform a more detailed, costlier comparison
+                # We use operator.itemgetter because it is much faster than dict comprehensions
+                # NOTE: Contratry to standard python class and instances, when the Model class has
+                #       attribute default values and the model instance doesn't has a corresponding
+                #       attribute, accessing the missing attribute raises an error in
+                #       __getattr__ instance of returning the class attribute
+                #      Thus, using operator.itemgetter() instead of operator.attrgetter() is valid
+                model_fields = type(self).model_fields.keys()
+                getter = operator.itemgetter(*model_fields) if model_fields else lambda _: _SENTINEL
+                try:
+                    return getter(self.__dict__) == getter(other.__dict__)
+                except KeyError:
+                    # In rare cases (such as when using the deprecated BaseModel.copy() method),
+                    # the __dict__ may not contain all model fields, which is how we can get here.
+                    # getter(self.__dict__) is much faster than any 'safe' method that accounts
+                    # for missing keys, and wrapping it in a `try` doesn't slow things down much
+                    # in the common case.
+                    self_fields_proxy = _SafeGetItemProxy(self.__dict__)
+                    other_fields_proxy = _SafeGetItemProxy(other.__dict__)
+                    return getter(self_fields_proxy) == getter(other_fields_proxy)
         else:
             return NotImplemented  # delegate to the other item in the comparison
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -914,33 +914,42 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             ):
                 return False
 
-            # Fix GH-7444 by comparing only pydantic fields
-            # We provide a fast-path for performance: __dict__ comparison is *much* faster
-            # See tests/benchmarks/test_basemodel_eq_performances.py and GH-7825 for benchmarks
+            # We only want to compare pydantic fields but ignoring fields is costly.
+            # We'll performance fast check first, and fallback only when need
+            # See GH-7444 and GH-7825 for rationale and a performance benchmark
+
+            # First, do the fast (and sometimes faulty) __dict__ comparison
             if self.__dict__ == other.__dict__:
                 # If the check above passes, then pydantic fields are equal, we can return early
                 return True
-            else:
-                # Else, we need to perform a more detailed, costlier comparison
-                # We use operator.itemgetter because it is much faster than dict comprehensions
-                # NOTE: Contratry to standard python class and instances, when the Model class has
-                #       attribute default values and the model instance doesn't has a corresponding
-                #       attribute, accessing the missing attribute raises an error in
-                #       __getattr__ instance of returning the class attribute
-                #      Thus, using operator.itemgetter() instead of operator.attrgetter() is valid
-                model_fields = type(self).model_fields.keys()
-                getter = operator.itemgetter(*model_fields) if model_fields else lambda _: _SENTINEL
-                try:
-                    return getter(self.__dict__) == getter(other.__dict__)
-                except KeyError:
-                    # In rare cases (such as when using the deprecated BaseModel.copy() method),
-                    # the __dict__ may not contain all model fields, which is how we can get here.
-                    # getter(self.__dict__) is much faster than any 'safe' method that accounts
-                    # for missing keys, and wrapping it in a `try` doesn't slow things down much
-                    # in the common case.
-                    self_fields_proxy = _SafeGetItemProxy(self.__dict__)
-                    other_fields_proxy = _SafeGetItemProxy(other.__dict__)
-                    return getter(self_fields_proxy) == getter(other_fields_proxy)
+
+            # We don't want to trigger unnecessary coslty filtering of __dict__ on all unequal objects, so we return
+            # early if there are no keys to ignore (we would just return False later on anyway)
+            model_fields = type(self).model_fields.keys()
+            if self.__dict__.keys() <= model_fields and other.__dict__.keys() <= model_fields:
+                return False
+
+            # If we reach here, there are non-pydantic-fields keys, mapped to unequal values, that we need to ignore
+            # Resort to coslty filtering of the __dict__ objects
+            # We use operator.itemgetter because it is much faster than dict comprehensions
+            # NOTE: Contratry to standard python class and instances, when the Model class has default value for an
+            # attribute  and the model instance doesn't have a corresponding attribute, accessing the missing attribute
+            # raises an error in BaseModel.__getattr__ instead of returning the class attribute
+            # So we can use operator.itemgetter() instead of operator.attrgetter()
+            getter = operator.itemgetter(*model_fields) if model_fields else lambda _: _SENTINEL
+            try:
+                return getter(self.__dict__) == getter(other.__dict__)
+            except KeyError:
+                # In rare cases (such as when using the deprecated BaseModel.copy() method),
+                # the __dict__ may not contain all model fields, which is how we can get here.
+                # getter(self.__dict__) is much faster than any 'safe' method that accounts
+                # for missing keys, and wrapping it in a `try` doesn't slow things down much
+                # in the common case.
+                self_fields_proxy = _SafeGetItemProxy(self.__dict__)
+                other_fields_proxy = _SafeGetItemProxy(other.__dict__)
+                return getter(self_fields_proxy) == getter(other_fields_proxy)
+
+        # other instance is not a BaseModel
         else:
             return NotImplemented  # delegate to the other item in the comparison
 

--- a/tests/benchmarks/basemodel_eq_performance.py
+++ b/tests/benchmarks/basemodel_eq_performance.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import dataclasses
+import enum
+import gc
+import itertools
+import operator
+import sys
+import textwrap
+import timeit
+from importlib import metadata
+from typing import TYPE_CHECKING, Any, Callable, Generic, Iterable, Sized, TypeVar
+
+# Do not import additional dependencies at top-level
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib import axes, figure
+
+import pydantic
+
+PYTHON_VERSION = '.'.join(map(str, sys.version_info))
+PYDANTIC_VERSION = metadata.version('pydantic')
+
+
+# New implementation of pydantic.BaseModel.__eq__ to test
+
+
+class OldImplementationModel(pydantic.BaseModel, frozen=True):
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, pydantic.BaseModel):
+            # When comparing instances of generic types for equality, as long as all field values are equal,
+            # only require their generic origin types to be equal, rather than exact type equality.
+            # This prevents headaches like MyGeneric(x=1) != MyGeneric[Any](x=1).
+            self_type = self.__pydantic_generic_metadata__['origin'] or self.__class__
+            other_type = other.__pydantic_generic_metadata__['origin'] or other.__class__
+
+            return (
+                self_type == other_type
+                and self.__dict__ == other.__dict__
+                and self.__pydantic_private__ == other.__pydantic_private__
+                and self.__pydantic_extra__ == other.__pydantic_extra__
+            )
+        else:
+            return NotImplemented  # delegate to the other item in the comparison
+
+
+class DictComprehensionEqModel(pydantic.BaseModel, frozen=True):
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, pydantic.BaseModel):
+            # When comparing instances of generic types for equality, as long as all field values are equal,
+            # only require their generic origin types to be equal, rather than exact type equality.
+            # This prevents headaches like MyGeneric(x=1) != MyGeneric[Any](x=1).
+            self_type = self.__pydantic_generic_metadata__['origin'] or self.__class__
+            other_type = other.__pydantic_generic_metadata__['origin'] or other.__class__
+
+            field_names = type(self).model_fields.keys()
+
+            return (
+                self_type == other_type
+                and ({k: self.__dict__[k] for k in field_names} == {k: other.__dict__[k] for k in field_names})
+                and self.__pydantic_private__ == other.__pydantic_private__
+                and self.__pydantic_extra__ == other.__pydantic_extra__
+            )
+        else:
+            return NotImplemented  # delegate to the other item in the comparison
+
+
+class ItemGetterEqModel(pydantic.BaseModel, frozen=True):
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, pydantic.BaseModel):
+            # When comparing instances of generic types for equality, as long as all field values are equal,
+            # only require their generic origin types to be equal, rather than exact type equality.
+            # This prevents headaches like MyGeneric(x=1) != MyGeneric[Any](x=1).
+            self_type = self.__pydantic_generic_metadata__['origin'] or self.__class__
+            other_type = other.__pydantic_generic_metadata__['origin'] or other.__class__
+
+            model_fields = type(self).model_fields.keys()
+            getter = operator.itemgetter(*model_fields) if model_fields else lambda _: None
+
+            return (
+                self_type == other_type
+                and getter(self.__dict__) == getter(other.__dict__)
+                and self.__pydantic_private__ == other.__pydantic_private__
+                and self.__pydantic_extra__ == other.__pydantic_extra__
+            )
+        else:
+            return NotImplemented  # delegate to the other item in the comparison
+
+
+class ItemGetterEqModelFastPath(pydantic.BaseModel, frozen=True):
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, pydantic.BaseModel):
+            # When comparing instances of generic types for equality, as long as all field values are equal,
+            # only require their generic origin types to be equal, rather than exact type equality.
+            # This prevents headaches like MyGeneric(x=1) != MyGeneric[Any](x=1).
+            self_type = self.__pydantic_generic_metadata__['origin'] or self.__class__
+            other_type = other.__pydantic_generic_metadata__['origin'] or other.__class__
+
+            # Perform common checks first
+            if not (
+                self_type == other_type
+                and self.__pydantic_private__ == other.__pydantic_private__
+                and self.__pydantic_extra__ == other.__pydantic_extra__
+            ):
+                return False
+
+            # Fix GH-7444 by comparing only pydantic fields
+            # We provide a fast-path for performance: __dict__ comparison is *much* faster
+            # See tests/benchmarks/test_basemodel_eq_performances.py and GH-7825 for benchmarks
+            if self.__dict__ == other.__dict__:
+                # If the check above passes, then pydantic fields are equal, we can return early
+                return True
+            else:
+                # Else, we need to perform a more detailed, costlier comparison
+                model_fields = type(self).model_fields.keys()
+                getter = operator.itemgetter(*model_fields) if model_fields else lambda _: None
+                return getter(self.__dict__) == getter(other.__dict__)
+        else:
+            return NotImplemented  # delegate to the other item in the comparison
+
+
+K = TypeVar('K')
+V = TypeVar('V')
+
+
+# We need a sentinel value for missing fields when comparing models
+# Models are equals if-and-only-if they miss the same fields, and since None is a legitimate value
+# we can't default to None
+# We use the single-value enum trick to allow correct typing when using a sentinel
+class _SentinelType(enum.Enum):
+    SENTINEL = enum.auto()
+
+
+_SENTINEL = _SentinelType.SENTINEL
+
+
+@dataclasses.dataclass
+class _SafeGetItemProxy(Generic[K, V]):
+    """Wrapper redirecting `__getitem__` to `get` and a sentinel value
+
+    This makes is safe to use in `operator.itemgetter` when some keys may be missing
+    """
+
+    wrapped: dict[K, V]
+
+    def __getitem__(self, __key: K) -> V | _SentinelType:
+        return self.wrapped.get(__key, _SENTINEL)
+
+    def __contains__(self, __key: K) -> bool:
+        return self.wrapped.__contains__(__key)
+
+
+class SafeItemGetterEqModelFastPath(pydantic.BaseModel, frozen=True):
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, pydantic.BaseModel):
+            # When comparing instances of generic types for equality, as long as all field values are equal,
+            # only require their generic origin types to be equal, rather than exact type equality.
+            # This prevents headaches like MyGeneric(x=1) != MyGeneric[Any](x=1).
+            self_type = self.__pydantic_generic_metadata__['origin'] or self.__class__
+            other_type = other.__pydantic_generic_metadata__['origin'] or other.__class__
+
+            # Perform common checks first
+            if not (
+                self_type == other_type
+                and self.__pydantic_private__ == other.__pydantic_private__
+                and self.__pydantic_extra__ == other.__pydantic_extra__
+            ):
+                return False
+
+            # Fix GH-7444 by comparing only pydantic fields
+            # We provide a fast-path for performance: __dict__ comparison is *much* faster
+            # See tests/benchmarks/test_basemodel_eq_performances.py and GH-7825 for benchmarks
+            if self.__dict__ == other.__dict__:
+                # If the check above passes, then pydantic fields are equal, we can return early
+                return True
+            else:
+                # Else, we need to perform a more detailed, costlier comparison
+                model_fields = type(self).model_fields.keys()
+                getter = operator.itemgetter(*model_fields) if model_fields else lambda _: None
+                return getter(_SafeGetItemProxy(self.__dict__)) == getter(_SafeGetItemProxy(other.__dict__))
+        else:
+            return NotImplemented  # delegate to the other item in the comparison
+
+
+class ItemGetterEqModelFastPathFallback(pydantic.BaseModel, frozen=True):
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, pydantic.BaseModel):
+            # When comparing instances of generic types for equality, as long as all field values are equal,
+            # only require their generic origin types to be equal, rather than exact type equality.
+            # This prevents headaches like MyGeneric(x=1) != MyGeneric[Any](x=1).
+            self_type = self.__pydantic_generic_metadata__['origin'] or self.__class__
+            other_type = other.__pydantic_generic_metadata__['origin'] or other.__class__
+
+            # Perform common checks first
+            if not (
+                self_type == other_type
+                and self.__pydantic_private__ == other.__pydantic_private__
+                and self.__pydantic_extra__ == other.__pydantic_extra__
+            ):
+                return False
+
+            # Fix GH-7444 by comparing only pydantic fields
+            # We provide a fast-path for performance: __dict__ comparison is *much* faster
+            # See tests/benchmarks/test_basemodel_eq_performances.py and GH-7825 for benchmarks
+            if self.__dict__ == other.__dict__:
+                # If the check above passes, then pydantic fields are equal, we can return early
+                return True
+            else:
+                # Else, we need to perform a more detailed, costlier comparison
+                model_fields = type(self).model_fields.keys()
+                getter = operator.itemgetter(*model_fields) if model_fields else lambda _: None
+                try:
+                    return getter(self.__dict__) == getter(other.__dict__)
+                except KeyError:
+                    return getter(_SafeGetItemProxy(self.__dict__)) == getter(_SafeGetItemProxy(other.__dict__))
+        else:
+            return NotImplemented  # delegate to the other item in the comparison
+
+
+IMPLEMENTATIONS = {
+    # Commented out because it is too slow for benchmark to complete in reasonable time
+    # "dict comprehension": DictComprehensionEqModel,
+    'itemgetter': ItemGetterEqModel,
+    'itemgetter+fastpath': ItemGetterEqModelFastPath,
+    # Commented-out because it is too slow to run with run_benchmark_random_unequal
+    #'itemgetter+safety+fastpath': SafeItemGetterEqModelFastPath,
+    'itemgetter+fastpath+safe-fallback': ItemGetterEqModelFastPathFallback,
+}
+
+# Benchmark running & plotting code
+
+
+def plot_all_benchmark(
+    bases: dict[str, type[pydantic.BaseModel]],
+    sizes: list[int],
+) -> figure.Figure:
+    import matplotlib.pyplot as plt
+
+    n_rows, n_cols = len(BENCHMARKS), 2
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(n_cols * 6, n_rows * 4))
+
+    for row, (name, benchmark) in enumerate(BENCHMARKS.items()):
+        for col, mimic_cached_property in enumerate([False, True]):
+            plot_benchmark(
+                f'{name}, {mimic_cached_property=}',
+                benchmark,
+                bases=bases,
+                sizes=sizes,
+                mimic_cached_property=mimic_cached_property,
+                ax=axes[row, col],
+            )
+    for ax in axes.ravel():
+        ax.legend()
+    fig.suptitle(f'python {PYTHON_VERSION}, pydantic {PYDANTIC_VERSION}')
+    return fig
+
+
+def plot_benchmark(
+    title: str,
+    benchmark: Callable,
+    bases: dict[str, type[pydantic.BaseModel]],
+    sizes: list[int],
+    mimic_cached_property: bool,
+    ax: axes.Axes | None = None,
+):
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    ax = ax or plt.gca()
+    arr_sizes = np.asarray(sizes)
+
+    baseline = benchmark(
+        title=f'{title}, baseline',
+        base=OldImplementationModel,
+        sizes=sizes,
+        mimic_cached_property=mimic_cached_property,
+    )
+    ax.plot(sizes, baseline / baseline, label='baseline')
+    for name, base in bases.items():
+        times = benchmark(
+            title=f'{title}, {name}',
+            base=base,
+            sizes=sizes,
+            mimic_cached_property=mimic_cached_property,
+        )
+        mask_valid = ~np.isnan(times)
+        ax.plot(arr_sizes[mask_valid], times[mask_valid] / baseline[mask_valid], label=name)
+
+    ax.set_title(title)
+    ax.set_xlabel('Number of pydantic fields')
+    ax.set_ylabel('Average time relative to baseline')
+    return ax
+
+
+class SizedIterable(Sized, Iterable):
+    pass
+
+
+def run_benchmark_nodiff(
+    title: str,
+    base: type[pydantic.BaseModel],
+    sizes: SizedIterable,
+    mimic_cached_property: bool,
+    n_execution: int = 10_000,
+    n_repeat: int = 5,
+) -> np.ndarray:
+    setup = textwrap.dedent(
+        """
+        import pydantic
+
+        Model = pydantic.create_model(
+            "Model",
+            __base__=Base,
+            **{f'x{i}': (int, i) for i in range(%(size)d)}
+        )
+        left = Model()
+        right = Model()
+        """
+    )
+    if mimic_cached_property:
+        # Mimic functools.cached_property editing __dict__
+        # NOTE: we must edit both objects, otherwise the dict don't have the same size and
+        # dict.__eq__ has a very fast path. This makes our timing comparison incorrect
+        # However, the value must be different, otherwise *our* __dict__ == right.__dict__
+        # fast-path prevents our correct code from running
+        setup += textwrap.dedent(
+            """
+            object.__setattr__(left, 'cache', None)
+            object.__setattr__(right, 'cache', -1)
+            """
+        )
+    statement = 'left == right'
+    namespace = {'Base': base}
+    return run_benchmark(
+        title,
+        setup=setup,
+        statement=statement,
+        n_execution=n_execution,
+        n_repeat=n_repeat,
+        globals=namespace,
+        params={'size': sizes},
+    )
+
+
+def run_benchmark_first_diff(
+    title: str,
+    base: type[pydantic.BaseModel],
+    sizes: SizedIterable,
+    mimic_cached_property: bool,
+    n_execution: int = 10_000,
+    n_repeat: int = 5,
+) -> np.ndarray:
+    setup = textwrap.dedent(
+        """
+        import pydantic
+
+        Model = pydantic.create_model(
+            "Model",
+            __base__=Base,
+            **{f'x{i}': (int, i) for i in range(%(size)d)}
+        )
+        left = Model()
+        right = Model(f0=-1) if %(size)d > 0 else Model()
+        """
+    )
+    if mimic_cached_property:
+        # Mimic functools.cached_property editing __dict__
+        # NOTE: we must edit both objects, otherwise the dict don't have the same size and
+        # dict.__eq__ has a very fast path. This makes our timing comparison incorrect
+        # However, the value must be different, otherwise *our* __dict__ == right.__dict__
+        # fast-path prevents our correct code from running
+        setup += textwrap.dedent(
+            """
+            object.__setattr__(left, 'cache', None)
+            object.__setattr__(right, 'cache', -1)
+            """
+        )
+    statement = 'left == right'
+    namespace = {'Base': base}
+    return run_benchmark(
+        title,
+        setup=setup,
+        statement=statement,
+        n_execution=n_execution,
+        n_repeat=n_repeat,
+        globals=namespace,
+        params={'size': sizes},
+    )
+
+
+def run_benchmark_last_diff(
+    title: str,
+    base: type[pydantic.BaseModel],
+    sizes: SizedIterable,
+    mimic_cached_property: bool,
+    n_execution: int = 10_000,
+    n_repeat: int = 5,
+) -> np.ndarray:
+    setup = textwrap.dedent(
+        """
+        import pydantic
+
+        Model = pydantic.create_model(
+            "Model",
+            __base__=Base,
+            # shift the range() so that there is a field named size
+            **{f'x{i}': (int, i) for i in range(1, %(size)d + 1)}
+        )
+        left = Model()
+        right = Model(f%(size)d=-1) if %(size)d > 0 else Model()
+        """
+    )
+    if mimic_cached_property:
+        # Mimic functools.cached_property editing __dict__
+        # NOTE: we must edit both objects, otherwise the dict don't have the same size and
+        # dict.__eq__ has a very fast path. This makes our timing comparison incorrect
+        # However, the value must be different, otherwise *our* __dict__ == right.__dict__
+        # fast-path prevents our correct code from running
+        setup += textwrap.dedent(
+            """
+            object.__setattr__(left, 'cache', None)
+            object.__setattr__(right, 'cache', -1)
+            """
+        )
+    statement = 'left == right'
+    namespace = {'Base': base}
+    return run_benchmark(
+        title,
+        setup=setup,
+        statement=statement,
+        n_execution=n_execution,
+        n_repeat=n_repeat,
+        globals=namespace,
+        params={'size': sizes},
+    )
+
+
+def run_benchmark_random_unequal(
+    title: str,
+    base: type[pydantic.BaseModel],
+    sizes: SizedIterable,
+    mimic_cached_property: bool,
+    n_samples: int = 100,
+    n_execution: int = 1_000,
+    n_repeat: int = 5,
+) -> np.ndarray:
+    import numpy as np
+
+    setup = textwrap.dedent(
+        """
+        import pydantic
+
+        Model = pydantic.create_model(
+            "Model",
+            __base__=Base,
+            **{f'x{i}': (int, i) for i in range(%(size)d)}
+        )
+        left = Model()
+        right = Model(f%(field)d=-1)
+        """
+    )
+    if mimic_cached_property:
+        # Mimic functools.cached_property editing __dict__
+        # NOTE: we must edit both objects, otherwise the dict don't have the same size and
+        # dict.__eq__ has a very fast path. This makes our timing comparison incorrect
+        # However, the value must be different, otherwise *our* __dict__ == right.__dict__
+        # fast-path prevents our correct code from running
+        setup += textwrap.dedent(
+            """
+            object.__setattr__(left, 'cache', None)
+            object.__setattr__(right, 'cache', -1)
+            """
+        )
+    statement = 'left == right'
+    namespace = {'Base': base}
+    arr_sizes = np.fromiter(sizes, dtype=int)
+    mask_valid_sizes = arr_sizes > 0
+    arr_valid_sizes = arr_sizes[mask_valid_sizes]  # we can't support 0 when sampling the field
+    rng = np.random.default_rng()
+    arr_fields = rng.integers(arr_valid_sizes, size=(n_samples, *arr_valid_sizes.shape))
+    # broadcast the sizes against their sample, so we can iterate on (size, field) tuple
+    # as parameters of the timing test
+    arr_size_broadcast, _ = np.meshgrid(arr_valid_sizes, arr_fields[:, 0])
+
+    results = run_benchmark(
+        title,
+        setup=setup,
+        statement=statement,
+        n_execution=n_execution,
+        n_repeat=n_repeat,
+        globals=namespace,
+        params={'size': arr_size_broadcast.ravel(), 'field': arr_fields.ravel()},
+    )
+    times = np.empty(arr_sizes.shape, dtype=float)
+    times[~mask_valid_sizes] = np.nan
+    times[mask_valid_sizes] = results.reshape((n_samples, *arr_valid_sizes.shape)).mean(axis=0)
+    return times
+
+
+BENCHMARKS = {
+    'All field equals': run_benchmark_nodiff,
+    'First field unequal': run_benchmark_first_diff,
+    'Last field unequal': run_benchmark_last_diff,
+    'Random unequal field': run_benchmark_random_unequal,
+}
+
+
+def run_benchmark(
+    title: str,
+    setup: str,
+    statement: str,
+    n_execution: int = 10_000,
+    n_repeat: int = 5,
+    globals: dict[str, Any] | None = None,
+    progress_bar: bool = True,
+    params: dict[str, SizedIterable] | None = None,
+) -> np.ndarray:
+    import numpy as np
+    import tqdm.auto as tqdm
+
+    namespace = globals or {}
+    # fast-path
+    if not params:
+        length = 1
+        packed_params = [()]
+    else:
+        length = len(next(iter(params.values())))
+        # This iterator yields a tuple of (key, value) pairs
+        # First, make a list of N iterator over (key, value), where the provided values are iterated
+        param_pairs = [zip(itertools.repeat(name), value) for name, value in params.items()]
+        # Then pack our individual parameter iterator into one
+        packed_params = zip(*param_pairs)
+
+    times = [
+        # Take the min of the repeats as recommended by timeit doc
+        min(
+            timeit.Timer(
+                setup=setup % dict(local_params),
+                stmt=statement,
+                globals=namespace,
+            ).repeat(repeat=n_repeat, number=n_execution)
+        )
+        / n_execution
+        for local_params in tqdm.tqdm(packed_params, desc=title, total=length, disable=not progress_bar)
+    ]
+    gc.collect()
+
+    return np.asarray(times, dtype=float)
+
+
+if __name__ == '__main__':
+    # run with `pdm run tests/benchmarks/test_basemodel_eq_performance.py`
+    import argparse
+    import pathlib
+
+    try:
+        import matplotlib  # noqa: F401
+        import numpy  # noqa: F401
+        import tqdm  # noqa: F401
+    except ImportError as err:
+        raise ImportError(
+            'This benchmark additionally depends on numpy, matplotlib and tqdm. '
+            'Install those in your environment to run the benchmark.'
+        ) from err
+
+    parser = argparse.ArgumentParser(
+        description='Test the performance of various BaseModel.__eq__ implementations fixing GH-7444.'
+    )
+    parser.add_argument(
+        '-o',
+        '--output-path',
+        default=None,
+        type=pathlib.Path,
+        help=(
+            'Output directory or file in which to save the benchmark results. '
+            'If a directory is passed, a default filename is used.'
+        ),
+    )
+    parser.add_argument(
+        '--min-n-fields',
+        type=int,
+        default=0,
+        help=('Test the performance of BaseModel.__eq__ on models with at least this number of fields. Defaults to 0.'),
+    )
+    parser.add_argument(
+        '--max-n-fields',
+        type=int,
+        default=100,
+        help=('Test the performance of BaseModel.__eq__ on models with up to this number of fields. Defaults to 100.'),
+    )
+
+    args = parser.parse_args()
+
+    import matplotlib.pyplot as plt
+
+    sizes = list(range(args.min_n_fields, args.max_n_fields))
+    fig = plot_all_benchmark(IMPLEMENTATIONS, sizes=sizes)
+    plt.tight_layout()
+
+    if args.output_path is None:
+        plt.show()
+    else:
+        if args.output_path.suffix:
+            filepath = args.output_path
+        else:
+            filepath = args.output_path / f"eq-benchmark_python-{PYTHON_VERSION.replace('.', '-')}.png"
+        fig.savefig(
+            filepath,
+            dpi=200,
+            facecolor='white',
+            transparent=False,
+        )
+        print(f'wrote {filepath!s}', file=sys.stderr)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,3 +1,4 @@
+import functools
 import importlib.util
 import re
 import sys
@@ -2704,3 +2705,33 @@ def test_recursive_root_models_in_discriminated_union():
         'title': 'Outer',
         'type': 'object',
     }
+
+
+def test_eq_with_cached_property():
+    """
+    Test BaseModel.__eq__ compatibility with functools.cached_property
+
+    See GH-7444: https://github.com/pydantic/pydantic/issues/7444
+    Previously, pydantic BaseModel.__eq__ compared the full __dict__ of
+    model instances. This is not compatible with e.g. functools.cached_property,
+    which caches the computed values in the instance's __dict__
+    """
+    # functools.cached_property doesn't exist in python 3.7
+    if sys.version_info >= (3, 8):
+
+        class Model(BaseModel):
+            attr: int
+
+            @functools.cached_property
+            def cached(self) -> int:
+                return 0
+
+        obj1 = Model(attr=1)
+        obj2 = Model(attr=1)
+        # ensure the instances are indeed equal before __dict__ mutations
+        assert obj1 == obj2
+        # This access to the cached_property has the side-effect of modifying obj1.__dict__
+        # See functools.cached_property documentation and source code
+        obj1.cached
+        # Ensure the objects still compare equals after caching a property
+        assert obj1 == obj2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -651,9 +651,11 @@ def test_hash_function_works_when_instance_dict_modified():
     assert hash(m) == h
 
     # Keys can be missing, e.g. when using the deprecated copy method.
-    # This should change the hash, and more importantly hashing shouldn't raise a KeyError.
+    # This could change the hash, and more importantly hashing shouldn't raise a KeyError
+    # We don't assert here, because a hash collision is possible: the hash is not guaranteed to change
+    # However, hashing must not raise an exception, which simply calling hash() checks for
     del m.__dict__['a']
-    assert h != hash(m)
+    hash(m)
 
 
 def test_default_hash_function_overrides_default_hash_function():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR fixes #7444. It is focused on fixing `pydantic.BaseModel.__eq__`, see #7786 for `pydantic.BaseModel.__hash__`.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
- Fix #7444 

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig