### PR TITLE
fix: support `pydantic.Field(kw_only=True)` with inherited dataclasses

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -163,7 +163,7 @@ def dataclass(
     else:
         kwargs = {}
 
-        def make_pydantic_fields_compatible(_):
+        def make_pydantic_fields_compatible(_) -> None:
             return None
 
     def create_dataclass(cls: type[Any]) -> type[PydanticDataclass]:

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -145,7 +145,12 @@ def dataclass(
         kwargs = dict(kw_only=kw_only, slots=slots)
 
         def make_pydantic_fields_compatible(cls: type[Any]) -> None:
-            """Make sure that stdlib `dataclasses` understands `Field` kwargs like `kw_only`"""
+            """Make sure that stdlib `dataclasses` understands `Field` kwargs like `kw_only`
+            To do that, we simply change
+              `x: int = pydantic.Field(..., kw_only=True)`
+            into
+              `x: int = dataclasses.field(default=pydantic.Field(..., kw_only=True), kw_only=True)`
+            """
             for field_name in cls.__annotations__:
                 try:
                     field_value = getattr(cls, field_name)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1644,6 +1644,21 @@ def test_kw_only():
     assert A(b='hi').b == 'hi'
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='kw_only is not available in python < 3.10')
+def test_kw_only_subclass():
+    @pydantic.dataclasses.dataclass
+    class A:
+        x: int
+        y: int = pydantic.Field(default=0, kw_only=True)
+
+    @pydantic.dataclasses.dataclass
+    class B(A):
+        z: int
+
+    assert B(1, 2) == B(x=1, y=0, z=2)
+    assert B(1, y=2, z=3) == B(x=1, y=2, z=3)
+
+
 def dataclass_decorators(include_identity: bool = False, exclude_combined: bool = False):
     decorators = [pydantic.dataclasses.dataclass, dataclasses.dataclass]
     ids = ['pydantic', 'stdlib']


### PR DESCRIPTION
## Change Summary
pydantic dataclasses support `pydantic.Field` and also support `kw_only` parameter.
But when we set `pydantic.Field(kw_only=True)` as value of a field, the stdlib dataclass behind the scene would use a field without the option causing some differences with the usage of pure stdlib dataclasses.

## Related issue number
closes #7770

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani