### PR TITLE
Add docs for unexpected_keyword_argument on dataclass

### DIFF
--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -1840,15 +1840,15 @@ from pydantic import TypeAdapter, ValidationError
 from pydantic.dataclasses import dataclass
 
 
-@dataclass(config={"extra": "forbid"})
+@dataclass(config={'extra': 'forbid'})
 class Foo:
     bar: int
 
 
 try:
-    TypeAdapter(Foo).validate_python({"bar": 1, "foobar": 2})
+    TypeAdapter(Foo).validate_python({'bar': 1, 'foobar': 2})
 except ValidationError as exc:
-    print(repr(exc.errors()[1]["type"]))
+    print(repr(exc.errors()[1]['type']))
     #> 'unexpected_keyword_argument'
 ```
 

--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -1833,6 +1833,25 @@ except ValidationError as exc:
     #> 'unexpected_keyword_argument'
 ```
 
+It is also raised when using pydantic.dataclasses and `extra=forbid`:
+
+```py
+from pydantic import TypeAdapter, ValidationError
+from pydantic.dataclasses import dataclass
+
+
+@dataclass(config={"extra": "forbid"})
+class Foo:
+    bar: int
+
+
+try:
+    TypeAdapter(Foo).validate_python({"bar": 1, "foobar": 2})
+except ValidationError as exc:
+    print(repr(exc.errors()[1]["type"]))
+    #> 'unexpected_keyword_argument'
+```
+
 ## `unexpected_positional_argument`
 
 This error is raised when you provide a positional value for a keyword-only

--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -1848,7 +1848,7 @@ class Foo:
 try:
     TypeAdapter(Foo).validate_python({'bar': 1, 'foobar': 2})
 except ValidationError as exc:
-    print(repr(exc.errors()[1]['type']))
+    print(repr(exc.errors()[0]['type']))
     #> 'unexpected_keyword_argument'
 ```
 


### PR DESCRIPTION
## Change Summary

Document that unexpected_keyword_argument also happens when using dataclasses and extras are forbidden

## Related issue number
None, trivial

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt