### PR TITLE
Fix invalid reference inside Fields/Immutability documentation

### DIFF
--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -651,7 +651,7 @@ See [Conversion Table](conversion_table.md) for more details on how Pydantic con
 
 ## Immutability
 
-The parameter `frozen` is used to emulate the [frozen dataclass] behaviour. It is used to prevent the field from being
+The parameter `frozen` is used to emulate the frozen dataclass behaviour. It is used to prevent the field from being
 assigned a new value after the model is created (immutability).
 
 See the [frozen dataclass documentation] for more details.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
On [Fields/Immutability Documentation](https://docs.pydantic.dev/latest/concepts/fields/#immutability), there is a broken markdown link that supposed to refer to the [frozen dataclass documentation](https://docs.python.org/3/library/dataclasses.html#frozen-instances).

As the link is already well defined several lines below it, I propose to remove this back to plain text.

<!-- Please give a short summary of the changes. -->

## Related issue number

None so far.

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist (this PR only contains documentation-related change)
* [ ] Tests pass on CI (awaiting label)
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb