### PR TITLE
Make the model name generation more robust in JSON schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1844,7 +1844,7 @@ class GenerateJsonSchema:
         core_ref, mode = core_mode_ref
         components = re.split(r'([\][,])', core_ref)
         # Remove IDs from each component
-        components = [x.split(':')[0] for x in components]
+        components = [x.rsplit(':', 1)[0] for x in components]
         core_ref_no_id = ''.join(components)
         # Remove everything before the last period from each "component"
         components = [re.sub(r'(?:[^.[\]]+\.)+((?:[^.[\]]+))', r'\1', x) for x in components]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,13 +50,14 @@ def disable_error_urls():
 
 @pytest.fixture
 def create_module(tmp_path, request):
-    def run(source_code_or_function, rewrite_assertions=True):
+    def run(source_code_or_function, rewrite_assertions=True, module_name_prefix=None):
         """
         Create module object, execute it and return
         Can be used as a decorator of the function from the source code of which the module will be constructed
 
         :param source_code_or_function string or function with body as a source code for created module
         :param rewrite_assertions: whether to rewrite assertions in module or not
+        :param module_name_prefix: string prefix to use in the name of the module, does not affect the name of the file.
 
         """
         if isinstance(source_code_or_function, FunctionType):
@@ -65,6 +66,8 @@ def create_module(tmp_path, request):
             source_code = source_code_or_function
 
         module_name, filename = _create_module_file(source_code, tmp_path, request.node.name)
+        if module_name_prefix:
+            module_name = module_name_prefix + module_name
 
         if rewrite_assertions:
             loader = AssertionRewritingHook(config=request.config)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5702,3 +5702,29 @@ def test_recursive_non_generic_model() -> None:
         },
         'allOf': [{'$ref': '#/$defs/Bar'}],
     }
+
+
+def test_module_with_colon_in_name(create_module):
+    module = create_module(
+        # language=Python
+        """
+from pydantic import BaseModel
+
+class Foo(BaseModel):
+    x: int
+        """,
+        module_name_prefix='C:\\',
+    )
+
+    foo_model = module.Foo
+    _, v_schema = models_json_schema([(foo_model, 'validation')])
+    assert v_schema == {
+        '$defs': {
+            'Foo': {
+                'properties': {'x': {'title': 'X', 'type': 'integer'}},
+                'required': ['x'],
+                'title': 'Foo',
+                'type': 'object',
+            }
+        }
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

This fixes an issue where the JSON schema can end up using the drive letter (like `C`, `D` etc) instead of the model name on Windows if the module with the model is imported from an absolute path on the filesystem (for example using importlib).  This was caused by splitting at the first colon `:` character to remove it and the ID following it, thus on an absolute path on Windows of the form `C:\...` ended up becoming just the drive letter. This fix changes it to remove the LAST colon character and anything following it.

Modified description post-further investigation of the issue / source of the problem:

This makes the model name used in the JSON Schema be correct also if the model is loaded from a module that has a colon in the name. This should not really happen in any correct use case (python modules should not typically have colons in them), but it's possible to achieve by accident if you use the absolute file path as the module name on Windows when working with importlib. In that case you would have ended up getting just the drive letter as a model name in the JSON Schema, this fix ensures it will still work correctly in that case.



## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

fix #7860

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
