### PR TITLE
Save return type generated from type annotation in ComputedFieldInfo

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1509,6 +1509,9 @@ class GenerateSchema:
             )
 
         return_type = replace_types(return_type, self._typevars_map)
+        # Create a new ComputedFieldInfo so that different type parametrizations of the same
+        # generic model's computed field can have different return types.
+        d.info = dataclasses.replace(d.info, return_type=return_type)
         return_type_schema = self.generate_schema(return_type)
         # Apply serializers to computed field if there exist
         return_type_schema = self._apply_field_serializers(

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -736,6 +736,10 @@ def test_generic_computed_field():
     assert A[int](x=1).model_dump() == {'x': 1, 'double_x': 2}
     assert A[str](x='abc').model_dump() == {'x': 'abc', 'double_x': 'abcabc'}
 
+    assert A(x='xxxxxx').model_computed_fields['double_x'].return_type == T
+    assert A[int](x=123).model_computed_fields['double_x'].return_type == int
+    assert A[str](x='x').model_computed_fields['double_x'].return_type == str
+
     class B(BaseModel, Generic[T]):
         @computed_field
         @property


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

`GenerateSchema._computed_field_schema` already looks at the return type annotation to determine the final return type of a computed field, this just saves that in the `ComputedFieldInfo.return_type`.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7858

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex