### PR TITLE
Warn if a class inherits from Generic before BaseModel

### DIFF
--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -45,3 +45,7 @@ class PydanticDeprecatedSince20(PydanticDeprecationWarning):
 
     def __init__(self, message: str, *args: object) -> None:
         super().__init__(message, *args, since=(2, 0), expected_removal=(3, 0))
+
+
+class GenericBeforeBaseModelWarning(Warning):
+    pass

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -247,7 +247,7 @@ def test_get_pydantic_core_schema_source_type() -> None:
 
     T = TypeVar('T')
 
-    class GenericModel(Generic[T], BaseModel):
+    class GenericModel(BaseModel, Generic[T]):
         y: T
 
     class _(BaseModel):

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -69,6 +69,7 @@ from pydantic._internal._generics import (
     recursively_defined_type_refs,
     replace_types,
 )
+from pydantic.warnings import GenericBeforeBaseModelWarning
 
 
 @pytest.fixture()
@@ -2034,9 +2035,14 @@ def test_generic_subclass_with_extra_type_with_hint_message():
     E = TypeVar('E', bound=BaseModel)
     D = TypeVar('D')
 
-    class BaseGenericClass(Generic[E, D], BaseModel):
-        uid: str
-        name: str
+    with pytest.warns(
+        GenericBeforeBaseModelWarning,
+        match='Classes should inherit from `BaseModel` before generic classes',
+    ):
+
+        class BaseGenericClass(Generic[E, D], BaseModel):
+            uid: str
+            name: str
 
     with pytest.raises(
         TypeError,
@@ -2046,9 +2052,13 @@ def test_generic_subclass_with_extra_type_with_hint_message():
             ' `class ChildGenericClass(BaseGenericClass, typing.Generic[~E, ~D]): ...`'
         ),
     ):
+        with pytest.warns(
+            GenericBeforeBaseModelWarning,
+            match='Classes should inherit from `BaseModel` before generic classes',
+        ):
 
-        class ChildGenericClass(BaseGenericClass[E, Dict[str, Any]]):
-            ...
+            class ChildGenericClass(BaseGenericClass[E, Dict[str, Any]]):
+                ...
 
 
 def test_multi_inheritance_generic_binding():
@@ -2626,9 +2636,14 @@ def test_no_generic_base():
 def test_reverse_order_generic_hashability():
     T = TypeVar('T')
 
-    class Model(Generic[T], BaseModel):
-        x: T
-        model_config = dict(frozen=True)
+    with pytest.warns(
+        GenericBeforeBaseModelWarning,
+        match='Classes should inherit from `BaseModel` before generic classes',
+    ):
+
+        class Model(Generic[T], BaseModel):
+            x: T
+            model_config = dict(frozen=True)
 
     m1 = Model[int](x=1)
     m2 = Model[int](x=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Emit a warning when writing:

```python
class Model(Generic[T], BaseModel):
```

instead of:

```python
class Model(BaseModel, Generic[T]):
```

More generally, `BaseModel` must appear in the `__mro__` before `Generic`, so indirect subclasses are also checked. This means that `__class_getitem__` will use `BaseModel` instead of `Generic` and `Model[T]` will return a model class rather than a `_GenericAlias`.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7845

Waiting for a reply to https://github.com/pydantic/pydantic/issues/6994#issuecomment-1773295810 before continuing here, but thought I should push what I have so far. The failing tests might be of interest.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu