### PR TITLE
Support `|` operator (Union) in PydanticRecursiveRef

### DIFF
--- a/pydantic/_internal/_forward_ref.py
+++ b/pydantic/_internal/_forward_ref.py
@@ -1,6 +1,7 @@
 from __future__ import annotations as _annotations
 
 from dataclasses import dataclass
+from typing import Union
 
 
 @dataclass
@@ -14,3 +15,9 @@ class PydanticRecursiveRef:
         """Defining __call__ is necessary for the `typing` module to let you use an instance of
         this class as the result of resolving a standard ForwardRef.
         """
+
+    def __or__(self, other):
+        return Union[self, other]  # type: ignore
+
+    def __ror__(self, other):
+        return Union[other, self]  # type: ignore

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -711,6 +711,7 @@ class Foobar(BaseModel):
     assert f.y.model_fields_set == {'x'}
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='needs 3.10 or newer')
 def test_recursive_models_union(create_module):
     module = create_module(
         # language=Python
@@ -724,12 +725,14 @@ T = TypeVar("T")
 
 class Foo(BaseModel):
     bar: Bar[str] | None = None
+    bar2: int | Bar[float]
 
 class Bar(BaseModel, Generic[T]):
     foo: Foo
 """
     )
     assert module.Foo.model_fields['bar'].annotation == typing.Optional[module.Bar[str]]
+    assert module.Foo.model_fields['bar2'].annotation == typing.Union[int, module.Bar[float]]
     assert module.Bar.model_fields['foo'].annotation == module.Foo
 
 

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -711,6 +711,28 @@ class Foobar(BaseModel):
     assert f.y.model_fields_set == {'x'}
 
 
+def test_recursive_models_union(create_module):
+    module = create_module(
+        # language=Python
+        """
+from __future__ import annotations
+
+from pydantic import BaseModel
+from typing import TypeVar, Generic
+
+T = TypeVar("T")
+
+class Foo(BaseModel):
+    bar: Bar[str] | None = None
+
+class Bar(BaseModel, Generic[T]):
+    foo: Foo
+"""
+    )
+    assert module.Foo.model_fields['bar'].annotation == typing.Optional[module.Bar[str]]
+    assert module.Bar.model_fields['foo'].annotation == module.Foo
+
+
 def test_force_rebuild():
     class Foobar(BaseModel):
         b: int


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Adds `__or__` and `__ror__` methods to `PydanticRecursiveRef` so that `a | b` returns a `typing.Union`.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7875

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt