### PR TITLE
Monkeypatch typing.get_args/origin to account for generic models

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -208,18 +208,28 @@ def iter_contained_typevars(v: Any) -> Iterator[TypeVarType]:
             yield from iter_contained_typevars(arg)
 
 
+original_get_args = typing_extensions.get_args
+original_get_origin = typing_extensions.get_origin
+
+
 def get_args(v: Any) -> Any:
     pydantic_generic_metadata: PydanticGenericMetadata | None = getattr(v, '__pydantic_generic_metadata__', None)
     if pydantic_generic_metadata:
         return pydantic_generic_metadata.get('args')
-    return typing_extensions.get_args(v)
+    return original_get_args(v)
 
 
 def get_origin(v: Any) -> Any:
     pydantic_generic_metadata: PydanticGenericMetadata | None = getattr(v, '__pydantic_generic_metadata__', None)
     if pydantic_generic_metadata:
         return pydantic_generic_metadata.get('origin')
-    return typing_extensions.get_origin(v)
+    return original_get_origin(v)
+
+
+typing_extensions.get_args = get_args
+typing_extensions.get_origin = get_origin
+typing.get_args = get_args
+typing.get_origin = get_origin
 
 
 def get_standard_typevars_map(cls: type[Any]) -> dict[TypeVarType, Any] | None:

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -228,8 +228,8 @@ def get_origin(v: Any) -> Any:
 
 typing_extensions.get_args = get_args
 typing_extensions.get_origin = get_origin
-typing.get_args = get_args
-typing.get_origin = get_origin
+typing.get_args = get_args  # type: ignore
+typing.get_origin = get_origin  # type: ignore
 
 
 def get_standard_typevars_map(cls: type[Any]) -> dict[TypeVarType, Any] | None:

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -4,7 +4,6 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import sys
-import typing
 from functools import partialmethod
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, cast, overload
@@ -14,7 +13,7 @@ from pydantic_core import core_schema as _core_schema
 from typing_extensions import Annotated, Literal, TypeAlias
 
 from . import GetCoreSchemaHandler as _GetCoreSchemaHandler
-from ._internal import _core_metadata, _decorators, _internal_dataclass
+from ._internal import _core_metadata, _decorators, _generics, _internal_dataclass
 from .annotated_handlers import GetCoreSchemaHandler
 from .errors import PydanticUserError
 
@@ -530,7 +529,7 @@ else:
             from pydantic import PydanticSchemaGenerationError
 
             # use the generic _origin_ as the second argument to isinstance when appropriate
-            instance_of_schema = core_schema.is_instance_schema(typing.get_origin(source) or source)
+            instance_of_schema = core_schema.is_instance_schema(_generics.get_origin(source) or source)
 
             try:
                 # Try to generate the "standard" schema, which will be used when loading from JSON

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import sys
+import typing
 from functools import partialmethod
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, cast, overload
@@ -13,7 +14,7 @@ from pydantic_core import core_schema as _core_schema
 from typing_extensions import Annotated, Literal, TypeAlias
 
 from . import GetCoreSchemaHandler as _GetCoreSchemaHandler
-from ._internal import _core_metadata, _decorators, _generics, _internal_dataclass
+from ._internal import _core_metadata, _decorators, _internal_dataclass
 from .annotated_handlers import GetCoreSchemaHandler
 from .errors import PydanticUserError
 
@@ -529,7 +530,7 @@ else:
             from pydantic import PydanticSchemaGenerationError
 
             # use the generic _origin_ as the second argument to isinstance when appropriate
-            instance_of_schema = core_schema.is_instance_schema(_generics.get_origin(source) or source)
+            instance_of_schema = core_schema.is_instance_schema(typing.get_origin(source) or source)
 
             try:
                 # Try to generate the "standard" schema, which will be used when loading from JSON

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1941,6 +1941,11 @@ def test_generic_with_user_defined_generic_field():
     with pytest.raises(ValidationError):
         model = Model[int](field=['a'])
 
+    # The global `get_args` variable here may not be the monkeypatched one.
+    import typing_extensions
+
+    assert typing_extensions.get_args(Model[int]) == (int,)
+
 
 def test_generic_annotated():
     T = TypeVar('T')

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1941,10 +1941,11 @@ def test_generic_with_user_defined_generic_field():
     with pytest.raises(ValidationError):
         model = Model[int](field=['a'])
 
-    # The global `get_args` variable here may not be the monkeypatched one.
+    # The global `get_args` and `get_origin` variables here may not be the monkeypatched ones
     import typing_extensions
 
     assert typing_extensions.get_args(Model[int]) == (int,)
+    assert typing_extensions.get_origin(Model[int]) == Model
 
 
 def test_generic_annotated():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Point `get_origin` and `get_args` on both `typing` and `typing_extensions` at the wrapper functions in `pydantic._internal._generics` which check `__pydantic_generic_metadata__`.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7837

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin