### PR TITLE
Fix version for `importlib_metadata` on python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     'typing-extensions>=4.6.1',
     'annotated-types>=0.4.0',
     "pydantic-core==2.11.0",
+    "importlib_metadata; python_version=='3.7'"
 ]
 dynamic = ['version', 'readme']
 


### PR DESCRIPTION
## Change Summary

Fix `importlib_metadata` requirement for Python 3.7

## Related issue number

Fix #7903

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex