### PR TITLE
Support json schema generation for `Enum` types with no cases.

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -59,13 +59,19 @@ class SchemaTransformer:
 def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchema:
     cases: list[Any] = list(enum_type.__members__.values())
 
+    def get_json_schema(_, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        json_schema = handler(core_schema.literal_schema([x.value for x in cases], ref=enum_ref))
+        original_schema = handler.resolve_ref_schema(json_schema)
+        update_json_schema(original_schema, updates)
+        return json_schema
+
     if not cases:
         # Use an isinstance check for enums with no cases.
         # This won't work with serialization or JSON schema, but that's okay -- the most important
         # use case for this is creating typevar bounds for generics that should be restricted to enums.
         # This is more consistent than it might seem at first, since you can only subclass enum.Enum
         # (or subclasses of enum.Enum) if all parent classes have no cases.
-        return core_schema.is_instance_schema(enum_type)
+        return core_schema.is_instance_schema(enum_type, metadata={'pydantic_js_functions': [get_json_schema]})
 
     use_enum_values = config.get('use_enum_values', False)
 
@@ -91,11 +97,6 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
     updates = {'title': enum_type.__name__, 'description': description}
     updates = {k: v for k, v in updates.items() if v is not None}
 
-    def get_json_schema(_, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-        json_schema = handler(core_schema.literal_schema([x.value for x in cases], ref=enum_ref))
-        original_schema = handler.resolve_ref_schema(json_schema)
-        update_json_schema(original_schema, updates)
-        return json_schema
 
     strict_python_schema = core_schema.is_instance_schema(enum_type)
     if use_enum_values:

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -59,6 +59,13 @@ class SchemaTransformer:
 def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchema:
     cases: list[Any] = list(enum_type.__members__.values())
 
+    enum_ref = get_type_ref(enum_type)
+    description = None if not enum_type.__doc__ else inspect.cleandoc(enum_type.__doc__)
+    if description == 'An enumeration.':  # This is the default value provided by enum.EnumMeta.__new__; don't use it
+        description = None
+    updates = {'title': enum_type.__name__, 'description': description}
+    updates = {k: v for k, v in updates.items() if v is not None}
+
     def get_json_schema(_, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
         json_schema = handler(core_schema.literal_schema([x.value for x in cases], ref=enum_ref))
         original_schema = handler.resolve_ref_schema(json_schema)
@@ -67,11 +74,17 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
 
     if not cases:
         # Use an isinstance check for enums with no cases.
-        # This won't work with serialization or JSON schema, but that's okay -- the most important
-        # use case for this is creating typevar bounds for generics that should be restricted to enums.
-        # This is more consistent than it might seem at first, since you can only subclass enum.Enum
-        # (or subclasses of enum.Enum) if all parent classes have no cases.
-        return core_schema.is_instance_schema(enum_type, metadata={'pydantic_js_functions': [get_json_schema]})
+        # The most important use case for this is creating TypeVar bounds for generics that should
+        # be restricted to enums. This is more consistent than it might seem at first, since you can only
+        # subclass enum.Enum (or subclasses of enum.Enum) if all parent classes have no cases.
+        # We use the get_json_schema function when an Enum subclass has been declared with no cases
+        # so that we can still generate a valid json schema.
+        if enum_type.__name__ in ['IntEnum', 'Enum']:
+            pydantic_js_functions = []
+        else:
+            pydantic_js_functions = [get_json_schema]
+
+        return core_schema.is_instance_schema(enum_type, metadata={'pydantic_js_functions': pydantic_js_functions})
 
     use_enum_values = config.get('use_enum_values', False)
 
@@ -89,14 +102,6 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
         except ValueError:
             # The type: ignore on the next line is to ignore the requirement of LiteralString
             raise PydanticCustomError('enum', f'Input should be {expected}', {'expected': expected})  # type: ignore
-
-    enum_ref = get_type_ref(enum_type)
-    description = None if not enum_type.__doc__ else inspect.cleandoc(enum_type.__doc__)
-    if description == 'An enumeration.':  # This is the default value provided by enum.EnumMeta.__new__; don't use it
-        description = None
-    updates = {'title': enum_type.__name__, 'description': description}
-    updates = {k: v for k, v in updates.items() if v is not None}
-
 
     strict_python_schema = core_schema.is_instance_schema(enum_type)
     if use_enum_values:

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -79,12 +79,7 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
         # subclass enum.Enum (or subclasses of enum.Enum) if all parent classes have no cases.
         # We use the get_json_schema function when an Enum subclass has been declared with no cases
         # so that we can still generate a valid json schema.
-        if enum_type.__name__ in ['IntEnum', 'Enum']:
-            pydantic_js_functions = []
-        else:
-            pydantic_js_functions = [get_json_schema]
-
-        return core_schema.is_instance_schema(enum_type, metadata={'pydantic_js_functions': pydantic_js_functions})
+        return core_schema.is_instance_schema(enum_type, metadata={'pydantic_js_functions': [get_json_schema]})
 
     use_enum_values = config.get('use_enum_values', False)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1621,12 +1621,6 @@ def test_enum_type():
         }
     ]
 
-    with pytest.raises(
-        PydanticInvalidForJsonSchema,
-        match=re.escape("Cannot generate a JsonSchema for core_schema.IsInstanceSchema (<enum 'Enum'>)"),
-    ):
-        Model.model_json_schema()
-
 
 def test_int_enum_type():
     class Model(BaseModel):
@@ -1654,12 +1648,6 @@ def test_int_enum_type():
             'type': 'is_instance_of',
         }
     ]
-
-    with pytest.raises(
-        PydanticInvalidForJsonSchema,
-        match=re.escape("Cannot generate a JsonSchema for core_schema.IsInstanceSchema (<enum 'IntEnum'>)"),
-    ):
-        Model.model_json_schema()
 
 
 @pytest.mark.parametrize('enum_base,strict', [(Enum, False), (IntEnum, False), (IntEnum, True)])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1723,6 +1723,17 @@ def test_strict_enum() -> None:
         User(demo_strict=0, demo_not_strict=1)
 
 
+def test_enum_with_no_cases() -> None:
+    class MyEnum(Enum):
+        pass
+
+    class MyModel(BaseModel):
+        e: MyEnum
+
+    json_schema = MyModel.model_json_schema()
+    assert json_schema['properties']['e']['enum'] == []
+
+
 @pytest.mark.parametrize(
     'kwargs,type_',
     [


### PR DESCRIPTION
## Change Summary

Support json schema generation for `Enum` types with no cases (via the same json schema generation pattern as is used for `Enum` types with cases).

## Related issue number

Fix #7896

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin