### PR TITLE
Fix `display_as_type` for `TypeAliasType` in python 3.12

### DIFF
--- a/pydantic/_internal/_repr.py
+++ b/pydantic/_internal/_repr.py
@@ -105,7 +105,10 @@ def display_as_type(obj: Any) -> str:
             args = ', '.join(map(repr, typing_extensions.get_args(obj)))
         else:
             args = ', '.join(map(display_as_type, typing_extensions.get_args(obj)))
-        return f'{obj.__qualname__}[{args}]'
+        try:
+            return f'{obj.__qualname__}[{args}]'
+        except AttributeError:
+            return str(obj)  # handles TypeAliasType in 3.12
     elif isinstance(obj, type):
         return obj.__qualname__
     else:

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -1,5 +1,4 @@
 import datetime
-import sys
 from typing import Dict, List, Tuple, TypeVar, Union
 
 import pytest
@@ -134,7 +133,6 @@ def test_recursive_type_alias() -> None:
     }
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 12), reason="TypeAliasType doesn't have __qualname__ yet")
 def test_type_alias_annotated() -> None:
     t = TypeAdapter(ShortMyList[int])
 
@@ -155,7 +153,6 @@ def test_type_alias_annotated() -> None:
     assert t.json_schema() == {'type': 'array', 'items': {'type': 'integer'}, 'maxItems': 1}
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 12), reason="TypeAliasType doesn't have __qualname__ yet")
 def test_type_alias_annotated_defs() -> None:
     # force use of refs by referencing the schema in multiple places
     t = TypeAdapter(Tuple[ShortMyList[int], ShortMyList[int]])
@@ -233,7 +230,6 @@ def test_recursive_generic_type_alias() -> None:
     }
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 12), reason="TypeAliasType doesn't have __qualname__ yet")
 def test_recursive_generic_type_alias_annotated() -> None:
     t = TypeAdapter(ShortRecursiveGenericAlias[int])
 
@@ -265,7 +261,6 @@ def test_recursive_generic_type_alias_annotated() -> None:
     }
 
 
-@pytest.mark.xfail(sys.version_info >= (3, 12), reason="TypeAliasType doesn't have __qualname__ yet")
 def test_recursive_generic_type_alias_annotated_defs() -> None:
     # force use of refs by referencing the schema in multiple places
     t = TypeAdapter(Tuple[ShortRecursiveGenericAlias[int], ShortRecursiveGenericAlias[int]])


### PR DESCRIPTION
@adriangb any issues with this? I think you added those xfails, this change seems reasonable to me since it only affects cases which would currently raise an AttributeError when trying to display a type. And the comment I added should be enough to indicate why it was added in case it becomes unnecessary in the future and anyone otherwise wants to remove it.

Related to https://github.com/pydantic/pydantic/pull/7893; if this gets merged then probably the xfail on the test added there will need to be removed before merging (or that xfail will need to be removed as part of this PR if that PR is merged first).