### PR TITLE
Add eval_type_backport to handle union operator in older Pythons

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -632,7 +632,7 @@ class GenerateSchema:
         # class Model(BaseModel):
         #   x: SomeImportedTypeAliasWithAForwardReference
         try:
-            obj = _typing_extra.eval_type_backport(obj, globalns=self._types_namespace, localns=None)
+            obj = _typing_extra.eval_type_backport(obj, globalns=self._types_namespace)
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -632,7 +632,7 @@ class GenerateSchema:
         # class Model(BaseModel):
         #   x: SomeImportedTypeAliasWithAForwardReference
         try:
-            obj = _typing_extra.evaluate_fwd_ref(obj, globalns=self._types_namespace)
+            obj = _typing_extra.eval_type_backport(obj, globalns=self._types_namespace, localns=None)
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -321,7 +321,7 @@ def get_function_type_hints(
         elif isinstance(value, str):
             value = _make_forward_ref(value)
 
-        type_hints[name] = eval_type_backport(value, globalns, types_namespace)  # type: ignore
+        type_hints[name] = eval_type_backport(value, globalns, types_namespace)
 
     return type_hints
 
@@ -436,7 +436,7 @@ else:
                     if isinstance(value, str):
                         value = _make_forward_ref(value, is_argument=False, is_class=True)
 
-                    value = eval_type_backport(value, base_globals, base_locals)  # type: ignore
+                    value = eval_type_backport(value, base_globals, base_locals)
                     hints[name] = value
             return (
                 hints if include_extras else {k: typing._strip_annotations(t) for k, t in hints.items()}  # type: ignore
@@ -476,7 +476,7 @@ else:
                     is_argument=not isinstance(obj, types.ModuleType),
                     is_class=False,
                 )
-            value = eval_type_backport(value, globalns, localns)  # type: ignore
+            value = eval_type_backport(value, globalns, localns)
             if name in defaults and defaults[name] is None:
                 value = typing.Optional[value]
             hints[name] = value

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -243,10 +243,10 @@ class UnionTransformer(ast.NodeTransformer):
         if globalns is None and localns is None:
             globalns = localns = {}
         elif globalns is None:
-            assert localns is not None
+            assert localns is not None  # apparently pyright doesn't infer this automatically
             globalns = localns
         elif localns is None:
-            assert globalns is not None
+            assert globalns is not None  # apparently pyright doesn't infer this automatically
             localns = globalns
 
         self.typing_name = f'typing_{uuid.uuid4().hex}'

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -229,7 +229,7 @@ def eval_type_lenient(value: Any, globalns: dict[str, Any] | None, localns: dict
         return value
 
 
-def is_unsupported_types_for_union_error(e: TypeError):
+def is_unsupported_types_for_union_error(e: TypeError) -> bool:
     return str(e).startswith('unsupported operand type(s) for |: ')
 
 
@@ -265,7 +265,7 @@ class UnionTransformer(ast.NodeTransformer):
             left_val = self.eval_type(left)
             right_val = self.eval_type(right)
             try:
-                left_val | right_val  # type: ignore
+                _ = left_val | right_val
             except TypeError as e:
                 if not is_unsupported_types_for_union_error(e):
                     raise

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -269,7 +269,7 @@ class UnionTransformer(ast.NodeTransformer):
         return node
 
 
-def eval_type_backport(value: Any, globalns: dict[str, Any] | None, localns: dict[str, Any] | None):
+def eval_type_backport(value: Any, globalns: dict[str, Any] | None = None, localns: dict[str, Any] | None = None):
     try:
         return typing._eval_type(value, globalns, localns)  # type: ignore
     except TypeError:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import sys
 from contextlib import nullcontext as does_not_raise
 from decimal import Decimal
 from inspect import signature
-from typing import Any, ContextManager, Iterable, NamedTuple, Optional, Type, Union, get_type_hints
+from typing import Any, ContextManager, Iterable, NamedTuple, Optional, Type, Union
 
 from dirty_equals import HasRepr, IsPartialDict
 from pydantic_core import SchemaError, SchemaSerializer, SchemaValidator
@@ -24,6 +24,7 @@ from pydantic import (
 )
 from pydantic._internal._config import ConfigWrapper, config_defaults
 from pydantic._internal._mock_val_ser import MockValSer
+from pydantic._internal._typing_extra import get_type_hints
 from pydantic.config import ConfigDict, JsonValue
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.errors import PydanticUserError
@@ -523,7 +524,7 @@ def test_multiple_inheritance_config():
     assert Child.model_config.get('use_enum_values') is True
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason='different on older versions')
+@pytest.mark.skipif(sys.version_info < (3, 9), reason='different on older versions')
 def test_config_wrapper_match():
     localns = {'_GenerateSchema': GenerateSchema, 'GenerateSchema': GenerateSchema, 'JsonValue': JsonValue}
     config_dict_annotations = [(k, str(v)) for k, v in get_type_hints(ConfigDict, localns=localns).items()]
@@ -567,7 +568,7 @@ def test_config_validation_error_cause():
     assert src_exc.__notes__[0] == '\nPydantic: cause of loc: foo'
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason='different on older versions')
+@pytest.mark.skipif(sys.version_info < (3, 9), reason='different on older versions')
 def test_config_defaults_match():
     localns = {'_GenerateSchema': GenerateSchema, 'GenerateSchema': GenerateSchema}
     config_dict_keys = sorted(list(get_type_hints(ConfigDict, localns=localns).keys()))

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -8,7 +8,7 @@ from collections.abc import Hashable
 from dataclasses import InitVar
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, List, Optional, Set, TypeVar, Union
+from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, List, Optional, Set, TypeVar
 
 import pytest
 from dirty_equals import HasRepr
@@ -1359,7 +1359,7 @@ def test_discriminated_union_basemodel_instance_value():
 
     @pydantic.dataclasses.dataclass
     class Top:
-        sub: Union[A, B] = dataclasses.field(metadata=dict(discriminator='l'))
+        sub: 'A | B' = dataclasses.field(metadata=dict(discriminator='l'))
 
     t = Top(sub=A(l='a'))
     assert isinstance(t, Top)

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -64,7 +64,7 @@ def test_discriminated_union_invalid_type():
     ):
 
         class Model(BaseModel):
-            x: Union[str, int] = Field(..., discriminator='qwe')
+            x: 'str | int' = Field(..., discriminator='qwe')
 
 
 def test_discriminated_union_defined_discriminator():
@@ -78,7 +78,7 @@ def test_discriminated_union_defined_discriminator():
     with pytest.raises(PydanticUserError, match="Model 'Cat' needs a discriminator field for key 'pet_type'"):
 
         class Model(BaseModel):
-            pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+            pet: 'Cat | Dog' = Field(..., discriminator='pet_type')
             number: int
 
 
@@ -94,7 +94,7 @@ def test_discriminated_union_literal_discriminator():
     with pytest.raises(PydanticUserError, match="Model 'Cat' needs field 'pet_type' to be of type `Literal`"):
 
         class Model(BaseModel):
-            pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+            pet: 'Cat | Dog' = Field(..., discriminator='pet_type')
             number: int
 
 
@@ -315,7 +315,7 @@ def test_discriminated_union_basemodel_instance_value():
         foo: Literal['b']
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='foo')
+        sub: 'A | B' = Field(..., discriminator='foo')
 
     t = Top(sub=A(foo='a'))
     assert isinstance(t, Top)
@@ -330,7 +330,7 @@ def test_discriminated_union_basemodel_instance_value_with_alias():
         literal: Literal['b'] = Field(alias='lit')
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='literal')
+        sub: 'A | B' = Field(..., discriminator='literal')
 
     with pytest.raises(ValidationError) as exc_info:
         Top(sub=A(literal='a'))
@@ -351,7 +351,7 @@ def test_discriminated_union_int():
         m: Literal[2]
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='m')
+        sub: 'A | B' = Field(..., discriminator='m')
 
     assert isinstance(Top.model_validate({'sub': {'m': 2}}).sub, B)
     with pytest.raises(ValidationError) as exc_info:
@@ -400,7 +400,7 @@ def test_discriminated_union_enum(base_class, choices):
         m: Literal[EnumValue.b]
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='m')
+        sub: 'A | B' = Field(..., discriminator='m')
 
     assert isinstance(Top.model_validate({'sub': {'m': EnumValue.b}}).sub, B)
     if isinstance(EnumValue.b, (int, str)):
@@ -433,7 +433,7 @@ def test_alias_different():
     with pytest.raises(TypeError, match=re.escape("Aliases for discriminator 'pet_type' must be the same (got T, U)")):
 
         class Model(BaseModel):
-            pet: Union[Cat, Dog] = Field(discriminator='pet_type')
+            pet: 'Cat | Dog' = Field(discriminator='pet_type')
 
 
 def test_alias_same():
@@ -446,7 +446,7 @@ def test_alias_same():
         d: str
 
     class Model(BaseModel):
-        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
+        pet: 'Cat | Dog' = Field(discriminator='pet_type')
 
     assert Model(**{'pet': {'typeOfPet': 'dog', 'd': 'milou'}}).pet.pet_type == 'dog'
 
@@ -467,7 +467,7 @@ def test_nested():
         name: str
 
     class Model(BaseModel):
-        pet: Union[CommonPet, Lizard] = Field(..., discriminator='pet_type')
+        pet: 'CommonPet | Lizard' = Field(..., discriminator='pet_type')
         n: int
 
     assert isinstance(Model(**{'pet': {'pet_type': 'dog', 'name': 'Milou'}, 'n': 5}).pet, Dog)
@@ -485,7 +485,7 @@ def test_generic():
         error_message: str
 
     class Container(BaseModel, Generic[T]):
-        result: Union[Success[T], Failure] = Field(discriminator='type')
+        result: 'Success[T] | Failure' = Field(discriminator='type')
 
     with pytest.raises(ValidationError, match="Unable to extract tag using discriminator 'type'"):
         Container[str].model_validate({'result': {}})
@@ -529,7 +529,7 @@ def test_optional_union():
         name: str
 
     class Pet(BaseModel):
-        pet: Optional[Union[Cat, Dog]] = Field(discriminator='pet_type')
+        pet: 'Cat | Dog | None' = Field(discriminator='pet_type')
 
     assert Pet(pet={'pet_type': 'cat', 'name': 'Milo'}).model_dump() == {'pet': {'name': 'Milo', 'pet_type': 'cat'}}
     assert Pet(pet={'pet_type': 'dog', 'name': 'Otis'}).model_dump() == {'pet': {'name': 'Otis', 'pet_type': 'dog'}}
@@ -576,7 +576,7 @@ def test_optional_union_with_defaults():
         name: str
 
     class Pet(BaseModel):
-        pet: Optional[Union[Cat, Dog]] = Field(default=None, discriminator='pet_type')
+        pet: 'Cat | Dog | None' = Field(default=None, discriminator='pet_type')
 
     assert Pet(pet={'pet_type': 'cat', 'name': 'Milo'}).model_dump() == {'pet': {'name': 'Milo', 'pet_type': 'cat'}}
     assert Pet(pet={'pet_type': 'dog', 'name': 'Otis'}).model_dump() == {'pet': {'name': 'Otis', 'pet_type': 'dog'}}
@@ -618,7 +618,7 @@ def test_aliases_matching_is_not_sufficient() -> None:
     with pytest.raises(PydanticUserError, match="Model 'Case1' needs a discriminator field for key 'kind'"):
 
         class TaggedParent(BaseModel):
-            tagged: Union[Case1, Case2] = Field(discriminator='kind')
+            tagged: 'Case1 | Case2' = Field(discriminator='kind')
 
 
 def test_nested_optional_unions() -> None:
@@ -635,7 +635,7 @@ def test_nested_optional_unions() -> None:
     MaybeDogLizard = Annotated[Union[Dog, Lizard, None], Field(discriminator='pet_type')]
 
     class Pet(BaseModel):
-        pet: Union[MaybeCatDog, MaybeDogLizard] = Field(discriminator='pet_type')
+        pet: 'MaybeCatDog | MaybeDogLizard' = Field(discriminator='pet_type')
 
     Pet.model_validate({'pet': {'pet_type': 'dog'}})
     Pet.model_validate({'pet': {'pet_type': 'cat'}})
@@ -724,7 +724,7 @@ def test_unions_of_optionals() -> None:
     MaybeDogLizard = Annotated[Optional[Union[Dog, Lizard]], 'some other annotation']
 
     class Model(BaseModel):
-        maybe_pet: Union[MaybeCat, MaybeDogLizard] = Field(discriminator='pet_type')
+        maybe_pet: 'MaybeCat | MaybeDogLizard' = Field(discriminator='pet_type')
 
     assert Model(**{'maybe_pet': None}).maybe_pet is None
     assert Model(**{'maybe_pet': {'typeOfPet': 'dog', 'd': 'milou'}}).maybe_pet.pet_type == 'dog'

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -52,7 +52,7 @@ from pydantic.functional_serializers import (
 
 def test_str_bytes():
     class Model(BaseModel):
-        v: Union[str, bytes]
+        v: 'str | bytes'
 
     m = Model(v='s')
     assert m.v == 's'
@@ -72,7 +72,7 @@ def test_str_bytes():
 
 def test_str_bytes_none():
     class Model(BaseModel):
-        v: Union[None, str, bytes] = ...
+        v: 'None | str | bytes' = ...
 
     m = Model(v='s')
     assert m.v == 's'
@@ -496,7 +496,7 @@ def test_recursive_list_error():
 
 def test_list_unions():
     class Model(BaseModel):
-        v: List[Union[int, str]] = ...
+        v: 'List[int | str]' = ...
 
     assert Model(v=[123, '456', 'foobar']).v == [123, '456', 'foobar']
 
@@ -511,7 +511,7 @@ def test_list_unions():
 
 def test_recursive_lists():
     class Model(BaseModel):
-        v: List[List[Union[int, float]]] = ...
+        v: 'List[List[int | float]]' = ...
 
     assert Model(v=[[1, 2], [3, '4', '4.1']]).v == [[1, 2], [3, 4, 4.1]]
     assert Model.model_fields['v'].annotation == List[List[Union[int, float]]]
@@ -1209,7 +1209,7 @@ def test_unable_to_infer():
 
 def test_multiple_errors():
     class Model(BaseModel):
-        a: Union[None, int, float, Decimal]
+        a: 'None | int | float | Decimal'
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='foobar')
@@ -1373,8 +1373,8 @@ def test_type_on_annotation():
         e: Type[FooBar]
         f: Type[FooBar] = FooBar
         g: Sequence[Type[FooBar]] = [FooBar]
-        h: Union[Type[FooBar], Sequence[Type[FooBar]]] = FooBar
-        i: Union[Type[FooBar], Sequence[Type[FooBar]]] = [FooBar]
+        h: 'Type[FooBar] | Sequence[Type[FooBar]]' = FooBar
+        i: 'Type[FooBar] | Sequence[Type[FooBar]]' = [FooBar]
 
         model_config = dict(arbitrary_types_allowed=True)
 
@@ -2555,8 +2555,8 @@ def test_union_literal_with_other_type(literal_type, other_type, data, json_valu
 
 def test_type_union():
     class Model(BaseModel):
-        a: Type[Union[str, bytes]]
-        b: Type[Union[Any, str]]
+        a: 'Type[str | bytes]'
+        b: 'Type[Any | str]'
 
     m = Model(a=bytes, b=int)
     assert m.model_dump() == {'a': bytes, 'b': int}

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -711,7 +711,6 @@ class Foobar(BaseModel):
     assert f.y.model_fields_set == {'x'}
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason='needs 3.10 or newer')
 def test_recursive_models_union(create_module):
     module = create_module(
         # language=Python

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -594,7 +594,7 @@ def test_complex_nesting():
     T = TypeVar('T')
 
     class MyModel(BaseModel, Generic[T]):
-        item: List[Dict[Union[int, T], str]]
+        item: 'List[Dict[int | T, str]]'
 
     item = [{1: 'a', 'a': 'a'}]
     model = MyModel[str](item=item)
@@ -1868,7 +1868,7 @@ def test_generic_recursive_models_complicated(create_module):
             m: 'M2[V1]'
 
         class M2(BaseModel, Generic[V3]):
-            m: Union[M1[V3, int], V3]
+            m: 'M1[V3, int] | V3'
 
         M1.model_rebuild()
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1278,7 +1278,7 @@ def test_callable_type(type_, default_value, base_json_schema, properties):
 )
 def test_callable_type_with_fallback(default_value, properties):
     class Model(BaseModel):
-        callback: Union[int, Callable[[int], int]] = default_value
+        callback: 'int | Callable[[int], int]' = default_value
 
     class MyGenerator(GenerateJsonSchema):
         ignored_warning_kinds = ()
@@ -1331,7 +1331,7 @@ def test_non_serializable_default(type_, default_value, properties):
 )
 def test_callable_fallback_with_non_serializable_default(warning_match):
     class Model(BaseModel):
-        callback: Union[int, Callable[[int], int]] = lambda x: x  # noqa E731
+        callback: 'int | Callable[[int], int]' = lambda x: x  # noqa E731
 
     class MyGenerator(GenerateJsonSchema):
         ignored_warning_kinds = ()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 import json
 import platform
 import re
-import sys
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
@@ -1841,22 +1840,21 @@ def test_class_kwargs_custom_config():
             a: int
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason='need 3.10 version')
 def test_new_union_origin():
     """On 3.10+, origin of `int | str` is `types.UnionType`, not `typing.Union`"""
 
     class Model(BaseModel):
-        x: int | str
+        x: 'int | str'
 
     assert Model(x=3).x == 3
     assert Model(x='3').x == '3'
     assert Model(x='pika').x == 'pika'
-    # assert Model.model_json_schema() == {
-    #     'title': 'Model',
-    #     'type': 'object',
-    #     'properties': {'x': {'title': 'X', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}},
-    #     'required': ['x'],
-    # }
+    assert Model.model_json_schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'x': {'title': 'X', 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}},
+        'required': ['x'],
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Union, cast
+from typing import Any, Dict, cast
 
 import pytest
 
@@ -116,7 +116,7 @@ def test_nested_models() -> None:
     calls: list[str] = []
 
     class Model(BaseModel):
-        inner: Union[Model, None]  # noqa
+        inner: Model | None
 
         @model_validator(mode='before')
         @classmethod

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -474,12 +474,12 @@ def test_root_model_dump_with_base_model(order):
     if order == 'BR':
 
         class Model(RootModel):
-            root: List[Union[BModel, RModel]]
+            root: 'List[BModel | RModel]'
 
     elif order == 'RB':
 
         class Model(RootModel):
-            root: List[Union[RModel, BModel]]
+            root: 'List[RModel | BModel]'
 
     m = Model([1, 2, {'value': 'abc'}])
 
@@ -508,7 +508,7 @@ def test_mixed_discriminated_union(data):
         str_value: str
 
     class Model(RootModel):
-        root: Union[SModel, RModel] = Field(discriminator='kind')
+        root: 'SModel | RModel' = Field(discriminator='kind')
 
     assert Model(data).model_dump() == data
     assert Model(**data).model_dump() == data

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4798,7 +4798,7 @@ def test_none_literal():
 
 def test_default_union_types():
     class DefaultModel(BaseModel):
-        v: Union[int, bool, str]
+        v: 'int | bool | str'
 
     # do it this way since `1 == True`
     assert repr(DefaultModel(v=True).v) == 'True'
@@ -4879,7 +4879,7 @@ def test_default_union_class():
         x: str
 
     class Model(BaseModel):
-        y: Union[A, B]
+        y: 'A | B'
 
     assert isinstance(Model(y=A(x='a')).y, A)
     assert isinstance(Model(y=B(x='b')).y, B)
@@ -4891,7 +4891,7 @@ def test_union_subclass(max_length: Union[int, None]):
         ...
 
     class Model(BaseModel):
-        x: Union[int, Annotated[str, Field(max_length=max_length)]]
+        x: 'int | Annotated[str, Field(max_length=max_length)]'
 
     v = Model(x=MyStr('1')).x
     assert type(v) is str
@@ -4900,7 +4900,7 @@ def test_union_subclass(max_length: Union[int, None]):
 
 def test_union_compound_types():
     class Model(BaseModel):
-        values: Union[Dict[str, str], List[str], Dict[str, List[str]]]
+        values: 'Dict[str, str] | List[str] | Dict[str, List[str]]'
 
     assert Model(values={'L': '1'}).model_dump() == {'values': {'L': '1'}}
     assert Model(values=['L1']).model_dump() == {'values': ['L1']}
@@ -4934,7 +4934,7 @@ def test_union_compound_types():
 
 def test_smart_union_compounded_types_edge_case():
     class Model(BaseModel):
-        x: Union[List[str], List[int]]
+        x: 'List[str] | List[int]'
 
     assert Model(x=[1, 2]).x == [1, 2]
     assert Model(x=['1', '2']).x == ['1', '2']
@@ -4949,7 +4949,7 @@ def test_union_typeddict():
         bar: str
 
     class M(BaseModel):
-        d: Union[Dict2, Dict1]
+        d: 'Dict2 | Dict1'
 
     assert M(d=dict(foo='baz')).d == {'foo': 'baz'}
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -67,16 +67,16 @@ def test_is_none_type():
 
 
 @pytest.mark.parametrize(
-    'union_gen', [lambda: typing.Union[int, str], lambda: int | str, eval_type_backport('int | str')]
+    'union',
+    [
+        typing.Union[int, str],
+        eval_type_backport(typing.ForwardRef('int | str')),
+        *([int | str] if sys.version_info >= (3, 10) else []),
+    ],
 )
-def test_is_union(union_gen):
-    try:
-        union = union_gen()
-    except TypeError:
-        pytest.skip('not supported in this python version')
-    else:
-        origin = get_origin(union)
-        assert origin_is_union(origin)
+def test_is_union(union):
+    origin = get_origin(union)
+    assert origin_is_union(origin)
 
 
 def test_is_literal_with_typing_extension_literal():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -9,6 +9,7 @@ from typing_extensions import Literal, get_origin
 from pydantic import Field  # noqa: F401
 from pydantic._internal._typing_extra import (
     NoneType,
+    eval_type_backport,
     get_function_type_hints,
     is_classvar,
     is_literal_type,
@@ -65,7 +66,9 @@ def test_is_none_type():
     assert is_none_type(Callable) is False
 
 
-@pytest.mark.parametrize('union_gen', [lambda: typing.Union[int, str], lambda: int | str])
+@pytest.mark.parametrize(
+    'union_gen', [lambda: typing.Union[int, str], lambda: int | str, eval_type_backport('int | str')]
+)
 def test_is_union(union_gen):
     try:
         union = union_gen()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 from enum import Enum
 from functools import partial, partialmethod
 from itertools import product
-from typing import Any, Callable, Deque, Dict, FrozenSet, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Callable, Deque, Dict, FrozenSet, List, NamedTuple, Optional, Tuple
 from unittest.mock import MagicMock
 
 import pytest
@@ -1670,7 +1670,7 @@ def test_nested_literal_validator():
 
 def test_union_literal_with_constraints():
     class Model(BaseModel, validate_assignment=True):
-        x: Union[Literal[42], Literal['pika']] = Field(frozen=True)
+        x: "Literal[42] | Literal['pika']" = Field(frozen=True)
 
     m = Model(x=42)
     with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Replaces all calls (outside v1) to `typing._eval_type` with the new `typing_extra.eval_type_backport` which uses AST modification to convert `X | Y` to `Union[X, Y]` when needed. This is only used when an appropriate TypeError is raised so it should usually only kick in on older Python versions. It might also help with cases like https://github.com/pydantic/pydantic/issues/7875 where `|` is simply unimplemented but probably shouldn't be treated as a complete solution for that kind of thing.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7873

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani