### PR TITLE
Fix plurals in validation error messages (in tests)

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -693,7 +693,7 @@ def test_validating_assignment_fail(ValidateAssignmentModel):
         {
             'type': 'string_too_short',
             'loc': ('b',),
-            'msg': 'String should have at least 1 characters',
+            'msg': 'String should have at least 1 character',
             'input': '',
             'ctx': {'min_length': 1},
         }
@@ -3045,7 +3045,7 @@ def test_schema_generator_customize_type_constraints_order() -> None:
         {
             'type': 'string_too_long',
             'loc': ('y',),
-            'msg': 'String should have at most 1 characters',
+            'msg': 'String should have at most 1 character',
             'input': ' 1 ',
             'ctx': {'max_length': 1},
         }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -673,6 +673,7 @@ def test_validating_assignment_pass(ValidateAssignmentModel):
     assert p.model_dump() == {'a': 2, 'b': 'hi'}
 
 
+@pytest.mark.xfail(reason='Needs new release of pydantic-core')
 def test_validating_assignment_fail(ValidateAssignmentModel):
     p = ValidateAssignmentModel(a=5, b='hello')
 
@@ -3030,6 +3031,7 @@ def test_schema_generator_customize_type_constraints() -> None:
     ]
 
 
+@pytest.mark.xfail(reason='Needs new release of pydantic-core')
 def test_schema_generator_customize_type_constraints_order() -> None:
     class Model(BaseModel):
         # whitespace will be stripped first, then max length will be checked, should pass on ' 1 '

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3057,7 +3057,7 @@ ANY_THING = object()
             ],
         ),
         (dict(max_digits=2, decimal_places=2), Decimal('0.99'), Decimal('0.99')),
-        (
+        pytest.param(
             dict(max_digits=2, decimal_places=1),
             Decimal('0.99'),
             [
@@ -3071,6 +3071,7 @@ ANY_THING = object()
                     },
                 }
             ],
+            marks=pytest.mark.xfail(reason='Needs new release of pydantic-core'),
         ),
         (
             dict(max_digits=3, decimal_places=1),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3064,7 +3064,7 @@ ANY_THING = object()
                 {
                     'type': 'decimal_max_places',
                     'loc': ('foo',),
-                    'msg': 'Decimal input should have no more than 1 decimal places',
+                    'msg': 'Decimal input should have no more than 1 decimal place',
                     'input': Decimal('0.99'),
                     'ctx': {
                         'decimal_places': 1,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

A complementary change to https://github.com/pydantic/pydantic-core/pull/1050 – adjust grammar in error message assertions.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [X] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
