### PR TITLE
Add CallableDiscriminator and Tag

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -882,10 +882,12 @@ Setting a discriminated union has many benefits:
 - the generated JSON schema implements the [associated OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object)
 
 #### Discriminated Unions with `str` discriminators
-In the case of a `Union` with multiple models, you sometimes know exactly which field of each
-model needs to be checked and validated and want to enforce this.
-To do that you can set the same field - let's call it `my_discriminator` - in each of the models
-with a discriminated value, which is one (or many) `Literal` value(s).
+Frequently, in the case of a `Union` with multiple models,
+there is a common field to all members of the union that can be used to distinguish
+which union case the data should be validated against; this is referred to as the "discriminator" in
+[OpenAPI](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/).
+To validate models based on that information you can set the same field - let's call it `my_discriminator` -
+in each of the models with a discriminated value, which is one (or many) `Literal` value(s).
 For your `Union`, you can set the discriminator in its value: `Field(discriminator='my_discriminator')`.
 
 

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -871,17 +871,23 @@ print(type(User(id='123', age='45').id))
 
 ### Discriminated Unions (a.k.a. Tagged Unions)
 
-When `Union` is used with multiple submodels, you sometimes know exactly which submodel needs to
-be checked and validated and want to enforce this.
-To do that you can set the same field - let's call it `my_discriminator` - in each of the submodels
-with a discriminated value, which is one (or many) `Literal` value(s).
-For your `Union`, you can set the discriminator in its value: `Field(discriminator='my_discriminator')`.
+We can use discriminated unions to more efficiently validate `Union` types.
+Discriminated unions can be used to validate `Union` types with multiple models, or combinations of
+models and primitive types.
 
 Setting a discriminated union has many benefits:
 
 - validation is faster since it is only attempted against one model
 - only one explicit error is raised in case of failure
 - the generated JSON schema implements the [associated OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object)
+
+#### Discriminated Unions with `str` discriminators
+In the case of a `Union` with multiple models, you sometimes know exactly which field of each
+model needs to be checked and validated and want to enforce this.
+To do that you can set the same field - let's call it `my_discriminator` - in each of the models
+with a discriminated value, which is one (or many) `Literal` value(s).
+For your `Union`, you can set the discriminator in its value: `Field(discriminator='my_discriminator')`.
+
 
 ```py requires="3.8"
 from typing import Literal, Union
@@ -922,9 +928,125 @@ except ValidationError as e:
     """
 ```
 
+#### Discriminated Unions with `CallableDiscriminator` discriminators
+In the case of a `Union` with multiple models, sometimes there isn't a single uniform field
+across all models that you can use as a discriminator. This is the perfect use case for the `CallableDiscriminator` approach.
+
+```py requires="3.8"
+from typing import Any, Literal, Union
+
+from typing_extensions import Annotated
+
+from pydantic import BaseModel, CallableDiscriminator, Tag
+
+
+class Pie(BaseModel):
+    time_to_cook: int
+    num_ingredients: int
+
+
+class ApplePie(Pie):
+    fruit: Literal['apple'] = 'apple'
+
+
+class PumpkinPie(Pie):
+    filling: Literal['pumpkin'] = 'pumpkin'
+
+
+def get_discriminator_value(v: Any) -> str:
+    if isinstance(v, dict):
+        return v.get('fruit', v.get('filling'))
+    return getattr(v, 'fruit', getattr(v, 'filling', None))
+
+
+class ThanksgivingDinner(BaseModel):
+    dessert: Annotated[
+        Union[
+            Annotated[ApplePie, Tag('apple')],
+            Annotated[PumpkinPie, Tag('pumpkin')],
+        ],
+        CallableDiscriminator(get_discriminator_value),
+    ]
+
+
+apple_variation = ThanksgivingDinner.model_validate(
+    {'dessert': {'fruit': 'apple', 'time_to_cook': 60, 'num_ingredients': 8}}
+)
+print(repr(apple_variation))
+"""
+ThanksgivingDinner(dessert=ApplePie(time_to_cook=60, num_ingredients=8, fruit='apple'))
+"""
+
+pumpkin_variation = ThanksgivingDinner.model_validate(
+    {
+        'dessert': {
+            'filling': 'pumpkin',
+            'time_to_cook': 40,
+            'num_ingredients': 6,
+        }
+    }
+)
+print(repr(pumpkin_variation))
+"""
+ThanksgivingDinner(dessert=PumpkinPie(time_to_cook=40, num_ingredients=6, filling='pumpkin'))
+"""
+```
+
+`CallableDiscriminators` can also be used to validate `Union` types with combinations of models and primitive types.
+
+For example:
+
+```py requires="3.8"
+from typing import Any, Union
+
+from typing_extensions import Annotated
+
+from pydantic import BaseModel, CallableDiscriminator, Tag
+
+
+def model_x_discriminator(v: Any) -> str:
+    if isinstance(v, str):
+        return 'str'
+    if isinstance(v, (dict, BaseModel)):
+        return 'model'
+
+
+class DiscriminatedModel(BaseModel):
+    x: Annotated[
+        Union[
+            Annotated[str, Tag('str')],
+            Annotated['DiscriminatedModel', Tag('model')],
+        ],
+        CallableDiscriminator(
+            model_x_discriminator,
+            custom_error_type='invalid_union_member',
+            custom_error_message='Invalid union member',
+            custom_error_context={'discriminator': 'str_or_model'},
+        ),
+    ]
+
+
+data = {'x': {'x': {'x': 'a'}}}
+m = DiscriminatedModel.model_validate(data)
+assert m == (
+    DiscriminatedModel(x=DiscriminatedModel(x=DiscriminatedModel(x='a')))
+)
+assert m.model_dump() == data
+```
+
 !!! note
     Using the [`typing.Annotated` fields syntax](../concepts/json_schema.md#typingannotated-fields) can be handy to regroup
-    the `Union` and `discriminator` information. See below for an example!
+    the `Union` and `discriminator` information. See the next example for more details.
+
+    There are a few ways to set a discriminator for a field, all varying slightly in syntax.
+
+    For `str` discriminators:
+        * `some_field: Union[...] = Field(discriminator='my_discriminator'`
+        * `some_field: Annotated[Union[...], Field(discriminator='my_discriminator')]`
+    For `CallableDiscriminator` discriminators:
+        * `some_field: Union[...] = Field(discriminator=CallableDiscriminator(...))`
+        * `some_field: Annotated[Union[...], CallableDiscriminator(...)]`
+        * `some_field: Annotated[Union[...], Field(discriminator=CallableDiscriminator(...))]`
 
 !!! warning
     Discriminated unions cannot be used with only a single variant, such as `Union[Cat]`.

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -1041,12 +1041,17 @@ assert m.model_dump() == data
     There are a few ways to set a discriminator for a field, all varying slightly in syntax.
 
     For `str` discriminators:
-        * `some_field: Union[...] = Field(discriminator='my_discriminator'`
-        * `some_field: Annotated[Union[...], Field(discriminator='my_discriminator')]`
+    ```
+    some_field: Union[...] = Field(discriminator='my_discriminator'
+    some_field: Annotated[Union[...], Field(discriminator='my_discriminator')]
+    ```
+
     For `CallableDiscriminator` discriminators:
-        * `some_field: Union[...] = Field(discriminator=CallableDiscriminator(...))`
-        * `some_field: Annotated[Union[...], CallableDiscriminator(...)]`
-        * `some_field: Annotated[Union[...], Field(discriminator=CallableDiscriminator(...))]`
+    ```
+    some_field: Union[...] = Field(discriminator=CallableDiscriminator(...))
+    some_field: Annotated[Union[...], CallableDiscriminator(...)]
+    some_field: Annotated[Union[...], Field(discriminator=CallableDiscriminator(...))]
+    ```
 
 !!! warning
     Discriminated unions cannot be used with only a single variant, such as `Union[Cat]`.

--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -667,7 +667,8 @@ print(repr(Model.model_validate({'pet': {'pet_kind': 'dog', 'age': 12}})))
 #> Model(pet=Dog(pet_kind='dog', age=12))
 ```
 
-See the [Discriminated Unions] for more details.
+You can also take advantage of `Annotated` to define your discriminated unions.
+See the [Discriminated Unions] docs for more details.
 
 ## Strict Mode
 

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -132,6 +132,8 @@ class Html(BaseModel):
     )
 ```
 
+See [Discriminated Unions] for more details.
+
 ## Use `Literal` not `Enum`
 
 Instead of using `Enum`, use `Literal` to define the structure of the data.
@@ -207,3 +209,5 @@ Instead of using nested models, use `TypedDict` to define the structure of the d
 ## Avoid wrap validators if you really care about performance
 
 <!-- TODO: I need help on this one. -->
+
+[Discriminated Unions]: ../api/standard_library_types.md#discriminated-unions-aka-tagged-unions

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -392,6 +392,9 @@ However, in most cases where you want to perform validation using multiple field
 
 ## Model validators
 
+??? api "API Documentation"
+    [`pydantic.functional_validators.model_validator`][pydantic.functional_validators.model_validator]<br>
+
 Validation can also be performed on the entire model's data using `@model_validator`.
 
 ```py

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -365,7 +365,7 @@ class Model(BaseModel):
 assert Model(pet={'pet_type': 'kitten'}).pet.pet_type == 'cat'
 ```
 
-## Callable discriminator no tag {#callable-discriminator-no-tag}
+## Callable discriminator case with no tag {#callable-discriminator-no-tag}
 
 This error is raised when a `Union` that uses a `CallableDiscriminator` doesn't have `Tag` annotations for all cases.
 

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -365,6 +365,62 @@ class Model(BaseModel):
 assert Model(pet={'pet_type': 'kitten'}).pet.pet_type == 'cat'
 ```
 
+## Callable discriminator no tag {#callable-discriminator-no-tag}
+
+This error is raised when a `Union` that uses a `CallableDiscriminator` doesn't have `Tag` annotations for all cases.
+
+```py
+from typing import Union
+
+from typing_extensions import Annotated
+
+from pydantic import BaseModel, CallableDiscriminator, PydanticUserError, Tag
+
+
+def model_x_discriminator(v):
+    if isinstance(v, str):
+        return 'str'
+    if isinstance(v, (dict, BaseModel)):
+        return 'model'
+
+
+# tag missing for both union choices
+try:
+
+    class DiscriminatedModel(BaseModel):
+        x: Annotated[
+            Union[str, 'DiscriminatedModel'],
+            CallableDiscriminator(model_x_discriminator),
+        ]
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'callable-discriminator-no-tag'
+
+# tag missing for `'DiscriminatedModel'` union choice
+try:
+
+    class DiscriminatedModel(BaseModel):
+        x: Annotated[
+            Union[Annotated[str, Tag('str')], 'DiscriminatedModel'],
+            CallableDiscriminator(model_x_discriminator),
+        ]
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'callable-discriminator-no-tag'
+
+# tag missing for `str` union choice
+try:
+
+    class DiscriminatedModel(BaseModel):
+        x: Annotated[
+            Union[str, Annotated['DiscriminatedModel', Tag('model')]],
+            CallableDiscriminator(model_x_discriminator),
+        ]
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'callable-discriminator-no-tag'
+```
+
 
 ## `TypedDict` version {#typed-dict-version}
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -181,6 +181,8 @@ __all__ = (
     'Base64UrlBytes',
     'Base64UrlStr',
     'GetPydanticSchema',
+    'Tag',
+    'CallableDiscriminator',
     # type_adapter
     'TypeAdapter',
     # version
@@ -320,6 +322,8 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'Base64UrlBytes': (__package__, '.types'),
     'Base64UrlStr': (__package__, '.types'),
     'GetPydanticSchema': (__package__, '.types'),
+    'Tag': (__package__, '.types'),
+    'CallableDiscriminator': (__package__, '.types'),
     # type_adapter
     'TypeAdapter': (__package__, '.type_adapter'),
     # warnings

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -48,6 +48,10 @@ NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY = 'pydantic.internal.needs_apply_di
 schema building because one of it's members refers to a definition that was not yet defined when the union
 was first encountered.
 """
+TAGGED_UNION_TAG_KEY = 'pydantic-tagged-union-tag'
+"""
+Used in a `Tag` schema to specify the tag used for a discriminated union.
+"""
 HAS_INVALID_SCHEMAS_METADATA_KEY = 'pydantic.internal.invalid'
 """Used to mark a schema that is invalid because it refers to a definition that was not yet defined when the
 schema was first encountered.

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -48,7 +48,7 @@ NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY = 'pydantic.internal.needs_apply_di
 schema building because one of it's members refers to a definition that was not yet defined when the union
 was first encountered.
 """
-TAGGED_UNION_TAG_KEY = 'pydantic-tagged-union-tag'
+TAGGED_UNION_TAG_KEY = 'pydantic.internal.tagged_union_tag'
 """
 Used in a `Tag` schema to specify the tag used for a discriminated union.
 """

--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -1,6 +1,6 @@
 from __future__ import annotations as _annotations
 
-from typing import Any, Hashable, Sequence
+from typing import TYPE_CHECKING, Any, Hashable, Sequence
 
 from pydantic_core import CoreSchema, core_schema
 
@@ -12,6 +12,9 @@ from ._core_utils import (
     collect_definitions,
     simplify_schema_references,
 )
+
+if TYPE_CHECKING:
+    from ..types import CallableDiscriminator
 
 CORE_SCHEMA_METADATA_DISCRIMINATOR_PLACEHOLDER_KEY = 'pydantic.internal.union_discriminator'
 
@@ -58,7 +61,9 @@ def apply_discriminators(schema: core_schema.CoreSchema) -> core_schema.CoreSche
 
 
 def apply_discriminator(
-    schema: core_schema.CoreSchema, discriminator: str, definitions: dict[str, core_schema.CoreSchema] | None = None
+    schema: core_schema.CoreSchema,
+    discriminator: str | CallableDiscriminator,
+    definitions: dict[str, core_schema.CoreSchema] | None = None,
 ) -> core_schema.CoreSchema:
     """Applies the discriminator and returns a new core schema.
 
@@ -83,6 +88,11 @@ def apply_discriminator(
             - If discriminator fields have different aliases.
             - If discriminator field not of type `Literal`.
     """
+    from ..types import CallableDiscriminator
+
+    if isinstance(discriminator, CallableDiscriminator):
+        return discriminator._convert_schema(schema)
+
     return _ApplyInferredDiscriminator(discriminator, definitions or {}).apply(schema)
 
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -82,6 +82,7 @@ from ._utils import is_valid_identifier, lenient_issubclass
 if TYPE_CHECKING:
     from ..fields import ComputedFieldInfo, FieldInfo
     from ..main import BaseModel
+    from ..types import CallableDiscriminator
     from ..validators import FieldValidatorModes
     from ._dataclasses import StandardDataclass
     from ._schema_generation_shared import GetJsonSchemaFunction
@@ -372,7 +373,11 @@ class GenerateSchema:
             ' `__get_pydantic_core_schema__` on `<some type>` otherwise to avoid infinite recursion.'
         )
 
-    def _apply_discriminator_to_union(self, schema: CoreSchema, discriminator: Any) -> CoreSchema:
+    def _apply_discriminator_to_union(
+        self, schema: CoreSchema, discriminator: str | CallableDiscriminator | None
+    ) -> CoreSchema:
+        if discriminator is None:
+            return schema
         try:
             return _discriminated_union.apply_discriminator(
                 schema,

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -30,6 +30,7 @@ PydanticErrorCodes = Literal[
     'discriminator-needs-literal',
     'discriminator-alias',
     'discriminator-validator',
+    'callable-discriminator-no-tag',
     'typed-dict-version',
     'model-field-overridden',
     'model-field-missing-annotation',

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -64,7 +64,7 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
     max_digits: int | None
     decimal_places: int | None
     union_mode: Literal['smart', 'left_to_right'] | None
-    discriminator: str | None
+    discriminator: str | types.CallableDiscriminator | None
     json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None
     frozen: bool | None
     validate_default: bool | None
@@ -101,7 +101,7 @@ class FieldInfo(_repr.Representation):
         description: The description of the field.
         examples: List of examples of the field.
         exclude: Whether to exclude the field from the model serialization.
-        discriminator: Field name for discriminating the type in a tagged union.
+        discriminator: Field name or CallableDiscriminator for discriminating the type in a tagged union.
         json_schema_extra: Dictionary of extra JSON schema properties.
         frozen: Whether the field is frozen.
         validate_default: Whether to validate the default value of the field.
@@ -122,7 +122,7 @@ class FieldInfo(_repr.Representation):
     description: str | None
     examples: list[Any] | None
     exclude: bool | None
-    discriminator: str | None
+    discriminator: str | types.CallableDiscriminator | None
     json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None
     frozen: bool | None
     validate_default: bool | None
@@ -682,7 +682,7 @@ def Field(  # noqa: C901
     description: str | None = _Unset,
     examples: list[Any] | None = _Unset,
     exclude: bool | None = _Unset,
-    discriminator: str | None = _Unset,
+    discriminator: str | types.CallableDiscriminator | None = _Unset,
     json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None = _Unset,
     frozen: bool | None = _Unset,
     validate_default: bool | None = _Unset,
@@ -727,7 +727,7 @@ def Field(  # noqa: C901
         description: Human-readable description.
         examples: Example values for this field.
         exclude: Whether to exclude the field from the model serialization.
-        discriminator: Field name for discriminating the type in a tagged union.
+        discriminator: Field name or CallableDiscriminator for discriminating the type in a tagged union.
         json_schema_extra: Any additional JSON schema data for the schema property.
         frozen: Whether the field is frozen.
         validate_default: Run validation that isn't only checking existence of defaults. This can be set to `True` or `False`. If not set, it defaults to `None`.

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -31,6 +31,7 @@ from pydantic_core import CoreSchema, PydanticCustomError, core_schema
 from typing_extensions import Annotated, Literal, Protocol, deprecated
 
 from ._internal import (
+    _core_utils,
     _fields,
     _internal_dataclass,
     _typing_extra,
@@ -2439,9 +2440,6 @@ class GetPydanticSchema:
     __hash__ = object.__hash__
 
 
-_TAGGED_UNION_TAG_KEY = 'pydantic-tagged-union-tag'
-
-
 @_dataclasses.dataclass(**_internal_dataclass.slots_true, frozen=True)
 class Tag:
     """Provides a way to specify the expected tag to use for a case with a callable discriminated union.
@@ -2455,7 +2453,7 @@ class Tag:
         schema = handler(source_type)
         metadata = schema.setdefault('metadata', {})
         assert isinstance(metadata, dict)
-        metadata[_TAGGED_UNION_TAG_KEY] = self.tag
+        metadata[_core_utils.TAGGED_UNION_TAG_KEY] = self.tag
         return schema
 
 
@@ -2496,7 +2494,7 @@ class CallableDiscriminator:
                 choice, tag = choice
             metadata = choice.get('metadata')
             if metadata is not None:
-                metadata_tag = metadata.get(_TAGGED_UNION_TAG_KEY)
+                metadata_tag = metadata.get(_core_utils.TAGGED_UNION_TAG_KEY)
                 if metadata_tag is not None:
                     tag = metadata_tag
             tagged_union_choices[tag] = choice

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2504,9 +2504,9 @@ class Tag:
     !!! note
         You must specify a `Tag` for every case in a `Union` that is associated with a `CallableDiscriminator`.
         Failing to do so will result in a `PydanticUserError` with code
-        [`callable-discriminator-no-tag`](../docs/errors/usage_errors.md#callable-discriminator-no-tag).
+        [`callable-discriminator-no-tag`](../errors/usage_errors.md#callable-discriminator-no-tag).
 
-    See the [Discriminated Unions](../docs/api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
+    See the [Discriminated Unions](../api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
     docs for more details on how to use `Tag`s.
     """
 
@@ -2582,7 +2582,7 @@ class CallableDiscriminator:
     # > ThanksgivingDinner(dessert=PumpkinPie(filling='pumpkin', time_to_cook=40, num_ingredients=6))
     ```
 
-    See the [Discriminated Unions](../docs/api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
+    See the [Discriminated Unions](../api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
     docs for more details on how to use `CallableDiscriminator`s.
     """
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2451,7 +2451,8 @@ class Tag:
 
     The primary role of the `Tag` here is to map the return value from the `CallableDiscriminator` function to
     the appropriate member of the `Union` in question.
-    ```
+
+    ```py requires="3.8"
     from typing import Any, Literal, Union
 
     from typing_extensions import Annotated
@@ -2532,7 +2533,8 @@ class CallableDiscriminator:
 
     Consider this example, which is much more performant with the use of `CallableDiscriminator` and thus a `TaggedUnion`
     than it would be as a normal `Union`.
-    ```
+
+    ```py requires="3.8"
     from typing import Any, Literal, Union
 
     from typing_extensions import Annotated

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2459,47 +2459,51 @@ class Tag:
 
     from pydantic import BaseModel, CallableDiscriminator, Tag
 
-
     class Pie(BaseModel):
         time_to_cook: int
         num_ingredients: int
 
-
     class ApplePie(Pie):
         fruit: Literal['apple'] = 'apple'
 
-
     class PumpkinPie(Pie):
         filling: Literal['pumpkin'] = 'pumpkin'
-
 
     def get_discriminator_value(v: Any) -> str:
         if isinstance(v, dict):
             return v.get('fruit', v.get('filling'))
         return getattr(v, 'fruit', getattr(v, 'filling', None))
 
-
     class ThanksgivingDinner(BaseModel):
         dessert: Annotated[
             Union[
-                Annotated[ApplePie, Tag("apple")],
-                Annotated[PumpkinPie, Tag("pumpkin")],
+                Annotated[ApplePie, Tag('apple')],
+                Annotated[PumpkinPie, Tag('pumpkin')],
             ],
             CallableDiscriminator(get_discriminator_value),
         ]
-
 
     apple_variation = ThanksgivingDinner.model_validate(
         {'dessert': {'fruit': 'apple', 'time_to_cook': 60, 'num_ingredients': 8}}
     )
     print(repr(apple_variation))
-    # > ThanksgivingDinner(dessert=ApplePie(fruit='apple', time_to_cook=60, num_ingredients=8))
+    '''
+    ThanksgivingDinner(dessert=ApplePie(time_to_cook=60, num_ingredients=8, fruit='apple'))
+    '''
 
     pumpkin_variation = ThanksgivingDinner.model_validate(
-        {'dessert': {'filling': 'pumpkin', 'time_to_cook': 40, 'num_ingredients': 6}}
+        {
+            'dessert': {
+                'filling': 'pumpkin',
+                'time_to_cook': 40,
+                'num_ingredients': 6,
+            }
+        }
     )
     print(repr(pumpkin_variation))
-    # > ThanksgivingDinner(dessert=PumpkinPie(filling='pumpkin', time_to_cook=40, num_ingredients=6))
+    '''
+    ThanksgivingDinner(dessert=PumpkinPie(time_to_cook=40, num_ingredients=6, filling='pumpkin'))
+    '''
     ```
 
     !!! note
@@ -2541,47 +2545,51 @@ class CallableDiscriminator:
 
     from pydantic import BaseModel, CallableDiscriminator, Tag
 
-
     class Pie(BaseModel):
         time_to_cook: int
         num_ingredients: int
 
-
     class ApplePie(Pie):
         fruit: Literal['apple'] = 'apple'
 
-
     class PumpkinPie(Pie):
         filling: Literal['pumpkin'] = 'pumpkin'
-
 
     def get_discriminator_value(v: Any) -> str:
         if isinstance(v, dict):
             return v.get('fruit', v.get('filling'))
         return getattr(v, 'fruit', getattr(v, 'filling', None))
 
-
     class ThanksgivingDinner(BaseModel):
         dessert: Annotated[
             Union[
-                Annotated[ApplePie, Tag("apple")],
-                Annotated[PumpkinPie, Tag("pumpkin")],
+                Annotated[ApplePie, Tag('apple')],
+                Annotated[PumpkinPie, Tag('pumpkin')],
             ],
             CallableDiscriminator(get_discriminator_value),
         ]
-
 
     apple_variation = ThanksgivingDinner.model_validate(
         {'dessert': {'fruit': 'apple', 'time_to_cook': 60, 'num_ingredients': 8}}
     )
     print(repr(apple_variation))
-    # > ThanksgivingDinner(dessert=ApplePie(fruit='apple', time_to_cook=60, num_ingredients=8))
+    '''
+    ThanksgivingDinner(dessert=ApplePie(time_to_cook=60, num_ingredients=8, fruit='apple'))
+    '''
 
     pumpkin_variation = ThanksgivingDinner.model_validate(
-        {'dessert': {'filling': 'pumpkin', 'time_to_cook': 40, 'num_ingredients': 6}}
+        {
+            'dessert': {
+                'filling': 'pumpkin',
+                'time_to_cook': 40,
+                'num_ingredients': 6,
+            }
+        }
     )
     print(repr(pumpkin_variation))
-    # > ThanksgivingDinner(dessert=PumpkinPie(filling='pumpkin', time_to_cook=40, num_ingredients=6))
+    '''
+    ThanksgivingDinner(dessert=PumpkinPie(time_to_cook=40, num_ingredients=6, filling='pumpkin'))
+    '''
     ```
 
     See the [Discriminated Unions](../api/standard_library_types.md#discriminated-unions-aka-tagged-unions)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2451,7 +2451,6 @@ class Tag:
 
     The primary role of the `Tag` here is to map the return value from the `CallableDiscriminator` function to
     the appropriate member of the `Union` in question.
-
     ```
     from typing import Any, Literal, Union
 
@@ -2502,7 +2501,12 @@ class Tag:
     # > ThanksgivingDinner(dessert=PumpkinPie(filling='pumpkin', time_to_cook=40, num_ingredients=6))
     ```
 
-    See the [Discriminated Unions](../api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
+    !!! note
+        You must specify a `Tag` for every case in a `Union` that is associated with a `CallableDiscriminator`.
+        Failing to do so will result in a `PydanticUserError` with code
+        [`callable-discriminator-no-tag`](../docs/errors/usage_errors.md#callable-discriminator-no-tag).
+
+    See the [Discriminated Unions](../docs/api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
     docs for more details on how to use `Tag`s.
     """
 
@@ -2578,7 +2582,7 @@ class CallableDiscriminator:
     # > ThanksgivingDinner(dessert=PumpkinPie(filling='pumpkin', time_to_cook=40, num_ingredients=6))
     ```
 
-    See the [Discriminated Unions](../api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
+    See the [Discriminated Unions](../docs/api/standard_library_types.md#discriminated-unions-aka-tagged-unions)
     docs for more details on how to use `CallableDiscriminator`s.
     """
 
@@ -2605,7 +2609,7 @@ class CallableDiscriminator:
 
         tagged_union_choices = {}
         for i, choice in enumerate(original_schema['choices']):
-            tag = f'case-{i}'
+            tag = None
             if isinstance(choice, tuple):
                 choice, tag = choice
             metadata = choice.get('metadata')
@@ -2613,6 +2617,11 @@ class CallableDiscriminator:
                 metadata_tag = metadata.get(_core_utils.TAGGED_UNION_TAG_KEY)
                 if metadata_tag is not None:
                     tag = metadata_tag
+            if tag is None:
+                raise PydanticUserError(
+                    f'`Tag` not provided for choice {choice} used with `CallableDiscriminator`',
+                    code='callable-discriminator-no-tag',
+                )
             tagged_union_choices[tag] = choice
 
         # Have to do these verbose checks to ensure falsy values ('' and {}) don't get ignored

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -8,9 +8,10 @@ from dirty_equals import HasRepr, IsStr
 from pydantic_core import SchemaValidator, core_schema
 from typing_extensions import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError, field_validator
+from pydantic import BaseModel, CallableDiscriminator, ConfigDict, Field, TypeAdapter, ValidationError, field_validator
 from pydantic._internal._discriminated_union import apply_discriminator
 from pydantic.errors import PydanticUserError
+from pydantic.types import Tag
 
 
 def test_discriminated_union_type():
@@ -1351,3 +1352,196 @@ def test_sequence_discriminated_union():
         'title': 'Model',
         'type': 'object',
     }
+
+
+def test_callable_discriminated_union_multi_field():
+    class Cat(BaseModel):
+        pet_type: Literal['cat'] = 'cat'
+
+    class Dog(BaseModel):
+        pet_kind: Literal['dog'] = 'dog'
+
+    class Fish(BaseModel):
+        pet_kind: Literal['fish'] = 'fish'
+
+    class Lizard(BaseModel):
+        pet_variety: Literal['lizard'] = 'lizard'
+
+    def get_discriminator_value(v):
+        if isinstance(v, dict):
+            return v.get('pet_type', v.get('pet_kind'))
+        return getattr(v, 'pet_type', getattr(v, 'pet_kind', None))
+
+    pet_adapter = TypeAdapter(
+        Annotated[
+            Union[Annotated[Cat, Tag('cat')], Annotated[Dog, Tag('dog')]],
+            CallableDiscriminator(get_discriminator_value),
+        ]
+    )
+
+    assert pet_adapter.validate_python({'pet_type': 'cat'}).pet_type == 'cat'
+    assert pet_adapter.validate_python({'pet_kind': 'dog'}).pet_kind == 'dog'
+    assert pet_adapter.validate_python(Cat()).pet_type == 'cat'
+    assert pet_adapter.validate_python(Dog()).pet_kind == 'dog'
+    assert pet_adapter.validate_json('{"pet_type":"cat"}').pet_type == 'cat'
+    assert pet_adapter.validate_json('{"pet_kind":"dog"}').pet_kind == 'dog'
+
+    # Unexpected discriminator value for dict
+    with pytest.raises(ValidationError) as exc_info:
+        pet_adapter.validate_python({'pet_kind': 'fish'})
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'discriminator': 'get_discriminator_value()', 'expected_tags': "'cat', 'dog'", 'tag': 'fish'},
+            'input': {'pet_kind': 'fish'},
+            'loc': (),
+            'msg': "Input tag 'fish' found using get_discriminator_value() does not "
+            "match any of the expected tags: 'cat', 'dog'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+    # Missing discriminator key for dict
+    with pytest.raises(ValidationError) as exc_info:
+        pet_adapter.validate_python({'pet_variety': 'lizard'})
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'discriminator': 'get_discriminator_value()'},
+            'input': {'pet_variety': 'lizard'},
+            'loc': (),
+            'msg': 'Unable to extract tag using discriminator get_discriminator_value()',
+            'type': 'union_tag_not_found',
+        }
+    ]
+
+    # Unexpected discriminator value for instance
+    with pytest.raises(ValidationError) as exc_info:
+        pet_adapter.validate_python(Fish())
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'discriminator': 'get_discriminator_value()', 'expected_tags': "'cat', 'dog'", 'tag': 'fish'},
+            'input': Fish(pet_kind='fish'),
+            'loc': (),
+            'msg': "Input tag 'fish' found using get_discriminator_value() does not "
+            "match any of the expected tags: 'cat', 'dog'",
+            'type': 'union_tag_invalid',
+        }
+    ]
+
+    # Missing discriminator key for instance
+    with pytest.raises(ValidationError) as exc_info:
+        pet_adapter.validate_python(Lizard())
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'discriminator': 'get_discriminator_value()'},
+            'input': Lizard(pet_variety='lizard'),
+            'loc': (),
+            'msg': 'Unable to extract tag using discriminator get_discriminator_value()',
+            'type': 'union_tag_not_found',
+        }
+    ]
+
+
+def test_callable_discriminated_union_recursive():
+    # Demonstrate that the errors suck without a callable discriminator:
+    class Model(BaseModel):
+        x: Union[str, 'Model']
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model.model_validate({'x': {'x': {'x': 1}}})
+    assert exc_info.value.errors(include_url=False) == [
+        {'input': {'x': {'x': 1}}, 'loc': ('x', 'str'), 'msg': 'Input should be a valid string', 'type': 'string_type'},
+        {
+            'input': {'x': 1},
+            'loc': ('x', 'Model', 'x', 'str'),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type',
+        },
+        {
+            'input': 1,
+            'loc': ('x', 'Model', 'x', 'Model', 'x', 'str'),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type',
+        },
+        {
+            'ctx': {'class_name': 'Model'},
+            'input': 1,
+            'loc': ('x', 'Model', 'x', 'Model', 'x', 'Model'),
+            'msg': 'Input should be a valid dictionary or instance of Model',
+            'type': 'model_type',
+        },
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model.model_validate({'x': {'x': {'x': {}}}})
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'input': {'x': {'x': {}}},
+            'loc': ('x', 'str'),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type',
+        },
+        {
+            'input': {'x': {}},
+            'loc': ('x', 'Model', 'x', 'str'),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type',
+        },
+        {
+            'input': {},
+            'loc': ('x', 'Model', 'x', 'Model', 'x', 'str'),
+            'msg': 'Input should be a valid string',
+            'type': 'string_type',
+        },
+        {
+            'input': {},
+            'loc': ('x', 'Model', 'x', 'Model', 'x', 'Model', 'x'),
+            'msg': 'Field required',
+            'type': 'missing',
+        },
+    ]
+
+    # Demonstrate that the errors suck less _with_ a callable discriminator:
+    def model_x_discriminator(v):
+        if isinstance(v, str):
+            return 'str'
+        if isinstance(v, (dict, BaseModel)):
+            return 'model'
+
+    class DiscriminatedModel(BaseModel):
+        x: Annotated[
+            Union[Annotated[str, Tag('str')], Annotated['DiscriminatedModel', Tag('model')]],
+            CallableDiscriminator(
+                model_x_discriminator,
+                custom_error_type='invalid_union_member',
+                custom_error_message='Invalid union member',
+                custom_error_context={'discriminator': 'str_or_model'},
+            ),
+        ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        DiscriminatedModel.model_validate({'x': {'x': {'x': 1}}})
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'ctx': {'discriminator': 'str_or_model'},
+            'input': 1,
+            'loc': ('x', 'model', 'x', 'model', 'x'),
+            'msg': 'Invalid union member',
+            'type': 'invalid_union_member',
+        }
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        DiscriminatedModel.model_validate({'x': {'x': {'x': {}}}})
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'input': {},
+            'loc': ('x', 'model', 'x', 'model', 'x', 'model', 'x'),
+            'msg': 'Field required',
+            'type': 'missing',
+        }
+    ]
+    # Demonstrate that the data is still handled properly when valid:
+    data = {'x': {'x': {'x': 'a'}}}
+    m = DiscriminatedModel.model_validate(data)
+    assert m == DiscriminatedModel(x=DiscriminatedModel(x=DiscriminatedModel(x='a')))
+    assert m.model_dump() == data


### PR DESCRIPTION
I think this should be preferred over https://github.com/pydantic/pydantic/pull/6915, mostly because the implementation there involves duplicating the list of types in the union, and generally seems more fragile.

I've opened as draft until docs/tests are added, hoping @sydney-runkle can help get this across the line tomorrow.