### PR TITLE
Move SerializeAsAny docstring to actual class so that the IDE can pic…

### DIFF
--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -256,7 +256,13 @@ if TYPE_CHECKING:
 else:
 
     @dataclasses.dataclass(**_internal_dataclass.slots_true)
-    class SerializeAsAny:  # noqa: D101
+    class SerializeAsAny:
+        """Force serialization to ignore whatever is defined in the schema and instead ask the object
+        itself how it should be serialized.
+        In particular, this means that when model subclasses are serialized, fields present in the subclass
+        but not in the original schema will be included.
+        """
+
         def __class_getitem__(cls, item: Any) -> Any:
             return Annotated[item, SerializeAsAny()]
 


### PR DESCRIPTION
## Change Summary

PyCharm does not display help for `SerializeAsAny` when the docstring is in the TYPE_CHECKING branch.
I moved it to the real class.

## Related issue number

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt