### PR TITLE
Update arbitrary class doc example using Annotated instead of constr

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -223,12 +223,13 @@ The example here uses [SQLAlchemy](https://www.sqlalchemy.org/), but the same ap
 
 ```py
 from typing import List
+from typing_extensions import Annotated
 
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import declarative_base
 
-from pydantic import BaseModel, ConfigDict, constr
+from pydantic import BaseModel, ConfigDict, StringConstraints
 
 Base = declarative_base()
 
@@ -246,9 +247,9 @@ class CompanyModel(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    public_key: constr(max_length=20)
-    name: constr(max_length=63)
-    domains: List[constr(max_length=255)]
+    public_key: Annotated[str, StringConstraints(max_length=20)]
+    name: Annotated[str, StringConstraints(max_length=63)]
+    domains: List[Annotated[str, StringConstraints(max_length=255)]]
 
 
 co_orm = CompanyOrm(


### PR DESCRIPTION
## Change Summary

In the documentation there is a code example for [Arbitrary class instances](https://docs.pydantic.dev/2.4/concepts/models/#arbitrary-class-instances) that uses[ `constr()`](https://docs.pydantic.dev/2.4/api/types/#pydantic.types.constr) which according to the documentation is its discouraged and will be deprecated in Pydantic 3.0 in favor of `Annotated` and `StringConstraints`

## Related issue number

None

## Checklist

* [ x ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ x ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ x ] Documentation reflects the changes where applicable
* [ x ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
