### PR TITLE
Don't decode bytes (which may not be UTF8) when displaying SecretBytes

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1495,8 +1495,6 @@ class _SecretField(Generic[SecretType]):
 
 
 def _secret_display(value: str | bytes) -> str:
-    if isinstance(value, bytes):
-        value = value.decode()
     return '**********' if value else ''
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4174,7 +4174,9 @@ def test_secretbytes():
         empty_password: SecretBytes
 
     # Initialize the model.
-    f = Foobar(password=b'wearebytes', empty_password=b'')
+    # Use bytes that can't be decoded with UTF8 (https://github.com/pydantic/pydantic/issues/7971)
+    password = b'\x89PNG\r\n\x1a\n'
+    f = Foobar(password=password, empty_password=b'')
 
     # Assert correct types.
     assert f.password.__class__.__name__ == 'SecretBytes'
@@ -4187,7 +4189,7 @@ def test_secretbytes():
     assert repr(f.empty_password) == "SecretBytes(b'')"
 
     # Assert retrieval of secret value is correct
-    assert f.password.get_secret_value() == b'wearebytes'
+    assert f.password.get_secret_value() == password
     assert f.empty_password.get_secret_value() == b''
 
     # Assert that SecretBytes is equal to SecretBytes if the secret is the same.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Removes unneeded `.decode()`.

I couldn't find any justification for decoding the bytes. The code was introduced in [this commit](https://github.com/pydantic/pydantic/pull/5674/commits/b904b986b6ef7d7fd8b59caf55ade9ae48945d94#diff-f7a381c0918da7ec905bfbe6aff2ccc72c2d0fd6da0dd3011ef1da892e42d57aR497-R498) in https://github.com/pydantic/pydantic/pull/5674 and I don't see any PR comments explaining it. @adriangb any idea?

There are some encodings where a non-empty byte string can decode to any empty string:

```python
>>> ''.encode('utf16')
b'\xff\xfe'
>>> ''.encode('utf16').decode('utf16')
''
>>> ''.encode('utf16').decode('utf16') == ''
True
```

but `.decode()` without arguments should always use UTF8 in Python 3 regardless of locale settings.

I've checked that any non-empty byte string with up to 3 bytes decodes to a non-empty string if it can be decoded at all:

```python
import itertools

count = 0
total = 0
for length in [1, 2, 3]:
    for b in itertools.product(range(256), repeat=length):
        total += 1
        b = bytes(b)
        assert b
        assert len(b) == length > 0
        try:
            s = b.decode()
        except UnicodeDecodeError:
            continue
        assert s
        assert len(s) > 0
        assert b == s.encode()
        count += 1

print(count)  # 2668544
print(total)  # 16843008
```

I also think that any non-empty byte string should be treated as non-empty when displaying even if it can be decoded to an empty unicode string. Although I'm also not sure about revealing whether *any* secret value is empty.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7971

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig