### PR TITLE
Add `examples` and `json_schema_extra` to `@computed_field`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1558,6 +1558,10 @@ class GenerateSchema:
             if description is not None:
                 json_schema['description'] = description
 
+            examples = d.info.examples
+            if examples is not None:
+                json_schema['examples'] = examples
+
             return json_schema
 
         metadata = build_metadata_dict(js_annotation_functions=[set_computed_field_metadata])

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1556,6 +1556,10 @@ class GenerateSchema:
             if examples is not None:
                 json_schema['examples'] = to_jsonable_python(examples)
 
+            json_schema_extra = d.info.json_schema_extra
+            if json_schema_extra is not None:
+                add_json_schema_extra(json_schema, json_schema_extra)
+
             return json_schema
 
         metadata = build_metadata_dict(js_annotation_functions=[set_computed_field_metadata])

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -37,7 +37,7 @@ from pydantic_core import CoreSchema, PydanticUndefined, core_schema, to_jsonabl
 from typing_extensions import Annotated, Final, Literal, TypeAliasType, TypedDict, get_args, get_origin, is_typeddict
 
 from ..annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
-from ..config import ConfigDict, JsonEncoder
+from ..config import ConfigDict, JsonDict, JsonEncoder
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
 from ..json_schema import JsonSchemaValue
 from ..version import version_short
@@ -987,15 +987,9 @@ class GenerateSchema:
 
         json_schema_extra = field_info.json_schema_extra
 
-        def json_schema_update_func(schema: CoreSchemaOrField, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            json_schema = {**handler(schema), **json_schema_updates}
-            if isinstance(json_schema_extra, dict):
-                json_schema.update(to_jsonable_python(json_schema_extra))
-            elif callable(json_schema_extra):
-                json_schema_extra(json_schema)
-            return json_schema
-
-        metadata = build_metadata_dict(js_annotation_functions=[json_schema_update_func])
+        metadata = build_metadata_dict(
+            js_annotation_functions=[get_json_schema_update_func(json_schema_updates, json_schema_extra)]
+        )
 
         # apply alias generator
         alias_generator = self._config_wrapper.alias_generator
@@ -1560,7 +1554,7 @@ class GenerateSchema:
 
             examples = d.info.examples
             if examples is not None:
-                json_schema['examples'] = examples
+                json_schema['examples'] = to_jsonable_python(examples)
 
             return json_schema
 
@@ -1711,20 +1705,8 @@ class GenerateSchema:
 
             json_schema_extra = metadata.json_schema_extra
             if json_schema_update or json_schema_extra:
-
-                def json_schema_update_func(
-                    core_schema: CoreSchemaOrField, handler: GetJsonSchemaHandler
-                ) -> JsonSchemaValue:
-                    json_schema = handler(core_schema)
-                    json_schema.update(json_schema_update)
-                    if isinstance(json_schema_extra, dict):
-                        json_schema.update(to_jsonable_python(json_schema_extra))
-                    elif callable(json_schema_extra):
-                        json_schema_extra(json_schema)
-                    return json_schema
-
                 CoreMetadataHandler(schema).metadata.setdefault('pydantic_js_annotation_functions', []).append(
-                    json_schema_update_func
+                    get_json_schema_update_func(json_schema_update, json_schema_extra)
                 )
         return schema
 
@@ -2007,6 +1989,28 @@ def _extract_get_pydantic_json_schema(tp: Any, schema: CoreSchema) -> GetJsonSch
         return None
 
     return js_modify_function
+
+
+def get_json_schema_update_func(
+    json_schema_update: JsonSchemaValue, json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None
+) -> GetJsonSchemaFunction:
+    def json_schema_update_func(
+        core_schema_or_field: CoreSchemaOrField, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        json_schema = {**handler(core_schema_or_field), **json_schema_update}
+        add_json_schema_extra(json_schema, json_schema_extra)
+        return json_schema
+
+    return json_schema_update_func
+
+
+def add_json_schema_extra(
+    json_schema: JsonSchemaValue, json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None
+):
+    if isinstance(json_schema_extra, dict):
+        json_schema.update(to_jsonable_python(json_schema_extra))
+    elif callable(json_schema_extra):
+        json_schema_extra(json_schema)
 
 
 class _CommonField(TypedDict):

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -963,6 +963,7 @@ class ComputedFieldInfo:
         title: Title of the computed field as in OpenAPI document, should be a short summary.
         description: Description of the computed field as in OpenAPI document.
         examples: Example values of the computed field as in OpenAPI document.
+        json_schema_extra: Dictionary of extra JSON schema properties.
         repr: A boolean indicating whether or not to include the field in the __repr__ output.
     """
 
@@ -974,6 +975,7 @@ class ComputedFieldInfo:
     title: str | None
     description: str | None
     examples: list[Any] | None
+    json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None
     repr: bool
 
 
@@ -990,6 +992,7 @@ def computed_field(
     title: str | None = None,
     description: str | None = None,
     examples: list[Any] | None = None,
+    json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None = None,
     repr: bool = True,
     return_type: Any = PydanticUndefined,
 ) -> typing.Callable[[PropertyT], PropertyT]:
@@ -1019,8 +1022,9 @@ def computed_field(
     alias: str | None = None,
     alias_priority: int | None = None,
     title: str | None = None,
-    examples: list[Any] | None = None,
     description: str | None = None,
+    examples: list[Any] | None = None,
+    json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None = None,
     repr: bool | None = None,
     return_type: Any = PydanticUndefined,
 ) -> PropertyT | typing.Callable[[PropertyT], PropertyT]:
@@ -1148,6 +1152,7 @@ def computed_field(
         description: Description to use when including this computed field in JSON Schema, defaults to the function's
             docstring
         examples: Example values to use when including this computed field in JSON Schema
+        json_schema_extra: Dictionary of extra JSON schema properties.
         repr: whether to include this computed field in model repr.
             Default is `False` for private properties and `True` for public properties.
         return_type: optional return for serialization logic to expect when serializing to JSON, if included
@@ -1174,7 +1179,9 @@ def computed_field(
         else:
             repr_ = repr
 
-        dec_info = ComputedFieldInfo(f, return_type, alias, alias_priority, title, description, examples, repr_)
+        dec_info = ComputedFieldInfo(
+            f, return_type, alias, alias_priority, title, description, examples, json_schema_extra, repr_
+        )
         return _decorators.PydanticDescriptorProxy(f, dec_info)
 
     if __f is None:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -962,6 +962,7 @@ class ComputedFieldInfo:
         alias_priority: priority of the alias. This affects whether an alias generator is used
         title: Title of the computed field as in OpenAPI document, should be a short summary.
         description: Description of the computed field as in OpenAPI document.
+        examples: Example values of the computed field as in OpenAPI document.
         repr: A boolean indicating whether or not to include the field in the __repr__ output.
     """
 
@@ -972,6 +973,7 @@ class ComputedFieldInfo:
     alias_priority: int | None
     title: str | None
     description: str | None
+    examples: list[Any] | None
     repr: bool
 
 
@@ -983,12 +985,13 @@ PropertyT = typing.TypeVar('PropertyT')
 @typing.overload
 def computed_field(
     *,
-    return_type: Any = PydanticUndefined,
     alias: str | None = None,
     alias_priority: int | None = None,
     title: str | None = None,
     description: str | None = None,
+    examples: list[Any] | None = None,
     repr: bool = True,
+    return_type: Any = PydanticUndefined,
 ) -> typing.Callable[[PropertyT], PropertyT]:
     ...
 
@@ -1016,6 +1019,7 @@ def computed_field(
     alias: str | None = None,
     alias_priority: int | None = None,
     title: str | None = None,
+    examples: list[Any] | None = None,
     description: str | None = None,
     repr: bool | None = None,
     return_type: Any = PydanticUndefined,
@@ -1140,9 +1144,10 @@ def computed_field(
         __f: the function to wrap.
         alias: alias to use when serializing this computed field, only used when `by_alias=True`
         alias_priority: priority of the alias. This affects whether an alias generator is used
-        title: Title to used when including this computed field in JSON Schema, currently unused waiting for #4697
-        description: Description to used when including this computed field in JSON Schema, defaults to the functions
-            docstring, currently unused waiting for #4697
+        title: Title to use when including this computed field in JSON Schema
+        description: Description to use when including this computed field in JSON Schema, defaults to the function's
+            docstring
+        examples: Example values to use when including this computed field in JSON Schema
         repr: whether to include this computed field in model repr.
             Default is `False` for private properties and `True` for public properties.
         return_type: optional return for serialization logic to expect when serializing to JSON, if included
@@ -1169,7 +1174,7 @@ def computed_field(
         else:
             repr_ = repr
 
-        dec_info = ComputedFieldInfo(f, return_type, alias, alias_priority, title, description, repr_)
+        dec_info = ComputedFieldInfo(f, return_type, alias, alias_priority, title, description, examples, repr_)
         return _decorators.PydanticDescriptorProxy(f, dec_info)
 
     if __f is None:

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -73,7 +73,7 @@ def test_computed_fields_json_schema():
             """An awesome area"""
             return self.width * self.length
 
-        @computed_field(title='Pikarea', description='Another area')
+        @computed_field(title='Pikarea', description='Another area', examples=[100, 200])
         @property
         def area2(self) -> int:
             return self.width * self.length
@@ -103,6 +103,7 @@ def test_computed_fields_json_schema():
             'area2': {
                 'title': 'Pikarea',
                 'description': 'Another area',
+                'examples': [100, 200],
                 'type': 'integer',
                 'readOnly': True,
             },

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -73,7 +73,12 @@ def test_computed_fields_json_schema():
             """An awesome area"""
             return self.width * self.length
 
-        @computed_field(title='Pikarea', description='Another area', examples=[100, 200])
+        @computed_field(
+            title='Pikarea',
+            description='Another area',
+            examples=[100, 200],
+            json_schema_extra={'foo': 42},
+        )
         @property
         def area2(self) -> int:
             return self.width * self.length
@@ -104,6 +109,7 @@ def test_computed_fields_json_schema():
                 'title': 'Pikarea',
                 'description': 'Another area',
                 'examples': [100, 200],
+                'foo': 42,
                 'type': 'integer',
                 'readOnly': True,
             },


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- Adds two parameters to `computed_field` with the same meanings as in `Field` to add info to the JSON schema. `examples` solves the primary user request, `json_schema_extra` was also mentioned in the issue comments.
- Updated some stale arg descriptions in the `computed_field` docstring,
- Factored out common code for handling `json_schema_extra` in `GenerateSchema`.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/7864

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex