### PR TITLE
Cleanup concepts/models(generic) example

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -620,11 +620,6 @@ from pydantic import BaseModel, ValidationError
 DataT = TypeVar('DataT')
 
 
-class Error(BaseModel):
-    code: int
-    message: str
-
-
 class DataModel(BaseModel):
     numbers: List[int]
     people: List[str]
@@ -635,7 +630,6 @@ class Response(BaseModel, Generic[DataT]):
 
 
 data = DataModel(numbers=[1, 2, 3], people=[])
-error = Error(code=404, message='Not found')
 
 print(Response[int](data=1))
 #> data=1


### PR DESCRIPTION
The example for Generic Models under concepts/models defines an `Error` model but makes no use of it. The example would look better without it, so it seems like a good idea to just remove it.

## Change Summary

Remove `Error` model from Generic Models example.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb