### PR TITLE
Document populate_by_name workaround issue

### DIFF
--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -195,8 +195,10 @@ print(user.model_dump(by_alias=True))  # (2)!
 
 
     user = User(name='johndoe')  # (1)!
+    user = User(username='johndoe')  # (2)!
     ```
-    1. Now VSCode will not show a warning
+    1. Now VSCode will not show a warning.
+    2. VSCode will show a warning here though.
 
     This is discussed in more detail in [this issue](https://github.com/pydantic/pydantic/issues/5893).
 


### PR DESCRIPTION
The workaround example for `populate_by_name` type checking breaks one way or the other: either it supports only field name or only field alias 😿 Tested with Pyright 1.1.333 (from Pylance)

Let's document it.

## Change Summary

Updates example to highlight the `populate_by_name` workaround still makes type checkers angry, except it now warns about using the alias.

## Related issue number

Related to #5893

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
