### PR TITLE
Drop `BaseModel.__slots__` to prevent lay-out conflicts with multiple inheritance

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -144,8 +144,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             code='base-model-instantiated',
         )
 
-    __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
-
     model_config = ConfigDict()
     __pydantic_complete__ = False
     __pydantic_root_model__ = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3085,3 +3085,12 @@ def test_shadow_attribute() -> None:
     assert getattr(One, 'foo', None) == ' edited!'
     assert getattr(Two, 'foo', None) == ' edited! edited!'
     assert getattr(Three, 'foo', None) == ' edited! edited!'
+
+
+def test_multiple_inheritance_with_slotful_model() -> None:
+    # No asserts required here: the `class` operator itself would fail.
+    # See also:
+    # - https://github.com/pydantic/pydantic/discussions/5770
+    # - https://github.com/pydantic/pydantic/issues/1875
+    class Child(BaseModel, Exception):
+        pass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR addresses #1875 and #5770, but also allows multiple inheritance from `BaseModel` with other slots-ful classes

As mentioned [here](https://github.com/pydantic/pydantic/issues/1875#issuecomment-752849476), the `BaseModel.__slots__` is the reason of the lay-out conflict. And as mentioned [here](https://github.com/pydantic/pydantic/discussions/5770#discussioncomment-7479874), it appears that the `__slots__` is a possible leftover from the distant past

## Related issue number

#1875 (already closed), and #5770 (discussion)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
