### PR TITLE
Allow str as argument to `Discriminator`

### DIFF
--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -597,8 +597,8 @@ print(user)
 ## Discriminator
 
 The parameter `discriminator` can be used to control the field that will be used to discriminate between different
-models in a union. It takes either the name of a field or a `CallableDiscriminator` instance. The `CallableDiscriminator`
-approach can be useful when the discriminator fields aren't the same for all of the models in the `Union`.
+models in a union. It takes either the name of a field or a `Discriminator` instance. The `Discriminator`
+approach can be useful when the discriminator fields aren't the same for all the models in the `Union`.
 
 The following example shows how to use `discriminator` with a field name:
 
@@ -628,14 +628,14 @@ print(Model.model_validate({'pet': {'pet_type': 'cat', 'age': 12}}))  # (1)!
 
 1. See more about [Helper Functions] in the [Models] page.
 
-The following example shows how to use `discriminator` with a `CallableDiscriminator` instance:
+The following example shows how to use the `discriminator` keyword argument with a `Discriminator` instance:
 
 ```py requires="3.8"
 from typing import Literal, Union
 
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, CallableDiscriminator, Field, Tag
+from pydantic import BaseModel, Discriminator, Field, Tag
 
 
 class Cat(BaseModel):
@@ -656,7 +656,7 @@ def pet_discriminator(v):
 
 class Model(BaseModel):
     pet: Union[Annotated[Cat, Tag('cat')], Annotated[Dog, Tag('dog')]] = Field(
-        discriminator=CallableDiscriminator(pet_discriminator)
+        discriminator=Discriminator(pet_discriminator)
     )
 
 

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -184,17 +184,18 @@ except ValidationError as e:
     """
 ```
 
-### Discriminated Unions with `CallableDiscriminator` discriminators
+### Discriminated Unions with callable `Discriminator`s
 
 In the case of a `Union` with multiple models, sometimes there isn't a single uniform field
-across all models that you can use as a discriminator. This is the perfect use case for the `CallableDiscriminator` approach.
+across all models that you can use as a discriminator.
+This is the perfect use case for a callable `Discriminator`.
 
 ```py requires="3.8"
 from typing import Any, Literal, Union
 
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, CallableDiscriminator, Tag
+from pydantic import BaseModel, Discriminator, Tag
 
 
 class Pie(BaseModel):
@@ -222,7 +223,7 @@ class ThanksgivingDinner(BaseModel):
             Annotated[ApplePie, Tag('apple')],
             Annotated[PumpkinPie, Tag('pumpkin')],
         ],
-        CallableDiscriminator(get_discriminator_value),
+        Discriminator(get_discriminator_value),
     ]
 
 
@@ -249,7 +250,7 @@ ThanksgivingDinner(dessert=PumpkinPie(time_to_cook=40, num_ingredients=6, fillin
 """
 ```
 
-`CallableDiscriminators` can also be used to validate `Union` types with combinations of models and primitive types.
+`Discriminator`s can also be used to validate `Union` types with combinations of models and primitive types.
 
 For example:
 
@@ -258,7 +259,7 @@ from typing import Any, Union
 
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, CallableDiscriminator, Tag
+from pydantic import BaseModel, Discriminator, Tag
 
 
 def model_x_discriminator(v: Any) -> str:
@@ -274,7 +275,7 @@ class DiscriminatedModel(BaseModel):
             Annotated[str, Tag('str')],
             Annotated['DiscriminatedModel', Tag('model')],
         ],
-        CallableDiscriminator(
+        Discriminator(
             model_x_discriminator,
             custom_error_type='invalid_union_member',
             custom_error_message='Invalid union member',
@@ -303,11 +304,11 @@ assert m.model_dump() == data
     some_field: Annotated[Union[...], Field(discriminator='my_discriminator')]
     ```
 
-    For `CallableDiscriminator` discriminators:
+    For callable `Discriminator`s:
     ```
-    some_field: Union[...] = Field(discriminator=CallableDiscriminator(...))
-    some_field: Annotated[Union[...], CallableDiscriminator(...)]
-    some_field: Annotated[Union[...], Field(discriminator=CallableDiscriminator(...))]
+    some_field: Union[...] = Field(discriminator=Discriminator(...))
+    some_field: Annotated[Union[...], Discriminator(...)]
+    some_field: Annotated[Union[...], Field(discriminator=Discriminator(...))]
     ```
 
 !!! warning
@@ -390,7 +391,7 @@ from typing import Union
 
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, CallableDiscriminator, Tag, ValidationError
+from pydantic import BaseModel, Discriminator, Tag, ValidationError
 
 
 # Errors are quite verbose with a normal Union:
@@ -474,7 +475,7 @@ class DiscriminatedModel(BaseModel):
             Annotated[str, Tag('str')],
             Annotated['DiscriminatedModel', Tag('model')],
         ],
-        CallableDiscriminator(
+        Discriminator(
             model_x_discriminator,
             custom_error_type='invalid_union_member',
             custom_error_message='Invalid union member',

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -367,14 +367,14 @@ assert Model(pet={'pet_type': 'kitten'}).pet.pet_type == 'cat'
 
 ## Callable discriminator case with no tag {#callable-discriminator-no-tag}
 
-This error is raised when a `Union` that uses a `CallableDiscriminator` doesn't have `Tag` annotations for all cases.
+This error is raised when a `Union` that uses a callable `Discriminator` doesn't have `Tag` annotations for all cases.
 
 ```py
 from typing import Union
 
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, CallableDiscriminator, PydanticUserError, Tag
+from pydantic import BaseModel, Discriminator, PydanticUserError, Tag
 
 
 def model_x_discriminator(v):
@@ -390,7 +390,7 @@ try:
     class DiscriminatedModel(BaseModel):
         x: Annotated[
             Union[str, 'DiscriminatedModel'],
-            CallableDiscriminator(model_x_discriminator),
+            Discriminator(model_x_discriminator),
         ]
 
 except PydanticUserError as exc_info:
@@ -402,7 +402,7 @@ try:
     class DiscriminatedModel(BaseModel):
         x: Annotated[
             Union[Annotated[str, Tag('str')], 'DiscriminatedModel'],
-            CallableDiscriminator(model_x_discriminator),
+            Discriminator(model_x_discriminator),
         ]
 
 except PydanticUserError as exc_info:
@@ -414,7 +414,7 @@ try:
     class DiscriminatedModel(BaseModel):
         x: Annotated[
             Union[str, Annotated['DiscriminatedModel', Tag('model')]],
-            CallableDiscriminator(model_x_discriminator),
+            Discriminator(model_x_discriminator),
         ]
 
 except PydanticUserError as exc_info:

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -182,7 +182,7 @@ __all__ = (
     'Base64UrlStr',
     'GetPydanticSchema',
     'Tag',
-    'CallableDiscriminator',
+    'Discriminator',
     'JsonValue',
     # type_adapter
     'TypeAdapter',
@@ -324,7 +324,7 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'Base64UrlStr': (__package__, '.types'),
     'GetPydanticSchema': (__package__, '.types'),
     'Tag': (__package__, '.types'),
-    'CallableDiscriminator': (__package__, '.types'),
+    'Discriminator': (__package__, '.types'),
     'JsonValue': (__package__, '.types'),
     # type_adapter
     'TypeAdapter': (__package__, '.type_adapter'),

--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -14,7 +14,7 @@ from ._core_utils import (
 )
 
 if TYPE_CHECKING:
-    from ..types import CallableDiscriminator
+    from ..types import Discriminator
 
 CORE_SCHEMA_METADATA_DISCRIMINATOR_PLACEHOLDER_KEY = 'pydantic.internal.union_discriminator'
 
@@ -62,7 +62,7 @@ def apply_discriminators(schema: core_schema.CoreSchema) -> core_schema.CoreSche
 
 def apply_discriminator(
     schema: core_schema.CoreSchema,
-    discriminator: str | CallableDiscriminator,
+    discriminator: str | Discriminator,
     definitions: dict[str, core_schema.CoreSchema] | None = None,
 ) -> core_schema.CoreSchema:
     """Applies the discriminator and returns a new core schema.
@@ -88,10 +88,13 @@ def apply_discriminator(
             - If discriminator fields have different aliases.
             - If discriminator field not of type `Literal`.
     """
-    from ..types import CallableDiscriminator
+    from ..types import Discriminator
 
-    if isinstance(discriminator, CallableDiscriminator):
-        return discriminator._convert_schema(schema)
+    if isinstance(discriminator, Discriminator):
+        if isinstance(discriminator.discriminator, str):
+            discriminator = discriminator.discriminator
+        else:
+            return discriminator._convert_schema(schema)
 
     return _ApplyInferredDiscriminator(discriminator, definitions or {}).apply(schema)
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -82,7 +82,7 @@ from ._utils import is_valid_identifier, lenient_issubclass
 if TYPE_CHECKING:
     from ..fields import ComputedFieldInfo, FieldInfo
     from ..main import BaseModel
-    from ..types import CallableDiscriminator
+    from ..types import Discriminator
     from ..validators import FieldValidatorModes
     from ._dataclasses import StandardDataclass
     from ._schema_generation_shared import GetJsonSchemaFunction
@@ -374,7 +374,7 @@ class GenerateSchema:
         )
 
     def _apply_discriminator_to_union(
-        self, schema: CoreSchema, discriminator: str | CallableDiscriminator | None
+        self, schema: CoreSchema, discriminator: str | Discriminator | None
     ) -> CoreSchema:
         if discriminator is None:
             return schema

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -64,7 +64,7 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
     max_digits: int | None
     decimal_places: int | None
     union_mode: Literal['smart', 'left_to_right'] | None
-    discriminator: str | types.CallableDiscriminator | None
+    discriminator: str | types.Discriminator | None
     json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None
     frozen: bool | None
     validate_default: bool | None
@@ -101,7 +101,7 @@ class FieldInfo(_repr.Representation):
         description: The description of the field.
         examples: List of examples of the field.
         exclude: Whether to exclude the field from the model serialization.
-        discriminator: Field name or CallableDiscriminator for discriminating the type in a tagged union.
+        discriminator: Field name or Discriminator for discriminating the type in a tagged union.
         json_schema_extra: Dictionary of extra JSON schema properties.
         frozen: Whether the field is frozen.
         validate_default: Whether to validate the default value of the field.
@@ -122,7 +122,7 @@ class FieldInfo(_repr.Representation):
     description: str | None
     examples: list[Any] | None
     exclude: bool | None
-    discriminator: str | types.CallableDiscriminator | None
+    discriminator: str | types.Discriminator | None
     json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None
     frozen: bool | None
     validate_default: bool | None
@@ -682,7 +682,7 @@ def Field(  # noqa: C901
     description: str | None = _Unset,
     examples: list[Any] | None = _Unset,
     exclude: bool | None = _Unset,
-    discriminator: str | types.CallableDiscriminator | None = _Unset,
+    discriminator: str | types.Discriminator | None = _Unset,
     json_schema_extra: JsonDict | typing.Callable[[JsonDict], None] | None = _Unset,
     frozen: bool | None = _Unset,
     validate_default: bool | None = _Unset,
@@ -727,7 +727,7 @@ def Field(  # noqa: C901
         description: Human-readable description.
         examples: Example values for this field.
         exclude: Whether to exclude the field from the model serialization.
-        discriminator: Field name or CallableDiscriminator for discriminating the type in a tagged union.
+        discriminator: Field name or Discriminator for discriminating the type in a tagged union.
         json_schema_extra: Any additional JSON schema data for the schema property.
         frozen: Whether the field is frozen.
         validate_default: Run validation that isn't only checking existence of defaults. This can be set to `True` or `False`. If not set, it defaults to `None`.

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -102,7 +102,7 @@ __all__ = (
     'GetPydanticSchema',
     'StringConstraints',
     'Tag',
-    'CallableDiscriminator',
+    'Discriminator',
     'JsonValue',
 )
 
@@ -2443,16 +2443,16 @@ class GetPydanticSchema:
 
 @_dataclasses.dataclass(**_internal_dataclass.slots_true, frozen=True)
 class Tag:
-    """Provides a way to specify the expected tag to use for a case with a callable discriminated union.
+    """Provides a way to specify the expected tag to use for a case of a (callable) discriminated union.
 
     Also provides a way to label a union case in error messages.
 
-    When using a `CallableDiscriminator`, attach a `Tag` to each case in the `Union` to specify the tag that
+    When using a callable `Discriminator`, attach a `Tag` to each case in the `Union` to specify the tag that
     should be used to identify that case. For example, in the below example, the `Tag` is used to specify that
     if `get_discriminator_value` returns `'apple'`, the input should be validated as an `ApplePie`, and if it
     returns `'pumpkin'`, the input should be validated as a `PumpkinPie`.
 
-    The primary role of the `Tag` here is to map the return value from the `CallableDiscriminator` function to
+    The primary role of the `Tag` here is to map the return value from the callable `Discriminator` function to
     the appropriate member of the `Union` in question.
 
     ```py
@@ -2460,7 +2460,7 @@ class Tag:
 
     from typing_extensions import Annotated, Literal
 
-    from pydantic import BaseModel, CallableDiscriminator, Tag
+    from pydantic import BaseModel, Discriminator, Tag
 
     class Pie(BaseModel):
         time_to_cook: int
@@ -2483,7 +2483,7 @@ class Tag:
                 Annotated[ApplePie, Tag('apple')],
                 Annotated[PumpkinPie, Tag('pumpkin')],
             ],
-            CallableDiscriminator(get_discriminator_value),
+            Discriminator(get_discriminator_value),
         ]
 
     apple_variation = ThanksgivingDinner.model_validate(
@@ -2510,8 +2510,8 @@ class Tag:
     ```
 
     !!! note
-        You must specify a `Tag` for every case in a `Union` that is associated with a `CallableDiscriminator`.
-        Failing to do so will result in a `PydanticUserError` with code
+        You must specify a `Tag` for every case in a `Union` that is associated with a
+        callable `Discriminator`. Failing to do so will result in a `PydanticUserError` with code
         [`callable-discriminator-no-tag`](../errors/usage_errors.md#callable-discriminator-no-tag).
 
     See the [Discriminated Unions](../concepts/unions.md#discriminated-unions)
@@ -2529,7 +2529,7 @@ class Tag:
 
 
 @_dataclasses.dataclass(**_internal_dataclass.slots_true, frozen=True)
-class CallableDiscriminator:
+class Discriminator:
     """Provides a way to use a custom callable as the way to extract the value of a union discriminator.
 
     This allows you to get validation behavior like you'd get from `Field(discriminator=<field_name>)`,
@@ -2538,7 +2538,7 @@ class CallableDiscriminator:
     Finally, this allows you to use a custom callable as the way to identify which member of a union a value
     belongs to, while still seeing all the performance benefits of a discriminated union.
 
-    Consider this example, which is much more performant with the use of `CallableDiscriminator` and thus a `TaggedUnion`
+    Consider this example, which is much more performant with the use of `Discriminator` and thus a `TaggedUnion`
     than it would be as a normal `Union`.
 
     ```py
@@ -2546,7 +2546,7 @@ class CallableDiscriminator:
 
     from typing_extensions import Annotated, Literal
 
-    from pydantic import BaseModel, CallableDiscriminator, Tag
+    from pydantic import BaseModel, Discriminator, Tag
 
     class Pie(BaseModel):
         time_to_cook: int
@@ -2569,7 +2569,7 @@ class CallableDiscriminator:
                 Annotated[ApplePie, Tag('apple')],
                 Annotated[PumpkinPie, Tag('pumpkin')],
             ],
-            CallableDiscriminator(get_discriminator_value),
+            Discriminator(get_discriminator_value),
         ]
 
     apple_variation = ThanksgivingDinner.model_validate(
@@ -2596,10 +2596,10 @@ class CallableDiscriminator:
     ```
 
     See the [Discriminated Unions](../concepts/unions.md#discriminated-unions)
-    docs for more details on how to use `CallableDiscriminator`s.
+    docs for more details on how to use `Discriminator`s.
     """
 
-    discriminator: Callable[[Any], Hashable]
+    discriminator: str | Callable[[Any], Hashable]
     custom_error_type: str | None = None
     custom_error_message: str | None = None
     custom_error_context: dict[str, int | str | float] | None = None
@@ -2609,8 +2609,13 @@ class CallableDiscriminator:
         if not origin or not _typing_extra.origin_is_union(origin):
             raise TypeError(f'{type(self).__name__} must be used with a Union type, not {source_type}')
 
-        original_schema = handler.generate_schema(source_type)
-        return self._convert_schema(original_schema)
+        if isinstance(self.discriminator, str):
+            from pydantic import Field
+
+            return handler(Annotated[source_type, Field(discriminator=self.discriminator)])
+        else:
+            original_schema = handler(source_type)
+            return self._convert_schema(original_schema)
 
     def _convert_schema(self, original_schema: core_schema.CoreSchema) -> core_schema.TaggedUnionSchema:
         if original_schema['type'] != 'union':
@@ -2632,7 +2637,7 @@ class CallableDiscriminator:
                     tag = metadata_tag
             if tag is None:
                 raise PydanticUserError(
-                    f'`Tag` not provided for choice {choice} used with `CallableDiscriminator`',
+                    f'`Tag` not provided for choice {choice} used with `Discriminator`',
                     code='callable-discriminator-no-tag',
                 )
             tagged_union_choices[tag] = choice
@@ -2762,7 +2767,7 @@ else:
                 Annotated[bool, Tag('bool')],
                 Annotated[None, Tag('NoneType')],
             ],
-            CallableDiscriminator(
+            Discriminator(
                 _get_type_name,
                 custom_error_type='invalid-json-value',
                 custom_error_message='input was not a valid JSON value',


### PR DESCRIPTION
(Also renamed `CallableDiscriminator` to `Discriminator`.)

As discussed @sydney-runkle 