### PR TITLE
Fix misbehavior for models referencing redefined type aliases

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -100,7 +100,7 @@ def get_type_ref(type_: type[Any], args_override: tuple[type[Any], ...] | None =
 
     module_name = getattr(origin, '__module__', '<No __module__>')
     if isinstance(origin, TypeAliasType):
-        type_ref = f'{module_name}.{origin.__name__}'
+        type_ref = f'{module_name}.{origin.__name__}:{id(origin)}'
     else:
         try:
             qualname = getattr(origin, '__qualname__', f'<No __qualname__: {origin}>')

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -337,3 +337,19 @@ def test_nested_generic_type_alias_type() -> None:
 
 def test_non_specified_generic_type_alias_type() -> None:
     assert TypeAdapter(MyList).json_schema() == {'items': {}, 'type': 'array'}
+
+
+def test_redefined_type_alias():
+    MyType = TypeAliasType('MyType', str)
+
+    class MyInnerModel(BaseModel):
+        x: MyType
+
+    MyType = TypeAliasType('MyType', int)
+
+    class MyOuterModel(BaseModel):
+        inner: MyInnerModel
+        y: MyType
+
+    data = {'inner': {'x': 'hello'}, 'y': 1}
+    assert MyOuterModel.model_validate(data).model_dump() == data


### PR DESCRIPTION
This fixes some rare edge cases, e.g., if redefining a type alias over the course of a module, with some model including references to multiple reassignments of the alias. (See the added test for an example.)