### PR TITLE
Fix custom type type casting used in multiple attributes

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -52,6 +52,7 @@ from ._core_utils import (
     define_expected_missing_refs,
     get_ref,
     get_type_ref,
+    is_function_with_inner_schema,
     is_list_like_schema_with_items_schema,
     simplify_schema_references,
     validate_core_schema,
@@ -619,7 +620,13 @@ class GenerateSchema:
 
         schema = self._unpack_refs_defs(schema)
 
-        ref = get_ref(schema)
+        if is_function_with_inner_schema(schema):
+            ref = schema['schema'].pop('ref', None)
+            if ref:
+                schema['ref'] = ref
+        else:
+            ref = get_ref(schema)
+
         if ref:
             self.defs.definitions[ref] = self._post_process_generated_schema(schema)
             return core_schema.definition_reference_schema(ref)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -33,10 +33,11 @@ from uuid import UUID
 import pytest
 from dirty_equals import HasRepr
 from pydantic_core import CoreSchema, SchemaValidator, core_schema, to_json
-from typing_extensions import Annotated, Literal, TypedDict
+from typing_extensions import Annotated, Literal, Self, TypedDict
 
 import pydantic
 from pydantic import (
+    AfterValidator,
     BaseModel,
     Field,
     GetCoreSchemaHandler,
@@ -5779,3 +5780,35 @@ class Foo(BaseModel):
             }
         }
     }
+
+
+def test_repeated_custom_type():
+    class Numeric(pydantic.BaseModel):
+        value: float
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: pydantic.GetCoreSchemaHandler) -> CoreSchema:
+            return core_schema.no_info_before_validator_function(cls.validate, handler(source_type))
+
+        @classmethod
+        def validate(cls, v: Any) -> Union[Dict[str, Any], Self]:
+            if isinstance(v, (str, float, int)):
+                return cls(value=v)
+            if isinstance(v, Numeric):
+                return v
+            if isinstance(v, dict):
+                return v
+            raise ValueError(f'Invalid value for {cls}: {v}')
+
+    def is_positive(value: Numeric):
+        assert value.value > 0.0, 'Must be positive'
+
+    class OuterModel(pydantic.BaseModel):
+        x: Numeric
+        y: Numeric
+        z: Annotated[Numeric, AfterValidator(is_positive)]
+
+    assert OuterModel(x=2, y=-1, z=1)
+
+    with pytest.raises(ValidationError):
+        OuterModel(x=2, y=-1, z=-1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

When a custom type with `__get_pydantic_core_schema__` is used in another BaseModel, it generates a function schema with the custom type defined as an inner schema. However only the inner schema is stored, and thus subsequent usage of the same custom type in another field would result in only the inner schema being used, and the custom validation is not used.

The proposed solution here is that the ref should be linked to the function schema, not the inner schema.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #7102

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt