### PR TITLE
Use positional-only `self` in `BaseModel` constructor, so no field name can ever conflict with it.

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -726,10 +726,10 @@ def init_context(value: Dict[str, Any]) -> Iterator[None]:
 class Model(BaseModel):
     my_number: int
 
-    def __init__(__pydantic_self__, **data: Any) -> None:
-        __pydantic_self__.__pydantic_validator__.validate_python(
+    def __init__(self, /, **data: Any) -> None:
+        self.__pydantic_validator__.validate_python(
             data,
-            self_instance=__pydantic_self__,
+            self_instance=self,
             context=_init_context_var.get(),
         )
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2187,7 +2187,7 @@ def generate_pydantic_signature(
         # Make sure the parameter for extra kwargs
         # does not have the same name as a field
         default_model_signature = [
-            ('__pydantic_self__', Parameter.POSITIONAL_OR_KEYWORD),
+            ('self', Parameter.POSITIONAL_ONLY),
             ('data', Parameter.VAR_KEYWORD),
         ]
         if [(p.name, p.kind) for p in present_params] == default_model_signature:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -150,18 +150,17 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     __pydantic_complete__ = False
     __pydantic_root_model__ = False
 
-    def __init__(__pydantic_self__, **data: Any) -> None:  # type: ignore
+    def __init__(self, /, **data: Any) -> None:  # type: ignore
         """Create a new model by parsing and validating input data from keyword arguments.
 
         Raises [`ValidationError`][pydantic_core.ValidationError] if the input data cannot be
         validated to form a valid model.
 
-        `__init__` uses `__pydantic_self__` instead of the more common `self` for the first arg to
-        allow `self` as a field name.
+        `self` is explicitly positional-only to allow `self` as a field name.
         """
         # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
         __tracebackhide__ = True
-        __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
+        self.__pydantic_validator__.validate_python(data, self_instance=self)
 
     # The following line sets a flag that we use to determine when `__init__` gets overridden by the user
     __init__.__pydantic_base_init__ = True

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -1148,6 +1148,16 @@ def add_method(
         first = [Argument(Var('_cls'), self_type, None, ARG_POS, True)]
     else:
         self_type = self_type or fill_typevars(info)
+        # `self` is positional *ONLY* here, but this can't be expressed
+        # fully in the mypy internal API. ARG_POS is the closest we can get.
+        # Using ARG_POS will, however, give mypy errors if a `self` field
+        # is present on a model:
+        #
+        #     Name "self" already defined (possibly by an import)  [no-redef]
+        #
+        # As a workaround, we give this argument a name that will
+        # never conflict. By its positional nature, this name will not
+        # be used or exposed to users.
         first = [Argument(Var('__pydantic_self__'), self_type, None, ARG_POS)]
     args = first + args
 

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -52,7 +52,7 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType]):
             )
         super().__init_subclass__(**kwargs)
 
-    def __init__(__pydantic_self__, root: RootModelRootType = PydanticUndefined, **data) -> None:  # type: ignore
+    def __init__(self, /, root: RootModelRootType = PydanticUndefined, **data) -> None:  # type: ignore
         __tracebackhide__ = True
         if data:
             if root is not PydanticUndefined:
@@ -60,7 +60,7 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType]):
                     '"RootModel.__init__" accepts either a single positional argument or arbitrary keyword arguments'
                 )
             root = data  # type: ignore
-        __pydantic_self__.__pydantic_validator__.validate_python(root, self_instance=__pydantic_self__)
+        self.__pydantic_validator__.validate_python(root, self_instance=self)
 
     __init__.__pydantic_base_init__ = True
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1296,6 +1296,14 @@ def test_self():
     }
 
 
+def test_no_name_conflict_in_constructor():
+    class Model(BaseModel):
+        self: int
+
+    m = Model(**{'__pydantic_self__': 4, 'self': 2})
+    assert m.self == 2
+
+
 def test_self_recursive():
     class SubModel(BaseModel):
         self: int


### PR DESCRIPTION
## Change Summary

As discussed in #7948, there is an edge case in the `BaseModel` constructor where using `__pydantic_self__` would give a `TypeError` instead of an expected `ValidationError`. This edge case can be solved by using positional-only arguments — as soon as Python 3.7 support is dropped (see  #7188)

## Related issue number

Fixes #7948 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## Notes

- I didn't make the changes for the `v1` module. I assume you'd rather not make any changes to it, right?
- CI for Python 3.7 will fail until support is officially dropped. Then, I'll rebase the changes and it'll be ready for review.


Selected Reviewer: @lig