### PR TITLE
Add deprecation warning + make `mkdocs build` strict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ clean:
 
 .PHONY: docs  ## Generate the docs
 docs:
-	pdm run mkdocs build
+	pdm run mkdocs build --strict
 
 .PHONY: help  ## Display this message
 help:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,12 @@ extra:
   version:
     provider: mike
 
+# https://www.mkdocs.org/user-guide/configuration/#validation
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+
 extra_css:
   - 'extra/terminal.css'
   - 'extra/tweaks.css'

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -843,6 +843,9 @@ def conlist(
         min_length: The minimum length of the list. Defaults to None.
         max_length: The maximum length of the list. Defaults to None.
         unique_items: Whether the items in the list must be unique. Defaults to None.
+            !!! warning Deprecated
+                The `unique_items` parameter is deprecated, use `Set` instead.
+                See [this issue](https://github.com/pydantic/pydantic-core/issues/296) for more details.
 
     Returns:
         The wrapped list type.


### PR DESCRIPTION
## Change Summary

Add deprecation warning for deprecated `unique_items` field + make `mkdocs build` strict.

## Related issue number

Fix #8076

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
