### PR TITLE
Correct Documentation Regarding Parsing Datetime Objects From Strings

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -58,7 +58,7 @@ types:
     * `int` or `float`; assumed as Unix time, i.e. seconds (if >= `-2e10` and <= `2e10`) or milliseconds
       (if < `-2e10`or > `2e10`) since 1 January 1970
     * `str`; the following formats are accepted:
-        * `YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]`
+        * `str` in a format pareseable by `datetime.datetime.fromisoformat`
         * `int` or `float` as a string (assumed as Unix time)
 
 ```py


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Changing documentation of `datetime.datetime` parsing to indicate that acceptable string values are only those supported by `datetime.datetime.fromisoformat`.

The current documentation says that a datetime can be in a string formatted like this (i.e. ISO-8601):
`YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]`

But in reality, Pydantic relies on the python standard library `datetime.datetime.fromisoformat` in order to convert non-`int`/`float` strings into `datetime.datetime` objects. 

It seems like a trivial difference, but the behavior of `datetime.datetime.fromisoformat` changed in Python v3.11 to be more permissive and to support, among other things, the trailing `Z` to indicate UTC time. Earlier versions of Python **do not support** this format. Until Pydantic deprecates support for Python versions below 3.11, this change is necessary to prevent a "gotcha" that I ran into when trying to convert datetimes from strings and then ran tests on Python v3.10.

As an additional consideration, you may want to include putting into the docs a preferred practice for converting non-standard datetime formats. For example, a highly generic way do it it would be like this:

```python
from typing_extensions import Annotated
import datetime
from dateutil.parser import parse as parse_dt

from pydantic import BeforeValidator

ParseDateTime = Annotated(datetime.datetime, BeforeValidator(lambda x: parse_dt(x)))
```

since `dateutil.parser.parse` supports a very wide array of formats, this should work for most formats. Another way to ensure Pydantic handles ISO-8601 datetime strings for all python versions would be to check Python versions, and if it is below 3.11, use `dateutil.parser.isoparse`, which supports ISO-8601 strings. But that would add a Pydantic dependency.

## Related issue number

No related issue

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [X] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb