### PR TITLE
Move the package description limit in HISTORY.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -521,6 +521,8 @@ First pre-release of Pydantic V2!
 
 See [this post](https://docs.pydantic.dev/blog/pydantic-v2-alpha/) for more details.
 
+<!-- package description limit -->
+
 ## v1.10.13 (2023-09-27)
 
 * Fix: Add max length check to `pydantic.validate_email`, #7673 by @hramezani
@@ -1342,8 +1344,6 @@ Thank you to pydantic's sponsors: @matin, @tiangolo, @chdsbd, @jorgecarleitao, a
 * Only check `TypeVar` param on base `GenericModel` class, [#842](https://github.com/pydantic/pydantic/pull/842) by @zpencerq
 * rename `Model._schema_cache` -> `Model.__schema_cache__`, `Model._json_encoder` -> `Model.__json_encoder__`,
   `Model._custom_root_type` -> `Model.__custom_root_type__`, [#851](https://github.com/pydantic/pydantic/pull/851) by @samuelcolvin
-
-<!-- package description limit -->
 
 ## v0.32.2 (2019-08-17)
 


### PR DESCRIPTION
(Hopefully?) closes https://github.com/pydantic/pydantic/issues/8096

The package description limit used to be placed at the last commit before the first v1 beta release, seems reasonable to me to move that to the last commit before the first v2 alpha release.

Seems to be kind of a bandaid, as ideally we'd have a way to fail in CI if the description gets too long, but this seems like a reasonable short term solution. (Though at the current rate of bugfixes/etc. it probably won't last as long as the last update did.)

I'm not sure how to tell how many bytes the description would be after trimming at the package description limit, because the markdown file itself is smaller than the error number I saw in #8096, but probably there is some way to get a proxy that's close enough. But, assuming this works, I think we should just merge this unless someone can put together a better solution in time for a 2.5.1 release.