### PR TITLE
refactor: use pre 3.10 style annotations for ConfigDict

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -6,6 +6,11 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+    Union,
     cast,
 )
 
@@ -30,6 +35,7 @@ if TYPE_CHECKING:
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
 
 
+# ruff: noqa: UP006,UP007
 class ConfigWrapper:
     """Internal wrapper for Config which exposes ConfigDict items as attributes."""
 
@@ -39,13 +45,13 @@ class ConfigWrapper:
 
     # all annotations are copied directly from ConfigDict, and should be kept up to date, a test will fail if they
     # stop matching
-    title: str | None
+    title: Optional[str]
     str_to_lower: bool
     str_to_upper: bool
     str_strip_whitespace: bool
     str_min_length: int
-    str_max_length: int | None
-    extra: ExtraValues | None
+    str_max_length: Optional[int]
+    extra: Optional[ExtraValues]
     frozen: bool
     populate_by_name: bool
     use_enum_values: bool
@@ -55,11 +61,11 @@ class ConfigWrapper:
     # whether to use the actual key provided in the data (e.g. alias or first alias for "field required" errors) instead of field_names
     # to construct error `loc`s, default `True`
     loc_by_alias: bool
-    alias_generator: Callable[[str], str] | None
-    ignored_types: tuple[type, ...]
+    alias_generator: Optional[Callable[[str], str]]
+    ignored_types: Tuple[Type[Any], ...]
     allow_inf_nan: bool
-    json_schema_extra: JsonDict | JsonSchemaExtraCallable | None
-    json_encoders: dict[type[object], JsonEncoder] | None
+    json_schema_extra: Optional[Union[JsonDict, JsonSchemaExtraCallable]]
+    json_encoders: Optional[Dict[Type[Any], JsonEncoder]]
 
     # new in V2
     strict: bool
@@ -70,11 +76,11 @@ class ConfigWrapper:
     # whether to validate default values during validation, default False
     validate_default: bool
     validate_return: bool
-    protected_namespaces: tuple[str, ...]
+    protected_namespaces: Tuple[str, ...]
     hide_input_in_errors: bool
     defer_build: bool
-    plugin_settings: dict[str, object] | None
-    schema_generator: type[GenerateSchema] | None
+    plugin_settings: Optional[Dict[str, object]]
+    schema_generator: Optional[Type[GenerateSchema]]
     json_schema_serialization_defaults_required: bool
     json_schema_mode_override: Literal['validation', 'serialization', None]
     coerce_numbers_to_str: bool

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,7 +1,7 @@
 """Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from typing_extensions import Literal, TypeAlias, TypedDict
 
@@ -26,10 +26,11 @@ JsonSchemaExtraCallable: TypeAlias = Union[
 ExtraValues = Literal['allow', 'ignore', 'forbid']
 
 
+# ruff: noqa: UP006,UP007
 class ConfigDict(TypedDict, total=False):
     """A TypedDict for configuring Pydantic behaviour."""
 
-    title: str | None
+    title: Optional[str]
     """The title for the generated JSON schema, defaults to the model's name"""
 
     str_to_lower: bool
@@ -43,10 +44,10 @@ class ConfigDict(TypedDict, total=False):
     str_min_length: int
     """The minimum length for str types. Defaults to `None`."""
 
-    str_max_length: int | None
+    str_max_length: Optional[int]
     """The maximum length for str types. Defaults to `None`."""
 
-    extra: ExtraValues | None
+    extra: Optional[ExtraValues]
     """
     Whether to ignore, allow, or forbid extra attributes during model initialization. Defaults to `'ignore'`.
 
@@ -315,7 +316,7 @@ class ConfigDict(TypedDict, total=False):
     loc_by_alias: bool
     """Whether to use the actual key provided in the data (e.g. alias) for error `loc`s rather than the field's name. Defaults to `True`."""
 
-    alias_generator: Callable[[str], str] | None
+    alias_generator: Optional[Callable[[str], str]]
     """
     A callable that takes a field name and returns an alias for it.
 
@@ -344,7 +345,7 @@ class ConfigDict(TypedDict, total=False):
         [`to_camel`][pydantic.alias_generators.to_camel], and [`to_snake`][pydantic.alias_generators.to_snake].
     """
 
-    ignored_types: tuple[type, ...]
+    ignored_types: Tuple[Type[Any], ...]
     """A tuple of types that may occur as values of class attributes without annotations. This is
     typically used for custom descriptors (classes that behave like `property`). If an attribute is set on a
     class without an annotation and has a type that is not in this tuple (or otherwise recognized by
@@ -354,10 +355,10 @@ class ConfigDict(TypedDict, total=False):
     allow_inf_nan: bool
     """Whether to allow infinity (`+inf` an `-inf`) and NaN values to float fields. Defaults to `True`."""
 
-    json_schema_extra: JsonDict | JsonSchemaExtraCallable | None
+    json_schema_extra: Optional[Union[JsonDict, JsonSchemaExtraCallable]]
     """A dict or callable to provide extra JSON schema properties. Defaults to `None`."""
 
-    json_encoders: dict[type[object], JsonEncoder] | None
+    json_encoders: Optional[Dict[Type[Any], JsonEncoder]]
     """
     A `dict` of custom JSON encoders for specific types. Defaults to `None`.
 
@@ -547,7 +548,7 @@ class ConfigDict(TypedDict, total=False):
     validate_return: bool
     """whether to validate the return value from call validators. Defaults to `False`."""
 
-    protected_namespaces: tuple[str, ...]
+    protected_namespaces: Tuple[str, ...]
     """
     A `tuple` of strings that prevent model to have field which conflict with them.
     Defaults to `('model_', )`).
@@ -676,13 +677,13 @@ class ConfigDict(TypedDict, total=False):
     [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild]. Defaults to False.
     """
 
-    plugin_settings: dict[str, object] | None
+    plugin_settings: Optional[Dict[str, object]]
     """A `dict` of settings for plugins. Defaults to `None`.
 
     See [Pydantic Plugins](../concepts/plugins.md) for details.
     """
 
-    schema_generator: type[_GenerateSchema] | None
+    schema_generator: Optional[Type[_GenerateSchema]]
     """
     A custom core schema generator class to use when generating JSON schemas.
     Useful if you want to change the way types are validated across an entire model/schema. Defaults to `None`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Rewrite `pydantic.ConfigDict` with pre 3.10 style annotations (e.g using `typing.Union` instead of `|`)

## Related issue number

Fixes #8134 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle