### PR TITLE
Fix mypy error on untyped ClassVar

### DIFF
--- a/tests/mypy/modules/success.py
+++ b/tests/mypy/modules/success.py
@@ -6,7 +6,7 @@ Do a little skipping about with types to demonstrate its usage.
 import os
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path, PurePath
-from typing import Any, Dict, ForwardRef, Generic, List, Optional, Type, TypeVar
+from typing import Any, ClassVar, Dict, ForwardRef, Generic, List, Optional, Type, TypeVar
 from uuid import UUID
 
 from typing_extensions import Annotated, TypedDict
@@ -300,3 +300,11 @@ def double(value: Any, handler: Any) -> int:
 
 class WrapValidatorModel(BaseModel):
     x: Annotated[int, WrapValidator(double)]
+
+
+class Abstract(BaseModel):
+    class_id: ClassVar
+
+
+class Concrete(Abstract):
+    class_id = 1

--- a/tests/mypy/outputs/1.0.1/mypy-default_ini/success.py
+++ b/tests/mypy/outputs/1.0.1/mypy-default_ini/success.py
@@ -6,7 +6,7 @@ Do a little skipping about with types to demonstrate its usage.
 import os
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path, PurePath
-from typing import Any, Dict, ForwardRef, Generic, List, Optional, Type, TypeVar
+from typing import Any, ClassVar, Dict, ForwardRef, Generic, List, Optional, Type, TypeVar
 from uuid import UUID
 
 from typing_extensions import Annotated, TypedDict
@@ -306,3 +306,11 @@ def double(value: Any, handler: Any) -> int:
 
 class WrapValidatorModel(BaseModel):
     x: Annotated[int, WrapValidator(double)]
+
+
+class Abstract(BaseModel):
+    class_id: ClassVar
+
+
+class Concrete(Abstract):
+    class_id = 1

--- a/tests/mypy/outputs/1.0.1/pyproject-default_toml/success.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-default_toml/success.py
@@ -6,7 +6,7 @@ Do a little skipping about with types to demonstrate its usage.
 import os
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path, PurePath
-from typing import Any, Dict, ForwardRef, Generic, List, Optional, Type, TypeVar
+from typing import Any, ClassVar, Dict, ForwardRef, Generic, List, Optional, Type, TypeVar
 from uuid import UUID
 
 from typing_extensions import Annotated, TypedDict
@@ -306,3 +306,11 @@ def double(value: Any, handler: Any) -> int:
 
 class WrapValidatorModel(BaseModel):
     x: Annotated[int, WrapValidator(double)]
+
+
+class Abstract(BaseModel):
+    class_id: ClassVar
+
+
+class Concrete(Abstract):
+    class_id = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

In order to differentiate fields and classvars, all classvars are stored in metadata and are propagated to child classes.
I created a `PydanticModelClassVar` which only stores the classvar name for now, but we might add more information if needed.

The best way I found was to add the `classvars` dict as a parameter to the `collect_field_and_classvars_from_stmt` method, to check if an untyped field is actually a classvar and should be ignored instead of throwing an error. 

**I did not figure out how to test these changes, help would be appreciated.**

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #8107

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
