### PR TITLE
Add `ConfigDict.ser_json_inf_nan`

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -187,6 +187,7 @@ Specifically, the following config options are relevant:
 * [`json_schema_extra`][pydantic.config.ConfigDict.json_schema_extra]
 * [`ser_json_timedelta`][pydantic.config.ConfigDict.ser_json_timedelta]
 * [`ser_json_bytes`][pydantic.config.ConfigDict.ser_json_bytes]
+* [`ser_json_inf_nan`][pydantic.config.ConfigDict.ser_json_inf_nan]
 
 ### Unenforced `Field` constraints
 

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -67,6 +67,7 @@ class ConfigWrapper:
     revalidate_instances: Literal['always', 'never', 'subclass-instances']
     ser_json_timedelta: Literal['iso8601', 'float']
     ser_json_bytes: Literal['utf8', 'base64']
+    ser_json_inf_nan: Literal['null', 'constants']
     # whether to validate default values during validation, default False
     validate_default: bool
     validate_return: bool
@@ -167,6 +168,7 @@ class ConfigWrapper:
                 strict=self.config_dict.get('strict'),
                 ser_json_timedelta=self.config_dict.get('ser_json_timedelta'),
                 ser_json_bytes=self.config_dict.get('ser_json_bytes'),
+                ser_json_inf_nan=self.config_dict.get('ser_json_inf_nan'),
                 from_attributes=self.config_dict.get('from_attributes'),
                 loc_by_alias=self.config_dict.get('loc_by_alias'),
                 revalidate_instances=self.config_dict.get('revalidate_instances'),
@@ -236,6 +238,7 @@ config_defaults = ConfigDict(
     revalidate_instances='never',
     ser_json_timedelta='iso8601',
     ser_json_bytes='utf8',
+    ser_json_inf_nan='null',
     validate_default=False,
     validate_return=False,
     protected_namespaces=('model_',),

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -542,7 +542,7 @@ class ConfigDict(TypedDict, total=False):
 
     ser_json_inf_nan: Literal['null', 'constants']
     """
-    The encoding of JSON serialized infinity and NaN float values. Accepts the string values of `'null'` and `'base64'`.
+    The encoding of JSON serialized infinity and NaN float values. Accepts the string values of `'null'` and `'constants'`.
     Defaults to `'null'`.
 
     - `'null'` will serialize infinity and NaN values as `null`.

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -540,6 +540,15 @@ class ConfigDict(TypedDict, total=False):
     - `'base64'` will serialize bytes to URL safe base64 strings.
     """
 
+    ser_json_inf_nan: Literal['null', 'constants']
+    """
+    The encoding of JSON serialized infinity and NaN float values. Accepts the string values of `'null'` and `'base64'`.
+    Defaults to `'null'`.
+
+    - `'null'` will serialize infinity and NaN values as `null`.
+    - `'constants'` will serialize infinity and NaN values as `Infinity` and `NaN`.
+    """
+
     # whether to validate default values during validation, default False
     validate_default: bool
     """Whether to validate default values during validation. Defaults to `False`."""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -38,7 +38,7 @@ from uuid import UUID
 import annotated_types
 import dirty_equals
 import pytest
-from dirty_equals import HasRepr, IsOneOf, IsStr
+from dirty_equals import HasRepr, IsFloatNan, IsOneOf, IsStr
 from pydantic_core import CoreSchema, PydanticCustomError, SchemaError, core_schema
 from typing_extensions import Annotated, Literal, TypedDict, get_args
 
@@ -2529,13 +2529,34 @@ def test_float_validation():
     ]
 
 
-def test_finite_float_validation():
+def test_infinite_float_validation():
     class Model(BaseModel):
         a: float = None
 
     assert Model(a=float('inf')).a == float('inf')
     assert Model(a=float('-inf')).a == float('-inf')
     assert math.isnan(Model(a=float('nan')).a)
+
+
+@pytest.mark.parametrize(
+    ('ser_json_inf_nan', 'input', 'output', 'python_roundtrip'),
+    (
+        ('null', float('inf'), 'null', None),
+        ('null', float('-inf'), 'null', None),
+        ('null', float('nan'), 'null', None),
+        ('constants', float('inf'), 'Infinity', float('inf')),
+        ('constants', float('-inf'), '-Infinity', float('-inf')),
+        ('constants', float('nan'), 'NaN', IsFloatNan),
+    ),
+)
+def test_infinite_float_json_serialization(ser_json_inf_nan, input, output, python_roundtrip):
+    class Model(BaseModel):
+        model_config = ConfigDict(ser_json_inf_nan=ser_json_inf_nan)
+        a: float
+
+    json_string = Model(a=input).model_dump_json()
+    assert json_string == f'{{"a":{output}}}'
+    assert json.loads(json_string) == {'a': python_roundtrip}
 
 
 @pytest.mark.parametrize('value', [float('inf'), float('-inf'), float('nan')])


### PR DESCRIPTION
## Change Summary

Exposes the `ser_json_inf_nan` config added to `pydantic-core` in https://github.com/pydantic/pydantic-core/pull/1062

Unfortunately this was missed off the 2.5 release, I guess it _could_ go in a patch release but strictly speaking better to hold until 2.6.

## Related issue number

Closes #7007 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
