### PR TITLE
prep for 2.5.2 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,22 @@
+## v2.5.2 (2023-11-19)
+
+[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.5.2)
+
+### What's Changed
+
+#### Packaging
+
+* uprev `pydantic-core` to 2.14.4
+
+#### New Features
+
+* Add `ConfigDict.ser_json_inf_nan` by @davidhewitt in [#8159](https://github.com/pydantic/pydantic/pull/8159)
+
+#### Fixes
+
+* Fix validation of `Literal` from JSON keys when used as `dict` key by @sydney-runkle in [pydantic/pydantic-core#1075](https://github.com/pydantic/pydantic-core/pull/1075)
+* Fix bug re `custom_init` on members of `Union` by @sydney-runkle in [pydantic/pydantic-core#1076](https://github.com/pydantic/pydantic-core/pull/1076)
+
 ## v2.5.1 (2023-11-15)
 
 [GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.5.1)

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 
 __all__ = 'VERSION', 'version_info'
 
-VERSION = '2.5.1'
+VERSION = '2.5.2'
 """The version of Pydantic."""
 
 


### PR DESCRIPTION
Prep for `2.5.2` patch release with some minor bug fixes, including a new version of `pydantic-core`.