### PR TITLE
Fix: `JsonValue` `bool` serialization

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2731,9 +2731,9 @@ if TYPE_CHECKING:
         List['JsonValue'],
         Dict[str, 'JsonValue'],
         str,
+        bool,
         int,
         float,
-        bool,
         None,
     ]
     """A `JsonValue` is used to represent a value that can be serialized to JSON.
@@ -2743,9 +2743,9 @@ if TYPE_CHECKING:
     * `List['JsonValue']`
     * `Dict[str, 'JsonValue']`
     * `str`
+    * `bool`
     * `int`
     * `float`
-    * `bool`
     * `None`
 
     The following example demonstrates how to use `JsonValue` to validate JSON data,
@@ -2787,9 +2787,9 @@ else:
                 Annotated[List['JsonValue'], Tag('list')],
                 Annotated[Dict[str, 'JsonValue'], Tag('dict')],
                 Annotated[str, Tag('str')],
+                Annotated[bool, Tag('bool')],
                 Annotated[int, Tag('int')],
                 Annotated[float, Tag('float')],
-                Annotated[bool, Tag('bool')],
                 Annotated[None, Tag('NoneType')],
             ],
             Discriminator(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6120,3 +6120,12 @@ def test_json_value():
             'type': 'invalid-json-value',
         }
     ]
+
+
+def test_json_value_roundtrip() -> None:
+    # see https://github.com/pydantic/pydantic/issues/8175
+    class MyModel(BaseModel):
+        val: Union[str, JsonValue]
+
+    round_trip_value = json.loads(MyModel(val=True).model_dump_json())['val']
+    assert round_trip_value is True, round_trip_value


### PR DESCRIPTION
## Change Summary

Make sure `JsonValue` serializes booleans correctly.

## Related issue number

Fix #8175

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
