### PR TITLE
Fix order of fields in field validators example

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -312,8 +312,8 @@ from pydantic import (
 
 
 class UserModel(BaseModel):
-    id: int
     name: str
+    id: int
 
     @field_validator('name')
     @classmethod

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -333,11 +333,11 @@ class UserModel(BaseModel):
         return v
 
 
-print(UserModel(id=1, name='John Doe'))
-#> id=1 name='John Doe'
+print(UserModel(name='John Doe', id=1))
+#> name='John Doe' id=1
 
 try:
-    UserModel(id=1, name='samuel')
+    UserModel(name='samuel', id=1)
 except ValidationError as e:
     print(e)
     """
@@ -347,7 +347,7 @@ except ValidationError as e:
     """
 
 try:
-    UserModel(id='abc', name='John Doe')
+    UserModel(name='John Doe', id=1)
 except ValidationError as e:
     print(e)
     """
@@ -357,7 +357,7 @@ except ValidationError as e:
     """
 
 try:
-    UserModel(id=1, name='John Doe!')
+    UserModel(name='John Doe!', id=1)
 except ValidationError as e:
     print(e)
     """


### PR DESCRIPTION
The docs say:
> in the code above, for example, you would not be able to access `info.data['id']` from within `name_must_contain_space`.

Which is true with this update

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex