### PR TITLE
Update strict docstring in model_validate method.

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -488,7 +488,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         Args:
             obj: The object to validate.
-            strict: Whether to raise an exception on invalid fields.
+            strict: Whether to enforce types strictly.
             from_attributes: Whether to extract data from object attributes.
             context: Additional context to pass to the validator.
 


### PR DESCRIPTION
## Change Summary

The docstring of the `model_validate` method indicates that `strict` is used to determine "Whether to raise an exception on invalid fields.".

This appears to be incorrect as errors with `strict == False` still lead to an exception being raised. Instead, it seems like `strict` is used to determine whether types are enforced strictly. This description of `strict` is the one used in all other versions of the `model_validate_*` methods and appears to be correct as can be seen in the following example:

```
from datetime import datetime
from typing import Tuple

from pydantic import BaseModel


class Delivery(BaseModel):
    timestamp: datetime
    dimensions: Tuple[int, int]

obj = {
    "timestamp": "2020-01-02T03:04:05Z",
    "dimensions": ["10", "20"],
}

Delivery.model_validate(obj=obj, strict=True) # Raises ValidationError
Delivery.model_validate(obj=obj, strict=False) # Succeeds

obj = {
    "timestamp": "2020-0105Z", # invalid datetime
    "dimensions": ["10", "20"],
}
Delivery.model_validate(obj=obj, strict=False) # Raises ValidationError
```

This change corrects the docstring associated with the `strict` parameter and aligns it with all the other `model_validate_*` docstrings.

## Related issue number

No issue raised since change is trivial.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist / Not Applicable
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle