### PR TITLE
Fix overload position of `computed_field`

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -970,6 +970,18 @@ class ComputedFieldInfo:
     repr: bool
 
 
+def _wrapped_property_is_private(property_: cached_property | property) -> bool:  # type: ignore
+    """Returns true if provided property is private, False otherwise."""
+    wrapped_name: str = ''
+
+    if isinstance(property_, property):
+        wrapped_name = getattr(property_.fget, '__name__', '')
+    elif isinstance(property_, cached_property):  # type: ignore
+        wrapped_name = getattr(property_.func, '__name__', '')  # type: ignore
+
+    return wrapped_name.startswith('_') and not wrapped_name.startswith('__')
+
+
 # this should really be `property[T], cached_proprety[T]` but property is not generic unlike cached_property
 # See https://github.com/python/typing/issues/985 and linked issues
 PropertyT = typing.TypeVar('PropertyT')
@@ -993,18 +1005,6 @@ def computed_field(
 @typing.overload
 def computed_field(__func: PropertyT) -> PropertyT:
     ...
-
-
-def _wrapped_property_is_private(property_: cached_property | property) -> bool:  # type: ignore
-    """Returns true if provided property is private, False otherwise."""
-    wrapped_name: str = ''
-
-    if isinstance(property_, property):
-        wrapped_name = getattr(property_.fget, '__name__', '')
-    elif isinstance(property_, cached_property):  # type: ignore
-        wrapped_name = getattr(property_.func, '__name__', '')  # type: ignore
-
-    return wrapped_name.startswith('_') and not wrapped_name.startswith('__')
 
 
 def computed_field(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

`_wrapped_property_is_private` was between the overload and the actual definition.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
