### PR TITLE
Explicitly raise an error if field names clashes with types

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1023,7 +1023,7 @@ except PydanticUserError as exc_info:
 Because type annotations are evaluated *after* assignments, you might get unexpected results when using a type annotation name
 that clashes with one of your fields. We raise an error in the following case:
 
-```py
+```py test="skip"
 from datetime import date
 
 from pydantic import BaseModel, Field
@@ -1035,9 +1035,8 @@ class Model(BaseModel):
 
 As a workaround, you can either use an alias or change your import:
 
-```py
+```py lint="skip"
 import datetime
-
 # Or `from datetime import date as _date`
 
 from pydantic import BaseModel, Field

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1018,5 +1018,31 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'root-model-extra'
 ```
 
+## Cannot evaluate type annotation (#unevaluable-type-annotation)
+
+Because type annotations are evaluated *after* assignments, you might get unexpected results when using a type annotation name
+that clashes with one of your fields. We raise an error in the following case:
+
+```py
+from datetime import date
+
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    date: date = Field(description="A date")
+```
+
+As a workaround, you can either use an alias or change your import:
+
+```py
+import datetime
+# Or `from datetime import date as _date`
+
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    date: datetime.date = Field(description="A date")
+
+```
 
 {% endraw %}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1026,7 +1026,7 @@ that clashes with one of your fields. We raise an error in the following case:
 ```py
 from datetime import date
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Model(BaseModel):
@@ -1045,7 +1045,6 @@ from pydantic import BaseModel, Field
 
 class Model(BaseModel):
     date: datetime.date = Field(description='A date')
-
 ```
 
 {% endraw %}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1037,9 +1037,11 @@ As a workaround, you can either use an alias or change your import:
 
 ```py
 import datetime
+
 # Or `from datetime import date as _date`
 
 from pydantic import BaseModel
+
 
 class Model(BaseModel):
     date: datetime.date = Field(description="A date")

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1028,6 +1028,7 @@ from datetime import date
 
 from pydantic import BaseModel
 
+
 class Model(BaseModel):
     date: date = Field(description="A date")
 ```

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1018,7 +1018,7 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'root-model-extra'
 ```
 
-## Cannot evaluate type annotation (#unevaluable-type-annotation)
+## Cannot evaluate type annotation {#unevaluable-type-annotation}
 
 Because type annotations are evaluated *after* assignments, you might get unexpected results when using a type annotation name
 that clashes with one of your fields. We raise an error in the following case:

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1030,7 +1030,7 @@ from pydantic import BaseModel
 
 
 class Model(BaseModel):
-    date: date = Field(description="A date")
+    date: date = Field(description='A date')
 ```
 
 As a workaround, you can either use an alias or change your import:
@@ -1040,11 +1040,11 @@ import datetime
 
 # Or `from datetime import date as _date`
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Model(BaseModel):
-    date: datetime.date = Field(description="A date")
+    date: datetime.date = Field(description='A date')
 
 ```
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -58,6 +58,7 @@ PydanticErrorCodes = Literal[
     'invalid_annotated_type',
     'type-adapter-config-unused',
     'root-model-extra',
+    'unevaluable-type-annotation',
 ]
 
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -321,12 +321,11 @@ class FieldInfo(_repr.Representation):
         Returns:
             A field object with the passed values.
         """
-
         if annotation is default:
-            raise RuntimeError(
+            raise PydanticUserError(
                 'Error when building FieldInfo from annotated attribute. '
-                "Make sure you don't have any field name clashing with a type annotation "
-                '(e.g. `date: date = Field(None)`).'
+                "Make sure you don't have any field name clashing with a type annotation ",
+                code='unevaluable-type-annotation',
             )
 
         final = False

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -321,6 +321,14 @@ class FieldInfo(_repr.Representation):
         Returns:
             A field object with the passed values.
         """
+
+        if annotation is default:
+            raise RuntimeError(
+                'Error when building FieldInfo from annotated attribute. '
+                "Make sure you don't have any field name clashing with a type annotation "
+                '(e.g. `date: date = Field(None)`).'
+            )
+
         final = False
         if _typing_extra.is_finalvar(annotation):
             final = True

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2434,10 +2434,10 @@ def test_invalid_forward_ref_model():
     """
     # The problem:
     if sys.version_info >= (3, 11):
-        error = RecursionError
-    else:
-        # See PR #8243, this was a TypeError raised by Python, but is now catched on the Pydantic side
+        # See PR #8243, this was a RecursionError raised by Python, but is now caught on the Pydantic side
         error = errors.PydanticUserError
+    else:
+        error = TypeError
     with pytest.raises(error):
 
         class M(BaseModel):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2435,14 +2435,10 @@ def test_invalid_forward_ref_model():
     # The problem:
     if sys.version_info >= (3, 11):
         error = RecursionError
-        kwargs = {}
     else:
-        error = TypeError
-        kwargs = {
-            'match': r'Forward references must evaluate to types\.'
-            r' Got FieldInfo\(annotation=NoneType, required=False\)\.'
-        }
-    with pytest.raises(error, **kwargs):
+        # See PR #8243, this was a TypeError raised by Python, but is now catched on the Pydantic side
+        error = errors.PydanticUserError
+    with pytest.raises(error):
 
         class M(BaseModel):
             B: ForwardRef('B') = Field(default=None)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1375,19 +1375,17 @@ def test_type_on_annotation():
         pass
 
     class Model(BaseModel):
-        a: int = int
-        b: Type[int]
-        c: Type[int] = int
-        d: FooBar = FooBar
-        e: Type[FooBar]
-        f: Type[FooBar] = FooBar
-        g: Sequence[Type[FooBar]] = [FooBar]
-        h: Union[Type[FooBar], Sequence[Type[FooBar]]] = FooBar
-        i: Union[Type[FooBar], Sequence[Type[FooBar]]] = [FooBar]
+        a: Type[int]
+        b: Type[int] = int
+        c: Type[FooBar]
+        d: Type[FooBar] = FooBar
+        e: Sequence[Type[FooBar]] = [FooBar]
+        f: Union[Type[FooBar], Sequence[Type[FooBar]]] = FooBar
+        g: Union[Type[FooBar], Sequence[Type[FooBar]]] = [FooBar]
 
         model_config = dict(arbitrary_types_allowed=True)
 
-    assert Model.model_fields.keys() == set('abcdefghi')
+    assert Model.model_fields.keys() == set('abcdefg')
 
 
 def test_assign_type():

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,7 @@
 import pytest
 
 import pydantic.dataclasses
-from pydantic import BaseModel, Field, RootModel, ValidationError, fields
+from pydantic import BaseModel, Field, PydanticUserError, RootModel, ValidationError, fields
 
 
 def test_field_info_annotation_keyword_argument():
@@ -18,11 +18,11 @@ def test_field_info_annotation_keyword_argument():
 
 
 def test_field_info_annotated_attribute_name_clashing():
-    """This tests that `FieldInfo.from_annotated_attribute` will raise a `RuntimeError` if attribute names clashes
+    """This tests that `FieldInfo.from_annotated_attribute` will raise a `PydanticUserError` if attribute names clashes
     with a type.
     """
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(PydanticUserError):
 
         class SubModel(BaseModel):
             a: int = 1

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -17,6 +17,20 @@ def test_field_info_annotation_keyword_argument():
     assert e.value.args == ('"annotation" is not permitted as a Field keyword argument',)
 
 
+def test_field_info_annotated_attribute_name_clashing():
+    """This tests that `FieldInfo.from_annotated_attribute` will raise a `RuntimeError` if attribute names clashes
+    with a type.
+    """
+
+    with pytest.raises(RuntimeError):
+
+        class SubModel(BaseModel):
+            a: int = 1
+
+        class Model(BaseModel):
+            SubModel: SubModel = Field()
+
+
 def test_init_var_field():
     @pydantic.dataclasses.dataclass
     class Foo:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Linked: https://github.com/pydantic/pydantic/issues/8240.

I'm raising inside `from_annotated_attribute` so I don't have to duplicate the logic for dataclass, BaseModel etc. But unfortunately I can't provide info to the user regarding the field causing the issue :/

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
