### PR TITLE
Fix issue not allowing validate_call decorator to be dynamically assigned to a class method.

### DIFF
--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -120,6 +120,11 @@ class ValidateCallWrapper:
         if obj is None:
             try:
                 # Handle the case where a method is accessed as a class attribute
+                # Its possible this wrapper is dynamically applied to a class attribute not allowing
+                # name to be populated by __set_name__. In this case, we'll manually acquire the name
+                # from the function reference.
+                if self._name is None:
+                    self._name = self.raw_function.__name__
                 return objtype.__getattribute__(objtype, self._name)  # type: ignore
             except AttributeError:
                 # This will happen the first time the attribute is accessed

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -118,7 +118,7 @@ class ValidateCallWrapper:
     def __get__(self, obj: Any, objtype: type[Any] | None = None) -> ValidateCallWrapper:
         """Bind the raw function and return another ValidateCallWrapper wrapping that."""
         if obj is None:
-            # Its possible this wrapper is dynamically applied to a class attribute not allowing
+            # It's possible this wrapper is dynamically applied to a class attribute not allowing
             # name to be populated by __set_name__. In this case, we'll manually acquire the name
             # from the function reference.
             if self._name is None:

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -118,13 +118,13 @@ class ValidateCallWrapper:
     def __get__(self, obj: Any, objtype: type[Any] | None = None) -> ValidateCallWrapper:
         """Bind the raw function and return another ValidateCallWrapper wrapping that."""
         if obj is None:
+            # Its possible this wrapper is dynamically applied to a class attribute not allowing
+            # name to be populated by __set_name__. In this case, we'll manually acquire the name
+            # from the function reference.
+            if self._name is None:
+                self._name = self.raw_function.__name__
             try:
                 # Handle the case where a method is accessed as a class attribute
-                # Its possible this wrapper is dynamically applied to a class attribute not allowing
-                # name to be populated by __set_name__. In this case, we'll manually acquire the name
-                # from the function reference.
-                if self._name is None:
-                    self._name = self.raw_function.__name__
                 return objtype.__getattribute__(objtype, self._name)  # type: ignore
             except AttributeError:
                 # This will happen the first time the attribute is accessed

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -684,6 +684,18 @@ def test_basemodel_method():
     assert bar.test('1') == (bar, 1)
 
 
+def test_dynamic_method_decoration():
+    class Foo:
+        def bar(self, value: str) -> str:
+            return f'bar-{value}'
+
+    Foo.bar = validate_call(Foo.bar)
+    assert Foo.bar
+
+    foo = Foo()
+    assert foo.bar('test') == 'bar-test'
+
+
 @pytest.mark.parametrize('decorator', [staticmethod, classmethod])
 def test_classmethod_order_error(decorator):
     name = decorator.__name__


### PR DESCRIPTION
## Change Summary

`validate_call` can now be dynamically set as class attribute.

```python
class Foo:
  def bar(self, value: str) -> str:
    return f'bar-{value}'
    
Foo.bar = validate_call(Foo.bar)
```

## Related issue number

fix https://github.com/pydantic/pydantic/issues/8245

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
