### PR TITLE
Add `pydantic_extra_types.mac_address` docs reference

### DIFF
--- a/docs/api/pydantic_extra_types_mac_address.md
+++ b/docs/api/pydantic_extra_types_mac_address.md
@@ -1,0 +1,1 @@
+::: pydantic_extra_types.mac_address


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The API documentation page for [`pydantic_extra_types.mac_address`](https://docs.pydantic.dev/latest/api/pydantic_extra_types_mac_address/) is currently empty as the Markdown file does not contain a reference to the correct module, e.g.

https://github.com/pydantic/pydantic/blob/b430e5aa9d1061e65753301ee014278eab66c437/docs/api/pydantic_extra_types_color.md?plain=1#L1

## Related issue number

#8254

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb