### PR TITLE
Remove hash check from northstar benchmark

### DIFF
--- a/tests/benchmarks/test_north_star.py
+++ b/tests/benchmarks/test_north_star.py
@@ -7,7 +7,6 @@ Used to gauge overall pydantic performance.
 import json
 from datetime import date, datetime, time
 from decimal import Decimal
-from hashlib import md5
 from pathlib import Path
 from typing import List, Union
 from uuid import UUID
@@ -64,7 +63,6 @@ def pydantic_type_adapter():
 
 
 _NORTH_STAR_DATA_PATH = Path(__file__).parent / 'north_star_data.json'
-_EXPECTED_NORTH_STAR_DATA_MD5 = '4d30ce33e301fd00c656f95e736c7785'
 
 
 @pytest.fixture(scope='module')
@@ -81,23 +79,6 @@ def _north_star_data_bytes() -> bytes:
         _NORTH_STAR_DATA_PATH.write_bytes(data)
     else:
         data = _NORTH_STAR_DATA_PATH.read_bytes()
-
-    # To make benchmarks a stable metric, validate the MD5 hash of the
-    # existing generated data. If the data is deliberately changed,
-    # update _EXPECTED_NORTH_STAR_DATA_MD5 above.
-    #
-    # NB updating Faker will almost certainly change the benchmark data.
-    data_md5 = md5(data).hexdigest()
-    if data_md5 != _EXPECTED_NORTH_STAR_DATA_MD5:
-        if needs_generating:
-            raise ValueError(
-                f'Expected hash {_EXPECTED_NORTH_STAR_DATA_MD5} for north star data, but generated {data_md5}'
-            )
-        else:
-            # MD5 hash mismatch, maybe shape of the data has changed. Delete
-            # and regenerate.
-            _NORTH_STAR_DATA_PATH.unlink()
-            return _north_star_data_bytes()
 
     return data
 


### PR DESCRIPTION
## Change Summary

Was doing more harm than good, breaking consistently with different faker versions.

If this causes a problem with benchmark stability, we can come up with an alternative way to measure this performance.

## Related issue number

Fix #8099

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
