### PR TITLE
Make `@validate_call` return a function instead of a custom descriptor - fixes binding issue with inheritance and adds `self/cls` argument to validation errors

### DIFF
--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -13,11 +13,7 @@ from ._config import ConfigWrapper
 
 
 class ValidateCallWrapper:
-    """This is a wrapper around a function that validates the arguments passed to it, and optionally the return value.
-
-    It's partially inspired by `wraps` which in turn uses `partial`, but extended to be a descriptor so
-    these functions can be applied to instance methods, class methods, static methods, as well as normal functions.
-    """
+    """This is a wrapper around a function that validates the arguments passed to it, and optionally the return value."""
 
     __slots__ = (
         '__pydantic_validator__',

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import inspect
-from dataclasses import dataclass
 from functools import partial
 from typing import Any, Awaitable, Callable
 
@@ -11,12 +10,6 @@ from ..config import ConfigDict
 from ..plugin._schema_validator import create_schema_validator
 from . import _generate_schema, _typing_extra
 from ._config import ConfigWrapper
-
-
-@dataclass
-class CallMarker:
-    function: Callable[..., Any]
-    validate_return: bool
 
 
 class ValidateCallWrapper:

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -27,12 +27,7 @@ class ValidateCallWrapper:
     """
 
     __slots__ = (
-        'raw_function',
-        '_config',
-        '_validate_return',
-        '__pydantic_core_schema__',
         '__pydantic_validator__',
-        '__signature__',
         '__name__',
         '__qualname__',
         '__annotations__',
@@ -40,31 +35,22 @@ class ValidateCallWrapper:
     )
 
     def __init__(self, function: Callable[..., Any], config: ConfigDict | None, validate_return: bool):
-        self.raw_function = function
-        self._config = config
-        self._validate_return = validate_return
-        self.__signature__ = inspect.signature(function)
         if isinstance(function, partial):
             func = function.func
             schema_type = func
             self.__name__ = f'partial({func.__name__})'
             self.__qualname__ = f'partial({func.__qualname__})'
-            self.__annotations__ = func.__annotations__
             self.__module__ = func.__module__
-            self.__doc__ = func.__doc__
         else:
             schema_type = function
             self.__name__ = function.__name__
             self.__qualname__ = function.__qualname__
-            self.__annotations__ = function.__annotations__
             self.__module__ = function.__module__
-            self.__doc__ = function.__doc__
 
         namespace = _typing_extra.add_module_globals(function, None)
         config_wrapper = ConfigWrapper(config)
         gen_schema = _generate_schema.GenerateSchema(config_wrapper, namespace)
         schema = gen_schema.clean_schema(gen_schema.generate_schema(function))
-        self.__pydantic_core_schema__ = schema
         core_config = config_wrapper.core_config(self)
 
         self.__pydantic_validator__ = create_schema_validator(
@@ -77,15 +63,11 @@ class ValidateCallWrapper:
             config_wrapper.plugin_settings,
         )
 
-        if self._validate_return:
-            return_type = (
-                self.__signature__.return_annotation
-                if self.__signature__.return_annotation is not self.__signature__.empty
-                else Any
-            )
+        if validate_return:
+            signature = inspect.signature(function)
+            return_type = signature.return_annotation if signature.return_annotation is not signature.empty else Any
             gen_schema = _generate_schema.GenerateSchema(config_wrapper, namespace)
             schema = gen_schema.clean_schema(gen_schema.generate_schema(return_type))
-            self.__return_pydantic_core_schema__ = schema
             validator = create_schema_validator(
                 schema,
                 schema_type,
@@ -95,7 +77,7 @@ class ValidateCallWrapper:
                 core_config,
                 config_wrapper.plugin_settings,
             )
-            if inspect.iscoroutinefunction(self.raw_function):
+            if inspect.iscoroutinefunction(function):
 
                 async def return_val_wrapper(aw: Awaitable[Any]) -> None:
                     return validator.validate_python(await aw)
@@ -104,7 +86,6 @@ class ValidateCallWrapper:
             else:
                 self.__return_pydantic_validator__ = validator.validate_python
         else:
-            self.__return_pydantic_core_schema__ = None
             self.__return_pydantic_validator__ = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -1,6 +1,7 @@
 """Decorator for validating function calls."""
 from __future__ import annotations as _annotations
 
+import functools
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
 
 from ._internal import _validate_call
@@ -50,17 +51,15 @@ def validate_call(
         if isinstance(function, (classmethod, staticmethod)):
             name = type(function).__name__
             raise TypeError(f'The `@{name}` decorator should be applied after `@validate_call` (put `@{name}` on top)')
-        v = _validate_call.ValidateCallWrapper(function, config, validate_return)
-
-        import functools
+        validate_call_wrapper = _validate_call.ValidateCallWrapper(function, config, validate_return)
 
         @functools.wraps(function)
-        def wrapper(*args, **kwargs):
-            return v(*args, **kwargs)
+        def wrapper_function(*args, **kwargs):
+            return validate_call_wrapper(*args, **kwargs)
 
-        wrapper.raw_function = function  # type: ignore
+        wrapper_function.raw_function = function  # type: ignore
 
-        return wrapper  # type: ignore
+        return wrapper_function  # type: ignore
 
     if __func:
         return validate(__func)

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -50,7 +50,17 @@ def validate_call(
         if isinstance(function, (classmethod, staticmethod)):
             name = type(function).__name__
             raise TypeError(f'The `@{name}` decorator should be applied after `@validate_call` (put `@{name}` on top)')
-        return _validate_call.ValidateCallWrapper(function, config, validate_return)  # type: ignore
+        v = _validate_call.ValidateCallWrapper(function, config, validate_return)
+
+        import functools
+
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            return v(*args, **kwargs)
+
+        wrapper.raw_function = function  # type: ignore
+
+        return wrapper  # type: ignore
 
     if __func:
         return validate(__func)

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -93,9 +93,7 @@ def test_wrap():
     assert foo_bar.__name__ == 'foo_bar'
     assert foo_bar.__module__ == 'tests.test_validate_call'
     assert foo_bar.__qualname__ == 'test_wrap.<locals>.foo_bar'
-    assert isinstance(foo_bar.__pydantic_core_schema__, dict)
     assert callable(foo_bar.raw_function)
-    assert repr(foo_bar) == f'ValidateCallWrapper({repr(foo_bar.raw_function)})'
     assert repr(inspect.signature(foo_bar)) == '<Signature (a: int, b: int)>'
 
 
@@ -369,8 +367,8 @@ def test_item_method():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
+        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
     ]
 
 
@@ -392,8 +390,8 @@ def test_class_method():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
+        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Testing an alternative to https://github.com/pydantic/pydantic/pull/8258

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/8146

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
