### PR TITLE
first pass at AliasGenerator support

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -17,10 +17,11 @@ if typing.TYPE_CHECKING:
 
     from . import dataclasses
     from ._internal._generate_schema import GenerateSchema as GenerateSchema
+    from .aliases import AliasChoices, AliasGenerator, AliasPath
     from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
     from .config import ConfigDict
     from .errors import *
-    from .fields import AliasChoices, AliasPath, Field, PrivateAttr, computed_field
+    from .fields import Field, PrivateAttr, computed_field
     from .functional_serializers import (
         PlainSerializer,
         SerializeAsAny,
@@ -92,11 +93,13 @@ __all__ = (
     'PydanticUndefinedAnnotation',
     'PydanticInvalidForJsonSchema',
     # fields
-    'AliasPath',
-    'AliasChoices',
     'Field',
     'computed_field',
     'PrivateAttr',
+    # alias
+    'AliasChoices',
+    'AliasGenerator',
+    'AliasPath',
     # main
     'BaseModel',
     'create_model',
@@ -240,11 +243,13 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'PydanticUndefinedAnnotation': (__package__, '.errors'),
     'PydanticInvalidForJsonSchema': (__package__, '.errors'),
     # fields
-    'AliasPath': (__package__, '.fields'),
-    'AliasChoices': (__package__, '.fields'),
     'Field': (__package__, '.fields'),
     'computed_field': (__package__, '.fields'),
     'PrivateAttr': (__package__, '.fields'),
+    # alias
+    'AliasChoices': (__package__, '.aliases'),
+    'AliasGenerator': (__package__, '.aliases'),
+    'AliasPath': (__package__, '.aliases'),
     # main
     'BaseModel': (__package__, '.main'),
     'create_model': (__package__, '.main'),

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -15,6 +15,7 @@ from typing_extensions import (
     Self,
 )
 
+from ..aliases import AliasGenerator
 from ..config import ConfigDict, ExtraValues, JsonDict, JsonEncoder, JsonSchemaExtraCallable
 from ..errors import PydanticUserError
 from ..warnings import PydanticDeprecatedSince20
@@ -55,7 +56,7 @@ class ConfigWrapper:
     # whether to use the actual key provided in the data (e.g. alias or first alias for "field required" errors) instead of field_names
     # to construct error `loc`s, default `True`
     loc_by_alias: bool
-    alias_generator: Callable[[str], str] | None
+    alias_generator: Callable[[str], str] | AliasGenerator | None
     ignored_types: tuple[type, ...]
     allow_inf_nan: bool
     json_schema_extra: JsonDict | JsonSchemaExtraCallable | None

--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -1,0 +1,126 @@
+"""Support for alias configurations."""
+from __future__ import annotations
+
+import dataclasses
+from typing import Callable
+
+from ._internal import _internal_dataclass
+
+__all__ = ('AliasGenerator', 'AliasPath', 'AliasChoices')
+
+
+@dataclasses.dataclass(**_internal_dataclass.slots_true)
+class AliasGenerator:
+    """Usage docs: https://docs.pydantic.dev/2.6/concepts/alias#alias-generator
+
+    A data class used by `alias_generator` as a convenience to create various aliases.
+
+    Attributes:
+        validation_alias: A callable that takes a field name and returns a validation alias for it.
+        alias: A callable that takes a field name and returns an alias for it.
+        serialization_alias: A callable that takes a field name and returns a serialization alias for it.
+    """
+
+    validation_alias: Callable[[str], str | AliasPath | AliasChoices] | None = None
+    alias: Callable[[str], str] | None = None
+    serialization_alias: Callable[[str], str] | None = None
+
+    def __init__(
+        self,
+        alias: Callable[[str], str] | None = None,
+        *,
+        validation_alias: Callable[[str], str | AliasPath | AliasChoices] | None = None,
+        serialization_alias: Callable[[str], str] | None = None,
+    ) -> None:
+        """Initialize the alias generator."""
+        self.validation_alias = validation_alias
+        self.alias = alias
+        self.serialization_alias = serialization_alias
+
+    def __call__(
+        self, field_name: str
+    ) -> tuple[str | list[str | int] | list[list[str | int]] | None, str | None, str | None]:
+        """Generate aliases for validation, serialization, and alias.
+
+        Returns:
+            A tuple of three aliases - validation, alias, and serialization.
+        """
+        validation_alias, alias, serialization_alias = None, None, None
+
+        if self.validation_alias is not None:
+            validation_alias = self.validation_alias(field_name)
+            if validation_alias:
+                if not isinstance(validation_alias, (str, AliasChoices, AliasPath)):
+                    raise TypeError(
+                        'Invalid `validation_alias` type. `validation_alias_generator` must produce'
+                        'a `validation_alias` of type `str`, `AliasChoices`, or `AliasPath`'
+                    )
+                if isinstance(validation_alias, (AliasChoices, AliasPath)):
+                    validation_alias = validation_alias.convert_to_aliases()
+        if self.serialization_alias is not None:
+            serialization_alias = self.serialization_alias(field_name)
+            if serialization_alias and not isinstance(serialization_alias, str):
+                raise TypeError(
+                    'Invalid `serialization_alias` type. `serialization_alias_generator` must produce'
+                    'a `serialization_alias` of type `str`'
+                )
+        if self.alias is not None:
+            alias = self.alias(field_name)
+            if alias and not isinstance(alias, str):
+                raise TypeError('Invalid `alias` type. `alias_generator` must produce a `alias` of type `str`')
+
+        return validation_alias, alias, serialization_alias
+
+
+@dataclasses.dataclass(**_internal_dataclass.slots_true)
+class AliasPath:
+    """Usage docs: https://docs.pydantic.dev/2.6/concepts/fields#aliaspath-and-aliaschoices
+
+    A data class used by `validation_alias` as a convenience to create aliases.
+
+    Attributes:
+        path: A list of string or integer aliases.
+    """
+
+    path: list[int | str]
+
+    def __init__(self, first_arg: str, *args: str | int) -> None:
+        self.path = [first_arg] + list(args)
+
+    def convert_to_aliases(self) -> list[str | int]:
+        """Converts arguments to a list of string or integer aliases.
+
+        Returns:
+            The list of aliases.
+        """
+        return self.path
+
+
+@dataclasses.dataclass(**_internal_dataclass.slots_true)
+class AliasChoices:
+    """Usage docs: https://docs.pydantic.dev/2.6/concepts/fields#aliaspath-and-aliaschoices
+
+    A data class used by `validation_alias` as a convenience to create aliases.
+
+    Attributes:
+        choices: A list containing a string or `AliasPath`.
+    """
+
+    choices: list[str | AliasPath]
+
+    def __init__(self, first_choice: str | AliasPath, *choices: str | AliasPath) -> None:
+        self.choices = [first_choice] + list(choices)
+
+    def convert_to_aliases(self) -> list[list[str | int]]:
+        """Converts arguments to a list of lists containing string or integer aliases.
+
+        Returns:
+            The list of aliases.
+        """
+        aliases: list[list[str | int]] = []
+        for c in self.choices:
+            if isinstance(c, AliasPath):
+                aliases.append(c.convert_to_aliases())
+            else:
+                aliases.append([c])
+        return aliases

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type, Union
 from typing_extensions import Literal, TypeAlias, TypedDict
 
 from ._migration import getattr_migration
+from .aliases import AliasGenerator
 
 if TYPE_CHECKING:
     from ._internal._generate_schema import GenerateSchema as _GenerateSchema
@@ -315,9 +316,14 @@ class ConfigDict(TypedDict, total=False):
     loc_by_alias: bool
     """Whether to use the actual key provided in the data (e.g. alias) for error `loc`s rather than the field's name. Defaults to `True`."""
 
-    alias_generator: Callable[[str], str] | None
+    alias_generator: Callable[[str], str] | AliasGenerator | None
     """
-    A callable that takes a field name and returns an alias for it.
+    A callable that takes a field name and returns an alias for it
+    or an instance of [`AliasGenerator`][pydantic.alias_generators.AliasGenerator]. Defaults to `None`.
+
+    When using a callable, the alias generator is used for both validation and serialization.
+    If you want to use different alias generators for validation and serialization, you can use
+    [`AliasGenerator`][pydantic.alias_generators.AliasGenerator] instead.
 
     If data source field names do not match your code style (e. g. CamelCase fields),
     you can automatically generate aliases using `alias_generator`:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -17,6 +17,7 @@ from typing_extensions import Literal, Unpack
 
 from . import types
 from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra, _utils
+from .aliases import AliasChoices, AliasPath
 from .config import JsonDict
 from .errors import PydanticUserError
 from .warnings import PydanticDeprecatedSince20
@@ -566,60 +567,6 @@ class FieldInfo(_repr.Representation):
                 value = getattr(self, s)
                 if value is not None and value is not PydanticUndefined:
                     yield s, value
-
-
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
-class AliasPath:
-    """Usage docs: https://docs.pydantic.dev/2.6/concepts/fields#aliaspath-and-aliaschoices
-
-    A data class used by `validation_alias` as a convenience to create aliases.
-
-    Attributes:
-        path: A list of string or integer aliases.
-    """
-
-    path: list[int | str]
-
-    def __init__(self, first_arg: str, *args: str | int) -> None:
-        self.path = [first_arg] + list(args)
-
-    def convert_to_aliases(self) -> list[str | int]:
-        """Converts arguments to a list of string or integer aliases.
-
-        Returns:
-            The list of aliases.
-        """
-        return self.path
-
-
-@dataclasses.dataclass(**_internal_dataclass.slots_true)
-class AliasChoices:
-    """Usage docs: https://docs.pydantic.dev/2.6/concepts/fields#aliaspath-and-aliaschoices
-
-    A data class used by `validation_alias` as a convenience to create aliases.
-
-    Attributes:
-        choices: A list containing a string or `AliasPath`.
-    """
-
-    choices: list[str | AliasPath]
-
-    def __init__(self, first_choice: str | AliasPath, *choices: str | AliasPath) -> None:
-        self.choices = [first_choice] + list(choices)
-
-    def convert_to_aliases(self) -> list[list[str | int]]:
-        """Converts arguments to a list of lists containing string or integer aliases.
-
-        Returns:
-            The list of aliases.
-        """
-        aliases: list[list[str | int]] = []
-        for c in self.choices:
-            if isinstance(c, AliasPath):
-                aliases.append(c.convert_to_aliases())
-            else:
-                aliases.append([c])
-        return aliases
 
 
 class _EmptyKwargs(typing_extensions.TypedDict):

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -5,8 +5,7 @@ from typing import Any, ContextManager, List, Optional
 import pytest
 from dirty_equals import IsStr
 
-from pydantic import BaseModel, ConfigDict, ValidationError
-from pydantic.fields import AliasChoices, AliasPath, Field
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, ValidationError
 
 
 def test_alias_generator():


### PR DESCRIPTION
## Change Summary

Add support for `AliasGenerator` dataclass which can be used to generate `validation_alias`, `alias`, and `serialization_alias` with various callables.

## Related issue number

Closes #8265

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
