### PR TITLE
Added tests for the case JsonValue contains subclassed primitive values

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2704,9 +2704,7 @@ def _get_type_name(x: Any) -> str:
     if type_ in _JSON_TYPES:
         return type_.__name__
 
-    # Handle proper subclasses; note we don't need to handle None here
-    if isinstance(x, bool):
-        return 'bool'
+    # Handle proper subclasses; note we don't need to handle None or bool here
     if isinstance(x, int):
         return 'int'
     if isinstance(x, float):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6126,6 +6126,27 @@ def test_json_value():
     ]
 
 
+def test_json_value_with_subclassed_types():
+    class IntType(int):
+        pass
+
+    class FloatType(float):
+        pass
+
+    class StrType(str):
+        pass
+
+    class ListType(list):
+        pass
+
+    class DictType(dict):
+        pass
+
+    adapter = TypeAdapter(JsonValue)
+    valid_json_data = {'int': IntType(), 'float': FloatType(), 'str': StrType(), 'list': ListType(), 'dict': DictType()}
+    assert adapter.validate_python(valid_json_data) == valid_json_data
+
+
 def test_json_value_roundtrip() -> None:
     # see https://github.com/pydantic/pydantic/issues/8175
     class MyModel(BaseModel):


### PR DESCRIPTION
## Change Summary

1. Added tests for the case JsonValue contains subclasses of primitive values.
2. Removed the check regarding bool subclass because it is not possible at all in python to my knowledge. Let me know if I am missing something, will revert.

## Related issue number

Contributes to #7656

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
