### PR TITLE
Inherit config from annotated model in TypeAdapter

### DIFF
--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -191,7 +191,7 @@ class TypeAdapter(Generic[T]):
         except AttributeError:
             core_schema = _get_schema(type, config_wrapper, parent_depth=_parent_depth + 1)
 
-        core_config = config_wrapper.core_config(None)
+        core_config = core_schema['config'] if 'config' in core_schema else config_wrapper.core_config(None)
         validator: SchemaValidator
         try:
             validator = _getattr_no_parents(type, '__pydantic_validator__')

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -153,6 +153,18 @@ def test_type_alias_annotated() -> None:
     assert t.json_schema() == {'type': 'array', 'items': {'type': 'integer'}, 'maxItems': 1}
 
 
+def test_type_alias_annotated_inherit_config() -> None:
+    class TestModel(BaseModel):
+        some_bytes: bytes
+        model_config = {'ser_json_bytes': 'base64'}
+
+    value = TestModel(some_bytes=b'\xaa')
+    t = TypeAdapter(Annotated[TestModel, ...])
+
+    assert value.model_dump(mode='json') == {'some_bytes': 'qg=='}
+    assert t.dump_python(value, mode='json') == {'some_bytes': 'qg=='}
+
+
 def test_type_alias_annotated_defs() -> None:
     # force use of refs by referencing the schema in multiple places
     t = TypeAdapter(Tuple[ShortMyList[int], ShortMyList[int]])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
I'm not sure if this logic is correct, so a first review is welcome. The main problem here is that `TypeAdapter` is not inheriting the config from a model when it is wrapped in `Annotated` because it is creating a serializer with an empty config. It works as expected when not wrapped in Annotated because it uses a cached schema & serializer directly from the model.

## Related issue number
closes #8214

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb