### PR TITLE
Fix type annotation of `ModelMetaclass.__prepare__`

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -8,7 +8,7 @@ import weakref
 from abc import ABCMeta
 from functools import partial
 from types import FunctionType
-from typing import Any, Callable, Generic, Mapping
+from typing import Any, Callable, Generic
 
 import typing_extensions
 from pydantic_core import PydanticUndefined, SchemaSerializer
@@ -216,7 +216,7 @@ class ModelMetaclass(ABCMeta):
             raise AttributeError(item)
 
     @classmethod
-    def __prepare__(cls, *args: Any, **kwargs: Any) -> Mapping[str, object]:
+    def __prepare__(cls, *args: Any, **kwargs: Any) -> dict[str, object]:
         return _ModelNamespaceDict()
 
     def __instancecheck__(self, instance: Any) -> bool:


### PR DESCRIPTION
## Change Summary

This fixes a type annotation that was fixed in the typeshed in https://github.com/python/typeshed/pull/11093. `type.__prepare__` (and thus `ModelMetaclass.__prepare__`) must return a mutable mapping. This is because during class creation, that namespace is populated when the class body is executed.

## Related issue number

As this change looks rather trivial, I have not created an issue.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani