### PR TITLE
Fix `to_snake` conversion

### DIFF
--- a/pydantic/alias_generators.py
+++ b/pydantic/alias_generators.py
@@ -39,6 +39,12 @@ def to_snake(camel: str) -> str:
     Returns:
         The converted string in snake_case.
     """
-    snake = re.sub(r'([a-zA-Z])([0-9])', lambda m: f'{m.group(1)}_{m.group(2)}', camel)
-    snake = re.sub(r'([a-z0-9])([A-Z])', lambda m: f'{m.group(1)}_{m.group(2)}', snake)
+    # Handle the sequence of uppercase letters followed by a lowercase letter
+    snake = re.sub(r'([A-Z]+)([A-Z][a-z])', lambda m: f'{m.group(1)}_{m.group(2)}', camel)
+    # Insert an underscore between a lowercase letter and an uppercase letter
+    snake = re.sub(r'([a-z])([A-Z])', lambda m: f'{m.group(1)}_{m.group(2)}', snake)
+    # Insert an underscore between a digit and an uppercase letter
+    snake = re.sub(r'([0-9])([A-Z])', lambda m: f'{m.group(1)}_{m.group(2)}', snake)
+    # Insert an underscore between a lowercase letter and a digit
+    snake = re.sub(r'([a-z])([0-9])', lambda m: f'{m.group(1)}_{m.group(2)}', snake)
     return snake.lower()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -529,6 +529,7 @@ def test_snake2camel(value: str, result: str) -> None:
         ('Camel2Snake', 'camel_2_snake'),
         ('_CamelToSnake', '_camel_to_snake'),
         ('CamelToSnake_', 'camel_to_snake_'),
+        ('CAMELToSnake', 'camel_to_snake'),
         ('__CamelToSnake__', '__camel_to_snake__'),
         ('Camel2', 'camel_2'),
         ('Camel2_', 'camel_2_'),


### PR DESCRIPTION
Fixes a case for `to_snake` conversion for sequence of uppercase letters followed by a lowercase letter
E.g. `assert to_snake("HTTPResponse") == "http_response"`

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- Fixes a case when converting a camel case string to snake case where sequence of uppercase letters followed by a lowercase letter
## Related issue number
fix #8315 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [X] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
