### PR TITLE
Initial fix for annotated fields with FieldInfo subtype.

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -288,7 +288,9 @@ class FieldInfo(_repr.Representation):
                 new_field_info.frozen = final or field_info.frozen
                 metadata: list[Any] = []
                 for a in extra_args:
-                    if not isinstance(a, FieldInfo):
+                    if not isinstance(a, FieldInfo) or (
+                        issubclass(type(a), FieldInfo) and not issubclass(FieldInfo, type(a))
+                    ):
                         metadata.append(a)
                     else:
                         metadata.extend(a.metadata)

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -1,6 +1,7 @@
 import sys
 from inspect import Parameter, Signature, signature
 from typing import Any, Generic, Iterable, Optional, TypeVar, Union
+from pydantic.fields import FieldInfo
 
 import pytest
 from typing_extensions import Annotated
@@ -190,3 +191,13 @@ def test_annotated_optional_field():
         foo: Annotated[Optional[int], Gt(1)] = None
 
     assert str(signature(Model)) == '(*, foo: Annotated[Optional[int], Gt(gt=1)] = None) -> None'
+
+def test_annotated_fieldinfo_subclass():
+    class Query(FieldInfo):
+        pass
+
+    class QueryParams(BaseModel):
+        q: Annotated[list[str], Query()]
+
+    sig = signature(QueryParams)
+    assert str(sig) == '(*, q: typing.Annotated[list[str], Query(annotation=NoneType, required=True)]) -> None'

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -1,13 +1,13 @@
 import sys
 from inspect import Parameter, Signature, signature
 from typing import Any, Generic, Iterable, Optional, TypeVar, Union
-from pydantic.fields import FieldInfo
 
 import pytest
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from pydantic._internal._typing_extra import is_annotated
+from pydantic.fields import FieldInfo
 
 
 def _equals(a: Union[str, Iterable[str]], b: Union[str, Iterable[str]]) -> bool:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Made changes so function signatures are consistent with version 1 of pydantic where fields use the Annotated[<type> , FieldInfoSubclass] type hint.

## Related issue number
fix #7978 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

please review.
