### PR TITLE
fix typos in docstring

### DIFF
--- a/pydantic/v1/schema.py
+++ b/pydantic/v1/schema.py
@@ -400,7 +400,7 @@ def get_flat_models_from_fields(fields: Sequence[ModelField], known_models: Type
     """
     Take a list of Pydantic  ``ModelField``s (from a model) that could have been declared as subclasses of ``BaseModel``
     (so, any of them could be a submodel), and generate a set with their models and all the sub-models in the tree.
-    I.e. if you pass a the fields of a model ``Foo`` (subclass of ``BaseModel``) as ``fields``, and on of them has a
+    I.e. if you pass the fields of a model ``Foo`` (subclass of ``BaseModel``) as ``fields``, and one of them has a
     field of type ``Bar`` (also subclass of ``BaseModel``) and that model ``Bar`` has a field of type ``Baz`` (also
     subclass of ``BaseModel``), the return value will be ``set([Foo, Bar, Baz])``.
 


### PR DESCRIPTION
## Change Summary

Fix two tiny typos in the docstring for `get_flat_models_from_fields` in `pydantic/v1/schema.py`.

## Related issue number

None

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] ~Unit tests for the changes exist~ – unnecessary in the absence of code changes
* [ ] ~Tests pass on CI~ – unnecessary in the absence of code changes
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig