### PR TITLE
config keyword guard in TypeAdapter.__init__ checks for pydantic dataclasses instead of stdlib dataclasses

### DIFF
--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -2,12 +2,12 @@
 from __future__ import annotations as _annotations
 
 import sys
-from pydantic.dataclasses import is_pydantic_dataclass
 from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Set, TypeVar, Union, cast, overload
 
 from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator, Some
 from typing_extensions import Literal, is_typeddict
 
+from pydantic.dataclasses import is_pydantic_dataclass
 from pydantic.errors import PydanticUserError
 from pydantic.main import BaseModel
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations as _annotations
 
 import sys
-from dataclasses import is_dataclass
+from pydantic.dataclasses import is_pydantic_dataclass
 from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Set, TypeVar, Union, cast, overload
 
 from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator, Some
@@ -171,7 +171,7 @@ class TypeAdapter(Generic[T]):
         config_wrapper = _config.ConfigWrapper(config)
 
         try:
-            type_has_config = issubclass(type, BaseModel) or is_dataclass(type) or is_typeddict(type)
+            type_has_config = issubclass(type, BaseModel) or is_pydantic_dataclass(type) or is_typeddict(type)
         except TypeError:
             # type is not a class
             type_has_config = False

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -178,7 +178,7 @@ class TypeAdapter(Generic[T]):
 
         if type_has_config and config is not None:
             raise PydanticUserError(
-                'Cannot use `config` when the type is a BaseModel, dataclass or TypedDict.'
+                'Cannot use `config` when the type is a BaseModel, pydantic dataclass or TypedDict.'
                 ' These types can have their own config and setting the config via the `config`'
                 ' parameter to TypeAdapter will not override it, thus the `config` you passed to'
                 ' TypeAdapter becomes meaningless, which is probably not what you want.',


### PR DESCRIPTION
When initializing TypeAdapter with an object and the `config` keyword argument, the target object is analyzed to see if a config can be applied to it.  When the target is a plain stdlib dataclasses.dataclass, an error is raised with the error message indicating that `BaseModel`, `dataclass` and `TypedDict` are not appropriate to use with a supplied config, as they already have their own config.

While classes decorated with `@pydantic.dataclasses.dataclass` do have an existing config, classes decorated with `@dataclasses.dataclass` (stdlib dataclasses) do not, and can safely be used with the `config` keyword.

This PR alters the check in `__init__` to look for pydantic dataclasses specifically, instead of stdlib dataclasses,
when determining if the `config` keyword argument can be used.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The check for `type_has_config` in `TypeAdapter.__init__` is altered to use `pydantic.dataclasses.is_pydantic_dataclass` instead of `dataclasses.is_dataclass`, so that the config keyword can be used with stdlib dataclasses.


## Related issue number

fixes #8326

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
