### PR TITLE
Add a test demonstrating why we don't reset the parent namespace in `create_model`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -133,6 +133,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # pydantic._internal._generate_schema.GenerateSchema.model_schema to work for a plain BaseModel annotation
         model_fields = {}
         __pydantic_decorators__ = _decorators.DecoratorInfos()
+        __pydantic_parent_namespace__ = None
         # Prevent `BaseModel` from being instantiated directly:
         __pydantic_validator__ = _mock_val_ser.MockValSer(
             'Pydantic models should inherit from BaseModel, BaseModel cannot be instantiated directly',

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -1,4 +1,5 @@
 import platform
+import re
 from typing import Generic, Optional, Tuple, TypeVar
 
 import pytest
@@ -76,6 +77,38 @@ def test_create_model_multi_inheritance():
     FooModel = create_model('FooModel', value=(int, ...), __base__=(BaseModel, Generic_T))
 
     assert FooModel.__orig_bases__ == (BaseModel, Generic_T)
+
+
+def test_create_model_must_not_reset_parent_namespace():
+    # It's important to use the annotation `'namespace'` as this is a particular string that is present
+    # in the parent namespace if you reset the parent namespace in the call to `create_model`.
+
+    AbcModel = create_model('AbcModel', abc=('namespace', None))
+    with pytest.raises(
+        PydanticUserError,
+        match=re.escape(
+            '`AbcModel` is not fully defined; you should define `namespace`, then call `AbcModel.model_rebuild()`.'
+        ),
+    ):
+        AbcModel(abc=1)
+
+    # Rebuild the model now that `namespace` is defined
+    namespace = int  # noqa F841
+    AbcModel.model_rebuild()
+
+    assert AbcModel(abc=1).abc == 1
+
+    with pytest.raises(ValidationError) as exc_info:
+        AbcModel(abc='a')
+    # insert_assert(exc_info.value.errors(include_url=False))
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_parsing',
+            'loc': ('abc',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'a',
+        }
+    ]
 
 
 def test_invalid_name():


### PR DESCRIPTION
Adds a test showing why the line of code removed in https://github.com/pydantic/pydantic/pull/8011 was there