### PR TITLE
Add support for field alias in dataclass signature

### DIFF
--- a/pydantic/_internal/_constructor_signature_generators.py
+++ b/pydantic/_internal/_constructor_signature_generators.py
@@ -52,7 +52,7 @@ def generate_pydantic_signature(
     for param in islice(present_params, 1, None):  # skip self arg
         # inspect does "clever" things to show annotations as strings because we have
         # `from __future__ import annotations` in main, we don't want that
-        if fields.get(param.name) and isinstance(fields[param.name].alias, str):
+        if fields.get(param.name):
             param_name = _field_name_or_alias(param.name, fields[param.name])
             param = param.replace(name=param_name)
         if param.annotation == 'Any':

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2487,9 +2487,10 @@ def test_signature():
         a: float = dataclasses.field(default_factory=float)
         b: float = Field(default=1.0)
         c: float = Field(default_factory=float)
+        d: int = dataclasses.field(metadata={'alias': 'dd'}, default=1)
 
     assert str(inspect.signature(Model)) == (
-        "(x: int, y: str = 'y', z: float = 1.0, a: float = <factory>, b: float = 1.0, c: float = <factory>) -> None"
+        "(x: int, y: str = 'y', z: float = 1.0, a: float = <factory>, b: float = 1.0, c: float = <factory>, dd: int = 1) -> None"
     )
 
 


### PR DESCRIPTION
Add support for field alias in dataclass signature

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Added support for field alias in dataclass signature.

When creating a `dataclass` 

```python
from dataclasses import field
from pydantic.dataclasses import dataclass, Field

@dataclass
class A:
    a: int = field(metadata={"ge": 1, "alias": "aa"}
```

The signature of `A` seems to ignore the alias of `a` 

```
# In [3]: A.__signature__
# Out[3]: <Signature (a: int) -> None>  # This should be "<Signature (aa: int) -> None>"

# The "ge" validation is supported
# In [4]: A(aa=0)
# ValidationError: 1 validation error for A
# aa
#  Input should be greater than or equal to 1 [type=greater_than_equal, input_value=0, input_type=int]
#    For further information visit https://errors.pydantic.dev/2.5/v/greater_than_equal
```

## Related issue number

Fixing #8367 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin