### PR TITLE
Fix a naming issue with JSON schema for generics parametrized by recursive type aliases

### DIFF
--- a/pydantic/_internal/_repr.py
+++ b/pydantic/_internal/_repr.py
@@ -93,6 +93,8 @@ def display_as_type(obj: Any) -> str:
         return '...'
     elif isinstance(obj, Representation):
         return repr(obj)
+    elif isinstance(obj, typing_extensions.TypeAliasType):
+        return str(obj)
 
     if not isinstance(obj, (_typing_extra.typing_base, _typing_extra.WithArgsTypes, type)):
         obj = obj.__class__

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -1,5 +1,6 @@
 import datetime
-from typing import Dict, List, Tuple, TypeVar, Union
+from dataclasses import dataclass
+from typing import Dict, Generic, List, Tuple, TypeVar, Union
 
 import pytest
 from annotated_types import MaxLen
@@ -131,6 +132,18 @@ def test_recursive_type_alias() -> None:
             }
         },
     }
+
+
+def test_recursive_type_alias_name():
+    T = TypeVar('T')
+
+    @dataclass
+    class MyGeneric(Generic[T]):
+        field: T
+
+    MyRecursiveType = TypeAliasType('MyRecursiveType', MyGeneric['MyRecursiveType'] | int)
+    json_schema = TypeAdapter(MyRecursiveType).json_schema()
+    assert sorted(json_schema['$defs'].keys()) == ['MyGeneric_MyRecursiveType_', 'MyRecursiveType']
 
 
 def test_type_alias_annotated() -> None:

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -141,7 +141,7 @@ def test_recursive_type_alias_name():
     class MyGeneric(Generic[T]):
         field: T
 
-    MyRecursiveType = TypeAliasType('MyRecursiveType', MyGeneric['MyRecursiveType'] | int)
+    MyRecursiveType = TypeAliasType('MyRecursiveType', Union[MyGeneric['MyRecursiveType'], int])
     json_schema = TypeAdapter(MyRecursiveType).json_schema()
     assert sorted(json_schema['$defs'].keys()) == ['MyGeneric_MyRecursiveType_', 'MyRecursiveType']
 


### PR DESCRIPTION
Currently, the set of generated refs in the added test is `['MyGeneric_TypeAliasType_', 'MyRecursiveType']`, rather than `['MyGeneric_MyRecursiveType_', 'MyRecursiveType']` as it should be.