### PR TITLE
Update Mypy docs with correct output from Mypy

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -108,7 +108,7 @@ If you've made any changes to the documentation (including changes to function s
 # Build documentation
 make docs
 # If you have changed the documentation, make sure it builds successfully.
-# You can also use `make docs-serve` to serve the documentation at localhost:8000
+# You can also use `pdm run mkdocs serve` to serve the documentation at localhost:8000
 ```
 
 ### Commit and push your changes

--- a/docs/integrations/mypy.md
+++ b/docs/integrations/mypy.md
@@ -25,13 +25,17 @@ print(m.middle_name)  # not a model field!
 Model()  # will raise a validation error for age and list_of_ints
 ```
 
-Without any special configuration, mypy catches one of the errors:
+Without any special configuration, mypy does not catch the [missing model field annotation](https://docs.pydantic.dev/2.5/errors/usage_errors/#model-field-missing-annotation) and warns about the `list_of_ints` argument which Pydantic parses correctly:
 
 ```
-16: error: "Model" has no attribute "middle_name"  [attr-defined]
+test.py:15: error: List item 1 has incompatible type "str"; expected "int"  [list-item]
+test.py:15: error: List item 2 has incompatible type "bytes"; expected "int"  [list-item]
+test.py:16: error: "Model" has no attribute "middle_name"  [attr-defined]
+test.py:17: error: Missing named argument "age" for "Model"  [call-arg]
+test.py:17: error: Missing named argument "list_of_ints" for "Model"  [call-arg]
 ```
 
-But [with the plugin enabled](#enabling-the-plugin), it catches both:
+But [with the plugin enabled](#enabling-the-plugin), it gives the correct error:
 ```
 9: error: Untyped fields disallowed  [pydantic-field]
 16: error: "Model" has no attribute "middle_name"  [attr-defined]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Docs description of `mypy`'s output is not correct. Running from a clean install local installation on Mac gave the output added to the docs. Mypy version 1.7.1 and pydantic version 2.5.2:

```shell
> pipenv run pip freeze
annotated-types==0.6.0
mypy==1.7.1
mypy-extensions==1.0.0
pydantic==2.5.2
pydantic_core==2.14.5
typing_extensions==4.9.0
```

Also updated contributing.md because `make docs-serve` does not work since https://github.com/pydantic/pydantic/commit/d3c02a45b52bb7d955e81d09906dfcb522fdc223 it seems.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
