### PR TITLE
Fix cached_property handling in dataclasses when copied

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -35,7 +35,7 @@ import copy
 import dataclasses
 import sys
 from contextlib import contextmanager
-from functools import wraps
+from functools import cached_property, wraps
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator, Optional, Type, TypeVar, Union, overload
 
 from typing_extensions import dataclass_transform
@@ -408,6 +408,8 @@ def create_pydantic_model_from_dataclass(
     model.__doc__ = dc_cls_doc if dc_cls_doc is not None else dc_cls.__doc__ or ''
     return model
 
+def _is_field_cached_property(obj: 'Dataclass', k: str) -> bool:
+    return isinstance(getattr(type(obj), k, None), cached_property)
 
 def _dataclass_validate_values(self: 'Dataclass') -> None:
     # validation errors can occur if this function is called twice on an already initialised dataclass.
@@ -417,9 +419,9 @@ def _dataclass_validate_values(self: 'Dataclass') -> None:
     if getattr(self, '__pydantic_has_field_info_default__', False):
         # We need to remove `FieldInfo` values since they are not valid as input
         # It's ok to do that because they are obviously the default values!
-        input_data = {k: v for k, v in self.__dict__.items() if not isinstance(v, FieldInfo)}
+        input_data = {k: v for k, v in self.__dict__.items() if not (isinstance(v, FieldInfo) or _is_field_cached_property(self, k))}
     else:
-        input_data = self.__dict__
+        input_data = {k: v for k, v in self.__dict__.items() if not _is_field_cached_property(self, k)}
     d, _, validation_error = validate_model(self.__pydantic_model__, input_data, cls=self.__class__)
     if validation_error:
         raise validation_error

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -35,7 +35,14 @@ import copy
 import dataclasses
 import sys
 from contextlib import contextmanager
-from functools import cached_property, wraps
+from functools import wraps
+
+try:
+    from functools import cached_property
+except ImportError:
+    # cached_property available only for python3.8+
+    pass
+
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator, Optional, Type, TypeVar, Union, overload
 
 from typing_extensions import dataclass_transform
@@ -408,8 +415,17 @@ def create_pydantic_model_from_dataclass(
     model.__doc__ = dc_cls_doc if dc_cls_doc is not None else dc_cls.__doc__ or ''
     return model
 
-def _is_field_cached_property(obj: 'Dataclass', k: str) -> bool:
-    return isinstance(getattr(type(obj), k, None), cached_property)
+
+if sys.version_info >= (3, 8):
+
+    def _is_field_cached_property(obj: 'Dataclass', k: str) -> bool:
+        return isinstance(getattr(type(obj), k, None), cached_property)
+
+else:
+
+    def _is_field_cached_property(obj: 'Dataclass', k: str) -> bool:
+        return False
+
 
 def _dataclass_validate_values(self: 'Dataclass') -> None:
     # validation errors can occur if this function is called twice on an already initialised dataclass.
@@ -419,7 +435,11 @@ def _dataclass_validate_values(self: 'Dataclass') -> None:
     if getattr(self, '__pydantic_has_field_info_default__', False):
         # We need to remove `FieldInfo` values since they are not valid as input
         # It's ok to do that because they are obviously the default values!
-        input_data = {k: v for k, v in self.__dict__.items() if not (isinstance(v, FieldInfo) or _is_field_cached_property(self, k))}
+        input_data = {
+            k: v
+            for k, v in self.__dict__.items()
+            if not (isinstance(v, FieldInfo) or _is_field_cached_property(self, k))
+        }
     else:
         input_data = {k: v for k, v in self.__dict__.items() if not _is_field_cached_property(self, k)}
     d, _, validation_error = validate_model(self.__pydantic_model__, input_data, cls=self.__class__)

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -101,7 +101,6 @@ def flatten_errors(
 ) -> Generator['ErrorDict', None, None]:
     for error in errors:
         if isinstance(error, ErrorWrapper):
-
             if loc:
                 error_loc = loc + error.loc_tuple()
             else:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -178,7 +178,6 @@ class FieldInfo(Representation):
         self.extra = kwargs
 
     def __repr_args__(self) -> 'ReprArgs':
-
         field_defaults_to_hide: Dict[str, Any] = {
             'repr': True,
             **self.__field_constraints__,
@@ -405,7 +404,6 @@ class ModelField(Representation):
         alias: Optional[str] = None,
         field_info: Optional[FieldInfo] = None,
     ) -> None:
-
         self.name: str = name
         self.has_alias: bool = alias is not None
         self.alias: str = alias if alias is not None else name
@@ -852,7 +850,6 @@ class ModelField(Representation):
     def validate(
         self, v: Any, values: Dict[str, Any], *, loc: 'LocStr', cls: Optional['ModelOrDc'] = None
     ) -> 'ValidateReturn':
-
         assert self.type_.__class__ is not DeferredType
 
         if self.type_.__class__ is ForwardRef:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -737,7 +737,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_defaults: bool,
         exclude_none: bool,
     ) -> Any:
-
         if isinstance(v, BaseModel):
             if to_dict:
                 v_dict = v.dict(
@@ -830,7 +829,6 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> 'TupleGenerator':
-
         # Merge field set excludes with explicit exclude parameter with explicit overriding field set options.
         # The extra "is not None" guards are not logically necessary but optimizes performance for the simple case.
         if exclude is not None or self.__exclude_fields__ is not None:

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -198,7 +198,6 @@ def model_schema(
 
 
 def get_field_info_schema(field: ModelField, schema_overrides: bool = False) -> Tuple[Dict[str, Any], bool]:
-
     # If no title is explicitly set, we don't set title in the schema for enums.
     # The behaviour is the same as `BaseModel` reference, where the default title
     # is in the definitions part of the schema.

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -481,6 +481,7 @@ else:
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SET TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+
 # This types superclass should be Set[T], but cython chokes on that...
 class ConstrainedSet(set):  # type: ignore
     # Needed for pydantic to detect that this is a set
@@ -568,6 +569,7 @@ def confrozenset(
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ LIST TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 # This types superclass should be List[T], but cython chokes on that...
 class ConstrainedList(list):  # type: ignore
@@ -1094,7 +1096,6 @@ class ByteSize(int):
 
     @classmethod
     def validate(cls, v: StrIntFloat) -> 'ByteSize':
-
         try:
             return cls(int(v))
         except ValueError:
@@ -1116,7 +1117,6 @@ class ByteSize(int):
         return cls(int(float(scalar) * unit_mult))
 
     def human_readable(self, decimal: bool = False) -> str:
-
         if decimal:
             divisor = 1000
             units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
@@ -1135,7 +1135,6 @@ class ByteSize(int):
         return f'{num:0.1f}{final_unit}'
 
     def to(self, unit: str) -> float:
-
         try:
             unit_div = BYTE_SIZES[unit.lower()]
         except KeyError:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -5,7 +5,12 @@ import re
 import sys
 from collections.abc import Hashable
 from datetime import datetime
-from functools import cached_property
+
+try:
+    from functools import cached_property
+except ImportError:
+    pass
+
 from pathlib import Path
 from typing import Callable, ClassVar, Dict, FrozenSet, List, Optional, Set, Union
 
@@ -1633,30 +1638,31 @@ def test_can_deepcopy_wrapped_dataclass_type():
     assert B is not A
     assert B(1) == A(1)
 
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='cached_property was introduced in python3.8 stdlib')
 def test_cached_property():
     @dataclasses.dataclass(frozen=True)
     class A:
         name: str
 
         @cached_property
-        def _name(self): 
-            return "name"
+        def _name(self):
+            return 'name'
 
     class MyModel(BaseModel, arbitrary_types_allowed=True, frozen=True, extra=Extra.forbid):
         scheduler: A
 
     models = {
-        "AX": MyModel(scheduler=A("a")),
+        'AX': MyModel(scheduler=A('a')),
     }
 
-    sched = A("sched")
+    sched = A('sched')
 
     models_2 = {
-        "AY": models["AX"].copy(update=dict(scheduler=sched)), 
+        'AY': models['AX'].copy(update=dict(scheduler=sched)),
     }
 
-    models |= models_2
+    models = {**models, **models_2}
 
-    models["AY"].scheduler._name
-    MyModel.parse_obj(models["AY"].dict())
-        
+    models['AY'].scheduler._name
+    MyModel.parse_obj(models['AY'].dict())

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -745,7 +745,6 @@ def test_generic_model_from_function_pickle_fail(create_module):
 
 
 def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
-
     # match identity checker otherwise we never get to the redefinition check
     monkeypatch.setattr('pydantic.generics.all_identical', lambda left, right: False)
 
@@ -975,7 +974,6 @@ def test_replace_types_with_user_defined_generic_type_field():
         pass
 
     class Model(GenericModel, Generic[T, KT, VT]):
-
         map_field: GenericMapping[KT, VT]
         list_field: GenericList[T]
 
@@ -1323,7 +1321,6 @@ def test_generic_with_user_defined_generic_field():
         pass
 
     class Model(GenericModel, Generic[T]):
-
         field: GenericList[T]
 
     model = Model[int](field=[5])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2186,7 +2186,6 @@ def test_class_kwargs_config_json_encoders():
 
 
 def test_class_kwargs_config_and_attr_conflict():
-
     with pytest.raises(
         TypeError, match='Specifying config in two places is ambiguous, use either Config attribute or class kwargs'
     ):

--- a/tests/test_rich_repr.py
+++ b/tests/test_rich_repr.py
@@ -25,7 +25,6 @@ def test_rich_repr() -> None:
 
 
 def test_rich_repr_color() -> None:
-
     color = Color((10, 20, 30, 0.1))
     rich_repr = list(color.__rich_repr__())
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -103,7 +103,6 @@ def test_convert_generics(type_, expectations):
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='NewType class was added in python 3.10.')
 def test_convert_generics_unsettable_args():
     class User(NewType):
-
         __origin__ = type(list[str])
         __args__ = (list['Hero'],)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->



## Change Summary

This avoids validating `cached_property` attributes in dataclasses

## Related issue number
Fix #8406 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
