### PR TITLE
Fix history

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,6 @@
 #### Fixes
 
 * Fix memory leak with recursive definitions creating reference cycles by @davidhewitt in [pydantic/pydantic-core#1125](https://github.com/pydantic/pydantic-core/pull/1125)
-* Fix `JsonValue` `bool` serialization by @sydney-runkle in [#8190](https://github.com/pydantic/pydantic/pull/8190)
 
 ## v2.5.2 (2023-11-22)
 


### PR DESCRIPTION
The `JsonValue` `bool` serialization was fixed in `2.5.2`