### PR TITLE
Allow different serializer to an Annotated type for `python` and `json` mode

### DIFF
--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -102,6 +102,17 @@ def test_serializer_annotated_plain_json():
     assert MyModel(x=1234).model_dump_json() == '{"x":"1,234"}'
 
 
+def test_serializer_annotated_plain_only_python():
+    FancyInt = Annotated[int, PlainSerializer(lambda x: f'{x:,}', return_type=str, when_used={'python'})]
+
+    class MyModel(BaseModel):
+        x: FancyInt
+
+    assert MyModel(x=1234).model_dump() == {'x': '1,234'}
+    assert MyModel(x=1234).model_dump_json() == '{"x":1234}'
+    assert MyModel(x=1234).model_dump(mode='json') == {'x': 1234}
+
+
 def test_serializer_annotated_wrap_always():
     def ser_wrap(v: Any, nxt: SerializerFunctionWrapHandler) -> str:
         return f'{nxt(v + 1):,}'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

`PlainSerializer` and `WrapSerializer` can take the arguments :
- `when_used` as a `str` like before or a `set` containing the literals `python` and/or `json`
- `unless_none` as  a `bool`

It will permit to have custom different serializer for the `python` and `json` mode using a `JsonOrPythonSchema`.

## Related issue number

fix #8086 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
