### PR TITLE
Introducing classproperty decorator for model_computed_fields

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -188,6 +188,11 @@ class ModelMetaclass(ABCMeta):
                 types_namespace=types_namespace,
                 create_model_module=_create_model_module,
             )
+
+            # If this is placed before the complete_model_class call above,
+            # the generic computed fields return type is set to PydanticUndefined
+            cls.model_computed_fields = {k: v.info for k, v in cls.__pydantic_decorators__.computed_fields.items()}
+
             # using super(cls, cls) on the next line ensures we only call the parent class's __pydantic_init_subclass__
             # I believe the `type: ignore` is only necessary because mypy doesn't realize that this code branch is
             # only hit for _proper_ subclasses of BaseModel

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -122,6 +122,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         __pydantic_serializer__: ClassVar[SchemaSerializer]
         __pydantic_validator__: ClassVar[SchemaValidator]
 
+        model_computed_fields: ClassVar[dict[str, ComputedFieldInfo]]
+        """A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects."""
+
         # Instance attributes
         # Note: we use the non-existent kwarg `init=False` in pydantic.fields.Field below so that @dataclass_transform
         # doesn't think these are valid as keyword arguments to the class initializer.
@@ -129,12 +132,12 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         __pydantic_fields_set__: set[str] = _Field(init=False)  # type: ignore
         __pydantic_private__: dict[str, Any] | None = _Field(init=False)  # type: ignore
 
-        model_computed_fields: ClassVar[dict[str, ComputedFieldInfo]]
     else:
         # `model_fields` and `__pydantic_decorators__` must be set for
         # pydantic._internal._generate_schema.GenerateSchema.model_schema to work for a plain BaseModel annotation
         model_fields = {}
         model_computed_fields = {}
+
         __pydantic_decorators__ = _decorators.DecoratorInfos()
         __pydantic_parent_namespace__ = None
         # Prevent `BaseModel` from being instantiated directly:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -58,6 +58,14 @@ __all__ = 'BaseModel', 'create_model'
 _object_setattr = _model_construction.object_setattr
 
 
+class classproperty:
+    def __init__(self, function) -> None:
+        self.fget = function
+
+    def __get__(self, instance, owner) -> Any:
+        return self.fget(owner)
+
+
 class BaseModel(metaclass=_model_construction.ModelMetaclass):
     """Usage docs: https://docs.pydantic.dev/2.6/concepts/models/
 
@@ -167,14 +175,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     # The following line sets a flag that we use to determine when `__init__` gets overridden by the user
     __init__.__pydantic_base_init__ = True
 
-    @property
-    def model_computed_fields(self) -> dict[str, ComputedFieldInfo]:
+    @classproperty
+    def model_computed_fields(cls) -> dict[str, ComputedFieldInfo]:
         """Get the computed fields of this model instance.
 
         Returns:
             A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects.
         """
-        return {k: v.info for k, v in self.__pydantic_decorators__.computed_fields.items()}
+        return {k: v.info for k, v in cls.__pydantic_decorators__.computed_fields.items()}
 
     @property
     def model_extra(self) -> dict[str, Any] | None:

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -62,6 +62,13 @@ def test_computed_fields_get():
     assert rect.model_dump() == {'width': 10, 'length': 5, 'area': 50, 'area2': 50}
     assert rect.model_dump_json() == '{"width":10,"length":5,"area":50,"area2":50}'
 
+    assert set(Rectangle.model_fields) == {'width', 'length'}
+    assert set(Rectangle.model_computed_fields) == {'area', 'area2'}
+
+    assert Rectangle.model_computed_fields['area'].description == 'An awesome area'
+    assert Rectangle.model_computed_fields['area2'].title == 'Pikarea'
+    assert Rectangle.model_computed_fields['area2'].description == 'Another area'
+
 
 def test_computed_fields_json_schema():
     class Rectangle(BaseModel):


### PR DESCRIPTION
## Change Summary

A `classproperty` decorator has been added in order to access `model_computed_fields` as a class attribute and an instance property.

## Related issue number
fix #7986

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin