### PR TITLE
Update docstrings for secret types

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1552,7 +1552,7 @@ class SecretStr(_SecretField[str]):
     print(user.password.get_secret_value())
     #> password1
     print((SecretStr('password'), SecretStr('')))
-    #> ('**********', '')
+    #> (SecretStr('**********'), SecretStr(''))
     ```
     """
 
@@ -1579,7 +1579,7 @@ class SecretBytes(_SecretField[bytes]):
     print(user.password.get_secret_value())
     #> b'password1'
     print((SecretBytes(b'password'), SecretBytes(b'')))
-    #> (b'**********', b'')
+    #> (SecretBytes(b'**********'), SecretBytes(b''))
     ```
     """
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1551,8 +1551,8 @@ class SecretStr(_SecretField[str]):
     #> username='scolvin' password=SecretStr('**********')
     print(user.password.get_secret_value())
     #> password1
-    print(SecretStr('password'), SecretStr(''))
-    #> '**********' ''
+    print((SecretStr('password'), SecretStr('')))
+    #> ('**********', '')
     ```
     """
 
@@ -1578,8 +1578,8 @@ class SecretBytes(_SecretField[bytes]):
     #> username='scolvin' password=SecretBytes(b'**********')
     print(user.password.get_secret_value())
     #> b'password1'
-    print(SecretBytes(b'password'), SecretBytes(b''))
-    #> b'**********' b''
+    print((SecretBytes(b'password'), SecretBytes(b'')))
+    #> (b'**********', b'')
     ```
     """
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1535,7 +1535,8 @@ def _secret_display(value: str | bytes) -> str:
 class SecretStr(_SecretField[str]):
     """A string used for storing sensitive information that you do not want to be visible in logging or tracebacks.
 
-    It displays `'**********'` instead of the string value on `repr()` and `str()` calls.
+    When the secret value is nonempty, it is displayed as `'**********'` instead of the underlying value in
+    calls to `repr()` and `str()`. If the value _is_ empty, it is displayed as `''`.
 
     ```py
     from pydantic import BaseModel, SecretStr
@@ -1550,6 +1551,8 @@ class SecretStr(_SecretField[str]):
     #> username='scolvin' password=SecretStr('**********')
     print(user.password.get_secret_value())
     #> password1
+    print(SecretStr('password'), SecretStr(''))
+    #> SecretStr('**********') SecretStr('')
     ```
     """
 
@@ -1561,6 +1564,8 @@ class SecretBytes(_SecretField[bytes]):
     """A bytes used for storing sensitive information that you do not want to be visible in logging or tracebacks.
 
     It displays `b'**********'` instead of the string value on `repr()` and `str()` calls.
+    When the secret value is nonempty, it is displayed as `b'**********'` instead of the underlying value in
+    calls to `repr()` and `str()`. If the value _is_ empty, it is displayed as `b''`.
 
     ```py
     from pydantic import BaseModel, SecretBytes
@@ -1573,6 +1578,8 @@ class SecretBytes(_SecretField[bytes]):
     #> username='scolvin' password=SecretBytes(b'**********')
     print(user.password.get_secret_value())
     #> b'password1'
+    print(SecretBytes(b'password'), SecretBytes(b''))
+    #> SecretBytes(b'**********') SecretBytes(b'')
     ```
     """
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1552,7 +1552,7 @@ class SecretStr(_SecretField[str]):
     print(user.password.get_secret_value())
     #> password1
     print(SecretStr('password'), SecretStr(''))
-    #> SecretStr('**********') SecretStr('')
+    #> '**********' ''
     ```
     """
 
@@ -1579,7 +1579,7 @@ class SecretBytes(_SecretField[bytes]):
     print(user.password.get_secret_value())
     #> b'password1'
     print(SecretBytes(b'password'), SecretBytes(b''))
-    #> SecretBytes(b'**********') SecretBytes(b'')
+    #> b'**********' b''
     ```
     """
 


### PR DESCRIPTION
Not sure if we should also add a note in the usage docs, etc.

@samuelcolvin might make sense to add a note somewhere justifying the behavior for empty string (namely, in HTML forms it can be useful to see the empty string when debugging).

It might be worth noting more explicitly somewhere that this type should not be used if you need to protect the use of the empty string as a value, and/or that you should ensure elsewhere that it is not used for user input / etc.