### PR TITLE
Update to `pyright==1.1.345`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
         node-version: '18'
 
     - name: install pyright
-      run: npm install -g pyright@1.1.335  # try to keep this in sync with .pre-commit-config.yaml
+      run: npm install -g pyright@1.1.343  # try to keep this in sync with .pre-commit-config.yaml
 
     - name: run pyright tests
       run: make test-pyright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
         node-version: '18'
 
     - name: install pyright
-      run: npm install -g pyright@1.1.344  # try to keep this in sync with .pre-commit-config.yaml
+      run: npm install -g pyright@1.1.345  # try to keep this in sync with .pre-commit-config.yaml
 
     - name: run pyright tests
       run: make test-pyright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
         node-version: '18'
 
     - name: install pyright
-      run: npm install -g pyright@1.1.343  # try to keep this in sync with .pre-commit-config.yaml
+      run: npm install -g pyright@1.1.344  # try to keep this in sync with .pre-commit-config.yaml
 
     - name: run pyright tests
       run: make test-pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
     types: [python]
     language: node
     pass_filenames: false
-    additional_dependencies: ["pyright@1.1.344"]  # try to keep this in sync with .github/workflows/ci.yml
+    additional_dependencies: ["pyright@1.1.345"]  # try to keep this in sync with .github/workflows/ci.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
     types: [python]
     language: node
     pass_filenames: false
-    additional_dependencies: ["pyright@1.1.343"]  # try to keep this in sync with .github/workflows/ci.yml
+    additional_dependencies: ["pyright@1.1.344"]  # try to keep this in sync with .github/workflows/ci.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
     types: [python]
     language: node
     pass_filenames: false
-    additional_dependencies: ["pyright@1.1.335"]  # try to keep this in sync with .github/workflows/ci.yml
+    additional_dependencies: ["pyright@1.1.343"]  # try to keep this in sync with .github/workflows/ci.yml

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -188,7 +188,7 @@ class PydanticDescriptorProxy(Generic[ReturnType]):
 
     def __set_name__(self, instance: Any, name: str) -> None:
         if hasattr(self.wrapped, '__set_name__'):
-            self.wrapped.__set_name__(instance, name)
+            self.wrapped.__set_name__(instance, name)  # pyright: ignore[reportFunctionMemberAccess]
 
     def __getattr__(self, __name: str) -> Any:
         """Forward checks for __isabstractmethod__ and such."""

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -626,7 +626,7 @@ class GenerateSchema:
         schema = self._unpack_refs_defs(schema)
 
         if is_function_with_inner_schema(schema):
-            ref = schema['schema'].pop('ref', None)
+            ref = schema['schema'].pop('ref', None)  # pyright: ignore[reportGeneralTypeIssues]
             if ref:
                 schema['ref'] = ref
         else:
@@ -2036,7 +2036,7 @@ def _extract_get_pydantic_json_schema(tp: Any, schema: CoreSchema) -> GetJsonSch
 
         has_custom_v2_modify_js_func = (
             js_modify_function is not None
-            and BaseModel.__get_pydantic_json_schema__.__func__
+            and BaseModel.__get_pydantic_json_schema__.__func__  # type: ignore
             not in (js_modify_function, getattr(js_modify_function, '__func__', None))
         )
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -165,7 +165,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         self.__pydantic_validator__.validate_python(data, self_instance=self)
 
     # The following line sets a flag that we use to determine when `__init__` gets overridden by the user
-    __init__.__pydantic_base_init__ = True
+    __init__.__pydantic_base_init__ = True  # pyright: ignore[reportFunctionMemberAccess]
 
     @property
     def model_computed_fields(self) -> dict[str, ComputedFieldInfo]:

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -62,10 +62,10 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType]):
             root = data  # type: ignore
         self.__pydantic_validator__.validate_python(root, self_instance=self)
 
-    __init__.__pydantic_base_init__ = True
+    __init__.__pydantic_base_init__ = True  # pyright: ignore[reportFunctionMemberAccess]
 
     @classmethod
-    def model_construct(cls: type[Model], root: RootModelRootType, _fields_set: set[str] | None = None) -> Model:
+    def model_construct(cls: type[Model], root: RootModelRootType, _fields_set: set[str] | None = None) -> Model:  # type: ignore
         """Create a new model using the provided root object and update fields set.
 
         Args:
@@ -110,7 +110,7 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType]):
 
     if typing.TYPE_CHECKING:
 
-        def model_dump(
+        def model_dump(  # type: ignore
             self,
             *,
             mode: Literal['json', 'python'] | str = 'python',

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -175,7 +175,7 @@ class TypeAdapter(Generic[T]):
             Depending on the type used, `mypy` might raise an error when instantiating a `TypeAdapter`. As a workaround, you can explicitly
             annotate your variable:
 
-            ```py
+            ```py test="skip"
             ta: TypeAdapter[Union[str, int]] = TypeAdapter(Union[str, int])  # type: ignore[arg-type]
             ```
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 
 import sys
 from dataclasses import is_dataclass
-from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Set, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Set, TypeVar, Union, cast, final, overload
 
 from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator, Some
 from typing_extensions import Literal, get_args, is_typeddict
@@ -107,6 +107,7 @@ def _type_has_config(type_: Any) -> bool:
         return False
 
 
+@final
 class TypeAdapter(Generic[T]):
     """Type adapters provide a flexible way to perform validation and serialization based on a Python type.
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -24,7 +24,6 @@ from .plugin._schema_validator import create_schema_validator
 
 T = TypeVar('T')
 
-MYPY = False
 
 if TYPE_CHECKING:
     # should be `set[int] | set[str] | dict[int, IncEx] | dict[str, IncEx] | None`, but mypy can't cope
@@ -122,105 +121,77 @@ class TypeAdapter(Generic[T]):
         serializer: The schema serializer for the type.
     """
 
-    if MYPY:
+    def __init__(
+        self,
+        type: type[T],
+        *,
+        config: ConfigDict | None = None,
+        _parent_depth: int = 2,
+        module: str | None = None,
+    ) -> None:
+        """Initializes the TypeAdapter object.
 
-        @overload
-        def __init__(
-            self: TypeAdapter[T],
-            type: type[T],
-            *,
-            config: ConfigDict | None = None,
-            _parent_depth: int = 2,
-            module: str | None = None,
-        ) -> None:
-            ...
+        Args:
+            type: The type associated with the `TypeAdapter`.
+            config: Configuration for the `TypeAdapter`, should be a dictionary conforming to [`ConfigDict`][pydantic.config.ConfigDict].
+            _parent_depth: depth at which to search the parent namespace to construct the local namespace.
+            module: The module that passes to plugin if provided.
 
-        # this overload is for non-type things like Union[int, str]
-        # Pyright currently handles this "correctly", but MyPy understands this as TypeAdapter[object]
-        # so an explicit type cast is needed
-        @overload
-        def __init__(
-            self: TypeAdapter[T],
-            type: T,
-            *,
-            config: ConfigDict | None = None,
-            _parent_depth: int = 2,
-            module: str | None = None,
-        ) -> None:
-            ...
-    else:
+        !!! note
+            You cannot use the `config` argument when instantiating a `TypeAdapter` if the type you're using has its own
+            config that cannot be overridden (ex: `BaseModel`, `TypedDict`, and `dataclass`). A
+            [`type-adapter-config-unused`](../errors/usage_errors.md#type-adapter-config-unused) error will be raised in this case.
 
-        def __init__(
-            self: TypeAdapter[T],
-            type: type[T],
-            *,
-            config: ConfigDict | None = None,
-            _parent_depth: int = 2,
-            module: str | None = None,
-        ) -> None:
-            """Initializes the TypeAdapter object.
+        !!! note
+            The `_parent_depth` argument is named with an underscore to suggest its private nature and discourage use.
+            It may be deprecated in a minor version, so we only recommend using it if you're
+            comfortable with potential change in behavior / support.
 
-            Args:
-                type: The type associated with the `TypeAdapter`.
-                config: Configuration for the `TypeAdapter`, should be a dictionary conforming to [`ConfigDict`][pydantic.config.ConfigDict].
-                _parent_depth: depth at which to search the parent namespace to construct the local namespace.
-                module: The module that passes to plugin if provided.
+        Returns:
+            A type adapter configured for the specified `type`.
+        """
+        type_is_annotated: bool = _typing_extra.is_annotated(type)
+        annotated_type: Any = get_args(type)[0] if type_is_annotated else None
+        type_has_config: bool = _type_has_config(annotated_type if type_is_annotated else type)
 
-            !!! note
-                You cannot use the `config` argument when instantiating a `TypeAdapter` if the type you're using has its own
-                config that cannot be overridden (ex: `BaseModel`, `TypedDict`, and `dataclass`). A
-                [`type-adapter-config-unused`](../errors/usage_errors.md#type-adapter-config-unused) error will be raised in this case.
+        if type_has_config and config is not None:
+            raise PydanticUserError(
+                'Cannot use `config` when the type is a BaseModel, dataclass or TypedDict.'
+                ' These types can have their own config and setting the config via the `config`'
+                ' parameter to TypeAdapter will not override it, thus the `config` you passed to'
+                ' TypeAdapter becomes meaningless, which is probably not what you want.',
+                code='type-adapter-config-unused',
+            )
 
-            !!! note
-                The `_parent_depth` argument is named with an underscore to suggest its private nature and discourage use.
-                It may be deprecated in a minor version, so we only recommend using it if you're
-                comfortable with potential change in behavior / support.
+        config_wrapper = _config.ConfigWrapper(config)
 
-            Returns:
-                A type adapter configured for the specified `type`.
-            """
-            type_is_annotated: bool = _typing_extra.is_annotated(type)
-            annotated_type: Any = get_args(type)[0] if type_is_annotated else None
-            type_has_config: bool = _type_has_config(annotated_type if type_is_annotated else type)
+        core_schema: CoreSchema
+        try:
+            core_schema = _getattr_no_parents(type, '__pydantic_core_schema__')
+        except AttributeError:
+            core_schema = _get_schema(type, config_wrapper, parent_depth=_parent_depth + 1)
 
-            if type_has_config and config is not None:
-                raise PydanticUserError(
-                    'Cannot use `config` when the type is a BaseModel, dataclass or TypedDict.'
-                    ' These types can have their own config and setting the config via the `config`'
-                    ' parameter to TypeAdapter will not override it, thus the `config` you passed to'
-                    ' TypeAdapter becomes meaningless, which is probably not what you want.',
-                    code='type-adapter-config-unused',
-                )
+        core_config = config_wrapper.core_config(None)
+        validator: SchemaValidator
+        try:
+            validator = _getattr_no_parents(type, '__pydantic_validator__')
+        except AttributeError:
+            if module is None:
+                f = sys._getframe(1)
+                module = cast(str, f.f_globals['__name__'])
+            validator = create_schema_validator(
+                core_schema, type, module, str(type), 'TypeAdapter', core_config, config_wrapper.plugin_settings
+            )  # type: ignore
 
-            config_wrapper = _config.ConfigWrapper(config)
+        serializer: SchemaSerializer
+        try:
+            serializer = _getattr_no_parents(type, '__pydantic_serializer__')
+        except AttributeError:
+            serializer = SchemaSerializer(core_schema, core_config)
 
-            core_schema: CoreSchema
-            try:
-                core_schema = _getattr_no_parents(type, '__pydantic_core_schema__')
-            except AttributeError:
-                core_schema = _get_schema(type, config_wrapper, parent_depth=_parent_depth + 1)
-
-            core_config = config_wrapper.core_config(None)
-            validator: SchemaValidator
-            try:
-                validator = _getattr_no_parents(type, '__pydantic_validator__')
-            except AttributeError:
-                if module is None:
-                    f = sys._getframe(1)
-                    module = cast(str, f.f_globals['__name__'])
-                validator = create_schema_validator(
-                    core_schema, type, module, str(type), 'TypeAdapter', core_config, config_wrapper.plugin_settings
-                )  # type: ignore
-
-            serializer: SchemaSerializer
-            try:
-                serializer = _getattr_no_parents(type, '__pydantic_serializer__')
-            except AttributeError:
-                serializer = SchemaSerializer(core_schema, core_config)
-
-            self.core_schema = core_schema
-            self.validator = validator
-            self.serializer = serializer
+        self.core_schema = core_schema
+        self.validator = validator
+        self.serializer = serializer
 
     def validate_python(
         self,

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -176,7 +176,11 @@ class TypeAdapter(Generic[T]):
             Depending on the type used, `mypy` might raise an error when instantiating a `TypeAdapter`. As a workaround, you can explicitly
             annotate your variable:
 
-            ```py test="skip"
+            ```py
+            from typing import Union
+
+            from pydantic import TypeAdapter
+
             ta: TypeAdapter[Union[str, int]] = TypeAdapter(Union[str, int])  # type: ignore[arg-type]
             ```
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations as _annotations
 
 import sys
 from dataclasses import is_dataclass
-from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Set, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Set, TypeVar, Union, cast
 
 from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator, Some
 from typing_extensions import Literal, get_args, is_typeddict


### PR DESCRIPTION
Required by https://github.com/pydantic/pydantic/pull/8237

Most of the changes are introduced by the new `standard` type checking mode.

One failure remains on:

https://github.com/pydantic/pydantic/blob/da468c48624b202685af4baebf0edf0df4402a81/pydantic/type_adapter.py#L109-L153

As described by the comment, pyright handles it currently and doesn't need the extra overload, hence the emitted diagnostic:

`error: Overload 2 for "__new__" will never be used because its parameters overlap overload 1 (reportOverlappingOverload)`

This can be fixed by adding an `if MYPY` block, but first I think we can remove one of the overload set (either `__init__` or `__new__`), I don't know if it makes much sense to have both defined (apart from IDE support, but in that case we can keep only the `__init__` overload set defined).

Edit: went for `__init__` and special cased mypy.

Selected Reviewer: @hramezani