### PR TITLE
chore: clarify `frozen` vs `allow_mutation` in docstring

### DIFF
--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -125,7 +125,7 @@ class ConfigDict(TypedDict, total=False):
     attributes are hashable. Defaults to `False`.
 
     Note:
-        On V1, this setting was called `allow_mutation`, and was `True` by default.
+        On V1, the inverse of this setting was called `allow_mutation`, and was `True` by default.
     """
 
     populate_by_name: bool


### PR DESCRIPTION
## Change Summary

Clarifies that `frozen` is the inverse of v1.`allow_mutation` in config docs.

## Related issue number

fix #8488 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist - NA
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

please review