### PR TITLE
version_info moved

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ vulnerability, please see our [security policy](https://github.com/pydantic/pyda
 To make it as simple as possible for us to help you, please include the output of the following call in your issue:
 
 ```bash
-python -c "import pydantic.utils; print(pydantic.utils.version_info())"
+python -c "import pydantic.version; print(pydantic.version.version_info())"
 ```
 If you're using Pydantic prior to **v1.3** (when `version_info()` was added), please manually include OS, Python
 version and pydantic version.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,6 +9,10 @@ To make it as simple as possible for us to help you, please include the output o
 ```bash
 python -c "import pydantic.version; print(pydantic.version.version_info())"
 ```
+If you're using Pydantic prior to **v2.0** please use:
+```bash
+python -c "import pydantic.utils; print(pydantic.utils.version_info())"
+```
 If you're using Pydantic prior to **v1.3** (when `version_info()` was added), please manually include OS, Python
 version and pydantic version.
 


### PR DESCRIPTION
Getting rid of warning:
pydantic/pydantic/_migration.py:283: UserWarning: `pydantic.utils:version_info` has been moved to `pydantic.version:version_info`.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
