### PR TITLE
docs: add replacement for 'ENCODER_BY_TYPE' to migration guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -778,6 +778,7 @@ For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringCons
 | `pydantic.PyObject` | [`pydantic.ImportString`][pydantic.types.ImportString] |
 
 ## Deprecated and moved in Pydantic V2
+
 | Pydantic V1 | Pydantic V2 |
 | --- | --- |
 | `pydantic.tools.schema_of` | `pydantic.deprecated.tools.schema_of` |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -779,29 +779,30 @@ For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringCons
 
 ## Deprecated and moved in Pydantic V2
 
-| Pydantic V1 | Pydantic V2 |
-| --- | --- |
-| `pydantic.tools.schema_of` | `pydantic.deprecated.tools.schema_of` |
-| `pydantic.tools.parse_obj_as` | `pydantic.deprecated.tools.parse_obj_as` |
-| `pydantic.tools.schema_json_of` | `pydantic.deprecated.tools.schema_json_of` |
-| `pydantic.json.pydantic_encoder` | `pydantic.deprecated.json.pydantic_encoder` |
-| `pydantic.validate_arguments` | `pydantic.deprecated.decorator.validate_arguments` |
-| `pydantic.json.custom_pydantic_encoder` | `pydantic.deprecated.json.custom_pydantic_encoder` |
-| `pydantic.json.timedelta_isoformat` | `pydantic.deprecated.json.timedelta_isoformat` |
-| `pydantic.decorator.validate_arguments` | `pydantic.deprecated.decorator.validate_arguments` |
-| `pydantic.class_validators.validator` | `pydantic.deprecated.class_validators.validator` |
+| Pydantic V1                                | Pydantic V2                                           |
+|--------------------------------------------|-------------------------------------------------------|
+| `pydantic.tools.schema_of`                 | `pydantic.deprecated.tools.schema_of`                 |
+| `pydantic.tools.parse_obj_as`              | `pydantic.deprecated.tools.parse_obj_as`              |
+| `pydantic.tools.schema_json_of`            | `pydantic.deprecated.tools.schema_json_of`            |
+| `pydantic.json.pydantic_encoder`           | `pydantic.deprecated.json.pydantic_encoder`           |
+| `pydantic.validate_arguments`              | `pydantic.deprecated.decorator.validate_arguments`    |
+| `pydantic.json.custom_pydantic_encoder`    | `pydantic.deprecated.json.custom_pydantic_encoder`    |
+| `pydantic.json.timedelta_isoformat`        | `pydantic.deprecated.json.timedelta_isoformat`        |
+| `pydantic.json.ENCODERS_BY_TYPE`           | `pydantic.deprecated.json.ENCODERS_BY_TYPE`           |
+| `pydantic.decorator.validate_arguments`    | `pydantic.deprecated.decorator.validate_arguments`    |
+| `pydantic.class_validators.validator`      | `pydantic.deprecated.class_validators.validator`      |
 | `pydantic.class_validators.root_validator` | `pydantic.deprecated.class_validators.root_validator` |
-| `pydantic.utils.deep_update` | `pydantic.v1.utils.deep_update` |
-| `pydantic.utils.GetterDict` | `pydantic.v1.utils.GetterDict` |
-| `pydantic.utils.lenient_issubclass` | `pydantic.v1.utils.lenient_issubclass` |
-| `pydantic.utils.lenient_isinstance` | `pydantic.v1.utils.lenient_isinstance` |
-| `pydantic.utils.is_valid_field` | `pydantic.v1.utils.is_valid_field` |
-| `pydantic.utils.update_not_none` | `pydantic.v1.utils.update_not_none` |
-| `pydantic.utils.import_string` | `pydantic.v1.utils.import_string` |
-| `pydantic.utils.Representation` | `pydantic.v1.utils.Representation` |
-| `pydantic.utils.ROOT_KEY` | `pydantic.v1.utils.ROOT_KEY` |
-| `pydantic.utils.smart_deepcopy` | `pydantic.v1.utils.smart_deepcopy` |
-| `pydantic.utils.sequence_like` | `pydantic.v1.utils.sequence_like` |
+| `pydantic.utils.deep_update`               | `pydantic.v1.utils.deep_update`                       |
+| `pydantic.utils.GetterDict`                | `pydantic.v1.utils.GetterDict`                        |
+| `pydantic.utils.lenient_issubclass`        | `pydantic.v1.utils.lenient_issubclass`                |
+| `pydantic.utils.lenient_isinstance`        | `pydantic.v1.utils.lenient_isinstance`                |
+| `pydantic.utils.is_valid_field`            | `pydantic.v1.utils.is_valid_field`                    |
+| `pydantic.utils.update_not_none`           | `pydantic.v1.utils.update_not_none`                   |
+| `pydantic.utils.import_string`             | `pydantic.v1.utils.import_string`                     |
+| `pydantic.utils.Representation`            | `pydantic.v1.utils.Representation`                    |
+| `pydantic.utils.ROOT_KEY`                  | `pydantic.v1.utils.ROOT_KEY`                          |
+| `pydantic.utils.smart_deepcopy`            | `pydantic.v1.utils.smart_deepcopy`                    |
+| `pydantic.utils.sequence_like`             | `pydantic.v1.utils.sequence_like`                     |
 
 ## Removed in Pydantic V2
 
@@ -997,31 +998,3 @@ For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringCons
 - `pydantic.utils.path_type`
 - `pydantic.utils.validate_field_name`
 - `pydantic.validate_model`
-
-## Customizing JSON Encoding for Pydantic Model with `ObjectId` Field in V2
-
-To ensure that instances of the model are serialized to JSON with the `ObjectId` field represented as a string, use a custom JSON encoder for instances of `ObjectId` since `ENCODERS_BY_TYPE` class is removed. For example:
-
-```
-from pydantic.json import ENCODERS_BY_TYPE
-from bson import ObjectId
-ENCODERS_BY_TYPE[ObjectId] = lambda v: str(v)
-```
-
-becomes:
-```
-from bson import ObjectId
-from pydantic import BaseModel, ConfigDict
-
-BaseModel.model_config["json_encoders"] = {ObjectId: lambda v: str(v)}
-
-
-class Item(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    id: ObjectId
-
-
-item = Item(id=ObjectId("5ff1e194b6a9d7a5f9a2741c"))
-print(item.model_dump_json())
-```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -778,31 +778,30 @@ For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringCons
 | `pydantic.PyObject` | [`pydantic.ImportString`][pydantic.types.ImportString] |
 
 ## Deprecated and moved in Pydantic V2
-
-| Pydantic V1                                | Pydantic V2                                           |
-|--------------------------------------------|-------------------------------------------------------|
-| `pydantic.tools.schema_of`                 | `pydantic.deprecated.tools.schema_of`                 |
-| `pydantic.tools.parse_obj_as`              | `pydantic.deprecated.tools.parse_obj_as`              |
-| `pydantic.tools.schema_json_of`            | `pydantic.deprecated.tools.schema_json_of`            |
-| `pydantic.json.pydantic_encoder`           | `pydantic.deprecated.json.pydantic_encoder`           |
-| `pydantic.validate_arguments`              | `pydantic.deprecated.decorator.validate_arguments`    |
-| `pydantic.json.custom_pydantic_encoder`    | `pydantic.deprecated.json.custom_pydantic_encoder`    |
-| `pydantic.json.timedelta_isoformat`        | `pydantic.deprecated.json.timedelta_isoformat`        |
-| `pydantic.json.ENCODERS_BY_TYPE`           | `pydantic.deprecated.json.ENCODERS_BY_TYPE`           |
-| `pydantic.decorator.validate_arguments`    | `pydantic.deprecated.decorator.validate_arguments`    |
-| `pydantic.class_validators.validator`      | `pydantic.deprecated.class_validators.validator`      |
+| Pydantic V1 | Pydantic V2 |
+| --- | --- |
+| `pydantic.tools.schema_of` | `pydantic.deprecated.tools.schema_of` |
+| `pydantic.tools.parse_obj_as` | `pydantic.deprecated.tools.parse_obj_as` |
+| `pydantic.tools.schema_json_of` | `pydantic.deprecated.tools.schema_json_of` |
+| `pydantic.json.pydantic_encoder` | `pydantic.deprecated.json.pydantic_encoder` |
+| `pydantic.validate_arguments` | `pydantic.deprecated.decorator.validate_arguments` |
+| `pydantic.json.custom_pydantic_encoder` | `pydantic.deprecated.json.custom_pydantic_encoder` |
+| `pydantic.json.ENCODERS_BY_TYPE` | `pydantic.deprecated.json.ENCODERS_BY_TYPE` |
+| `pydantic.json.timedelta_isoformat` | `pydantic.deprecated.json.timedelta_isoformat` |
+| `pydantic.decorator.validate_arguments` | `pydantic.deprecated.decorator.validate_arguments` |
+| `pydantic.class_validators.validator` | `pydantic.deprecated.class_validators.validator` |
 | `pydantic.class_validators.root_validator` | `pydantic.deprecated.class_validators.root_validator` |
-| `pydantic.utils.deep_update`               | `pydantic.v1.utils.deep_update`                       |
-| `pydantic.utils.GetterDict`                | `pydantic.v1.utils.GetterDict`                        |
-| `pydantic.utils.lenient_issubclass`        | `pydantic.v1.utils.lenient_issubclass`                |
-| `pydantic.utils.lenient_isinstance`        | `pydantic.v1.utils.lenient_isinstance`                |
-| `pydantic.utils.is_valid_field`            | `pydantic.v1.utils.is_valid_field`                    |
-| `pydantic.utils.update_not_none`           | `pydantic.v1.utils.update_not_none`                   |
-| `pydantic.utils.import_string`             | `pydantic.v1.utils.import_string`                     |
-| `pydantic.utils.Representation`            | `pydantic.v1.utils.Representation`                    |
-| `pydantic.utils.ROOT_KEY`                  | `pydantic.v1.utils.ROOT_KEY`                          |
-| `pydantic.utils.smart_deepcopy`            | `pydantic.v1.utils.smart_deepcopy`                    |
-| `pydantic.utils.sequence_like`             | `pydantic.v1.utils.sequence_like`                     |
+| `pydantic.utils.deep_update` | `pydantic.v1.utils.deep_update` |
+| `pydantic.utils.GetterDict` | `pydantic.v1.utils.GetterDict` |
+| `pydantic.utils.lenient_issubclass` | `pydantic.v1.utils.lenient_issubclass` |
+| `pydantic.utils.lenient_isinstance` | `pydantic.v1.utils.lenient_isinstance` |
+| `pydantic.utils.is_valid_field` | `pydantic.v1.utils.is_valid_field` |
+| `pydantic.utils.update_not_none` | `pydantic.v1.utils.update_not_none` |
+| `pydantic.utils.import_string` | `pydantic.v1.utils.import_string` |
+| `pydantic.utils.Representation` | `pydantic.v1.utils.Representation` |
+| `pydantic.utils.ROOT_KEY` | `pydantic.v1.utils.ROOT_KEY` |
+| `pydantic.utils.smart_deepcopy` | `pydantic.v1.utils.smart_deepcopy` |
+| `pydantic.utils.sequence_like` | `pydantic.v1.utils.sequence_like` |
 
 ## Removed in Pydantic V2
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -997,3 +997,31 @@ For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringCons
 - `pydantic.utils.path_type`
 - `pydantic.utils.validate_field_name`
 - `pydantic.validate_model`
+
+## Customizing JSON Encoding for Pydantic Model with `ObjectId` Field in V2
+
+To ensure that instances of the model are serialized to JSON with the `ObjectId` field represented as a string, use a custom JSON encoder for instances of `ObjectId` since `ENCODERS_BY_TYPE` class is removed. For example:
+
+```
+from pydantic.json import ENCODERS_BY_TYPE
+from bson import ObjectId
+ENCODERS_BY_TYPE[ObjectId] = lambda v: str(v)
+```
+
+becomes:
+```
+from bson import ObjectId
+from pydantic import BaseModel, ConfigDict
+
+BaseModel.model_config["json_encoders"] = {ObjectId: lambda v: str(v)}
+
+
+class Item(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    id: ObjectId
+
+
+item = Item(id=ObjectId("5ff1e194b6a9d7a5f9a2741c"))
+print(item.model_dump_json())
+```


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
I appended a work around code for replacing `ENCODERS_BY_TYPE` in V2 to the docs **Migration Guide**
<!-- Please give a short summary of the changes. -->

## Related issue number
fix #8426
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt