### PR TITLE
fix for namespace issue with dataclasses with from __future__ import annotations

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -266,7 +266,7 @@ def collect_dataclass_fields(
 
     source_module = sys.modules.get(cls.__module__)
     if source_module is not None:
-        types_namespace = {**source_module.__dict__, **types_namespace}
+        types_namespace = {**source_module.__dict__, **(types_namespace or {})}
 
     for ann_name, dataclass_field in dataclass_fields.items():
         ann_type = _typing_extra.eval_type_lenient(dataclass_field.type, types_namespace, cls_localns)

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -264,6 +264,10 @@ def collect_dataclass_fields(
     dataclass_fields: dict[str, dataclasses.Field] = cls.__dataclass_fields__
     cls_localns = dict(vars(cls))  # this matches get_cls_type_hints_lenient, but all tests pass with `= None` instead
 
+    source_module = sys.modules.get(cls.__module__)
+    if source_module is not None:
+        types_namespace = {**source_module.__dict__, **types_namespace}
+
     for ann_name, dataclass_field in dataclass_fields.items():
         ann_type = _typing_extra.eval_type_lenient(dataclass_field.type, types_namespace, cls_localns)
         if is_classvar(ann_type):


### PR DESCRIPTION
## Change Summary

Fix namespace information for the case where `from __future__ import anotations` is used with pydantic dataclasses.

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/8475

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
