### PR TITLE
Fix schema-building bug with TypeAliasType for types with refs

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -228,6 +228,14 @@ class _WalkCoreSchema:
     def handle_definitions_schema(self, schema: core_schema.DefinitionsSchema, f: Walk) -> core_schema.CoreSchema:
         new_definitions: list[core_schema.CoreSchema] = []
         for definition in schema['definitions']:
+            if 'schema_ref' and 'ref' in definition:
+                # This indicates a purposely indirect reference
+                # We want to keep such references around for implications related to JSON schema, etc.:
+                new_definitions.append(definition)
+                # However, we still need to walk the referenced definition:
+                self.walk(definition, f)
+                continue
+
             updated_definition = self.walk(definition, f)
             if 'ref' in updated_definition:
                 # If the updated definition schema doesn't have a 'ref', it shouldn't go in the definitions


### PR DESCRIPTION
Fixes an issue with building schemas that was affecting FastUI.

In particular, closes https://github.com/pydantic/pydantic/issues/8320.

There are definitely still many misbehaviors related to complex usage of `TypeAliasType` that I've discovered while playing with it, but given how small this is and that it unblocks FastUI, I think we should merge this and think about fixing those once we have minimal reproductions.