### PR TITLE
WIP Fix: init=False in dataclass fields ignored

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -172,6 +172,10 @@ def dataclass(
             if field_value.repr is not True:
                 field_args['repr'] = field_value.repr
 
+            # Set `init` attribute if it's explicitly specified to be `False`.
+            if field_value.init is False:
+                field_args['init'] = field_value.init
+
             setattr(cls, field_name, dataclasses.field(**field_args))
 
     def create_dataclass(cls: type[Any]) -> type[PydanticDataclass]:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -64,6 +64,7 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
     frozen: bool | None
     validate_default: bool | None
     repr: bool
+    init: bool | None
     init_var: bool | None
     kw_only: bool | None
 
@@ -101,7 +102,9 @@ class FieldInfo(_repr.Representation):
         frozen: Whether the field is frozen.
         validate_default: Whether to validate the default value of the field.
         repr: Whether to include the field in representation of the model.
-        init_var: Whether the field should be included in the constructor of the dataclass.
+        init: If true (the default), this field is included as a parameter to the generated `__init__` of the dataclass
+        init_var: Whether the field is an "init-only" field: used as a parameter to the generated `__init__` method, but
+            not included as a field of the resulting model.
         kw_only: Whether the field should be a keyword-only argument in the constructor of the dataclass.
         metadata: List of metadata constraints.
     """
@@ -122,6 +125,7 @@ class FieldInfo(_repr.Representation):
     frozen: bool | None
     validate_default: bool | None
     repr: bool
+    init: bool | None
     init_var: bool | None
     kw_only: bool | None
     metadata: list[Any]
@@ -143,6 +147,7 @@ class FieldInfo(_repr.Representation):
         'frozen',
         'validate_default',
         'repr',
+        'init',
         'init_var',
         'kw_only',
         'metadata',
@@ -203,6 +208,7 @@ class FieldInfo(_repr.Representation):
         self.validate_default = kwargs.pop('validate_default', None)
         self.frozen = kwargs.pop('frozen', None)
         # currently only used on dataclasses
+        self.init = kwargs.pop('init', None)
         self.init_var = kwargs.pop('init_var', None)
         self.kw_only = kwargs.pop('kw_only', None)
 
@@ -623,6 +629,7 @@ def Field(  # noqa: C901
     frozen: bool | None = _Unset,
     validate_default: bool | None = _Unset,
     repr: bool = _Unset,
+    init: bool | None = _Unset,
     init_var: bool | None = _Unset,
     kw_only: bool | None = _Unset,
     pattern: str | None = _Unset,
@@ -668,8 +675,10 @@ def Field(  # noqa: C901
         validate_default: If `True`, apply validation to the default value every time you create an instance.
             Otherwise, for performance reasons, the default value of the field is trusted and not validated.
         repr: A boolean indicating whether to include the field in the `__repr__` output.
-        init_var: Whether the field should be included in the constructor of the dataclass.
+        init: Whether the field should be included in the generated constructor of the dataclass.
             (Only applies to dataclasses.)
+        init_var: Whether the field is `init-only`. Used as a parameter to the generated `__init__` method, but not
+            included as a field of the resulting model. (Only applies to dataclasses.)
         kw_only: Whether the field should be a keyword-only argument in the constructor of the dataclass.
             (Only applies to dataclasses.)
         strict: If `True`, strict validation is applied to the field.
@@ -777,6 +786,7 @@ def Field(  # noqa: C901
         pattern=pattern,
         validate_default=validate_default,
         repr=repr,
+        init=init,
         init_var=init_var,
         kw_only=kw_only,
         strict=strict,

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -616,6 +616,23 @@ def test_nested_schema():
     }
 
 
+@pytest.mark.parametrize(
+    'init_false_field', [dataclasses.field(init=False, default=-1), pydantic.dataclasses.Field(init=False, default=-1)]
+)
+def test_init_false(init_false_field):
+    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='forbid'))
+    class MyDataclass:
+        a: int = init_false_field
+        b: int = pydantic.dataclasses.Field(default=2)
+
+    signature = inspect.signature(MyDataclass)
+    # `a` should not be in the __init__
+    assert 'a' not in signature.parameters.keys()
+    assert 'b' in signature.parameters.keys()
+
+    assert isinstance(MyDataclass(b=2), MyDataclass)
+
+
 def test_initvar():
     @pydantic.dataclasses.dataclass
     class TestInitVar:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- Added `init` attribute to `FieldInfo` and `Field`
- Added check for `init` in `make_pydantic_fields_compatible`
- Added test to confirm `init=False` fields don't show up in the signature
- Corrected docstring for `init_var`


## Related issue number

WIP Partial fix for https://github.com/pydantic/pydantic/issues/8454

- Previously, setting `init=False` in std field and pydantic's Field had no effect, the field still appears as a parameter in the generated `__init__`

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## Notes
- Haven't updated docs for the new `init` parameters yet.
- Unfortunately, can still use the `init=False` fields as parameters in the dataclass constructor... I think this is because of pydantic allowing the "extra" params that aren't explicitly defined
- Even setting `ConfigDict(extra='forbid')` doesn't lead to throwing a `ValidationError`. From some debugging, it doesn't look like the model schema understands the `init=False`. So more work needed to actually throw an error.

For example:
```
@pytest.mark.parametrize(
    'init_false_field', [dataclasses.field(init=False, default=-1), pydantic.dataclasses.Field(init=False, default=-1)]
)
def test_init_false(init_false_field):
    @pydantic.dataclasses.dataclass(config=ConfigDict(extra='forbid'))
    class MyDataclass:
        a: int = init_false_field
        b: int = pydantic.dataclasses.Field(default=2)

    signature = inspect.signature(MyDataclass)
    # `a` should not be in the __init__
    assert 'a' not in signature.parameters.keys()
    assert 'b' in signature.parameters.keys()

    assert isinstance(MyDataclass(b=2), MyDataclass)
    # test passes up until here
    
    # however, this does not throw an error
    _ = MyDataclass(a=1, b=2)
    
    # this DOES throw a validation error, when that `extra='forbid'` is used
    _ = MyDataclass(a=1, b=2, c=3)
```
