### PR TITLE
fix for #8512

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -153,13 +153,17 @@ class PlainValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.WithInfoValidatorFunction
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: _GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        schema = handler(source_type)
+        serialization = schema.get('serialization', None)
         info_arg = _inspect_validator(self.func, 'plain')
         if info_arg:
             func = cast(core_schema.WithInfoValidatorFunction, self.func)
-            return core_schema.with_info_plain_validator_function(func, field_name=handler.field_name)
+            return core_schema.with_info_plain_validator_function(
+                func, field_name=handler.field_name, serialization=serialization
+            )
         else:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
-            return core_schema.no_info_plain_validator_function(func)
+            return core_schema.no_info_plain_validator_function(func, serialization=serialization)
 
 
 @dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -20,6 +20,7 @@ from pydantic import (
     ConfigDict,
     Field,
     GetCoreSchemaHandler,
+    PlainSerializer,
     PydanticDeprecatedSince20,
     PydanticUserError,
     TypeAdapter,
@@ -2810,3 +2811,18 @@ def test_validate_default_raises_for_dataclasses() -> None:
             'ctx': {'error': IsInstance(AssertionError)},
         },
     ]
+
+
+def test_plain_validator_plain_serializer() -> None:
+    ser_type = str
+
+    class Blah(BaseModel):
+        enabled: Annotated[
+            bool,
+            PlainSerializer(lambda x: ser_type(int(x)), return_type=ser_type),
+            PlainValidator(lambda x: bool(int(x))),
+        ]
+
+    blah = Blah(enabled='0')
+    data = blah.model_dump()
+    assert isinstance(data['enabled'], ser_type)


### PR DESCRIPTION
## Change Summary

This is hopefully a fix for #8512, that I've reported a few days ago. 

Basically, it makes `PlainValidator.__get_pydantic_core_schema__` reuse other annotations informations.

If I did anything wrong, please let me know.
  
## Related issue number

fix #8512 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
