### PR TITLE
Add a `with_config` decorator to comply with typing spec

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -3,6 +3,7 @@
       group_by_category: false
       members:
         - ConfigDict
+        - with_config
         - ExtraValues
         - BaseConfig
 

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -98,6 +98,17 @@ class User:
 
 Alternatively, the [`with_config`][pydantic.config.with_config] decorator can be used to comply with type checkers.
 
+```py
+from typing_extensions import TypedDict
+
+from pydantic import ConfigDict, with_config
+
+
+@with_config(ConfigDict(str_to_lower=True))
+class Model(TypedDict):
+    x: str
+```
+
 ## Change behaviour globally
 
 If you wish to change the behaviour of Pydantic globally, you can create your own custom `BaseModel`

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -57,7 +57,7 @@ from pydantic.dataclasses import dataclass
 config = ConfigDict(str_max_length=10, validate_assignment=True)
 
 
-@dataclass(config=config)  # (1)!
+@dataclass(config=config)
 class User:
     id: int
     name: str = 'John Doe'
@@ -76,26 +76,27 @@ except ValidationError as e:
     """
 ```
 
+## Configuration with `dataclass` from the standard library or `TypedDict`
 
-1. If using the `dataclass` from the standard library or `TypedDict`, you should use `__pydantic_config__` instead.
-   See:
+If using the `dataclass` from the standard library or `TypedDict`, you should use `__pydantic_config__` instead.
 
-    ```py
-    from dataclasses import dataclass
-    from datetime import datetime
+```py
+from dataclasses import dataclass
+from datetime import datetime
 
-    from pydantic import ConfigDict
+from pydantic import ConfigDict
 
 
-    @dataclass
-    class User:
-        __pydantic_config__ = ConfigDict(strict=True)
+@dataclass
+class User:
+    __pydantic_config__ = ConfigDict(strict=True)
 
-        id: int
-        name: str = 'John Doe'
-        signup_ts: datetime = None
-    ```
+    id: int
+    name: str = 'John Doe'
+    signup_ts: datetime = None
+```
 
+Alternatively, the [`with_config`][pydantic.config.with_config] decorator can be used to comply with type checkers.
 
 ## Change behaviour globally
 

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
     from ._internal._generate_schema import GenerateSchema as GenerateSchema
     from .aliases import AliasChoices, AliasGenerator, AliasPath
     from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
-    from .config import ConfigDict
+    from .config import ConfigDict, with_config
     from .errors import *
     from .fields import Field, PrivateAttr, computed_field
     from .functional_serializers import (
@@ -80,6 +80,7 @@ __all__ = (
     'WrapSerializer',
     # config
     'ConfigDict',
+    'with_config',
     # deprecated V1 config, these are imported via `__getattr__` below
     'BaseConfig',
     'Extra',
@@ -234,6 +235,7 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'WrapSerializer': (__package__, '.functional_serializers'),
     # config
     'ConfigDict': (__package__, '.config'),
+    'with_config': (__package__, '.config'),
     # validate call
     'validate_call': (__package__, '.validate_call_decorator'),
     # errors

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -913,7 +913,9 @@ _TypeT = TypeVar('_TypeT', bound=type)
 
 
 def with_config(config: ConfigDict) -> Callable[[_TypeT], _TypeT]:
-    """A convenience decorator to set a [Pydantic configuration](config.md) on a `TypedDict` or a `dataclass` from the standard library.
+    """Usage docs: https://docs.pydantic.dev/2.6/concepts/config/#configuration-with-dataclass-from-the-standard-library-or-typeddict
+
+    A convenience decorator to set a [Pydantic configuration](config.md) on a `TypedDict` or a `dataclass` from the standard library.
 
     Although the configuration can be set using the `__pydantic_config__` attribute, it does not play well with type checkers,
     especially with `TypedDict`.

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1,7 +1,7 @@
 """Configuration for Pydantic models."""
 from __future__ import annotations as _annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type, TypeVar, Union
 
 from typing_extensions import Literal, TypeAlias, TypedDict
 
@@ -11,7 +11,7 @@ from .aliases import AliasGenerator
 if TYPE_CHECKING:
     from ._internal._generate_schema import GenerateSchema as _GenerateSchema
 
-__all__ = ('ConfigDict',)
+__all__ = ('ConfigDict', 'with_config')
 
 
 JsonValue: TypeAlias = Union[int, float, str, bool, None, List['JsonValue'], 'JsonDict']
@@ -907,6 +907,19 @@ class ConfigDict(TypedDict, total=False):
     Note:
         The structure of validation errors are likely to change in future pydantic versions. Pydantic offers no guarantees about the structure of validation errors. Should be used for visual traceback debugging only.
     """
+
+
+_TypeT = TypeVar('_TypeT', bound=type)
+
+
+def with_config(config: ConfigDict) -> Callable[[_TypeT], _TypeT]:
+    """A convenience decorator to set a Pydantic configuration on a `TypedDict`."""
+
+    def inner(typed_dict: _TypeT, /) -> _TypeT:
+        setattr(typed_dict, '__pydantic_config__', config)
+        return typed_dict
+
+    return inner
 
 
 __getattr__ = getattr_migration(__name__)

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -913,11 +913,32 @@ _TypeT = TypeVar('_TypeT', bound=type)
 
 
 def with_config(config: ConfigDict) -> Callable[[_TypeT], _TypeT]:
-    """A convenience decorator to set a Pydantic configuration on a `TypedDict`."""
+    """A convenience decorator to set a [Pydantic configuration](config.md) on a `TypedDict` or a `dataclass` from the standard library.
 
-    def inner(typed_dict: _TypeT, /) -> _TypeT:
-        setattr(typed_dict, '__pydantic_config__', config)
-        return typed_dict
+    Although the configuration can be set using the `__pydantic_config__` attribute, it does not play well with type checkers,
+    especially with `TypedDict`.
+
+    !!! example "Usage"
+
+        ```py
+        from typing import TypedDict
+
+        from pydantic import ConfigDict, with_config
+
+        @with_config(ConfigDict(str_to_lower=True))
+        class Model(TypedDict):
+            x: str
+
+        ta = TypeAdapter(Model)
+
+        print(ta.validate_python({'x': 'ABC'}))
+        #> {'x': 'abc'}
+        ```
+    """
+
+    def inner(TypedDictClass: _TypeT, /) -> _TypeT:
+        TypedDictClass.__pydantic_config__ = config
+        return TypedDictClass
 
     return inner
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -921,9 +921,9 @@ def with_config(config: ConfigDict) -> Callable[[_TypeT], _TypeT]:
     !!! example "Usage"
 
         ```py
-        from typing import TypedDict
+        from typing_extensions import TypedDict
 
-        from pydantic import ConfigDict, with_config
+        from pydantic import ConfigDict, TypeAdapter, with_config
 
         @with_config(ConfigDict(str_to_lower=True))
         class Model(TypedDict):

--- a/tests/mypy/modules/with_config_decorator.py
+++ b/tests/mypy/modules/with_config_decorator.py
@@ -1,0 +1,11 @@
+from typing import TypedDict
+
+from pydantic import ConfigDict, with_config
+
+
+@with_config(ConfigDict(str_to_lower=True))
+class Model(TypedDict):
+    a: str
+
+
+model = Model(a='ABC')

--- a/tests/mypy/outputs/1.0.1/pyproject-default_toml/with_config_decorator.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-default_toml/with_config_decorator.py
@@ -1,0 +1,11 @@
+from typing import TypedDict
+
+from pydantic import ConfigDict, with_config
+
+
+@with_config(ConfigDict(str_to_lower=True))
+class Model(TypedDict):
+    a: str
+
+
+model = Model(a='ABC')

--- a/tests/mypy/outputs/1.1.1/pyproject-default_toml/with_config_decorator.py
+++ b/tests/mypy/outputs/1.1.1/pyproject-default_toml/with_config_decorator.py
@@ -7,4 +7,5 @@ from pydantic import ConfigDict, with_config
 class Model(TypedDict):
     a: str
 
+
 model = Model(a='ABC')

--- a/tests/mypy/outputs/1.1.1/pyproject-default_toml/with_config_decorator.py
+++ b/tests/mypy/outputs/1.1.1/pyproject-default_toml/with_config_decorator.py
@@ -1,0 +1,10 @@
+from typing import TypedDict
+
+from pydantic import ConfigDict, with_config
+
+
+@with_config(ConfigDict(str_to_lower=True))
+class Model(TypedDict):
+    a: str
+
+model = Model(a='ABC')

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -110,6 +110,7 @@ cases = (
         ('mypy-plugin-strict-no-any.ini', 'dataclass_no_any.py'),
         ('mypy-plugin-very-strict.ini', 'metaclass_args.py'),
         ('pyproject-default.toml', 'computed_fields.py'),
+        ('pyproject-default.toml', 'with_config_decorator.py'),
     ]
 )
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -32,6 +32,7 @@ from pydantic import (
     field_serializer,
     field_validator,
     model_validator,
+    with_config,
 )
 from pydantic._internal._mock_val_ser import MockValSer
 from pydantic.dataclasses import is_pydantic_dataclass, rebuild_dataclass
@@ -2404,6 +2405,24 @@ def test_model_config_override_in_decorator_empty_config() -> None:
 
     ta = TypeAdapter(Model)
     assert ta.validate_python({'x': 'ABC '}).x == 'ABC '
+
+
+def test_dataclasses_with_config_decorator():
+    @dataclasses.dataclass
+    @with_config(ConfigDict(str_to_lower=True))
+    class Model1:
+        x: str
+
+    ta = TypeAdapter(Model1)
+    assert ta.validate_python({'x': 'ABC'}).x == 'abc'
+
+    @with_config(ConfigDict(str_to_lower=True))
+    @dataclasses.dataclass
+    class Model2:
+        x: str
+
+    ta = TypeAdapter(Model2)
+    assert ta.validate_python({'x': 'ABC'}).x == 'abc'
 
 
 def test_pydantic_field_annotation():

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -20,6 +20,7 @@ from pydantic import (
     PositiveInt,
     PydanticUserError,
     ValidationError,
+    with_config,
 )
 from pydantic._internal._decorators import get_attribute_from_bases
 from pydantic.functional_serializers import field_serializer, model_serializer
@@ -919,3 +920,13 @@ def test_typeddict_mro():
         pass
 
     assert get_attribute_from_bases(C, 'x') == 2
+
+
+def test_typeddict_with_config_decorator():
+    @with_config(ConfigDict(str_to_lower=True))
+    class Model(TypedDict):
+        x: str
+
+    ta = TypeAdapter(Model)
+
+    assert ta.validate_python({'x': 'ABC'}) == {'x': 'abc'}


### PR DESCRIPTION
May fix https://github.com/pydantic/pydantic/issues/8514, as suggested in a comment.

If accepted, better documentation will follow

Selected Reviewer: @dmontagu