### PR TITLE
Fix strict parsing for some `Sequence`s

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1390,25 +1390,13 @@ class GenerateSchema:
         item_type = self._get_first_arg_or_any(sequence_type)
         item_type_schema = self.generate_schema(item_type)
         list_schema = core_schema.list_schema(item_type_schema)
-        tuple_schema = core_schema.tuple_schema([item_type_schema], variadic_item_index=0)
 
         python_schema = core_schema.is_instance_schema(typing.Sequence, cls_repr='Sequence')
         if item_type != Any:
             from ._validators import sequence_validator
 
             python_schema = core_schema.chain_schema(
-                [
-                    python_schema,
-                    core_schema.no_info_wrap_validator_function(
-                        sequence_validator,
-                        core_schema.union_schema(
-                            [
-                                list_schema,
-                                tuple_schema,
-                            ]
-                        ),
-                    ),
-                ],
+                [python_schema, core_schema.no_info_wrap_validator_function(sequence_validator, list_schema)],
             )
         return core_schema.json_or_python_schema(json_schema=list_schema, python_schema=python_schema)
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1388,14 +1388,27 @@ class GenerateSchema:
     def _sequence_schema(self, sequence_type: Any) -> core_schema.CoreSchema:
         """Generate schema for a Sequence, e.g. `Sequence[int]`."""
         item_type = self._get_first_arg_or_any(sequence_type)
+        item_type_schema = self.generate_schema(item_type)
+        list_schema = core_schema.list_schema(item_type_schema)
+        tuple_schema = core_schema.tuple_schema([item_type_schema], variadic_item_index=0)
 
-        list_schema = core_schema.list_schema(self.generate_schema(item_type))
         python_schema = core_schema.is_instance_schema(typing.Sequence, cls_repr='Sequence')
         if item_type != Any:
             from ._validators import sequence_validator
 
             python_schema = core_schema.chain_schema(
-                [python_schema, core_schema.no_info_wrap_validator_function(sequence_validator, list_schema)],
+                [
+                    python_schema,
+                    core_schema.no_info_wrap_validator_function(
+                        sequence_validator,
+                        core_schema.union_schema(
+                            [
+                                list_schema,
+                                tuple_schema,
+                            ]
+                        ),
+                    ),
+                ],
             )
         return core_schema.json_or_python_schema(json_schema=list_schema, python_schema=python_schema)
 

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -31,6 +31,9 @@ def sequence_validator(
             {'type_name': value_type.__name__},
         )
 
+    if value_type == tuple:
+        __input_value = list(__input_value)
+
     v_list = validator(__input_value)
 
     # the rest of the logic is just re-creating the original type from `v_list`
@@ -39,6 +42,8 @@ def sequence_validator(
     elif issubclass(value_type, range):
         # return the list as we probably can't re-create the range
         return v_list
+    elif value_type == tuple:
+        return tuple(v_list)
     else:
         # best guess at how to re-create the original type, more custom construction logic might be required
         return value_type(v_list)  # type: ignore[call-arg]

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -31,6 +31,11 @@ def sequence_validator(
             {'type_name': value_type.__name__},
         )
 
+    # TODO: refactor sequence validation to validate with either a list or a tuple
+    # schema, depending on the type of the value.
+    # Additionally, we should be able to remove one of either this validator or the
+    # SequenceValidator in _std_types_schema.py (preferably this one, while porting over some logic).
+    # Effectively, a refactor for sequence validation is needed.
     if value_type == tuple:
         __input_value = list(__input_value)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2389,6 +2389,10 @@ def test_sequence_fails(cls, value, errors):
     assert exc_info.value.errors(include_url=False) == errors
 
 
+def test_sequence_strict():
+    assert TypeAdapter(Sequence[int]).validate_python((), strict=True) == ()
+
+
 def test_int_validation():
     class Model(BaseModel):
         a: PositiveInt = None


### PR DESCRIPTION
## Change Summary

Handle this case properly, right now, it errors:

```py
from typing import Sequence

from pydantic import TypeAdapter

assert TypeAdapter(Sequence[int]).validate_python((), strict=True) == ()
```

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/8604

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig