### PR TITLE
model_dump: Improve docstring

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -299,8 +299,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             mode: The mode in which `to_python` should run.
                 If mode is 'json', the output will only contain JSON serializable types.
                 If mode is 'python', the output may contain non-JSON-serializable Python objects.
-            include: A list of fields to include in the output.
-            exclude: A list of fields to exclude from the output.
+            include: A set of fields to include in the output.
+            exclude: A set of fields to exclude from the output.
             by_alias: Whether to use the field's alias in the dictionary key if defined.
             exclude_unset: Whether to exclude fields that have not been explicitly set.
             exclude_defaults: Whether to exclude fields that are set to their default value.


### PR DESCRIPTION
The include/exclude parameters do not accept lists, only sets and dicts. This confused me for a bit when I was using the method just now.

https://docs.pydantic.dev/2.2/usage/serialization/#advanced-include-and-exclude explains the advanced options in detail, but a set of strings is the simplest use case that people most likely want, so let's just put "set" in the docstring.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani