### PR TITLE
Handle __pydantic_extra__ annotation being a string or inherited

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2842,11 +2842,12 @@ def test_extra_validator_named() -> None:
 
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow')
+        __pydantic_extra__: 'dict[str, Foo]'
 
     class Child(Model):
-        __pydantic_extra__: Dict[str, Foo]
+        y: int
 
-    m = Child(a={'x': '1'})
+    m = Child(a={'x': '1'}, y=2)
     assert m.__pydantic_extra__ == {'a': Foo(x=1)}
 
     # insert_assert(Child.model_json_schema())
@@ -2860,7 +2861,8 @@ def test_extra_validator_named() -> None:
             }
         },
         'additionalProperties': {'$ref': '#/$defs/Foo'},
-        'properties': {},
+        'properties': {'y': {'title': 'Y', 'type': 'integer'}},
+        'required': ['y'],
         'title': 'Child',
         'type': 'object',
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Evaluates `__pydantic_extra__` to an actual type when it's a string, e.g. because of `from __future__ import annotations`.

Also fixes another bug in that area: the loop `for tp in (cls, *cls.__mro__):` didn't use the variable `tp` so the annotation was not checked on parent classes.

## Related issue number

Closes https://github.com/pydantic/pydantic/issues/8647

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
