### PR TITLE
Fix bug with mypy plugin and `no_strict_optional = True`

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -475,9 +475,9 @@ class PydanticModelTransformer:
                 return False
 
         is_settings = any(base.fullname == BASESETTINGS_FULLNAME for base in info.mro[:-1])
-        self.add_initializer(fields, config, is_settings, is_root_model)
-        self.add_model_construct_method(fields, config, is_settings)
         try:
+            self.add_initializer(fields, config, is_settings, is_root_model)
+            self.add_model_construct_method(fields, config, is_settings)
             self.set_frozen(fields, frozen=config.frozen is True)
         except _DeferAnalysis:
             if not self._api.final_iteration:

--- a/tests/mypy/configs/pyproject-plugin-no-strict-optional.toml
+++ b/tests/mypy/configs/pyproject-plugin-no-strict-optional.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["poetry>=0.12"]
+build_backend = "poetry.masonry.api"
+
+[tool.poetry]
+name = "test"
+version = "0.0.1"
+readme = "README.md"
+authors = [
+    "author@example.com"
+]
+
+[tool.poetry.dependencies]
+python = "*"
+
+[tool.pytest.ini_options]
+addopts = "-v -p no:warnings"
+
+[tool.mypy]
+plugins = [
+    "pydantic.mypy"
+]
+follow_imports = "silent"
+no_strict_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [
+    'pydantic_core.*',
+]
+follow_imports = "skip"

--- a/tests/mypy/modules/no_strict_optional.py
+++ b/tests/mypy/modules/no_strict_optional.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class MongoSettings(BaseModel):
+    MONGO_PASSWORD: str | None

--- a/tests/mypy/modules/no_strict_optional.py
+++ b/tests/mypy/modules/no_strict_optional.py
@@ -1,5 +1,7 @@
+from typing import Union
+
 from pydantic import BaseModel
 
 
 class MongoSettings(BaseModel):
-    MONGO_PASSWORD: str | None
+    MONGO_PASSWORD: Union[str, None]

--- a/tests/mypy/outputs/1.0.1/pyproject-plugin-no-strict-optional_toml/no_strict_optional.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-plugin-no-strict-optional_toml/no_strict_optional.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class MongoSettings(BaseModel):
+    MONGO_PASSWORD: str | None

--- a/tests/mypy/outputs/1.0.1/pyproject-plugin-no-strict-optional_toml/no_strict_optional.py
+++ b/tests/mypy/outputs/1.0.1/pyproject-plugin-no-strict-optional_toml/no_strict_optional.py
@@ -1,5 +1,7 @@
+from typing import Union
+
 from pydantic import BaseModel
 
 
 class MongoSettings(BaseModel):
-    MONGO_PASSWORD: str | None
+    MONGO_PASSWORD: Union[str, None]

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -111,6 +111,7 @@ cases = (
         ('mypy-plugin-very-strict.ini', 'metaclass_args.py'),
         ('pyproject-default.toml', 'computed_fields.py'),
         ('pyproject-default.toml', 'with_config_decorator.py'),
+        ('pyproject-plugin-no-strict-optional.toml', 'no_strict_optional.py'),
     ]
 )
 


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/8665

The issue was originally introduced in #7411 (which, if you look at the body, I noted that I was concerned that there was a deeper issue not being addressed). I still have those concerns, but at the very least I think with the changes in this PR, the  `_DeferAnalysis` exception should always get handled, even if it does something that causes the mypy plugin to otherwise misbehave. (That exception was the source of the issue reported in #8665.)

There were some code paths that could raise a `_DeferAnalysis` exception but which were not included in the `try: except:`.

I was able to reproduce the error in #8665 with the code sample provided, and this change fixed it. I also checked and I am pretty confident that there are no code paths that can raise that error now that aren't covered by the updated `try: except:`.