### PR TITLE
Drop pypy-3.8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,6 @@ jobs:
           # macos tests with pypy take ages (>10mins) since pypy is very slow
           # so we only test pypy on ubuntu
           - os: ubuntu
-            python-version: 'pypy3.8'
-          - os: ubuntu
             python-version: 'pypy3.9'
           - os: ubuntu
             python-version: 'pypy3.10'


### PR DESCRIPTION
We have the following bullet in the `HISTORY.md`:

* Drop Python 3.7, and PyPy 3.7 and 3.8 by @davidhewitt in [pydantic/pydantic-core#1129](https://github.com/pydantic/pydantic-core/pull/1129)

This just removes the no-longer-supported-job from CI.