### PR TITLE
Fix test failures with pytest-8.0.0 due to `pytest.warns()` starting to work inside `pytest.raises()`

### DIFF
--- a/pydantic/deprecated/class_validators.py
+++ b/pydantic/deprecated/class_validators.py
@@ -109,6 +109,14 @@ def validator(
         Callable: A decorator that can be used to decorate a
             function to be used as a validator.
     """
+    warn(
+        'Pydantic V1 style `@validator` validators are deprecated.'
+        ' You should migrate to Pydantic V2 style `@field_validator` validators,'
+        ' see the migration guide for more details',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if allow_reuse is True:  # pragma: no cover
         warn(_ALLOW_REUSE_WARNING_MESSAGE, DeprecationWarning)
     fields = tuple((__field, *fields))
@@ -124,14 +132,6 @@ def validator(
             "E.g. usage should be `@validator('<field_name_1>', '<field_name_2>', ...)`",
             code='validator-invalid-fields',
         )
-
-    warn(
-        'Pydantic V1 style `@validator` validators are deprecated.'
-        ' You should migrate to Pydantic V2 style `@field_validator` validators,'
-        ' see the migration guide for more details',
-        DeprecationWarning,
-        stacklevel=2,
-    )
 
     mode: Literal['before', 'after'] = 'before' if pre is True else 'after'
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -556,11 +556,9 @@ def test_use_no_fields():
         class Model(BaseModel):
             a: str
 
-            with pytest.warns(PydanticDeprecatedSince20, match=V1_VALIDATOR_DEPRECATION_MATCH):
-
-                @validator()
-                def checker(cls, v):
-                    return v
+            @validator()
+            def checker(cls, v):
+                return v
 
 
 def test_use_no_fields_field_validator():


### PR DESCRIPTION
## Change Summary

Fix the test suite problems that cause test failures with pytest-8.0.0, due to `pytest.warns()` being fixed to work inside `pytest.raises()`.

I've specifically:

1. Removed `pytest.warns()` when no warning could be produced because of invalid function call raising `TypeError`.
2. Moved the Pydantic V1 deprecation warning earlier in the function to ensure that it is emitted even if the function raises an exception. If you prefer, I can change that to remove the `pytest.warns()` assertion instead.

This doesn't fix all the test failures reported in the linked bug, though. `test_validator_bad_fields_throws_configerror` fails due to changed exception representation, and I don't know how to clearly handle both versions.

Additionally, `test_root_validator_allow_reuse_same_field` fails with the default `-Werror` (I didn't include that in the bug), since `pytest.warns()` passes the warning through. However, adding a second `pytest.warns()` to check for that breaks the test with older pytest versions, where the warning is captured by the other `pytest.warns()`.

## Related issue number

Fix #8674

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani