### PR TITLE
Fix inheriting annotations in dataclasses

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -93,7 +93,7 @@ else:
 
 
 @dataclass_transform(field_specifiers=(dataclasses.field, Field))
-def dataclass(  # noqa: C901
+def dataclass(
     _cls: type[_T] | None = None,
     *,
     init: Literal[False] = False,
@@ -153,6 +153,10 @@ def dataclass(  # noqa: C901
         into
           `x: int = dataclasses.field(default=pydantic.Field(..., kw_only=True), kw_only=True)`
         """
+        # In Python 3.8, dataclasses checks cls.__dict__['__annotations__'] for annotations,
+        # so we start from there as well.
+        annotations = cls.__dict__.get('__annotations__') or {}
+
         for annotation_cls in cls.__mro__:
             # In Python < 3.9, `__annotations__` might not be present if there are no fields.
             # we therefore need to use `getattr` to avoid an `AttributeError`.
@@ -175,11 +179,9 @@ def dataclass(  # noqa: C901
 
                 setattr(cls, field_name, dataclasses.field(**field_args))
 
-                # In Python 3.8, dataclasses checks cls.__dict__['__annotations__'] for annotations,
-                # so we must make sure it's initialized before we add to it.
-                if cls.__dict__.get('__annotations__') is None:
-                    cls.__annotations__ = {}
-                cls.__annotations__[field_name] = annotation_cls.__annotations__[field_name]
+                annotations[field_name] = annotation_cls.__annotations__[field_name]
+
+        cls.__annotations__ = annotations
 
     def create_dataclass(cls: type[Any]) -> type[PydanticDataclass]:
         """Create a Pydantic dataclass from a regular dataclass.

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -93,7 +93,7 @@ else:
 
 
 @dataclass_transform(field_specifiers=(dataclasses.field, Field))
-def dataclass(
+def dataclass(  # noqa: C901
     _cls: type[_T] | None = None,
     *,
     init: Literal[False] = False,

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -153,26 +153,28 @@ def dataclass(
         into
           `x: int = dataclasses.field(default=pydantic.Field(..., kw_only=True), kw_only=True)`
         """
-        # In Python < 3.9, `__annotations__` might not be present if there are no fields.
-        # we therefore need to use `getattr` to avoid an `AttributeError`.
-        for field_name in getattr(cls, '__annotations__', []):
-            field_value = getattr(cls, field_name, None)
-            # Process only if this is an instance of `FieldInfo`.
-            if not isinstance(field_value, FieldInfo):
-                continue
+        for annotation_cls in cls.__mro__:
+            # In Python < 3.9, `__annotations__` might not be present if there are no fields.
+            # we therefore need to use `getattr` to avoid an `AttributeError`.
+            for field_name in getattr(annotation_cls, '__annotations__', []):
+                field_value = getattr(cls, field_name, None)
+                # Process only if this is an instance of `FieldInfo`.
+                if not isinstance(field_value, FieldInfo):
+                    continue
 
-            # Initialize arguments for the standard `dataclasses.field`.
-            field_args: dict = {'default': field_value}
+                # Initialize arguments for the standard `dataclasses.field`.
+                field_args: dict = {'default': field_value}
 
-            # Handle `kw_only` for Python 3.10+
-            if sys.version_info >= (3, 10) and field_value.kw_only:
-                field_args['kw_only'] = True
+                # Handle `kw_only` for Python 3.10+
+                if sys.version_info >= (3, 10) and field_value.kw_only:
+                    field_args['kw_only'] = True
 
-            # Set `repr` attribute if it's explicitly specified to be not `True`.
-            if field_value.repr is not True:
-                field_args['repr'] = field_value.repr
+                # Set `repr` attribute if it's explicitly specified to be not `True`.
+                if field_value.repr is not True:
+                    field_args['repr'] = field_value.repr
 
-            setattr(cls, field_name, dataclasses.field(**field_args))
+                setattr(cls, field_name, dataclasses.field(**field_args))
+                cls.__annotations__[field_name] = annotation_cls.__annotations__[field_name]
 
     def create_dataclass(cls: type[Any]) -> type[PydanticDataclass]:
         """Create a Pydantic dataclass from a regular dataclass.

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -153,7 +153,7 @@ def dataclass(  # noqa: C901
         into
           `x: int = dataclasses.field(default=pydantic.Field(..., kw_only=True), kw_only=True)`
         """
-        for annotation_cls in cls.__mro__[::-1]:
+        for annotation_cls in cls.__mro__:
             # In Python < 3.9, `__annotations__` might not be present if there are no fields.
             # we therefore need to use `getattr` to avoid an `AttributeError`.
             for field_name in getattr(annotation_cls, '__annotations__', []):

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2808,7 +2808,12 @@ def test_annotations_with_override() -> None:
         b: str = pydantic.dataclasses.Field()
         d: str = pydantic.dataclasses.Field()
 
-    b = B(a='a', b='b', c='c', d='d')
-    for field_name in ['a', 'b', 'c', 'd']:
-        assert B.__pydantic_fields__[field_name].annotation is str
-        assert getattr(b, field_name) == field_name
+    @pydantic.dataclasses.dataclass()
+    class C(B):
+        pass
+
+    for _dataclass in [B, C]:
+        instance = _dataclass(a='a', b='b', c='c', d='d')
+        for field_name in ['a', 'b', 'c', 'd']:
+            assert _dataclass.__pydantic_fields__[field_name].annotation is str
+            assert getattr(instance, field_name) == field_name

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2796,29 +2796,6 @@ def test_annotations_valid_for_field_inheritance_with_existing_field() -> None:
     assert b.b == 'b'
 
 
-def test_annotations_with_override() -> None:
-    @pydantic.dataclasses.dataclass()
-    class A:
-        a: int
-        b: int
-        c: int = pydantic.dataclasses.Field()
-        d: int = pydantic.dataclasses.Field()
-
-    # note, the order of fields is different here, as to test that the annotation
-    # is correctly set on the field no matter the base's default / current class's default
-    @pydantic.dataclasses.dataclass()
-    class B(A):
-        a: str
-        c: str
-        b: str = pydantic.dataclasses.Field()
-        d: str = pydantic.dataclasses.Field()
-
-    b = B(a='a', b='b', c='c', d='d')
-    for field_name in ['a', 'b', 'c', 'd']:
-        assert B.__pydantic_fields__[field_name].annotation is str
-        assert getattr(b, field_name) == field_name
-
-
 def test_annotation_with_double_override() -> None:
     @pydantic.dataclasses.dataclass()
     class A:
@@ -2840,7 +2817,8 @@ def test_annotation_with_double_override() -> None:
     class C(B):
         ...
 
-    c = C(a='a', b='b', c='c', d='d')
-    for field_name in ['a', 'b', 'c', 'd']:
-        assert C.__pydantic_fields__[field_name].annotation is str
-        assert getattr(c, field_name) == field_name
+    for class_ in [B, C]:
+        instance = class_(a='a', b='b', c='c', d='d')
+        for field_name in ['a', 'b', 'c', 'd']:
+            assert class_.__pydantic_fields__[field_name].annotation is str
+            assert getattr(instance, field_name) == field_name

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2759,3 +2759,17 @@ def test_disallow_init_false_and_init_var_true() -> None:
         @pydantic.dataclasses.dataclass
         class Foo:
             bar: str = Field(..., init=False, init_var=True)
+
+
+def test_annotations_valid_for_field_inheritance() -> None:
+    # testing https://github.com/pydantic/pydantic/issues/8670
+
+    class A:
+        a: int = pydantic.dataclasses.Field()
+
+    @pydantic.dataclasses.dataclass()
+    class B(A):
+        ...
+
+    assert 'a' in B.__pydantic_fields__
+    assert 'a' in B.__annotations__

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2771,5 +2771,4 @@ def test_annotations_valid_for_field_inheritance() -> None:
     class B(A):
         ...
 
-    assert 'a' in B.__pydantic_fields__
-    assert 'a' in B.__annotations__
+    assert B.__pydantic_fields__['a'].annotation is int

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2772,3 +2772,23 @@ def test_annotations_valid_for_field_inheritance() -> None:
         ...
 
     assert B.__pydantic_fields__['a'].annotation is int
+
+    assert B(a=1).a == 1
+
+
+def test_annotations_valid_for_field_inheritance_with_existing_field() -> None:
+    # variation on testing https://github.com/pydantic/pydantic/issues/8670
+
+    class A:
+        a: int = pydantic.dataclasses.Field()
+
+    @pydantic.dataclasses.dataclass()
+    class B(A):
+        b: str
+
+    assert B.__pydantic_fields__['a'].annotation is int
+    assert B.__pydantic_fields__['b'].annotation is str
+
+    b = B(a=1, b='b')
+    assert b.a == 1
+    assert b.b == 'b'

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2796,17 +2796,17 @@ def test_annotations_valid_for_field_inheritance_with_existing_field() -> None:
 
 def test_annotations_with_override() -> None:
     class A:
-        a: int = pydantic.dataclasses.Field()
-        b: int = pydantic.dataclasses.Field()
-        c: int
-        d: int
+        a: int
+        b: int
+        c: int = pydantic.dataclasses.Field()
+        d: int = pydantic.dataclasses.Field()
 
     @pydantic.dataclasses.dataclass()
     class B(A):
-        a: str = pydantic.dataclasses.Field()
-        b: str
-        c: str = pydantic.dataclasses.Field()
-        d: str
+        a: str
+        c: str
+        b: str = pydantic.dataclasses.Field()
+        d: str = pydantic.dataclasses.Field()
 
     b = B(a='a', b='b', c='c', d='d')
     for field_name in ['a', 'b', 'c', 'd']:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2792,3 +2792,23 @@ def test_annotations_valid_for_field_inheritance_with_existing_field() -> None:
     b = B(a=1, b='b')
     assert b.a == 1
     assert b.b == 'b'
+
+
+def test_annotations_with_override() -> None:
+    class A:
+        a: int = pydantic.dataclasses.Field()
+        b: int = pydantic.dataclasses.Field()
+        c: int
+        d: int
+
+    @pydantic.dataclasses.dataclass()
+    class B(A):
+        a: str = pydantic.dataclasses.Field()
+        b: str
+        c: str = pydantic.dataclasses.Field()
+        d: str
+
+    b = B(a='a', b='b', c='c', d='d')
+    for field_name in ['a', 'b', 'c', 'd']:
+        assert B.__pydantic_fields__[field_name].annotation is str
+        assert getattr(b, field_name) == field_name


### PR DESCRIPTION
## Change Summary

We recently modified how we handle making pydantic `Field`s compatible with `dataclass` fields (various changes in 2.6). This fixes an inheritance issue introduced by those changes.

Thanks @alexmojaki for the starter code for the fix!

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/8670

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @lig