### PR TITLE
Fix `ByteSize` error `type` change

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1789,7 +1789,7 @@ class ByteSize(int):
                     core_schema.int_schema(ge=0),
                 ],
                 custom_error_type='byte_size',
-                custom_error_message='could not parse value and unit from byte string or integer',
+                custom_error_message='could not parse value and unit from byte string',
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(
                 int, return_schema=core_schema.int_schema(ge=0)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1787,7 +1787,9 @@ class ByteSize(int):
                 [
                     core_schema.str_schema(pattern=cls.byte_string_pattern),
                     core_schema.int_schema(ge=0),
-                ]
+                ],
+                custom_error_type='byte_size',
+                custom_error_message='could not parse value and unit from byte string or integer',
             ),
             serialization=core_schema.plain_serializer_function_ser_schema(
                 int, return_schema=core_schema.int_schema(ge=0)


### PR DESCRIPTION
## Change Summary

The `ByteSize` validation should only cause errors of type `byte_size` or `byte_size_unit` as to avoid a breaking change.

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/8676

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
