### PR TITLE
Fix typo and broken link in TypeAdapter description in "Why" docs

### DIFF
--- a/docs/why.md
+++ b/docs/why.md
@@ -272,7 +272,7 @@ Pydantic provides four ways to create schemas and perform validation and seriali
 
 1. [`BaseModel`](concepts/models.md) &mdash; Pydantic's own super class with many common utilities available via instance methods.
 2. [`pydantic.dataclasses.dataclass`](concepts/dataclasses.md) &mdash; a wrapper around standard dataclasses which performs validation when a dataclass is initialized.
-3. [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] &mdash; a general way to adapt any type for validation and serialization. This allows types like [`TypedDict`](api/standard_library_types.md#typeddict) and [`NampedTuple`](api/standard_library_types.md#namedtuple) to be validated as well as simple scalar values like `int` or `timedelta` &mdash; [all types](concepts/types.md) supported can be used with `TypeAdapter`.
+3. [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] &mdash; a general way to adapt any type for validation and serialization. This allows types like [`TypedDict`](api/standard_library_types.md#typeddict) and [`NamedTuple`](api/standard_library_types.md#typingnamedtuple) to be validated as well as simple scalar values like `int` or `timedelta` &mdash; [all types](concepts/types.md) supported can be used with `TypeAdapter`.
 4. [`validate_call`](concepts/validation_decorator.md) &mdash; a decorator to perform validation when calling a function.
 
 ??? example "Example - schema based on TypedDict"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I changed the misspelled `NampedTuple` to `NamedTuple` and updated its hyperlink, which appears to have been accidentally broken by #7417.

## Related issue number

The PR template says that an issue is only required for non-trivial changes. If need be, I can create one for this PR to track.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
