### PR TITLE
Allow an optional separator splitting the value and unit of the result of `ByteSize.human_readable`.

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1826,7 +1826,7 @@ class ByteSize(int):
         Args:
             decimal: If True, use decimal units (e.g. 1000 bytes per KB). If False, use binary units
                 (e.g. 1024 bytes per KiB).
-            separator: Split the value and unit with a specific separator.
+            separator: A string used to split the value and unit. Defaults to an empty string ('').
 
         Returns:
             A human readable string representation of the byte size.

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1826,7 +1826,7 @@ class ByteSize(int):
         Args:
             decimal: If True, use decimal units (e.g. 1000 bytes per KB). If False, use binary units
                 (e.g. 1024 bytes per KiB).
-            separator: If True, the result will be separated by a space (` `) between the value and 
+            separator: If True, the result will be separated by a space (` `) between the value and
                 unit. If False, the result will remain inseparate.
 
         Returns:

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1740,6 +1740,8 @@ class ByteSize(int):
     #> 44.4PiB
     print(m.size.human_readable(decimal=True))
     #> 50.0PB
+    print(m.size.human_readable(separator=True))
+    #> 44.4 PiB
 
     print(m.size.to('TiB'))
     #> 45474.73508864641
@@ -1818,12 +1820,14 @@ class ByteSize(int):
 
         return cls(int(float(scalar) * unit_mult))
 
-    def human_readable(self, decimal: bool = False) -> str:
+    def human_readable(self, decimal: bool = False, separator: bool = False) -> str:
         """Converts a byte size to a human readable string.
 
         Args:
             decimal: If True, use decimal units (e.g. 1000 bytes per KB). If False, use binary units
                 (e.g. 1024 bytes per KiB).
+            separator: If True, the result will be separated by a space (` `) between the value and 
+                unit. If False, the result will remain inseparate.
 
         Returns:
             A human readable string representation of the byte size.
@@ -1837,16 +1841,18 @@ class ByteSize(int):
             units = 'B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'
             final_unit = 'EiB'
 
+        sep = ' ' if separator else ''
+
         num = float(self)
         for unit in units:
             if abs(num) < divisor:
                 if unit == 'B':
-                    return f'{num:0.0f}{unit}'
+                    return f'{num:0.0f}{sep}{unit}'
                 else:
-                    return f'{num:0.1f}{unit}'
+                    return f'{num:0.1f}{sep}{unit}'
             num /= divisor
 
-        return f'{num:0.1f}{final_unit}'
+        return f'{num:0.1f}{sep}{final_unit}'
 
     def to(self, unit: str) -> float:
         """Converts a byte size to another unit, including both byte and bit units.

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1740,7 +1740,7 @@ class ByteSize(int):
     #> 44.4PiB
     print(m.size.human_readable(decimal=True))
     #> 50.0PB
-    print(m.size.human_readable(separator=True))
+    print(m.size.human_readable(separator=' '))
     #> 44.4 PiB
 
     print(m.size.to('TiB'))
@@ -1820,14 +1820,13 @@ class ByteSize(int):
 
         return cls(int(float(scalar) * unit_mult))
 
-    def human_readable(self, decimal: bool = False, separator: bool = False) -> str:
+    def human_readable(self, decimal: bool = False, separator: str = '') -> str:
         """Converts a byte size to a human readable string.
 
         Args:
             decimal: If True, use decimal units (e.g. 1000 bytes per KB). If False, use binary units
                 (e.g. 1024 bytes per KiB).
-            separator: If True, the result will be separated by a space (` `) between the value and
-                unit. If False, the result will remain inseparate.
+            separator: Split the value and unit with a specific separator.
 
         Returns:
             A human readable string representation of the byte size.
@@ -1841,18 +1840,16 @@ class ByteSize(int):
             units = 'B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'
             final_unit = 'EiB'
 
-        sep = ' ' if separator else ''
-
         num = float(self)
         for unit in units:
             if abs(num) < divisor:
                 if unit == 'B':
-                    return f'{num:0.0f}{sep}{unit}'
+                    return f'{num:0.0f}{separator}{unit}'
                 else:
-                    return f'{num:0.1f}{sep}{unit}'
+                    return f'{num:0.1f}{separator}{unit}'
             num /= divisor
 
-        return f'{num:0.1f}{sep}{final_unit}'
+        return f'{num:0.1f}{separator}{final_unit}'
 
     def to(self, unit: str) -> float:
         """Converts a byte size to another unit, including both byte and bit units.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4462,7 +4462,7 @@ def test_bytesize_conversions(input_value, output, human_bin, human_dec, human_s
 
     assert m.size.human_readable() == human_bin
     assert m.size.human_readable(decimal=True) == human_dec
-    assert m.size.human_readable(separator=True) == human_sep
+    assert m.size.human_readable(separator=' ') == human_sep
 
 
 def test_bytesize_to():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4436,23 +4436,23 @@ def test_frozenset_field_not_convertible():
 
 
 @pytest.mark.parametrize(
-    'input_value,output,human_bin,human_dec',
+    'input_value,output,human_bin,human_dec,human_sep',
     (
-        (1, 1, '1B', '1B'),
-        ('1', 1, '1B', '1B'),
-        ('1.0', 1, '1B', '1B'),
-        ('1b', 1, '1B', '1B'),
-        ('1.5 KB', int(1.5e3), '1.5KiB', '1.5KB'),
-        ('1.5 K', int(1.5e3), '1.5KiB', '1.5KB'),
-        ('1.5 MB', int(1.5e6), '1.4MiB', '1.5MB'),
-        ('1.5 M', int(1.5e6), '1.4MiB', '1.5MB'),
-        ('5.1kib', 5222, '5.1KiB', '5.2KB'),
-        ('6.2EiB', 7148113328562451456, '6.2EiB', '7.1EB'),
-        ('8bit', 1, '1B', '1B'),
-        ('1kbit', 125, '125B', '125B'),
+        (1, 1, '1B', '1B', '1 B'),
+        ('1', 1, '1B', '1B', '1 B'),
+        ('1.0', 1, '1B', '1B', '1 B'),
+        ('1b', 1, '1B', '1B', '1 B'),
+        ('1.5 KB', int(1.5e3), '1.5KiB', '1.5KB', '1.5 KiB'),
+        ('1.5 K', int(1.5e3), '1.5KiB', '1.5KB', '1.5 KiB'),
+        ('1.5 MB', int(1.5e6), '1.4MiB', '1.5MB', '1.4 MiB'),
+        ('1.5 M', int(1.5e6), '1.4MiB', '1.5MB', '1.4 MiB'),
+        ('5.1kib', 5222, '5.1KiB', '5.2KB', '5.1 KiB'),
+        ('6.2EiB', 7148113328562451456, '6.2EiB', '7.1EB', '6.2 EiB'),
+        ('8bit', 1, '1B', '1B', '1 B'),
+        ('1kbit', 125, '125B', '125B', '125 B'),
     ),
 )
-def test_bytesize_conversions(input_value, output, human_bin, human_dec):
+def test_bytesize_conversions(input_value, output, human_bin, human_dec, human_sep):
     class Model(BaseModel):
         size: ByteSize
 
@@ -4462,6 +4462,7 @@ def test_bytesize_conversions(input_value, output, human_bin, human_dec):
 
     assert m.size.human_readable() == human_bin
     assert m.size.human_readable(decimal=True) == human_dec
+    assert m.size.human_readable(separator=True) == human_sep
 
 
 def test_bytesize_to():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Allow splitting the value and unit of the result of `ByteSize.human_readable` with a separator providing by the argument `separator`.

```python
>>> size = ByteSize(12345678)
>>> size.human_readable()
'11.8MiB'
>>> size.human_readable(separator=' ')
'11.8 MiB'
```

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #8668

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb