### PR TITLE
Fix unsupported types bug with plain validator

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -153,8 +153,14 @@ class PlainValidator:
     func: core_schema.NoInfoValidatorFunction | core_schema.WithInfoValidatorFunction
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: _GetCoreSchemaHandler) -> core_schema.CoreSchema:
-        schema = handler(source_type)
-        serialization = core_schema.wrap_serializer_function_ser_schema(function=lambda v, h: h(v), schema=schema)
+        from pydantic import PydanticSchemaGenerationError
+
+        try:
+            schema = handler(source_type)
+            serialization = core_schema.wrap_serializer_function_ser_schema(function=lambda v, h: h(v), schema=schema)
+        except PydanticSchemaGenerationError:
+            serialization = None
+
         info_arg = _inspect_validator(self.func, 'plain')
         if info_arg:
             func = cast(core_schema.WithInfoValidatorFunction, self.func)


### PR DESCRIPTION
## Change Summary

Unsupported types have previously been supported with `PlainValidator` annotations. This broke with https://github.com/pydantic/pydantic/pull/8567/files in 2.6. This PR aims to fix this bug. The following now occurs, which matches the behavior in 2.5.3:

```py
from typing import TypeAlias, Annotated

import pydantic
from pydantic import PlainValidator

class UnsupportedClass:
    pass


PreviouslySupportedType: TypeAlias = Annotated[
    UnsupportedClass,
    PlainValidator(lambda _: UnsupportedClass())
]

type_adapter = pydantic.TypeAdapter(PreviouslySupportedType)

model = type_adapter.validate_python("abcdefg")
print(model)
#> <__main__.UnsupportedClass object at 0x104f82cb0>
print(type_adapter.dump_python(model))
#> <__main__.UnsupportedClass object at 0x104f82cb0>
print(type_adapter.dump_json(model))
"""
Traceback (most recent call last):
  File "/Users/programming/pydantic_work/pydantic/test.py", line 22, in <module>
    print(type_adapter.dump_json(model))
  File "/Users/programming/pydantic_work/pydantic/pydantic/type_adapter.py", line 377, in dump_json
    return self.serializer.to_json(
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class '__main__.UnsupportedClass'>
"""
```

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/8697

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
