### PR TITLE
Use ``is_valid_field`` from 1.x for ``mypy`` plugin

### DIFF
--- a/pydantic/v1/mypy.py
+++ b/pydantic/v1/mypy.py
@@ -65,6 +65,8 @@ from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 from mypy.version import __version__ as mypy_version
 
+from .utils import is_valid_field
+
 try:
     from mypy.types import TypeVarDef  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover
@@ -90,12 +92,6 @@ BUILTINS_NAME = 'builtins' if MYPY_VERSION_TUPLE >= (0, 930) else '__builtins__'
 
 # Increment version if plugin changes and mypy caches should be invalidated
 __version__ = 2
-
-
-def is_valid_field(name: str) -> bool:
-    if not name.startswith('_'):
-        return True
-    return ROOT_KEY == name
 
 
 def plugin(version: str) -> 'TypingType[Plugin]':

--- a/pydantic/v1/mypy.py
+++ b/pydantic/v1/mypy.py
@@ -65,8 +65,6 @@ from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 from mypy.version import __version__ as mypy_version
 
-from pydantic.utils import is_valid_field
-
 try:
     from mypy.types import TypeVarDef  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover
@@ -92,6 +90,12 @@ BUILTINS_NAME = 'builtins' if MYPY_VERSION_TUPLE >= (0, 930) else '__builtins__'
 
 # Increment version if plugin changes and mypy caches should be invalidated
 __version__ = 2
+
+
+def is_valid_field(name: str) -> bool:
+    if not name.startswith('_'):
+        return True
+    return ROOT_KEY == name
 
 
 def plugin(version: str) -> 'TypingType[Plugin]':


### PR DESCRIPTION
## Change Summary

https://github.com/pydantic/pydantic/blob/3ddb509786089f9df0658303545ae4b66db2d47c/pydantic/utils.py#L696-L699

This brings the `mypy` plugin in the `v1` namespace in line with how `1.x` actually behaved.

Importing this from the `pydantic` namespace created warnings in our v1/v2 codebase.

## Related issue number

No issue, couldn't find one and this seems like a simple enough change.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist > seems unnecessary?
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle

skip change file check