### PR TITLE
Fix resolution of forward refs in dataclass base classes that are not present in the subclass module namespace

### DIFF
--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1622,6 +1622,30 @@ def test_cross_module_cyclic_reference_dataclass(create_module):
     ]
 
 
+def test_base_dataclasses_annotations_resolving(create_module):
+    # Have to use a string due to the __future__ import
+    module_a = create_module(
+        """
+from __future__ import annotations
+
+import dataclasses
+from typing import NewType
+
+OddInt = NewType('OddInt', int)
+
+@dataclasses.dataclass
+class D1:
+    d1: OddInt
+"""
+    )
+
+    @dataclasses.dataclass
+    class D2(module_a.D1):
+        d2: int
+
+    assert TypeAdapter(D2).validate_python({'d1': 1, 'd2': 2}) == D2(d1=1, d2=2)
+
+
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='kw_only is not available in python < 3.10')
 def test_kw_only():
     @pydantic.dataclasses.dataclass(kw_only=True)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1622,7 +1622,14 @@ def test_cross_module_cyclic_reference_dataclass(create_module):
     ]
 
 
-@pytest.mark.parametrize('dataclass_decorator', [pydantic.dataclasses.dataclass, dataclasses.dataclass])
+@pytest.mark.parametrize(
+    'dataclass_decorator',
+    [
+        pydantic.dataclasses.dataclass,
+        dataclasses.dataclass,
+    ],
+    ids=['pydantic', 'stdlib'],
+)
 def test_base_dataclasses_annotations_resolving(create_module, dataclass_decorator: Callable):
     @create_module
     def module():
@@ -1634,15 +1641,25 @@ def test_base_dataclasses_annotations_resolving(create_module, dataclass_decorat
         @dataclasses.dataclass
         class D1:
             d1: 'OddInt'
+            s: str
+
+            __pydantic_config__ = {'str_to_lower': True}
 
     @dataclass_decorator
     class D2(module.D1):
         d2: int
 
-    assert TypeAdapter(D2).validate_python({'d1': 1, 'd2': 2}) == D2(d1=1, d2=2)
+    assert TypeAdapter(D2).validate_python({'d1': 1, 'd2': 2, 's': 'ABC'}) == D2(d1=1, d2=2, s='abc')
 
 
-@pytest.mark.parametrize('dataclass_decorator', [pydantic.dataclasses.dataclass, dataclasses.dataclass])
+@pytest.mark.parametrize(
+    'dataclass_decorator',
+    [
+        pydantic.dataclasses.dataclass,
+        dataclasses.dataclass,
+    ],
+    ids=['pydantic', 'stdlib'],
+)
 def test_base_dataclasses_annotations_resolving_with_override(create_module, dataclass_decorator: Callable):
     @create_module
     def module1():
@@ -1655,6 +1672,8 @@ def test_base_dataclasses_annotations_resolving_with_override(create_module, dat
         class D1:
             db_id: 'IDType'
 
+            __pydantic_config__ = {'str_to_lower': True}
+
     @create_module
     def module2():
         import dataclasses
@@ -1665,12 +1684,15 @@ def test_base_dataclasses_annotations_resolving_with_override(create_module, dat
         @dataclasses.dataclass
         class D2:
             db_id: 'IDType'
+            s: str
+
+            __pydantic_config__ = {'str_to_lower': False}
 
     @dataclass_decorator
     class D3(module1.D1, module2.D2):
         ...
 
-    assert TypeAdapter(D3).validate_python({'db_id': 42}) == D3(db_id=42)
+    assert TypeAdapter(D3).validate_python({'db_id': 42, 's': 'ABC'}) == D3(db_id=42, s='abc')
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='kw_only is not available in python < 3.10')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

(Text mostly copied from #8730) When the base class of a dataclass has an annotation type that is not imported by the module the subclass is in, and `from __future__ import annotations` is in use (or in my case, Cython is in use), an error occurs.

The root cause is that when pydantic builds up the type namespace, it does not consider base classes (https://github.com/pydantic/pydantic/blob/main/pydantic/_internal/_generate_schema.py#L1474). This is fine for models, because each base class builds a schema immediately, but does not work for plain stdlib dataclasses. This PR adds code to iterate though all of the base classes of the dataclass that are also dataclasses, and push their namespaces as well, which should cover all of the fields which Pydantic will attempt to resolve.

## Related issue number

Fixes #8730

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @alexmojaki