### PR TITLE
model_json_schema export with Annotated types misses 'required' parameters

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -372,6 +372,8 @@ class FieldInfo(_repr.Representation):
             if _typing_extra.is_annotated(annotation):
                 first_arg, *extra_args = typing_extensions.get_args(annotation)
                 field_infos = [a for a in extra_args if isinstance(a, FieldInfo)]
+                if default is Ellipsis:
+                    default = PydanticUndefined
                 field_info = FieldInfo.merge_field_infos(*field_infos, annotation=first_arg, default=default)
                 metadata: list[Any] = []
                 for a in extra_args:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6,14 +6,7 @@ import typing
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
-from ipaddress import (
-    IPv4Address,
-    IPv4Interface,
-    IPv4Network,
-    IPv6Address,
-    IPv6Interface,
-    IPv6Network,
-)
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
 from typing import (
     Any,
@@ -75,15 +68,7 @@ from pydantic.json_schema import (
     model_json_schema,
     models_json_schema,
 )
-from pydantic.networks import (
-    AnyUrl,
-    EmailStr,
-    IPvAnyAddress,
-    IPvAnyInterface,
-    IPvAnyNetwork,
-    MultiHostUrl,
-    NameEmail,
-)
+from pydantic.networks import AnyUrl, EmailStr, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork, MultiHostUrl, NameEmail
 from pydantic.type_adapter import TypeAdapter
 from pydantic.types import (
     UUID1,
@@ -5947,3 +5932,23 @@ def test_recursive_json_schema_build() -> None:
         c: ModelC
 
     assert Model.model_json_schema()
+
+
+def test_json_schema_annotated_with_field() -> None:
+    """Check if the ellipsis in the signature is considered as a required field."""
+
+    from pydantic import create_model
+
+    Model = create_model(
+        'test_model',
+        bar=(Annotated[int, Field(description='Bar description')], ...),
+    )
+
+    assert Model.model_json_schema() == {
+        'properties': {
+            'bar': {'description': 'Bar description', 'title': 'Bar', 'type': 'integer'},
+        },
+        'required': ['bar'],
+        'title': 'test_model',
+        'type': 'object',
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

When using an Annotation with a FieldInfo and an Ellipsis, the Ellipsis was considered as a default value. Therefore, the field was not considered mandatory.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #8780

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
