### PR TITLE
Fix default inclusion in `FieldInfo.__repr_args__`

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -574,7 +574,9 @@ class FieldInfo(_repr.Representation):
                 continue
             if s == 'serialization_alias' and self.serialization_alias == self.alias:
                 continue
-            if s == 'default_factory' and self.default_factory is not None:
+            if s == 'default' and self.default is not PydanticUndefined:
+                yield 'default', self.default
+            elif s == 'default_factory' and self.default_factory is not None:
                 yield 'default_factory', _repr.PlainRepr(_repr.display_as_type(self.default_factory))
             else:
                 value = getattr(self, s)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import pytest
 
 import pydantic.dataclasses
@@ -113,8 +115,8 @@ def test_model_field_default_info():
     """Test that __repr_args__ of FieldInfo includes the default value when it's set to None."""
 
     class Model(BaseModel):
-        a: int | None = Field(default=None)
-        b: int | None = None
+        a: Union[int, None] = Field(default=None)
+        b: Union[int, None] = None
 
     assert str(Model.model_fields) == (
         "{'a': FieldInfo(annotation=Union[int, NoneType], required=False, default=None), "

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -107,3 +107,16 @@ def test_frozen_field_repr():
 
     assert repr(Model.model_fields['non_frozen_field']) == 'FieldInfo(annotation=int, required=True)'
     assert repr(Model.model_fields['frozen_field']) == 'FieldInfo(annotation=int, required=True, frozen=True)'
+
+
+def test_model_field_default_info():
+    """Test that __repr_args__ of FieldInfo includes the default value when it's set to None."""
+
+    class Model(BaseModel):
+        a: int | None = Field(default=None)
+        b: int | None = None
+
+    assert str(Model.model_fields) == (
+        "{'a': FieldInfo(annotation=Union[int, NoneType], required=False, default=None), "
+        "'b': FieldInfo(annotation=Union[int, NoneType], required=False, default=None)}"
+    )

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -64,7 +64,9 @@ def test_forward_ref_auto_update_no_model(create_module):
     assert b.model_dump() == {'b': {'a': {'b': {'a': None}}}}
 
     # model_fields is complete on Foo
-    assert repr(module.Foo.model_fields['a']) == ('FieldInfo(annotation=Union[Bar, NoneType], required=False)')
+    assert repr(module.Foo.model_fields['a']) == (
+        'FieldInfo(annotation=Union[Bar, NoneType], required=False, default=None)'
+    )
 
     assert module.Foo.__pydantic_complete__ is False
     # Foo gets auto-rebuilt during the first attempt at validation
@@ -159,7 +161,7 @@ def test_self_forward_ref_collection(create_module):
     ]
 
     assert repr(module.Foo.model_fields['a']) == 'FieldInfo(annotation=int, required=False, default=123)'
-    assert repr(module.Foo.model_fields['b']) == 'FieldInfo(annotation=Foo, required=False)'
+    assert repr(module.Foo.model_fields['b']) == 'FieldInfo(annotation=Foo, required=False, default=None)'
     if sys.version_info < (3, 10):
         return
     assert repr(module.Foo.model_fields['c']) == ('FieldInfo(annotation=List[Foo], required=False, ' 'default=[])')


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/8629

Make sure that when `default=None` is set, this is reflected when you print out `FieldInfo` instances.

Selected Reviewer: @Kludex