### PR TITLE
Add better error message for improper definition of RootModel with Generic

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -14,7 +14,7 @@ import typing_extensions
 from pydantic_core import PydanticUndefined, SchemaSerializer
 from typing_extensions import dataclass_transform, deprecated
 
-from pydantic.root_model import RootModel
+from pydantic import RootModel
 
 from ..errors import PydanticUndefinedAnnotation, PydanticUserError
 from ..plugin._schema_validator import create_schema_validator
@@ -184,7 +184,7 @@ class ModelMetaclass(ABCMeta):
                             error_message += (
                                 f' Note: `typing.Generic` must go last: `class {cls.__name__}({bases_str}): ...`)'
                             )
-                        raise TypeError(error_message)
+                    raise TypeError(error_message)
                 cls.__pydantic_generic_metadata__ = {
                     'origin': None,
                     'args': (),


### PR DESCRIPTION
## Change Summary

This PR add a new error message when creating a generic RootModel without providing the generic to the model in the class inheritance. Now, it mention the needed parametrization of the RootModel itself

## Related issue number

fix #8712 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
