### PR TITLE
Fix link to company announcement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Define how data should be in pure, canonical Python 3.8+; validate it with Pydan
 ## Pydantic Company :rocket:
 
 We've started a company based on the principles that I believe have led to Pydantic's success.
-Learning more from the [Company Announcement](https://pydantic.dev/announcement/).
+Learning more from the [Company Announcement](https://blog.pydantic.dev/blog/2023/02/16/company-announcement--pydantic/).
 
 ## Pydantic V1.10 vs. V2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The link in the readme about the company announcement is actually simply a link to the blog/announcement page of pydantic's website, and it is not immediately clear that this isn't a broken link, added to the fact that people have to search for the actual page that was referred to. This PR modifies it to point directly to the actual announcement.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
