### PR TITLE
fix link to model_dump_json()

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -1207,7 +1207,7 @@ print(validation_schema)
 ## Customizing the `$ref`s in JSON Schema
 
 The format of `$ref`s can be altered by calling [`model_json_schema()`][pydantic.main.BaseModel.model_json_schema]
-or `model_dump_json()`][pydantic.main.BaseModel.model_dump_json] with the `ref_template` keyword argument.
+or [`model_dump_json()`][pydantic.main.BaseModel.model_dump_json] with the `ref_template` keyword argument.
 The definitions are always stored under the key `$defs`, but a specified prefix can be used for the references.
 
 This is useful if you need to extend or modify the JSON schema default definitions location. For example, with OpenAPI:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixed the link to `model_dump_json()` on the [JSON schema](https://docs.pydantic.dev/latest/concepts/json_schema/#customizing-the-refs-in-json-schema) documentation page.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
