### PR TITLE
Improve error message for improper `RootModel` subclasses

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -33,7 +33,6 @@ if typing.TYPE_CHECKING:
     from ..fields import Field as PydanticModelField
     from ..fields import FieldInfo, ModelPrivateAttr
     from ..main import BaseModel
-    from ..root_model import RootModelRootType
 else:
     # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
     # and https://youtrack.jetbrains.com/issue/PY-51428
@@ -138,6 +137,8 @@ class ModelMetaclass(ABCMeta):
                 parent_parameters = getattr(cls, '__pydantic_generic_metadata__', {}).get('parameters', ())
                 parameters = getattr(cls, '__parameters__', None) or parent_parameters
                 if parameters and parent_parameters and not all(x in parameters for x in parent_parameters):
+                    from ..root_model import RootModelRootType
+
                     missing_parameters = tuple(x for x in parameters if x not in parent_parameters)
                     if RootModelRootType in parent_parameters and RootModelRootType not in parameters:
                         # This is a special case where the user has subclassed `RootModel`, but has not parametrized

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -156,15 +156,15 @@ class ModelMetaclass(ABCMeta):
                             f'All parameters must be present on typing.Generic;'
                             f' you should inherit from {generic_type_label}.'
                         )
-                    if Generic not in bases:  # pragma: no cover
-                        # We raise an error here not because it is desirable, but because some cases are mishandled.
-                        # It would be nice to remove this error and still have things behave as expected, it's just
-                        # challenging because we are using a custom `__class_getitem__` to parametrize generic models,
-                        # and not returning a typing._GenericAlias from it.
-                        bases_str = ', '.join([x.__name__ for x in bases] + [generic_type_label])
-                        error_message += (
-                            f' Note: `typing.Generic` must go last: `class {cls.__name__}({bases_str}): ...`)'
-                        )
+                        if Generic not in bases:  # pragma: no cover
+                            # We raise an error here not because it is desirable, but because some cases are mishandled.
+                            # It would be nice to remove this error and still have things behave as expected, it's just
+                            # challenging because we are using a custom `__class_getitem__` to parametrize generic models,
+                            # and not returning a typing._GenericAlias from it.
+                            bases_str = ', '.join([x.__name__ for x in bases] + [generic_type_label])
+                            error_message += (
+                                f' Note: `typing.Generic` must go last: `class {cls.__name__}({bases_str}): ...`)'
+                            )
                     raise TypeError(error_message)
 
                 cls.__pydantic_generic_metadata__ = {

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -653,7 +653,7 @@ def test_model_validate_strings(root_type, input_value, expected, raises_match, 
 def test_model_construction_with_invalid_generic_specification() -> None:
     T_ = TypeVar('T_', bound=BaseModel)
 
-    with pytest.raises(TypeError, match='You should ensure that RootModel is correctly parameterized'):
+    with pytest.raises(TypeError, match='You should parametrize RootModel directly'):
 
         class GenericRootModel(RootModel, Generic[T_]):
             root: Union[T_, int]

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -656,4 +656,4 @@ def test_model_construction_with_invalid_generic_specification() -> None:
     with pytest.raises(TypeError, match='You should ensure that RootModel is correctly parameterized'):
 
         class GenericRootModel(RootModel, Generic[T_]):
-            root: Union[T_ | int]
+            root: Union[T_, int]

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -1,11 +1,11 @@
 import pickle
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Generic, List, Optional, Union
 
 import pytest
 from pydantic_core import CoreSchema
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
-from typing_extensions import Annotated, Literal
+from typing_extensions import Annotated, Literal, TypeVar
 
 from pydantic import (
     Base64Str,
@@ -648,3 +648,12 @@ def test_model_validate_strings(root_type, input_value, expected, raises_match, 
             Model.model_validate_strings(input_value, strict=strict)
     else:
         assert Model.model_validate_strings(input_value, strict=strict).root == expected
+
+
+def test_model_construction_with_invalid_generic_specification() -> None:
+    T_ = TypeVar('T_', bound=BaseModel)
+
+    with pytest.raises(TypeError, match='You should ensure that RootModel is correctly parameterized'):
+
+        class GenericRootModel(RootModel, Generic[T_]):
+            root: Union[T_ | int]


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/8712

Improve error message in the case where `RootModel` isn't parametrized properly with generics.

Alternative to https://github.com/pydantic/pydantic/pull/8804.

Selected Reviewer: @samuelcolvin