### PR TITLE
Reorganize `pyproject.toml` sections

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -3,10 +3,9 @@
 
 [metadata]
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:3bf8ccaefcdd7ac0c02606dbb435934025578ce34798b72ea97bd85e39ac6702"
+strategy = ["cross_platform"]
+lock_version = "4.4.1"
+content_hash = "sha256:55624d6d83af291bfaba90cb8ecaf41ee4cfecad9a3aa04d6945640b5475efc0"
 
 [[package]]
 name = "annotated-types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,24 +2,6 @@
 requires = ['hatchling', 'hatch-fancy-pypi-readme>=22.5.0']
 build-backend = 'hatchling.build'
 
-[tool.hatch.version]
-path = 'pydantic/version.py'
-
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.hatch.build.targets.sdist]
-# limit which files are included in the sdist (.tar.gz) asset,
-# see https://github.com/pydantic/pydantic/pull/4542
-include = [
-    '/README.md',
-    '/HISTORY.md',
-    '/Makefile',
-    '/pydantic',
-    '/tests',
-    '/requirements',
-]
-
 [project]
 name = 'pydantic'
 description = 'Data validation using Python type hints'
@@ -73,6 +55,47 @@ dynamic = ['version', 'readme']
 [project.optional-dependencies]
 email = ['email-validator>=2.0.0']
 
+[project.urls]
+Homepage = 'https://github.com/pydantic/pydantic'
+Documentation = 'https://docs.pydantic.dev'
+Funding = 'https://github.com/sponsors/samuelcolvin'
+Source = 'https://github.com/pydantic/pydantic'
+Changelog = 'https://docs.pydantic.dev/latest/changelog/'
+
+[tool.hatch.version]
+path = 'pydantic/version.py'
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.sdist]
+# limit which files are included in the sdist (.tar.gz) asset,
+# see https://github.com/pydantic/pydantic/pull/4542
+include = [
+    '/README.md',
+    '/HISTORY.md',
+    '/Makefile',
+    '/pydantic',
+    '/tests',
+    '/requirements',
+]
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = 'text/markdown'
+# construct the PyPI readme from README.md and HISTORY.md
+fragments = [
+    {path = "README.md"},
+    {text = "\n## Changelog\n\n"},
+    {path = "HISTORY.md", pattern = "(.+?)<!-- package description limit -->"},
+    {text = "\n... see [here](https://docs.pydantic.dev/changelog/#v0322-2019-08-17) for earlier changes.\n"},
+]
+# convert GitHuB issue/PR numbers and handles to links
+substitutions = [
+    {pattern = '(\s+)#(\d+)', replacement = '\1[#\2](https://github.com/pydantic/pydantic/issues/\2)'},
+    {pattern = '(\s+)@([\w\-]+)', replacement = '\1[@\2](https://github.com/\2)'},
+    {pattern = '@@', replacement = '@'},
+]
+
 [tool.pdm.dev-dependencies]
 docs = [
     "autoflake",
@@ -108,6 +131,7 @@ testing = [
     "faker>=18.13.0",
     "pytest-benchmark>=4.0.0",
     "pytest-codspeed~=2.2.0",
+    "packaging>=23.2",
 ]
 testing-extra = [
     # used when generate devtools docs example
@@ -128,29 +152,6 @@ memray = [
 [tool.pdm.resolution.overrides]
 # requires Python > 3.8, we only test with 3.8 in CI but because of it won't lock properly
 pytest-memray = "1.5.0"
-
-[project.urls]
-Homepage = 'https://github.com/pydantic/pydantic'
-Documentation = 'https://docs.pydantic.dev'
-Funding = 'https://github.com/sponsors/samuelcolvin'
-Source = 'https://github.com/pydantic/pydantic'
-Changelog = 'https://docs.pydantic.dev/latest/changelog/'
-
-[tool.hatch.metadata.hooks.fancy-pypi-readme]
-content-type = 'text/markdown'
-# construct the PyPI readme from README.md and HISTORY.md
-fragments = [
-    {path = "README.md"},
-    {text = "\n## Changelog\n\n"},
-    {path = "HISTORY.md", pattern = "(.+?)<!-- package description limit -->"},
-    {text = "\n... see [here](https://docs.pydantic.dev/changelog/#v0322-2019-08-17) for earlier changes.\n"},
-]
-# convert GitHuB issue/PR numbers and handles to links
-substitutions = [
-    {pattern = '(\s+)#(\d+)', replacement = '\1[#\2](https://github.com/pydantic/pydantic/issues/\2)'},
-    {pattern = '(\s+)@([\w\-]+)', replacement = '\1[@\2](https://github.com/\2)'},
-    {pattern = '@@', replacement = '@'},
-]
 
 [tool.pytest.ini_options]
 testpaths = 'tests'
@@ -233,7 +234,6 @@ source = [
     '/Users/runner/work/pydantic/pydantic/pydantic/',
     'D:\a\pydantic\pydantic\pydantic',
 ]
-
 
 [tool.pyright]
 include = ['pydantic']


### PR DESCRIPTION
As per https://github.com/pydantic/pydantic/pull/8237.

the `project` table wasn't set at the top of file, which would make `pdm` move it around in the file each time a `pdm` command was run.

Added `packaging` as a dev dependency. It is used in https://github.com/pydantic/pydantic/pull/8237 but added here to avoid conflicts (`packaging` is already implicitly included in the lock file so test passes in https://github.com/pydantic/pydantic/pull/8237, this is just to make it explicit here)