### PR TITLE
Fix discriminated union schema gen bug

### DIFF
--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -54,6 +54,7 @@ def apply_discriminators(schema: core_schema.CoreSchema) -> core_schema.CoreSche
         if discriminator is not None:
             if definitions is None:
                 definitions = collect_definitions(schema)
+                definitions = {k: recurse(v, inner) for k, v in definitions.items()}
             s = apply_discriminator(s, discriminator, definitions)
         return s
 

--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -54,6 +54,11 @@ def apply_discriminators(schema: core_schema.CoreSchema) -> core_schema.CoreSche
         if discriminator is not None:
             if definitions is None:
                 definitions = collect_definitions(schema)
+                # After we collect the definitions schemas, we must run through the discriminator
+                # application logic for each one. This step is crucial to prevent an exponential
+                # increase in complexity that occurs if schemas are left as 'union' schemas
+                # rather than 'tagged-union' schemas.
+                # For more details, see https://github.com/pydantic/pydantic/pull/8904#discussion_r1504687302
                 definitions = {k: recurse(v, inner) for k, v in definitions.items()}
             s = apply_discriminator(s, discriminator, definitions)
         return s

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1852,3 +1852,27 @@ def test_nested_discriminator() -> None:
         'title': 'MyModel',
         'type': 'object',
     }
+
+
+def test_nested_schema_gen_uses_tagged_union_in_ref() -> None:
+    class NestedState(BaseModel):
+        state_type: Literal['nested']
+        substate: 'AnyState'
+
+    # If this type is left out, the model behaves normally again
+    class LoopState(BaseModel):
+        state_type: Literal['loop']
+        substate: 'AnyState'
+
+    class LeafState(BaseModel):
+        state_type: Literal['leaf']
+
+    AnyState = Annotated[NestedState | LoopState | LeafState, Field(..., discriminator='state_type')]
+    NestedState.model_rebuild()
+    LoopState.model_rebuild()
+    adapter = TypeAdapter(AnyState)
+
+    assert adapter.core_schema['schema']['type'] == 'tagged-union'
+    for definition in adapter.core_schema['definitions']:
+        if definition['schema']['model_name'] in ['NestedState', 'LoopState']:
+            assert definition['schema']['fields']['substate']['schema']['schema']['type'] == 'tagged-union'

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1867,7 +1867,7 @@ def test_nested_schema_gen_uses_tagged_union_in_ref() -> None:
     class LeafState(BaseModel):
         state_type: Literal['leaf']
 
-    AnyState = Annotated[NestedState | LoopState | LeafState, Field(..., discriminator='state_type')]
+    AnyState = Annotated[Union[NestedState, LoopState, LeafState], Field(..., discriminator='state_type')]
     NestedState.model_rebuild()
     LoopState.model_rebuild()
     adapter = TypeAdapter(AnyState)


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/8709

With this code snippet:

```py
from __future__ import annotations
from typing import Literal, Annotated
from pydantic import Field, TypeAdapter, BaseModel

class NestedState(BaseModel):
    state_type: Literal["nested"]
    substate: AnyState

# If this type is left out, the model behaves normally again
class LoopState(BaseModel):
    state_type: Literal["loop"]
    substate: AnyState

class LeafState(BaseModel):
    state_type: Literal["leaf"]

AnyState = Annotated[NestedState | LoopState | LeafState, Field(..., discriminator="state_type")]

def build_nested_state(n):
    if n <= 0:
        return {"state_type": "leaf"}
    else:
        return {"state_type": "loop", "substate": {"state_type": "nested", "substate": build_nested_state(n-1)}}
        
adapter = TypeAdapter(AnyState)
```

Previously:

```py
# the next statement takes around 0.8s
adapter.validate_python(build_nested_state(9))

# the next statement takes around 3.5s
adapter.validate_python(build_nested_state(10))

# the next statement takes around 12.5s
adapter.validate_python(build_nested_state(11))
```

Now, note the speedups:

```py
start = time.time()
adapter.validate_python(build_nested_state(9))
print(time.time() - start)
#> 0.0063190460205078125

start = time.time()
adapter.validate_python(build_nested_state(10))
print(time.time() - start)
#> 0.02297687530517578

start = time.time()
adapter.validate_python(build_nested_state(11))
print(time.time() - start)
#> 0.057311058044433594
```