### PR TITLE
Fix nested discriminated union schema gen, pt 2

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -42,11 +42,6 @@ _LIST_LIKE_SCHEMA_WITH_ITEMS_TYPES = {'list', 'set', 'frozenset'}
 
 _DEFINITIONS_CACHE_METADATA_KEY = 'pydantic.definitions_cache'
 
-NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY = 'pydantic.internal.needs_apply_discriminated_union'
-"""Used to mark a schema that has a discriminated union that needs to be checked for validity at the end of
-schema building because one of it's members refers to a definition that was not yet defined when the union
-was first encountered.
-"""
 TAGGED_UNION_TAG_KEY = 'pydantic.internal.tagged_union_tag'
 """
 Used in a `Tag` schema to specify the tag used for a discriminated union.

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -48,7 +48,6 @@ from . import _core_utils, _decorators, _discriminated_union, _known_annotated_m
 from ._config import ConfigWrapper, ConfigWrapperStack
 from ._core_metadata import CoreMetadataHandler, build_metadata_dict
 from ._core_utils import (
-    NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY,
     CoreSchemaOrField,
     collect_invalid_schemas,
     define_expected_missing_refs,
@@ -312,7 +311,6 @@ class GenerateSchema:
         '_config_wrapper_stack',
         '_types_namespace_stack',
         '_typevars_map',
-        '_needs_apply_discriminated_union',
         '_has_invalid_schema',
         'field_name_stack',
         'defs',
@@ -328,7 +326,6 @@ class GenerateSchema:
         self._config_wrapper_stack = ConfigWrapperStack(config_wrapper)
         self._types_namespace_stack = TypesNamespaceStack(types_namespace)
         self._typevars_map = typevars_map
-        self._needs_apply_discriminated_union = False
         self._has_invalid_schema = False
         self.field_name_stack = _FieldNameStack()
         self.defs = _Definitions()
@@ -345,7 +342,6 @@ class GenerateSchema:
         obj._config_wrapper_stack = config_wrapper_stack
         obj._types_namespace_stack = types_namespace_stack
         obj._typevars_map = typevars_map
-        obj._needs_apply_discriminated_union = False
         obj._has_invalid_schema = False
         obj.field_name_stack = _FieldNameStack()
         obj.defs = defs
@@ -426,15 +422,10 @@ class GenerateSchema:
             )
         except _discriminated_union.MissingDefinitionForUnionRef:
             # defer until defs are resolved
-            _discriminated_union.set_discriminator(
+            _discriminated_union.set_discriminator_in_metadata(
                 schema,
                 discriminator,
             )
-            if 'metadata' in schema:
-                schema['metadata'][NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY] = True
-            else:
-                schema['metadata'] = {NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY: True}
-            self._needs_apply_discriminated_union = True
             return schema
 
     class CollectedInvalid(Exception):
@@ -736,24 +727,16 @@ class GenerateSchema:
         return args[0], args[1]
 
     def _post_process_generated_schema(self, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
-        if 'metadata' in schema:
-            metadata = schema['metadata']
-            metadata[NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY] = self._needs_apply_discriminated_union
-        else:
-            schema['metadata'] = {
-                NEEDS_APPLY_DISCRIMINATED_UNION_METADATA_KEY: self._needs_apply_discriminated_union,
-            }
+        if 'metadata' not in schema:
+            schema['metadata'] = {}
         return schema
 
     def _generate_schema(self, obj: Any) -> core_schema.CoreSchema:
         """Recursively generate a pydantic-core schema for any supported python type."""
         has_invalid_schema = self._has_invalid_schema
         self._has_invalid_schema = False
-        needs_apply_discriminated_union = self._needs_apply_discriminated_union
-        self._needs_apply_discriminated_union = False
         schema = self._post_process_generated_schema(self._generate_schema_inner(obj))
         self._has_invalid_schema = self._has_invalid_schema or has_invalid_schema
-        self._needs_apply_discriminated_union = self._needs_apply_discriminated_union or needs_apply_discriminated_union
         return schema
 
     def _generate_schema_inner(self, obj: Any) -> core_schema.CoreSchema:

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1868,8 +1868,6 @@ def test_nested_schema_gen_uses_tagged_union_in_ref() -> None:
         state_type: Literal['leaf']
 
     AnyState = Annotated[Union[NestedState, LoopState, LeafState], Field(..., discriminator='state_type')]
-    NestedState.model_rebuild()
-    LoopState.model_rebuild()
     adapter = TypeAdapter(AnyState)
 
     assert adapter.core_schema['schema']['type'] == 'tagged-union'


### PR DESCRIPTION
```py
from __future__ import annotations
import time
from typing import Literal, Annotated

from pydantic import Field, TypeAdapter, BaseModel
from pydantic._internal._core_utils import pretty_print_core_schema

class NestedState(BaseModel):
    state_type: Literal["nested"]
    substate: AnyState

class LoopState(BaseModel):
    state_type: Literal["loop"]
    substate: AnyState

class LeafState(BaseModel):
    state_type: Literal["leaf"]

AnyState = Annotated[NestedState | LoopState | LeafState, Field(..., discriminator="state_type")]

def build_nested_state(n):
    if n <= 0:
        return {"state_type": "leaf"}
    else:
        return {"state_type": "loop", "substate": {"state_type": "nested", "substate": build_nested_state(n-1)}}
        
adapter = TypeAdapter(AnyState)

start = time.time()
adapter.validate_python(build_nested_state(9))
print(time.time() - start)
#> 6.818771362304688e-05

start = time.time()
adapter.validate_python(build_nested_state(10))
print(time.time() - start)
#> 1.6927719116210938e-05

start = time.time()
adapter.validate_python(build_nested_state(11))
print(time.time() - start)
#> 1.6927719116210938e-05

pretty_print_core_schema(adapter.core_schema, True)
"""
{
    'type': 'definitions',
    'schema': {
        'type': 'tagged-union',
        'choices': {
            'nested': {'type': 'definition-ref', 'schema_ref': '__main__.NestedState:4629701792'},
            'loop': {'type': 'definition-ref', 'schema_ref': '__main__.LoopState:4898226368'},
            'leaf': {'type': 'definition-ref', 'schema_ref': '__main__.LeafState:4898242800'}
        },
        'discriminator': 'state_type',
        'strict': False,
        'from_attributes': True
    },
    'definitions': [
        {
            'type': 'model',
            'cls': <class '__main__.LeafState'>,
            'schema': {'type': 'model-fields', 'fields': {'state_type': {'type': 'model-field', 'schema': {'type': 'literal', 'expected': ['leaf']}}}, 'model_name': 'LeafState'},
            'ref': '__main__.LeafState:4898242800'
        },
        {
            'type': 'model',
            'cls': <class '__main__.LoopState'>,
            'schema': {
                'type': 'model-fields',
                'fields': {
                    'state_type': {'type': 'model-field', 'schema': {'type': 'literal', 'expected': ['loop']}},
                    'substate': {
                        'type': 'model-field',
                        'schema': {
                            'type': 'default',
                            'schema': {
                                'type': 'tagged-union',
                                'choices': {
                                    'nested': {'type': 'definition-ref', 'schema_ref': '__main__.NestedState:4629701792'},
                                    'loop': {'type': 'definition-ref', 'schema_ref': '__main__.LoopState:4898226368'},
                                    'leaf': {'type': 'definition-ref', 'schema_ref': '__main__.LeafState:4898242800'}
                                },
                                'discriminator': 'state_type',
                                'strict': False,
                                'from_attributes': True
                            },
                            'default': Ellipsis
                        }
                    }
                },
                'model_name': 'LoopState'
            },
            'ref': '__main__.LoopState:4898226368'
        },
        {
            'type': 'model',
            'cls': <class '__main__.NestedState'>,
            'schema': {
                'type': 'model-fields',
                'fields': {
                    'state_type': {'type': 'model-field', 'schema': {'type': 'literal', 'expected': ['nested']}},
                    'substate': {
                        'type': 'model-field',
                        'schema': {
                            'type': 'default',
                            'schema': {
                                'type': 'tagged-union',
                                'choices': {
                                    'nested': {'type': 'definition-ref', 'schema_ref': '__main__.NestedState:4629701792'},
                                    'loop': {'type': 'definition-ref', 'schema_ref': '__main__.LoopState:4898226368'},
                                    'leaf': {'type': 'definition-ref', 'schema_ref': '__main__.LeafState:4898242800'}
                                },
                                'discriminator': 'state_type',
                                'strict': False,
                                'from_attributes': True
                            },
                            'default': Ellipsis
                        }
                    }
                },
                'model_name': 'NestedState'
            },
            'ref': '__main__.NestedState:4629701792'
        }
    ]
}
"""
```

The above schema is now **actually** correct, and isn't cluttered with metadata tags relating to the application of discriminated unions :)