### PR TITLE
Fix TypeAdapter to respect defer_build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,7 +171,7 @@ plugins:
         options:
           members_order: source
           separate_signature: true
-          filters: ["!^_"]
+          filters: ["!^_(?!defer_build_mode)"]
           docstring_options:
             ignore_init_summary: true
           merge_init_into_class: true

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -75,6 +75,7 @@ class ConfigWrapper:
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
     defer_build: bool
+    defer_build_mode: Literal['only_model', 'always']
     plugin_settings: dict[str, object] | None
     schema_generator: type[GenerateSchema] | None
     json_schema_serialization_defaults_required: bool
@@ -254,6 +255,7 @@ config_defaults = ConfigDict(
     hide_input_in_errors=False,
     json_encoders=None,
     defer_build=False,
+    defer_build_mode='only_model',
     plugin_settings=None,
     schema_generator=None,
     json_schema_serialization_defaults_required=False,

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -75,7 +75,7 @@ class ConfigWrapper:
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
     defer_build: bool
-    defer_build_mode: Literal['only_model', 'always']
+    _defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
     plugin_settings: dict[str, object] | None
     schema_generator: type[GenerateSchema] | None
     json_schema_serialization_defaults_required: bool
@@ -255,7 +255,7 @@ config_defaults = ConfigDict(
     hide_input_in_errors=False,
     json_encoders=None,
     defer_build=False,
-    defer_build_mode='only_model',
+    _defer_build_mode=('model',),
     plugin_settings=None,
     schema_generator=None,
     json_schema_serialization_defaults_required=False,

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -44,7 +44,7 @@ from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation,
 from ..json_schema import JsonSchemaValue
 from ..version import version_short
 from ..warnings import PydanticDeprecatedSince20
-from . import _core_utils, _decorators, _discriminated_union, _known_annotated_metadata, _typing_extra
+from . import _core_utils, _decorators, _discriminated_union, _known_annotated_metadata, _mock_val_ser, _typing_extra
 from ._config import ConfigWrapper, ConfigWrapperStack
 from ._core_metadata import CoreMetadataHandler, build_metadata_dict
 from ._core_utils import (
@@ -646,9 +646,11 @@ class GenerateSchema:
                     source, CallbackGetCoreSchemaHandler(self._generate_schema_inner, self, ref_mode=ref_mode)
                 )
         # fmt: off
-        elif (existing_schema := getattr(obj, '__pydantic_core_schema__', None)) is not None and existing_schema.get(
-            'cls', None
-        ) == obj:
+        elif (
+            (existing_schema := getattr(obj, '__pydantic_core_schema__', None)) is not None
+            and not isinstance(existing_schema, _mock_val_ser.MockCoreSchema)
+            and existing_schema.get('cls', None) == obj
+        ):
             schema = existing_schema
         # fmt: on
         elif (validators := getattr(obj, '__get_validators__', None)) is not None:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -44,7 +44,7 @@ from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation,
 from ..json_schema import JsonSchemaValue
 from ..version import version_short
 from ..warnings import PydanticDeprecatedSince20
-from . import _core_utils, _decorators, _discriminated_union, _known_annotated_metadata, _mock_val_ser, _typing_extra
+from . import _core_utils, _decorators, _discriminated_union, _known_annotated_metadata, _typing_extra
 from ._config import ConfigWrapper, ConfigWrapperStack
 from ._core_metadata import CoreMetadataHandler, build_metadata_dict
 from ._core_utils import (
@@ -76,6 +76,7 @@ from ._docs_extraction import extract_docstrings_from_cls
 from ._fields import collect_dataclass_fields, get_type_hints_infer_globalns
 from ._forward_ref import PydanticRecursiveRef
 from ._generics import get_standard_typevars_map, has_instance_in_type, recursively_defined_type_refs, replace_types
+from ._mock_val_ser import MockCoreSchema
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._typing_extra import is_finalvar, is_self_type
 from ._utils import lenient_issubclass
@@ -648,7 +649,7 @@ class GenerateSchema:
         # fmt: off
         elif (
             (existing_schema := getattr(obj, '__pydantic_core_schema__', None)) is not None
-            and not isinstance(existing_schema, _mock_val_ser.MockCoreSchema)
+            and not isinstance(existing_schema, MockCoreSchema)
             and existing_schema.get('cls', None) == obj
         ):
             schema = existing_schema

--- a/pydantic/_internal/_mock_val_ser.py
+++ b/pydantic/_internal/_mock_val_ser.py
@@ -120,7 +120,7 @@ def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = '
         f' then call `{cls_name}.model_rebuild()`.'
     )
 
-    def attempt_rebuild(attr_fn: Callable[[type[BaseModel]], T]) -> Callable[[], T | None]:
+    def attempt_rebuild_fn(attr_fn: Callable[[type[BaseModel]], T]) -> Callable[[], T | None]:
         def handler() -> T | None:
             if cls.model_rebuild(raise_errors=False, _parent_namespace_depth=5) is not False:
                 return attr_fn(cls)
@@ -132,19 +132,19 @@ def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = '
     cls.__pydantic_core_schema__ = MockCoreSchema(  # type: ignore[assignment]
         undefined_type_error_message,
         code='class-not-fully-defined',
-        attempt_rebuild=attempt_rebuild(lambda c: c.__pydantic_core_schema__),
+        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_core_schema__),
     )
     cls.__pydantic_validator__ = MockValSer(  # type: ignore[assignment]
         undefined_type_error_message,
         code='class-not-fully-defined',
         val_or_ser='validator',
-        attempt_rebuild=attempt_rebuild(lambda c: c.__pydantic_validator__),
+        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_validator__),
     )
     cls.__pydantic_serializer__ = MockValSer(  # type: ignore[assignment]
         undefined_type_error_message,
         code='class-not-fully-defined',
         val_or_ser='serializer',
-        attempt_rebuild=attempt_rebuild(lambda c: c.__pydantic_serializer__),
+        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_serializer__),
     )
 
 
@@ -165,7 +165,7 @@ def set_dataclass_mocks(
         f' then call `pydantic.dataclasses.rebuild_dataclass({cls_name})`.'
     )
 
-    def attempt_rebuild(attr_fn: Callable[[type[PydanticDataclass]], T]) -> Callable[[], T | None]:
+    def attempt_rebuild_fn(attr_fn: Callable[[type[PydanticDataclass]], T]) -> Callable[[], T | None]:
         def handler() -> T | None:
             if rebuild_dataclass(cls, raise_errors=False, _parent_namespace_depth=5) is not False:
                 return attr_fn(cls)
@@ -177,17 +177,17 @@ def set_dataclass_mocks(
     cls.__pydantic_core_schema__ = MockCoreSchema(  # type: ignore[assignment]
         undefined_type_error_message,
         code='class-not-fully-defined',
-        attempt_rebuild=attempt_rebuild(lambda c: c.__pydantic_core_schema__),
+        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_core_schema__),
     )
     cls.__pydantic_validator__ = MockValSer(  # type: ignore[assignment]
         undefined_type_error_message,
         code='class-not-fully-defined',
         val_or_ser='validator',
-        attempt_rebuild=attempt_rebuild(lambda c: c.__pydantic_validator__),
+        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_validator__),
     )
     cls.__pydantic_serializer__ = MockValSer(  # type: ignore[assignment]
         undefined_type_error_message,
         code='class-not-fully-defined',
         val_or_ser='validator',
-        attempt_rebuild=attempt_rebuild(lambda c: c.__pydantic_serializer__),
+        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_serializer__),
     )

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -531,7 +531,7 @@ def complete_model_class(
         ref_mode='unpack',
     )
 
-    if config_wrapper.defer_build:
+    if config_wrapper.defer_build and 'model' in config_wrapper._defer_build_mode:
         set_model_mocks(cls, cls_name)
         return False
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -23,7 +23,7 @@ from ._decorators import DecoratorInfos, PydanticDescriptorProxy, get_attribute_
 from ._fields import collect_model_fields, is_valid_field_name, is_valid_privateattr_name
 from ._generate_schema import GenerateSchema
 from ._generics import PydanticGenericMetadata, get_model_typevars_map
-from ._mock_val_ser import MockValSer, set_model_mocks
+from ._mock_val_ser import set_model_mocks
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
 from ._typing_extra import get_cls_types_namespace, is_annotated, is_classvar, parent_frame_namespace
@@ -231,14 +231,6 @@ class ModelMetaclass(ABCMeta):
             private_attributes = self.__dict__.get('__private_attributes__')
             if private_attributes and item in private_attributes:
                 return private_attributes[item]
-            if item == '__pydantic_core_schema__':
-                # This means the class didn't get a schema generated for it, likely because there was an undefined reference
-                maybe_mock_validator = getattr(self, '__pydantic_validator__', None)
-                if isinstance(maybe_mock_validator, MockValSer):
-                    rebuilt_validator = maybe_mock_validator.rebuild()
-                    if rebuilt_validator is not None:
-                        # In this case, a validator was built, and so `__pydantic_core_schema__` should now be set
-                        return getattr(self, '__pydantic_core_schema__')
             raise AttributeError(item)
 
     @classmethod

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -114,6 +114,10 @@ def is_annotated(ann_type: Any) -> bool:
     return origin is not None and lenient_issubclass(origin, Annotated)
 
 
+def annotated_type(type_: Any) -> Any | None:
+    return get_args(type_)[0] if is_annotated(type_) else None
+
+
 def is_namedtuple(type_: type[Any]) -> bool:
     """Check if a given class is a named tuple.
     It can be either a `typing.NamedTuple` or `collections.namedtuple`.

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -715,24 +715,28 @@ class ConfigDict(TypedDict, total=False):
     used nested within other models, or when you want to manually define type namespace via
     [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild].
 
-    See also [`defer_build_mode`][pydantic.config.ConfigDict.defer_build_mode].
+    See also [`_defer_build_mode`][pydantic.config.ConfigDict._defer_build_mode].
 
     !!! note
         `defer_build` does not work by default with FastAPI Pydantic models. Meaning the validator and serializer
-        is constructed immediately when the model is used in FastAPI routes instead of construction being deferred.
-        You also need to use [`defer_build_mode='always'`][pydantic.config.ConfigDict.defer_build_mode] with
-        FastAPI models.
+        is constructed immediately when the model is used in FastAPI routes. You also need to define
+        [`_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict._defer_build_mode] with FastAPI
+        models. This parameter is also required for the deferred building due to FastAPI relying on `TypeAdapter`s.
     """
 
-    defer_build_mode: Literal['only_model', 'always']
+    _defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
     """
-    Controls when [`defer_build`][pydantic.config.ConfigDict.defer_build] is applicable. Defaults to `'only_model'`.
+    Controls when [`defer_build`][pydantic.config.ConfigDict.defer_build] is applicable. Defaults to `('model',)`.
 
     Due to backwards compatibility reasons [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] does not by default
-    respect `defer_build`. Meaning when `defer_build` is `True` and `defer_build_mode` is the default `'only_model'`
+    respect `defer_build`. Meaning when `defer_build` is `True` and `_defer_build_mode` is the default `('model',)`
     then `TypeAdapter` immediately constructs validator and serializer instead of postponing it until the first model
-    validation. Set this to `'always'` to make `TypeAdapter` respect the `defer_build` so it postpones validator and
-    serializer construction until the first validation.
+    validation. Set this to `('model', 'type_adapter')` to make `TypeAdapter` respect the `defer_build` so it postpones
+    validator and serializer construction until the first validation.
+
+    !!! note
+        The `_defer_build_mode` parameter is named with an underscore to suggest this is an experimental feature. It may
+        be removed or changed in the future.
     """
 
     plugin_settings: dict[str, object] | None

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -721,7 +721,7 @@ class ConfigDict(TypedDict, total=False):
         `defer_build` does not work by default with FastAPI Pydantic models. Meaning the validator and serializer
         is constructed immediately when the model is used in FastAPI routes. You also need to define
         [`_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict._defer_build_mode] with FastAPI
-        models. This parameter is also required for the deferred building due to FastAPI relying on `TypeAdapter`s.
+        models. This parameter is required for the deferred building due to FastAPI relying on `TypeAdapter`s.
     """
 
     _defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -709,23 +709,29 @@ class ConfigDict(TypedDict, total=False):
 
     defer_build: bool
     """
-    Whether to defer model validator and serializer construction until the first model validation.
+    Whether to defer model validator and serializer construction until the first model validation. Defaults to False.
 
     This can be useful to avoid the overhead of building models which are only
     used nested within other models, or when you want to manually define type namespace via
-    [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild]. Defaults to False.
+    [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild].
 
     See also [`defer_build_mode`][pydantic.config.ConfigDict.defer_build_mode].
+
+    !!! note
+        `defer_build` does not work by default with FastAPI Pydantic models. Meaning the validator and serializer
+        is constructed immediately when the model is used in FastAPI routes instead of construction being deferred.
+        You also need to use [`defer_build_mode='always'`][pydantic.config.ConfigDict.defer_build_mode] with
+        FastAPI models.
     """
 
     defer_build_mode: Literal['only_model', 'always']
     """
-    Controls when [`defer_build`][pydantic.config.ConfigDict.defer_build] is applicable. Defaults to `"only_model"`.
+    Controls when [`defer_build`][pydantic.config.ConfigDict.defer_build] is applicable. Defaults to `'only_model'`.
 
     Due to backwards compatibility reasons [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] does not by default
-    respect `defer_build`. Meaning when `defer_build` is `True` and `defer_build_mode` is the default `"only_model"`
+    respect `defer_build`. Meaning when `defer_build` is `True` and `defer_build_mode` is the default `'only_model'`
     then `TypeAdapter` immediately constructs validator and serializer instead of postponing it until the first model
-    validation. Set this to `"always"` to make `TypeAdapter` respect the `defer_build` so it postpones validator and
+    validation. Set this to `'always'` to make `TypeAdapter` respect the `defer_build` so it postpones validator and
     serializer construction until the first validation.
     """
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -718,10 +718,11 @@ class ConfigDict(TypedDict, total=False):
     See also [`_defer_build_mode`][pydantic.config.ConfigDict._defer_build_mode].
 
     !!! note
-        `defer_build` does not work by default with FastAPI Pydantic models. Meaning the validator and serializer
-        is constructed immediately when the model is used in FastAPI routes. You also need to define
+        `defer_build` does not work by default with FastAPI Pydantic models. By default, the validator and serializer
+        for said models is constructed immediately for FastAPI routes. You also need to define
         [`_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict._defer_build_mode] with FastAPI
-        models. This parameter is required for the deferred building due to FastAPI relying on `TypeAdapter`s.
+        models in order for `defer_build=True` to take effect. This additional (experimental) parameter is required for
+        the deferred building due to FastAPI relying on `TypeAdapter`s.
     """
 
     _defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
@@ -730,13 +731,13 @@ class ConfigDict(TypedDict, total=False):
 
     Due to backwards compatibility reasons [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] does not by default
     respect `defer_build`. Meaning when `defer_build` is `True` and `_defer_build_mode` is the default `('model',)`
-    then `TypeAdapter` immediately constructs validator and serializer instead of postponing it until the first model
-    validation. Set this to `('model', 'type_adapter')` to make `TypeAdapter` respect the `defer_build` so it postpones
-    validator and serializer construction until the first validation.
+    then `TypeAdapter` immediately constructs its validator and serializer instead of postponing said construction until
+    the first model validation. Set this to `('model', 'type_adapter')` to make `TypeAdapter` respect the `defer_build`
+    so it postpones validator and serializer construction until the first validation or serialization.
 
     !!! note
         The `_defer_build_mode` parameter is named with an underscore to suggest this is an experimental feature. It may
-        be removed or changed in the future.
+        be removed or changed in the future in a minor release.
     """
 
     plugin_settings: dict[str, object] | None

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -714,6 +714,19 @@ class ConfigDict(TypedDict, total=False):
     This can be useful to avoid the overhead of building models which are only
     used nested within other models, or when you want to manually define type namespace via
     [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild]. Defaults to False.
+
+    See also [`defer_build_mode`][pydantic.config.ConfigDict.defer_build_mode].
+    """
+
+    defer_build_mode: Literal['only_model', 'always']
+    """
+    Controls when [`defer_build`][pydantic.config.ConfigDict.defer_build] is applicable. Defaults to `"only_model"`.
+
+    Due to backwards compatibility reasons [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] does not by default
+    respect `defer_build`. Meaning when `defer_build` is `True` and `defer_build_mode` is the default `"only_model"`
+    then `TypeAdapter` immediately constructs validator and serializer instead of postponing it until the first model
+    validation. Set this to `"always"` to make `TypeAdapter` respect the `defer_build` so it postpones validator and
+    serializer construction until the first validation.
     """
 
     plugin_settings: dict[str, object] | None

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2226,12 +2226,14 @@ def model_json_schema(
     from .main import BaseModel
 
     schema_generator_instance = schema_generator(by_alias=by_alias, ref_template=ref_template)
-    if isinstance(cls.__pydantic_validator__, _mock_val_ser.MockValSer):
-        cls.__pydantic_validator__.rebuild()
+
+    if isinstance(cls.__pydantic_core_schema__, _mock_val_ser.MockCoreSchema):
+        cls.__pydantic_core_schema__.rebuild()
 
     if cls is BaseModel:
         raise AttributeError('model_json_schema() must be called on a subclass of BaseModel, not BaseModel itself.')
-    assert '__pydantic_core_schema__' in cls.__dict__, 'this is a bug! please report it'
+
+    assert not isinstance(cls.__pydantic_core_schema__, _mock_val_ser.MockCoreSchema), 'this is a bug! please report it'
     return schema_generator_instance.generate(cls.__pydantic_core_schema__, mode=mode)
 
 
@@ -2263,8 +2265,8 @@ def models_json_schema(
                     element, along with the optional title and description keys.
     """
     for cls, _ in models:
-        if isinstance(cls.__pydantic_validator__, _mock_val_ser.MockValSer):
-            cls.__pydantic_validator__.rebuild()
+        if isinstance(cls.__pydantic_core_schema__, _mock_val_ser.MockCoreSchema):
+            cls.__pydantic_core_schema__.rebuild()
 
     instance = schema_generator(by_alias=by_alias, ref_template=ref_template)
     inputs = [(m, mode, m.__pydantic_core_schema__) for m, mode in models]

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -145,6 +145,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         __pydantic_decorators__ = _decorators.DecoratorInfos()
         __pydantic_parent_namespace__ = None
         # Prevent `BaseModel` from being instantiated directly:
+        __pydantic_core_schema__ = _mock_val_ser.MockCoreSchema(
+            'Pydantic models should inherit from BaseModel, BaseModel cannot be instantiated directly',
+            code='base-model-instantiated',
+        )
         __pydantic_validator__ = _mock_val_ser.MockValSer(
             'Pydantic models should inherit from BaseModel, BaseModel cannot be instantiated directly',
             val_or_ser='validator',
@@ -594,7 +598,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
         # Only use the cached value from this _exact_ class; we don't want one from a parent class
         # This is why we check `cls.__dict__` and don't use `cls.__pydantic_core_schema__` or similar.
-        if '__pydantic_core_schema__' in cls.__dict__:
+        schema = cls.__dict__.get('__pydantic_core_schema__')
+        if schema is not None and not isinstance(schema, _mock_val_ser.MockCoreSchema):
             # Due to the way generic classes are built, it's possible that an invalid schema may be temporarily
             # set on generic classes. I think we could resolve this to ensure that we get proper schema caching
             # for generics, but for simplicity for now, we just always rebuild if the class has a generic origin.

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -121,8 +121,9 @@ class TypeAdapter(Generic[T]):
     **Note:** By default, `TypeAdapter` does not respect the
     [`defer_build=True`][pydantic.config.ConfigDict.defer_build] setting in the
     [`model_config`][pydantic.BaseModel.model_config] or in the `TypeAdapter` constructor `config`. You need to also
-    explicitly set [`defer_build_mode="always"`][pydantic.config.ConfigDict.defer_build_mode] of the config to defer
-    the model validator and serializer construction. This is required due to backwards compatibility reasons.
+    explicitly set [`_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict._defer_build_mode] of the
+    config to defer the model validator and serializer construction. Thus, this feature is opt-in to ensure backwards
+    compatibility.
 
     Attributes:
         core_schema: The core schema for the type.
@@ -290,7 +291,7 @@ class TypeAdapter(Generic[T]):
 
     @classmethod
     def _is_defer_build_config(cls, config: ConfigDict) -> bool:
-        return config.get('defer_build', False) is True and config.get('defer_build_mode', 'only_model') != 'only_model'
+        return config.get('defer_build', False) is True and 'type_adapter' in config.get('_defer_build_mode', tuple())
 
     def validate_python(
         self,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,6 +49,7 @@ from pydantic import (
     field_validator,
 )
 from pydantic._internal._mock_val_ser import MockCoreSchema
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 
 def test_success():
@@ -2987,9 +2988,17 @@ def test_arbitrary_types_not_a_type() -> None:
     assert ta.validate_python(bar) is bar
 
 
-def test_deferred_core_schema() -> None:
-    class Foo(BaseModel):
-        x: 'Bar'
+@pytest.mark.parametrize('is_dataclass', [False, True])
+def test_deferred_core_schema(is_dataclass: bool) -> None:
+    if is_dataclass:
+
+        @pydantic_dataclass
+        class Foo:
+            x: 'Bar'
+    else:
+
+        class Foo(BaseModel):
+            x: 'Bar'
 
     assert isinstance(Foo.__pydantic_core_schema__, MockCoreSchema)
     with pytest.raises(PydanticUserError, match='`Foo` is not fully defined'):
@@ -2998,7 +3007,7 @@ def test_deferred_core_schema() -> None:
     class Bar(BaseModel):
         pass
 
-    assert Foo.__pydantic_core_schema__['type'] == 'model'
+    assert Foo.__pydantic_core_schema__['type'] == ('dataclass' if is_dataclass else 'model')
     assert isinstance(Foo.__pydantic_core_schema__, dict)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,6 +48,7 @@ from pydantic import (
     constr,
     field_validator,
 )
+from pydantic._internal._mock_val_ser import MockCoreSchema
 
 
 def test_success():
@@ -2990,13 +2991,15 @@ def test_deferred_core_schema() -> None:
     class Foo(BaseModel):
         x: 'Bar'
 
+    assert isinstance(Foo.__pydantic_core_schema__, MockCoreSchema)
     with pytest.raises(PydanticUserError, match='`Foo` is not fully defined'):
-        Foo.__pydantic_core_schema__
+        Foo.__pydantic_core_schema__['type']
 
     class Bar(BaseModel):
         pass
 
-    assert Foo.__pydantic_core_schema__
+    assert Foo.__pydantic_core_schema__['type'] == 'model'
+    assert isinstance(Foo.__pydantic_core_schema__, dict)
 
 
 def test_help(create_module):

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -8,9 +8,9 @@ import pytest
 from pydantic_core import ValidationError
 from typing_extensions import Annotated, Literal, TypeAlias, TypedDict
 
-import pydantic
 from pydantic import BaseModel, Field, TypeAdapter, ValidationInfo, create_model, field_validator
 from pydantic.config import ConfigDict
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.errors import PydanticUserError
 
 ItemType = TypeVar('ItemType')
@@ -378,7 +378,7 @@ def test_eval_type_backport():
 @pytest.mark.parametrize('defer_build_mode', [('model',), ('type_adapter',), ('model', 'type_adapter')])
 @pytest.mark.parametrize('is_annotated', [False, True])  # FastAPI heavily uses Annotated
 def test_respects_defer_build(
-    defer_build: bool, defer_build_mode: tuple[Literal['model', 'type_adapter']], is_annotated: bool
+    defer_build: bool, defer_build_mode: Tuple[Literal['model', 'type_adapter']], is_annotated: bool
 ) -> None:
     class Model(BaseModel, defer_build=defer_build, _defer_build_mode=defer_build_mode):
         x: int
@@ -386,11 +386,11 @@ def test_respects_defer_build(
     class SubModel(Model):
         y: Optional[int] = None
 
-    @pydantic.dataclasses.dataclass(config=ConfigDict(defer_build=defer_build, _defer_build_mode=defer_build_mode))
+    @pydantic_dataclass(config=ConfigDict(defer_build=defer_build, _defer_build_mode=defer_build_mode))
     class DataClassModel:
         x: int
 
-    @pydantic.dataclasses.dataclass
+    @pydantic_dataclass
     class SubDataClassModel(DataClassModel):
         y: Optional[int] = None
 

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -375,18 +375,18 @@ def test_eval_type_backport():
 
 
 @pytest.mark.parametrize('defer_build', [False, True])
-@pytest.mark.parametrize('defer_build_mode', ['only_model', 'always'])
+@pytest.mark.parametrize('defer_build_mode', [('model',), ('type_adapter',), ('model', 'type_adapter')])
 @pytest.mark.parametrize('is_annotated', [False, True])  # FastAPI heavily uses Annotated
 def test_respects_defer_build(
-    defer_build: bool, defer_build_mode: Literal['only_model', 'always'], is_annotated: bool
+    defer_build: bool, defer_build_mode: tuple[Literal['model', 'type_adapter']], is_annotated: bool
 ) -> None:
-    class Model(BaseModel, defer_build=defer_build, defer_build_mode=defer_build_mode):
+    class Model(BaseModel, defer_build=defer_build, _defer_build_mode=defer_build_mode):
         x: int
 
     class SubModel(Model):
         y: Optional[int] = None
 
-    @pydantic.dataclasses.dataclass(config=ConfigDict(defer_build=defer_build, defer_build_mode=defer_build_mode))
+    @pydantic.dataclasses.dataclass(config=ConfigDict(defer_build=defer_build, _defer_build_mode=defer_build_mode))
     class DataClassModel:
         x: int
 
@@ -395,7 +395,7 @@ def test_respects_defer_build(
         y: Optional[int] = None
 
     class TypedDictModel(TypedDict):
-        __pydantic_config__ = ConfigDict(defer_build=defer_build, defer_build_mode=defer_build_mode)  # type: ignore
+        __pydantic_config__ = ConfigDict(defer_build=defer_build, _defer_build_mode=defer_build_mode)  # type: ignore
         x: int
 
     models: list[tuple[type, Optional[ConfigDict]]] = [
@@ -406,15 +406,15 @@ def test_respects_defer_build(
         (DataClassModel, None),
         (SubDataClassModel, None),
         (TypedDictModel, None),
-        (Dict[str, int], ConfigDict(defer_build=defer_build, defer_build_mode=defer_build_mode)),
+        (Dict[str, int], ConfigDict(defer_build=defer_build, _defer_build_mode=defer_build_mode)),
     ]
 
     for model, adapter_config in models:
         tested_model = Annotated[model, Field(title='abc')] if is_annotated else model
 
         ta = TypeAdapter(tested_model, config=adapter_config)
-        if defer_build and defer_build_mode == 'always':
-            assert ta._schema_handlers is None, f'{tested_model} should be defer_build'
+        if defer_build and 'type_adapter' in defer_build_mode:
+            assert ta._schema_handlers is None, f'{tested_model} should be built deferred'
         else:
             assert ta._schema_handlers is not None
 

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -70,62 +70,117 @@ OuterDict = Dict[str, 'IntList']
 
 
 @pytest.mark.parametrize('defer_build', [False, True])
-def test_global_namespace_variables(defer_build: bool):
+@pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
+def test_global_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
     config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    ta = TypeAdapter(OuterDict, config=config)
 
-    v = TypeAdapter(OuterDict, config=config).validate_python
-    res = v({'foo': [1, '2']})
-    assert res == {'foo': [1, 2]}
+    assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
+
+    if method == 'validate':
+        assert ta.validate_python({'foo': [1, '2']}) == {'foo': [1, 2]}
+    elif method == 'serialize':
+        assert ta.dump_python({'foo': [1, 2]}) == {'foo': [1, 2]}
+    elif method == 'json_schema':
+        assert ta.json_schema()['type'] == 'object'
+    else:
+        assert method == 'json_schemas'
+        schemas, _ = TypeAdapter.json_schemas([(OuterDict, 'validation', ta)])
+        assert schemas[(OuterDict, 'validation')]['type'] == 'object'
 
 
 @pytest.mark.parametrize('defer_build', [False, True])
-def test_model_global_namespace_variables(defer_build: bool):
+@pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
+def test_model_global_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
     class MyModel(BaseModel):
         model_config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
         x: OuterDict
 
-    v = TypeAdapter(MyModel).validate_python
-    res = v({'x': {'foo': [1, '2']}})
-    assert res.model_dump() == {'x': {'foo': [1, 2]}}
+    ta = TypeAdapter(MyModel)
+
+    assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
+
+    if method == 'validate':
+        assert ta.validate_python({'x': {'foo': [1, '2']}}) == MyModel(x={'foo': [1, 2]})
+    elif method == 'serialize':
+        assert ta.dump_python(MyModel(x={'foo': [1, 2]})) == {'x': {'foo': [1, 2]}}
+    elif method == 'json_schema':
+        assert ta.json_schema()['title'] == 'MyModel'
+    else:
+        assert method == 'json_schemas'
+        _, json_schema = TypeAdapter.json_schemas([(MyModel, 'validation', TypeAdapter(MyModel))])
+        assert 'MyModel' in json_schema['$defs']
 
 
 @pytest.mark.parametrize('defer_build', [False, True])
-def test_local_namespace_variables(defer_build: bool):
-    config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
-
+@pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
+def test_local_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
     IntList = List[int]  # noqa: F841
     OuterDict = Dict[str, 'IntList']
 
-    v = TypeAdapter(OuterDict, config=config).validate_python
+    config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    ta = TypeAdapter(OuterDict, config=config)
 
-    res = v({'foo': [1, '2']})
-    assert res == {'foo': [1, 2]}
+    assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
+
+    if method == 'validate':
+        assert ta.validate_python({'foo': [1, '2']}) == {'foo': [1, 2]}
+    elif method == 'serialize':
+        assert ta.dump_python({'foo': [1, 2]}) == {'foo': [1, 2]}
+    elif method == 'json_schema':
+        assert ta.json_schema()['type'] == 'object'
+    else:
+        assert method == 'json_schemas'
+        schemas, _ = TypeAdapter.json_schemas([(OuterDict, 'validation', ta)])
+        assert schemas[(OuterDict, 'validation')]['type'] == 'object'
 
 
 @pytest.mark.parametrize('defer_build', [False, True])
-def test_model_local_namespace_variables(defer_build: bool):
+@pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
+def test_model_local_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
     IntList = List[int]  # noqa: F841
 
     class MyModel(BaseModel):
         model_config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
         x: Dict[str, 'IntList']
 
-    v = TypeAdapter(MyModel).validate_python
+    ta = TypeAdapter(MyModel)
 
-    res = v({'x': {'foo': [1, '2']}})
-    assert res.model_dump() == {'x': {'foo': [1, 2]}}
+    assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
+
+    if method == 'validate':
+        assert ta.validate_python({'x': {'foo': [1, '2']}}) == MyModel(x={'foo': [1, 2]})
+    elif method == 'serialize':
+        assert ta.dump_python(MyModel(x={'foo': [1, 2]})) == {'x': {'foo': [1, 2]}}
+    elif method == 'json_schema':
+        assert ta.json_schema()['title'] == 'MyModel'
+    else:
+        assert method == 'json_schemas'
+        _, json_schema = TypeAdapter.json_schemas([(MyModel, 'validation', ta)])
+        assert 'MyModel' in json_schema['$defs']
 
 
 @pytest.mark.parametrize('defer_build', [False, True])
+@pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="ForwardRef doesn't accept module as a parameter in Python < 3.9")
-def test_top_level_fwd_ref(defer_build: bool):
+def test_top_level_fwd_ref(defer_build: bool, method: str, generate_schema_calls):
     config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
 
     FwdRef = ForwardRef('OuterDict', module=__name__)
-    v = TypeAdapter(FwdRef, config=config).validate_python
+    ta = TypeAdapter(FwdRef, config=config)
 
-    res = v({'foo': [1, '2']})
-    assert res == {'foo': [1, 2]}
+    assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
+
+    if method == 'validate':
+        assert ta.validate_python({'foo': [1, '2']}) == {'foo': [1, 2]}
+    elif method == 'serialize':
+        assert ta.dump_python({'foo': [1, 2]}) == {'foo': [1, 2]}
+    elif method == 'json_schema':
+        assert ta.json_schema()['type'] == 'object'
+    else:
+        assert method == 'json_schemas'
+        schemas, _ = TypeAdapter.json_schemas([(FwdRef, 'validation', ta)])
+        assert schemas[(FwdRef, 'validation')]['type'] == 'object'
 
 
 MyUnion: TypeAlias = 'Union[str, int]'
@@ -333,13 +388,22 @@ def test_validate_python_from_attributes() -> None:
     ],
     ids=repr,
 )
-def test_validate_strings(field_type, input_value, expected, raises_match, strict):
-    ta = TypeAdapter(field_type)
+@pytest.mark.parametrize('defer_build', [False, True])
+def test_validate_strings(
+    field_type, input_value, expected, raises_match, strict, defer_build: bool, generate_schema_calls
+):
+    config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    ta = TypeAdapter(field_type, config=config)
+
+    assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
+
     if raises_match is not None:
         with pytest.raises(expected, match=raises_match):
             ta.validate_strings(input_value, strict=strict)
     else:
         assert ta.validate_strings(input_value, strict=strict) == expected
+
+    assert generate_schema_calls.count == 1, 'Should not build duplicates'
 
 
 @pytest.mark.parametrize('strict', [True, False])
@@ -465,46 +529,52 @@ def test_core_schema_respects_defer_build(model: Any, config: ConfigDict, genera
 
     if config['defer_build'] and 'type_adapter' in config['_defer_build_mode']:
         assert generate_schema_calls.count == 0, 'Should be built deferred'
-        assert 'core_schema' not in type_adapter.__dict__, 'Should be initialized deferred via cached_property'
+        assert type_adapter._core_schema is None, 'Should be initialized deferred'
     else:
         built_inside_type_adapter = 'Dict' in str(model) or 'Annotated' in str(model)
         assert generate_schema_calls.count == (1 if built_inside_type_adapter else 0), f'Should be built ({model})'
-        assert type_adapter.__dict__.get('core_schema') is not None, 'Should be initialized before usage'
+        assert type_adapter._core_schema is not None, 'Should be initialized before usage'
 
     json_schema = type_adapter.json_schema()  # Use it
     assert "'type': 'integer'" in str(json_schema)  # Sanity check
 
-    assert type_adapter.__dict__.get('core_schema') is not None, 'Should be initialized after the usage'
+    assert type_adapter._core_schema is not None, 'Should be initialized after the usage'
 
 
 @pytest.mark.parametrize('model, config', MODELS_CONFIGS)
-def test_validator_respects_defer_build(model: Any, config: ConfigDict) -> None:
+def test_validator_respects_defer_build(model: Any, config: ConfigDict, generate_schema_calls) -> None:
     type_adapter = TypeAdapter(model) if _type_has_config(model) else TypeAdapter(model, config=config)
 
     if config['defer_build'] and 'type_adapter' in config['_defer_build_mode']:
-        assert 'validator' not in type_adapter.__dict__, 'Should be initialized deferred via cached_property'
+        assert generate_schema_calls.count == 0, 'Should be built deferred'
+        assert type_adapter._validator is None, 'Should be initialized deferred'
     else:
-        assert type_adapter.__dict__.get('validator') is not None, 'Should be initialized before usage'
+        built_inside_type_adapter = 'Dict' in str(model) or 'Annotated' in str(model)
+        assert generate_schema_calls.count == (1 if built_inside_type_adapter else 0), f'Should be built ({model})'
+        assert type_adapter._validator is not None, 'Should be initialized before usage'
 
     validated = type_adapter.validate_python({'x': 1})  # Use it
     assert (validated['x'] if isinstance(validated, dict) else getattr(validated, 'x')) == 1  # Sanity check
 
-    assert type_adapter.__dict__.get('validator') is not None, 'Should be initialized after the usage'
+    assert type_adapter._validator is not None, 'Should be initialized after the usage'
 
 
 @pytest.mark.parametrize('model, config', MODELS_CONFIGS)
-def test_serializer_respects_defer_build(model: Any, config: ConfigDict) -> None:
+def test_serializer_respects_defer_build(model: Any, config: ConfigDict, generate_schema_calls) -> None:
     type_ = _annotated_type(model) or model
     dumped = dict(x=1) if 'Dict[' in str(type_) else type_(x=1)
 
     type_adapter = TypeAdapter(model) if _type_has_config(model) else TypeAdapter(model, config=config)
 
     if config['defer_build'] and 'type_adapter' in config['_defer_build_mode']:
-        assert 'serializer' not in type_adapter.__dict__, 'Should be initialized deferred via cached_property'
+        assert generate_schema_calls.count == 0, 'Should be built deferred'
+        assert type_adapter._serializer is None, 'Should be initialized deferred'
     else:
-        assert type_adapter.__dict__.get('serializer') is not None, 'Should be initialized before usage'
+        built_inside_type_adapter = 'Dict' in str(model) or 'Annotated' in str(model)
+        assert generate_schema_calls.count == (1 if built_inside_type_adapter else 0), f'Should be built ({model})'
+        assert type_adapter._serializer is not None, 'Should be initialized before usage'
 
     raw = type_adapter.dump_json(dumped)  # Use it
     assert json.loads(raw.decode())['x'] == 1  # Sanity check
 
-    assert type_adapter.__dict__.get('serializer') is not None, 'Should be initialized after the usage'
+    assert type_adapter._serializer is not None, 'Should be initialized after the usage'

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -414,10 +414,12 @@ def test_respects_defer_build(
 
         ta = TypeAdapter(tested_model, config=adapter_config)
         if defer_build and 'type_adapter' in defer_build_mode:
-            assert ta._schema_handlers is None, f'{tested_model} should be built deferred'
+            assert not ta._schema_initialized, f'{tested_model} should be built deferred'
         else:
-            assert ta._schema_handlers is not None
+            assert ta._schema_initialized
 
-        validated = ta.validate_python({'x': 1})
+        validated = ta.validate_python({'x': 1})  # Sanity check it works
         assert (validated['x'] if isinstance(validated, dict) else getattr(validated, 'x')) == 1
-        assert ta._schema_handlers is not None
+
+        assert ta.core_schema
+        assert ta._schema_initialized


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Makes `TypeAdapter` to respect `defer_build` so it constructs the core schema on first validation when `_defer_build_mode` is set to include `type_adapter`.

## Related issue number

Partly related to https://github.com/pydantic/pydantic/issues/6768 but this does not fix the root performance issue. But allows `defer_build` to work with FastAPI (which heavily relies on `TypeAdapter`+`Annotated` under the hood).

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin