### PR TITLE
Add enum and type to the JSON schema for single item literals

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -732,24 +732,22 @@ class GenerateJsonSchema:
         # jsonify the expected values
         expected = [to_jsonable_python(v) for v in expected]
 
+        result: dict[str, Any] = {'enum': expected}
         if len(expected) == 1:
-            return {'const': expected[0]}
+            result['const'] = expected[0]
 
         types = {type(e) for e in expected}
         if types == {str}:
-            return {'enum': expected, 'type': 'string'}
+            result['type'] = 'string'
         elif types == {int}:
-            return {'enum': expected, 'type': 'integer'}
+            result['type'] = 'integer'
         elif types == {float}:
-            return {'enum': expected, 'type': 'number'}
+            result['type'] = 'number'
         elif types == {bool}:
-            return {'enum': expected, 'type': 'boolean'}
+            result['type'] = 'boolean'
         elif types == {list}:
-            return {'enum': expected, 'type': 'array'}
-        # there is not None case because if it's mixed it hits the final `else`
-        # if it's a single Literal[None] then it becomes a `const` schema above
-        else:
-            return {'enum': expected}
+            result['type'] = 'array'
+        return result
 
     def is_instance_schema(self, schema: core_schema.IsInstanceSchema) -> JsonSchemaValue:
         """Handles JSON schema generation for a core schema that checks if a value is an instance of a class.

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1353,6 +1353,7 @@ def test_discriminated_union_basemodel_instance_value():
 
     t = Top(sub=A(l='a'))
     assert isinstance(t, Top)
+    # insert_assert(model_json_schema(Top))
     assert model_json_schema(Top) == {
         'title': 'Top',
         'type': 'object',
@@ -1365,8 +1366,18 @@ def test_discriminated_union_basemodel_instance_value():
         },
         'required': ['sub'],
         '$defs': {
-            'A': {'properties': {'l': {'const': 'a', 'title': 'L'}}, 'required': ['l'], 'title': 'A', 'type': 'object'},
-            'B': {'properties': {'l': {'const': 'b', 'title': 'L'}}, 'required': ['l'], 'title': 'B', 'type': 'object'},
+            'A': {
+                'properties': {'l': {'const': 'a', 'enum': ['a'], 'title': 'L', 'type': 'string'}},
+                'required': ['l'],
+                'title': 'A',
+                'type': 'object',
+            },
+            'B': {
+                'properties': {'l': {'const': 'b', 'enum': ['b'], 'title': 'L', 'type': 'string'}},
+                'required': ['l'],
+                'title': 'B',
+                'type': 'object',
+            },
         },
     }
 

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1235,16 +1235,28 @@ def test_union_in_submodel() -> None:
             },
             'UnionModel1': {
                 'properties': {
-                    'type': {'const': 1, 'default': 1, 'title': 'Type'},
-                    'other': {'const': 'UnionModel1', 'default': 'UnionModel1', 'title': 'Other'},
+                    'type': {'const': 1, 'default': 1, 'enum': [1], 'title': 'Type', 'type': 'integer'},
+                    'other': {
+                        'const': 'UnionModel1',
+                        'default': 'UnionModel1',
+                        'enum': ['UnionModel1'],
+                        'title': 'Other',
+                        'type': 'string',
+                    },
                 },
                 'title': 'UnionModel1',
                 'type': 'object',
             },
             'UnionModel2': {
                 'properties': {
-                    'type': {'const': 2, 'default': 2, 'title': 'Type'},
-                    'other': {'const': 'UnionModel2', 'default': 'UnionModel2', 'title': 'Other'},
+                    'type': {'const': 2, 'default': 2, 'enum': [2], 'title': 'Type', 'type': 'integer'},
+                    'other': {
+                        'const': 'UnionModel2',
+                        'default': 'UnionModel2',
+                        'enum': ['UnionModel2'],
+                        'title': 'Other',
+                        'type': 'string',
+                    },
                 },
                 'title': 'UnionModel2',
                 'type': 'object',
@@ -1317,11 +1329,12 @@ def test_sequence_discriminated_union():
         pet: Sequence[Pet]
         n: int
 
+    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         '$defs': {
             'Cat': {
                 'properties': {
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                     'meows': {'title': 'Meows', 'type': 'integer'},
                 },
                 'required': ['pet_type', 'meows'],
@@ -1330,7 +1343,7 @@ def test_sequence_discriminated_union():
             },
             'Dog': {
                 'properties': {
-                    'pet_type': {'const': 'dog', 'title': 'Pet Type'},
+                    'pet_type': {'const': 'dog', 'enum': ['dog'], 'title': 'Pet Type', 'type': 'string'},
                     'barks': {'title': 'Barks', 'type': 'number'},
                 },
                 'required': ['pet_type', 'barks'],
@@ -1796,12 +1809,13 @@ def test_nested_discriminator() -> None:
         blending: float
 
     MyModel.model_rebuild()
+    # insert_assert(MyModel.model_json_schema())
     assert MyModel.model_json_schema() == {
         '$defs': {
             'Step_A': {
                 'properties': {
                     'count': {'title': 'Count', 'type': 'integer'},
-                    'type': {'const': 'stepA', 'title': 'Type'},
+                    'type': {'const': 'stepA', 'enum': ['stepA'], 'title': 'Type', 'type': 'string'},
                 },
                 'required': ['type', 'count'],
                 'title': 'Step_A',
@@ -1809,7 +1823,7 @@ def test_nested_discriminator() -> None:
             },
             'Step_B': {
                 'properties': {
-                    'type': {'const': 'stepB', 'title': 'Type'},
+                    'type': {'const': 'stepB', 'enum': ['stepB'], 'title': 'Type', 'type': 'string'},
                     'value': {'title': 'Value', 'type': 'number'},
                 },
                 'required': ['type', 'value'],
@@ -1829,7 +1843,7 @@ def test_nested_discriminator() -> None:
                         'title': 'Steps',
                     },
                     'sub_models': {'items': {'$ref': '#/$defs/SubModel'}, 'title': 'Sub Models', 'type': 'array'},
-                    'type': {'const': 'mixed', 'title': 'Type'},
+                    'type': {'const': 'mixed', 'enum': ['mixed'], 'title': 'Type', 'type': 'string'},
                 },
                 'required': ['type', 'sub_models', 'blending'],
                 'title': 'SubModel',
@@ -1847,7 +1861,7 @@ def test_nested_discriminator() -> None:
                 'title': 'Steps',
             },
             'sub_models': {'items': {'$ref': '#/$defs/SubModel'}, 'title': 'Sub Models', 'type': 'array'},
-            'type': {'const': 'mixed', 'title': 'Type'},
+            'type': {'const': 'mixed', 'enum': ['mixed'], 'title': 'Type', 'type': 'string'},
         },
         'required': ['type', 'sub_models'],
         'title': 'MyModel',

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2665,11 +2665,12 @@ def test_recursive_root_models_in_discriminated_union():
     validated = Outer.model_validate({'a': {'kind': '1', 'two': None}, 'b': {'kind': '2', 'one': None}})
     assert validated == Outer(a=Root1(root=Model1(two=None)), b=Root2(root=Model2(one=None)))
 
+    # insert_assert(Outer.model_json_schema())
     assert Outer.model_json_schema() == {
         '$defs': {
             'Model1': {
                 'properties': {
-                    'kind': {'const': '1', 'default': '1', 'title': 'Kind'},
+                    'kind': {'const': '1', 'default': '1', 'enum': ['1'], 'title': 'Kind', 'type': 'string'},
                     'two': {'anyOf': [{'$ref': '#/$defs/Model2'}, {'type': 'null'}]},
                 },
                 'required': ['two'],
@@ -2678,7 +2679,7 @@ def test_recursive_root_models_in_discriminated_union():
             },
             'Model2': {
                 'properties': {
-                    'kind': {'const': '2', 'default': '2', 'title': 'Kind'},
+                    'kind': {'const': '2', 'default': '2', 'enum': ['2'], 'title': 'Kind', 'type': 'string'},
                     'one': {'anyOf': [{'$ref': '#/$defs/Model1'}, {'type': 'null'}]},
                 },
                 'required': ['one'],

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -540,6 +540,7 @@ def test_discriminated_union_forward_ref(create_module):
     # Ensure the rebuild has happened automatically despite validation failure
     assert module.Pet.__pydantic_complete__ is True
 
+    # insert_assert(module.Pet.model_json_schema())
     assert module.Pet.model_json_schema() == {
         'title': 'Pet',
         'required': ['pet'],
@@ -555,13 +556,13 @@ def test_discriminated_union_forward_ref(create_module):
             'Cat': {
                 'title': 'Cat',
                 'type': 'object',
-                'properties': {'type': {'const': 'cat', 'title': 'Type'}},
+                'properties': {'type': {'const': 'cat', 'enum': ['cat'], 'title': 'Type', 'type': 'string'}},
                 'required': ['type'],
             },
             'Dog': {
                 'title': 'Dog',
                 'type': 'object',
-                'properties': {'type': {'const': 'dog', 'title': 'Type'}},
+                'properties': {'type': {'const': 'dog', 'enum': ['dog'], 'title': 'Type', 'type': 'string'}},
                 'required': ['type'],
             },
         },

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -2433,8 +2433,9 @@ def test_generic_enum_bound():
         }
     ]
 
+    # insert_assert(Model[MyEnum].model_json_schema())
     assert Model[MyEnum].model_json_schema() == {
-        '$defs': {'MyEnum': {'const': 1, 'title': 'MyEnum'}},
+        '$defs': {'MyEnum': {'const': 1, 'enum': [1], 'title': 'MyEnum', 'type': 'integer'}},
         'properties': {'x': {'$ref': '#/$defs/MyEnum'}},
         'required': ['x'],
         'title': 'Model[test_generic_enum_bound.<locals>.MyEnum]',
@@ -2484,8 +2485,9 @@ def test_generic_intenum_bound():
         }
     ]
 
+    # insert_assert(Model[MyEnum].model_json_schema())
     assert Model[MyEnum].model_json_schema() == {
-        '$defs': {'MyEnum': {'const': 1, 'title': 'MyEnum', 'type': 'integer'}},
+        '$defs': {'MyEnum': {'const': 1, 'enum': [1], 'title': 'MyEnum', 'type': 'integer'}},
         'properties': {'x': {'$ref': '#/$defs/MyEnum'}},
         'required': ['x'],
         'title': 'Model[test_generic_intenum_bound.<locals>.MyEnum]',

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2256,10 +2256,11 @@ def test_literal_schema():
         c: Literal['a', 1]
         d: Literal['a', Literal['b'], 1, 2]
 
+    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         'properties': {
-            'a': {'const': 1, 'title': 'A'},
-            'b': {'const': 'a', 'title': 'B'},
+            'a': {'const': 1, 'enum': [1], 'title': 'A', 'type': 'integer'},
+            'b': {'const': 'a', 'enum': ['a'], 'title': 'B', 'type': 'string'},
             'c': {'enum': ['a', 1], 'title': 'C'},
             'd': {'enum': ['a', 'b', 1, 2], 'title': 'D'},
         },
@@ -2281,7 +2282,7 @@ def test_literal_enum():
     # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         'properties': {
-            'kind': {'const': 'foo', 'title': 'Kind'},
+            'kind': {'const': 'foo', 'enum': ['foo'], 'title': 'Kind', 'type': 'string'},
             'other': {'enum': ['foo', 'bar'], 'title': 'Other', 'type': 'string'},
         },
         'required': ['kind', 'other'],
@@ -2323,7 +2324,7 @@ def test_literal_types() -> None:
             'int_literal': {'enum': [123, 456], 'title': 'Int Literal', 'type': 'integer'},
             'float_literal': {'$ref': '#/$defs/FloatEnum'},
             'bool_literal': {'enum': [True, False], 'title': 'Bool Literal', 'type': 'boolean'},
-            'none_literal': {'const': None, 'title': 'None Literal'},
+            'none_literal': {'const': None, 'enum': [None], 'title': 'None Literal'},
             'list_literal': {'$ref': '#/$defs/ListEnum'},
             'mixed_literal': {'enum': [123, 'abc'], 'title': 'Mixed Literal'},
         },
@@ -3641,13 +3642,13 @@ def test_discriminated_union():
     assert Model.model_json_schema() == {
         '$defs': {
             'Cat': {
-                'properties': {'pet_type': {'const': 'cat', 'title': 'Pet Type'}},
+                'properties': {'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'}},
                 'required': ['pet_type'],
                 'title': 'Cat',
                 'type': 'object',
             },
             'Dog': {
-                'properties': {'pet_type': {'const': 'dog', 'title': 'Pet Type'}},
+                'properties': {'pet_type': {'const': 'dog', 'enum': ['dog'], 'title': 'Pet Type', 'type': 'string'}},
                 'required': ['pet_type'],
                 'title': 'Dog',
                 'type': 'object',
@@ -3697,13 +3698,13 @@ def test_discriminated_annotated_union():
     assert Model.model_json_schema() == {
         '$defs': {
             'Cat': {
-                'properties': {'pet_type': {'const': 'cat', 'title': 'Pet Type'}},
+                'properties': {'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'}},
                 'required': ['pet_type'],
                 'title': 'Cat',
                 'type': 'object',
             },
             'Dog': {
-                'properties': {'pet_type': {'const': 'dog', 'title': 'Pet Type'}},
+                'properties': {'pet_type': {'const': 'dog', 'enum': ['dog'], 'title': 'Pet Type', 'type': 'string'}},
                 'required': ['pet_type'],
                 'title': 'Dog',
                 'type': 'object',
@@ -3756,13 +3757,14 @@ def test_nested_discriminated_union():
     class Cat(BaseModel):
         pet: Annotated[Union[BlackCat, WhiteCat], Field(discriminator='color')]
 
+    # insert_assert(Cat.model_json_schema())
     assert Cat.model_json_schema() == {
         '$defs': {
             'BlackCatWithHeight': {
                 'properties': {
-                    'color': {'const': 'black', 'title': 'Color'},
+                    'color': {'const': 'black', 'enum': ['black'], 'title': 'Color', 'type': 'string'},
                     'height': {'title': 'Height', 'type': 'number'},
-                    'info': {'const': 'height', 'title': 'Info'},
+                    'info': {'const': 'height', 'enum': ['height'], 'title': 'Info', 'type': 'string'},
                 },
                 'required': ['color', 'info', 'height'],
                 'title': 'BlackCatWithHeight',
@@ -3770,8 +3772,8 @@ def test_nested_discriminated_union():
             },
             'BlackCatWithWeight': {
                 'properties': {
-                    'color': {'const': 'black', 'title': 'Color'},
-                    'info': {'const': 'weight', 'title': 'Info'},
+                    'color': {'const': 'black', 'enum': ['black'], 'title': 'Color', 'type': 'string'},
+                    'info': {'const': 'weight', 'enum': ['weight'], 'title': 'Info', 'type': 'string'},
                     'weight': {'title': 'Weight', 'type': 'number'},
                 },
                 'required': ['color', 'info', 'weight'],
@@ -3780,7 +3782,7 @@ def test_nested_discriminated_union():
             },
             'WhiteCat': {
                 'properties': {
-                    'color': {'const': 'white', 'title': 'Color'},
+                    'color': {'const': 'white', 'enum': ['white'], 'title': 'Color', 'type': 'string'},
                     'white_cat_info': {'title': 'White Cat Info', 'type': 'string'},
                 },
                 'required': ['color', 'white_cat_info'],
@@ -3863,9 +3865,9 @@ def test_deeper_nested_discriminated_annotated_union():
             'BlackCatWithHeight': {
                 'properties': {
                     'black_infos': {'title': 'Black Infos', 'type': 'string'},
-                    'color': {'const': 'black', 'title': 'Color'},
-                    'info': {'const': 'height', 'title': 'Info'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'black', 'enum': ['black'], 'title': 'Color', 'type': 'string'},
+                    'info': {'const': 'height', 'enum': ['height'], 'title': 'Info', 'type': 'string'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'info', 'black_infos'],
                 'title': 'BlackCatWithHeight',
@@ -3874,9 +3876,9 @@ def test_deeper_nested_discriminated_annotated_union():
             'BlackCatWithWeight': {
                 'properties': {
                     'black_infos': {'title': 'Black Infos', 'type': 'string'},
-                    'color': {'const': 'black', 'title': 'Color'},
-                    'info': {'const': 'weight', 'title': 'Info'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'black', 'enum': ['black'], 'title': 'Color', 'type': 'string'},
+                    'info': {'const': 'weight', 'enum': ['weight'], 'title': 'Info', 'type': 'string'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'info', 'black_infos'],
                 'title': 'BlackCatWithWeight',
@@ -3885,7 +3887,7 @@ def test_deeper_nested_discriminated_annotated_union():
             'Dog': {
                 'properties': {
                     'dog_name': {'title': 'Dog Name', 'type': 'string'},
-                    'pet_type': {'const': 'dog', 'title': 'Pet Type'},
+                    'pet_type': {'const': 'dog', 'enum': ['dog'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'dog_name'],
                 'title': 'Dog',
@@ -3893,8 +3895,8 @@ def test_deeper_nested_discriminated_annotated_union():
             },
             'WhiteCat': {
                 'properties': {
-                    'color': {'const': 'white', 'title': 'Color'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'white', 'enum': ['white'], 'title': 'Color', 'type': 'string'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                     'white_infos': {'title': 'White Infos', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'white_infos'],
@@ -4047,9 +4049,9 @@ def test_discriminated_annotated_union_literal_enum():
             'BlackCatWithHeight': {
                 'properties': {
                     'black_infos': {'title': 'Black Infos', 'type': 'string'},
-                    'color': {'const': 'black', 'title': 'Color'},
-                    'info': {'const': 0, 'title': 'Info'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'black', 'enum': ['black'], 'title': 'Color', 'type': 'string'},
+                    'info': {'const': 0, 'enum': [0], 'title': 'Info', 'type': 'integer'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'info', 'black_infos'],
                 'title': 'BlackCatWithHeight',
@@ -4058,9 +4060,9 @@ def test_discriminated_annotated_union_literal_enum():
             'BlackCatWithWeight': {
                 'properties': {
                     'black_infos': {'title': 'Black Infos', 'type': 'string'},
-                    'color': {'const': 'black', 'title': 'Color'},
-                    'info': {'const': 1, 'title': 'Info'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'black', 'enum': ['black'], 'title': 'Color', 'type': 'string'},
+                    'info': {'const': 1, 'enum': [1], 'title': 'Info', 'type': 'integer'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'info', 'black_infos'],
                 'title': 'BlackCatWithWeight',
@@ -4069,7 +4071,7 @@ def test_discriminated_annotated_union_literal_enum():
             'Dog': {
                 'properties': {
                     'dog_name': {'title': 'Dog Name', 'type': 'string'},
-                    'pet_type': {'const': 'dog', 'title': 'Pet Type'},
+                    'pet_type': {'const': 'dog', 'enum': ['dog'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'dog_name'],
                 'title': 'Dog',
@@ -4077,8 +4079,8 @@ def test_discriminated_annotated_union_literal_enum():
             },
             'WhiteCat': {
                 'properties': {
-                    'color': {'const': 'white', 'title': 'Color'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'white', 'enum': ['white'], 'title': 'Color', 'type': 'string'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                     'white_infos': {'title': 'White Infos', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'white_infos'],
@@ -4197,7 +4199,7 @@ def test_alias_same():
             'Cat': {
                 'properties': {
                     'c': {'title': 'C', 'type': 'string'},
-                    'typeOfPet': {'const': 'cat', 'title': 'Typeofpet'},
+                    'typeOfPet': {'const': 'cat', 'enum': ['cat'], 'title': 'Typeofpet', 'type': 'string'},
                 },
                 'required': ['typeOfPet', 'c'],
                 'title': 'Cat',
@@ -4206,7 +4208,7 @@ def test_alias_same():
             'Dog': {
                 'properties': {
                     'd': {'title': 'D', 'type': 'string'},
-                    'typeOfPet': {'const': 'dog', 'title': 'Typeofpet'},
+                    'typeOfPet': {'const': 'dog', 'enum': ['dog'], 'title': 'Typeofpet', 'type': 'string'},
                 },
                 'required': ['typeOfPet', 'd'],
                 'title': 'Dog',
@@ -4248,6 +4250,7 @@ def test_nested_python_dataclasses():
         # This is the same behavior as in v1
         child: List[ChildModel]
 
+    # insert_assert(model_json_schema(dataclass(NestedModel)))
     assert model_json_schema(dataclass(NestedModel)) == {
         '$defs': {
             'ChildModel': {
@@ -4287,13 +4290,14 @@ def test_discriminated_union_in_list():
         pets: Pet
         n: int
 
+    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         '$defs': {
             'BlackCat': {
                 'properties': {
                     'black_name': {'title': 'Black Name', 'type': 'string'},
-                    'color': {'const': 'black', 'title': 'Color'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'black', 'enum': ['black'], 'title': 'Color', 'type': 'string'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'black_name'],
                 'title': 'BlackCat',
@@ -4302,7 +4306,7 @@ def test_discriminated_union_in_list():
             'Dog': {
                 'properties': {
                     'name': {'title': 'Name', 'type': 'string'},
-                    'pet_type': {'const': 'dog', 'title': 'Pet Type'},
+                    'pet_type': {'const': 'dog', 'enum': ['dog'], 'title': 'Pet Type', 'type': 'string'},
                 },
                 'required': ['pet_type', 'name'],
                 'title': 'Dog',
@@ -4310,8 +4314,8 @@ def test_discriminated_union_in_list():
             },
             'WhiteCat': {
                 'properties': {
-                    'color': {'const': 'white', 'title': 'Color'},
-                    'pet_type': {'const': 'cat', 'title': 'Pet Type'},
+                    'color': {'const': 'white', 'enum': ['white'], 'title': 'Color', 'type': 'string'},
+                    'pet_type': {'const': 'cat', 'enum': ['cat'], 'title': 'Pet Type', 'type': 'string'},
                     'white_name': {'title': 'White Name', 'type': 'string'},
                 },
                 'required': ['pet_type', 'color', 'white_name'],

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4980,16 +4980,21 @@ def test_none_literal():
         my_json_none='null',
     )
 
+    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         'title': 'Model',
         'type': 'object',
         'properties': {
-            'my_none': {'const': None, 'title': 'My None'},
-            'my_none_list': {'type': 'array', 'items': {'const': None}, 'title': 'My None List'},
-            'my_none_dict': {'type': 'object', 'additionalProperties': {'const': None}, 'title': 'My None Dict'},
+            'my_none': {'const': None, 'enum': [None], 'title': 'My None'},
+            'my_none_list': {'items': {'const': None, 'enum': [None]}, 'title': 'My None List', 'type': 'array'},
+            'my_none_dict': {
+                'additionalProperties': {'const': None, 'enum': [None]},
+                'title': 'My None Dict',
+                'type': 'object',
+            },
             'my_json_none': {
                 'contentMediaType': 'application/json',
-                'contentSchema': {'const': None},
+                'contentSchema': {'const': None, 'enum': [None]},
                 'title': 'My Json None',
                 'type': 'string',
             },


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/8905

However, I think we should be careful about merging this, as any change to the JSON schema usually comes with some complaints. In particular, it's probably a good idea to track down the initial commit adding the use of `constant` and determine if it might be a problem to include the duplicate information about the enum value.

Probably also a good idea to make sure this doesn't break swagger UI in some way.

Another option, whether this causes any problems we can find or not, would be to expose the change by way of some config setting which would ensure that people wouldn't be affected unless they opted in, but then they also wouldn't benefit from improvements to integration with some JSON schema tools... 🤷‍♂️ not sure what's best.