### PR TITLE
Further schema gen simplification

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -40,8 +40,6 @@ _CORE_SCHEMA_FIELD_TYPES = {'typed-dict-field', 'dataclass-field', 'model-field'
 _FUNCTION_WITH_INNER_SCHEMA_TYPES = {'function-before', 'function-after', 'function-wrap'}
 _LIST_LIKE_SCHEMA_WITH_ITEMS_TYPES = {'list', 'set', 'frozenset'}
 
-_DEFINITIONS_CACHE_METADATA_KEY = 'pydantic.definitions_cache'
-
 TAGGED_UNION_TAG_KEY = 'pydantic.internal.tagged_union_tag'
 """
 Used in a `Tag` schema to specify the tag used for a discriminated union.

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1154,13 +1154,11 @@ class GenerateSchema:
         else:
             choices_with_tags: list[CoreSchema | tuple[CoreSchema, str]] = []
             for choice in choices:
-                metadata = choice.get('metadata', {})
-                if isinstance(metadata, dict):
-                    tag = metadata.get(_core_utils.TAGGED_UNION_TAG_KEY)
-                    if tag is not None:
-                        choices_with_tags.append((choice, tag))
-                    else:
-                        choices_with_tags.append(choice)
+                tag = choice.get('metadata', {}).get(_core_utils.TAGGED_UNION_TAG_KEY)
+                if tag is not None:
+                    choices_with_tags.append((choice, tag))
+                else:
+                    choices_with_tags.append(choice)
             s = core_schema.union_schema(choices_with_tags)
 
         if nullable:


### PR DESCRIPTION
Removing unnecessary step that adds a `metadata` field to a schema as an empty dict, if it doesn't exist.

Selected Reviewer: @alexmojaki