### PR TITLE
Ability to pass context to serialization (fix #7143)

### DIFF
--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -736,7 +736,6 @@ print(model.model_dump(context={'stopwords': ['document']}))
 ```
 
 
-
 ## `model_copy(...)`
 
 ??? api "API Documentation"

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -735,6 +735,7 @@ print(model.model_dump(context={'stopwords': ['document']}))
 #> {'text': 'This is an example'}
 ```
 
+Similarly, you can [use a context for validation](../concepts/validators.md#validation-context).
 
 ## `model_copy(...)`
 

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -702,6 +702,40 @@ print(person.model_dump(exclude_defaults=True))  # (3)!
 2. `age` excluded from the output because `exclude_unset` was set to `True`, and `age` was not set in the Person constructor.
 3. `age` excluded from the output because `exclude_defaults` was set to `True`, and `age` takes the default value of `None`.
 
+## Serialization Context
+
+You can pass a context object to the serialization methods which can be accessed from the `info`
+argument to decorated serializer functions. This is useful when you need to dynamically update the
+serialization behavior during runtime. For example, if you wanted a field to be dumped depending on
+a dynamically controllable set of allowed values, this could be done by passing the allowed values
+by context:
+
+```python
+from pydantic import BaseModel, SerializationInfo, field_serializer
+
+
+class Model(BaseModel):
+    text: str
+
+    @field_serializer('text')
+    def remove_stopwords(self, v: str, info: SerializationInfo):
+        context = info.context
+        if context:
+            stopwords = context.get('stopwords', set())
+            v = ' '.join(w for w in v.split() if w.lower() not in stopwords)
+        return v
+
+
+model = Model.model_construct(**{'text': 'This is an example document'})
+print(model.model_dump())  # no context
+#> {'text': 'This is an example document'}
+print(model.model_dump(context={'stopwords': ['this', 'is', 'an']}))
+#> {'text': 'example document'}
+print(model.model_dump(context={'stopwords': ['document']}))
+#> {'text': 'This is an example'}
+```
+
+
 
 ## `model_copy(...)`
 

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -709,6 +709,8 @@ except ValidationError as exc:
     """
 ```
 
+Similarly, you can [use a context for serialization](../concepts/serialization.md#serialization-context).
+
 ### Using validation context with `BaseModel` initialization
 Although there is no way to specify a context in the standard `BaseModel` initializer, you can work around this through
 the use of `contextvars.ContextVar` and a custom `__init__` method:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -292,6 +292,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         mode: typing_extensions.Literal['json', 'python'] | str = 'python',
         include: IncEx = None,
         exclude: IncEx = None,
+        context: dict[str, Any] | None = None,
         by_alias: bool = False,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
@@ -309,6 +310,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 If mode is 'python', the output may contain non-JSON-serializable Python objects.
             include: A set of fields to include in the output.
             exclude: A set of fields to exclude from the output.
+            context: Additional context to pass to the serializer.
             by_alias: Whether to use the field's alias in the dictionary key if defined.
             exclude_unset: Whether to exclude fields that have not been explicitly set.
             exclude_defaults: Whether to exclude fields that are set to their default value.
@@ -325,6 +327,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             by_alias=by_alias,
             include=include,
             exclude=exclude,
+            context=context,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
@@ -338,6 +341,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         indent: int | None = None,
         include: IncEx = None,
         exclude: IncEx = None,
+        context: dict[str, Any] | None = None,
         by_alias: bool = False,
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
@@ -353,6 +357,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             indent: Indentation to use in the JSON output. If None is passed, the output will be compact.
             include: Field(s) to include in the JSON output.
             exclude: Field(s) to exclude from the JSON output.
+            context: Additional context to pass to the serializer.
             by_alias: Whether to serialize using field aliases.
             exclude_unset: Whether to exclude fields that have not been explicitly set.
             exclude_defaults: Whether to exclude fields that are set to their default value.
@@ -368,6 +373,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             indent=indent,
             include=include,
             exclude=exclude,
+            context=context,
             by_alias=by_alias,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -124,6 +124,7 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType], metaclass=_RootMod
             mode: Literal['json', 'python'] | str = 'python',
             include: Any = None,
             exclude: Any = None,
+            context: dict[str, Any] | None = None,
             by_alias: bool = False,
             exclude_unset: bool = False,
             exclude_defaults: bool = False,

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1159,3 +1159,39 @@ def test_subclass_support_unions_with_forward_ref() -> None:
 
     foo_recursive = Foo(items=[Foo(items=[Baz(bar_id=42, baz_id=99)])])
     assert foo_recursive.model_dump() == {'items': [{'items': [{'bar_id': 42}]}]}
+
+
+def test_serialize_python_context() -> None:
+    contexts: List[Any] = [None, None, {'foo': 'bar'}]
+
+    class Model(BaseModel):
+        x: int
+
+        @field_serializer('x')
+        def serialize_x(self, v: int, info: SerializationInfo) -> int:
+            assert info.context == contexts.pop(0)
+            return v
+
+    m = Model.model_construct(**{'x': 1})
+    m.model_dump()
+    m.model_dump(context=None)
+    m.model_dump(context={'foo': 'bar'})
+    assert contexts == []
+
+
+def test_serialize_json_context() -> None:
+    contexts: List[Any] = [None, None, {'foo': 'bar'}]
+
+    class Model(BaseModel):
+        x: int
+
+        @field_serializer('x')
+        def serialize_x(self, v: int, info: SerializationInfo) -> int:
+            assert info.context == contexts.pop(0)
+            return v
+
+    m = Model.model_construct(**{'x': 1})
+    m.model_dump_json()
+    m.model_dump_json(context=None)
+    m.model_dump_json(context={'foo': 'bar'})
+    assert contexts == []

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1194,4 +1194,3 @@ def test_plain_serializer_with_std_type() -> None:
     m = MyModel(x=1)
     assert m.model_dump() == {'x': 1.0}
     assert m.model_dump_json() == '{"x":1.0}'
-


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Implements the python frontend for the ability to pass context to serialization, which was implemented in pydantic/pydantic-core#1215.
**Note that this PR will only be complete once pydantic adopts pydantic-core's release to come.**

## Related issue number

fix #7143

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin