### PR TITLE
fix sequence like validator with strict True

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -274,7 +274,7 @@ class SequenceValidator:
     item_source_type: type[Any]
     min_length: int | None = None
     max_length: int | None = None
-    strict: bool = False
+    strict: bool | None = None
 
     def serialize_sequence_via_list(
         self, v: Any, handler: core_schema.SerializerFunctionWrapHandler, info: core_schema.SerializationInfo
@@ -298,7 +298,6 @@ class SequenceValidator:
             items_schema = None
         else:
             items_schema = handler.generate_schema(self.item_source_type)
-
         metadata = {'min_length': self.min_length, 'max_length': self.max_length, 'strict': self.strict}
 
         if self.mapped_origin in (list, set, frozenset):
@@ -325,8 +324,7 @@ class SequenceValidator:
                 )
             else:
                 coerce_instance_wrap = partial(core_schema.no_info_after_validator_function, self.mapped_origin)
-            # Due that we are using list schema in deque/Counter, strict should be overwritten if it's given
-            metadata['strict'] = False
+
             constrained_schema = core_schema.list_schema(items_schema, **metadata)
 
             check_instance = core_schema.json_or_python_schema(
@@ -397,7 +395,7 @@ def sequence_like_prepare_pydantic_annotations(
     return (
         source_type,
         [
-            SequenceValidator(mapped_origin, item_source_type, **metadata, strict=_config.get('strict', False)),
+            SequenceValidator(mapped_origin, item_source_type, **metadata),
             *remaining_annotations,
         ],
     )

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -392,13 +392,7 @@ def sequence_like_prepare_pydantic_annotations(
 
     metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
     _known_annotated_metadata.check_metadata(metadata, _known_annotated_metadata.SEQUENCE_CONSTRAINTS, source_type)
-    return (
-        source_type,
-        [
-            SequenceValidator(mapped_origin, item_source_type, **metadata),
-            *remaining_annotations,
-        ],
-    )
+    return (source_type, [SequenceValidator(mapped_origin, item_source_type, **metadata), *remaining_annotations])
 
 
 MAPPING_ORIGIN_MAP: dict[Any, Any] = {

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -325,7 +325,8 @@ class SequenceValidator:
                 )
             else:
                 coerce_instance_wrap = partial(core_schema.no_info_after_validator_function, self.mapped_origin)
-
+            # Due that we are using list schema in deque/Counter, strict should be overwrite if it's given
+            metadata['strict'] = False
             constrained_schema = core_schema.list_schema(items_schema, **metadata)
 
             check_instance = core_schema.json_or_python_schema(
@@ -393,8 +394,13 @@ def sequence_like_prepare_pydantic_annotations(
 
     metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
     _known_annotated_metadata.check_metadata(metadata, _known_annotated_metadata.SEQUENCE_CONSTRAINTS, source_type)
-
-    return (source_type, [SequenceValidator(mapped_origin, item_source_type, **metadata), *remaining_annotations])
+    return (
+        source_type,
+        [
+            SequenceValidator(mapped_origin, item_source_type, **metadata, strict=_config.get('strict', False)),
+            *remaining_annotations,
+        ],
+    )
 
 
 MAPPING_ORIGIN_MAP: dict[Any, Any] = {

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -326,7 +326,10 @@ class SequenceValidator:
             else:
                 coerce_instance_wrap = partial(core_schema.no_info_after_validator_function, self.mapped_origin)
 
-            constrained_schema = core_schema.list_schema(items_schema, **metadata)
+            # we have to use a lax list schema here, because we need to validate the deque's
+            # items via a list schema, but it's ok if the deque itself is not a list (same for Counter)
+            metadata_with_strict_override = {**metadata, 'strict': False}
+            constrained_schema = core_schema.list_schema(items_schema, **metadata_with_strict_override)
 
             check_instance = core_schema.json_or_python_schema(
                 json_schema=core_schema.list_schema(),

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -298,6 +298,7 @@ class SequenceValidator:
             items_schema = None
         else:
             items_schema = handler.generate_schema(self.item_source_type)
+
         metadata = {'min_length': self.min_length, 'max_length': self.max_length, 'strict': self.strict}
 
         if self.mapped_origin in (list, set, frozenset):
@@ -392,6 +393,7 @@ def sequence_like_prepare_pydantic_annotations(
 
     metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
     _known_annotated_metadata.check_metadata(metadata, _known_annotated_metadata.SEQUENCE_CONSTRAINTS, source_type)
+
     return (source_type, [SequenceValidator(mapped_origin, item_source_type, **metadata), *remaining_annotations])
 
 

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -325,7 +325,7 @@ class SequenceValidator:
                 )
             else:
                 coerce_instance_wrap = partial(core_schema.no_info_after_validator_function, self.mapped_origin)
-            # Due that we are using list schema in deque/Counter, strict should be overwrite if it's given
+            # Due that we are using list schema in deque/Counter, strict should be overwritten if it's given
             metadata['strict'] = False
             constrained_schema = core_schema.list_schema(items_schema, **metadata)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2378,13 +2378,13 @@ def test_model_validate_strict() -> None:
 
 
 @pytest.mark.xfail(
-    reason='To make validating json with strict=True work with sequence types it must be handled in pydantic-core'
+    reason='strict=True in model_validate_json does not overwrite strict=False given in ConfigDict'
     'See issue: https://github.com/pydantic/pydantic/issues/8930'
 )
 def test_model_validate_list_strict() -> None:
-    # FIXME: This change must be implemented in pydantic-core. When ConfigDict(strict=False)
-    # the validate_json method is not overwriting strict false coming from sequence like schema
-    # See: https://github.com/pydantic/pydantic/issues/8930
+    # FIXME: This change must be implemented in pydantic-core. The argument strict=True
+    # in model_validate_json method is not overwriting the one set with ConfigDict(strict=False)
+    # for sequence like types. See: https://github.com/pydantic/pydantic/issues/8930
 
     class LaxModel(BaseModel):
         x: List[str]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2379,11 +2379,12 @@ def test_model_validate_strict() -> None:
 
 @pytest.mark.xfail(
     reason='To make validating json with strict=True work with sequence types it must be handled in pydantic-core'
-    'See issue: '
+    'See issue: https://github.com/pydantic/pydantic/issues/8930'
 )
 def test_model_validate_list_strict() -> None:
     # FIXME: This change must be implemented in pydantic-core. When ConfigDict(strict=False)
     # the validate_json method is not overwriting strict false coming from sequence like schema
+    # See: https://github.com/pydantic/pydantic/issues/8930
 
     class LaxModel(BaseModel):
         x: List[str]

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -496,6 +496,21 @@ def test_config_arbitrary_types_allowed():
     ]
 
 
+def test_config_strict():
+    @validate_call(config=dict(strict=True))
+    def foo(a: int, b: List[str]):
+        return f'{a}, {b[0]}'
+
+    assert foo(1, ['bar', 'foobar']) == '1, bar'
+    with pytest.raises(ValidationError) as exc_info:
+        foo('foo', ('bar', 'foobar'))
+    # # insert_assert(exc_info.value.errors(include_url=False))
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'int_type', 'loc': (0,), 'msg': 'Input should be a valid integer', 'input': 'foo'},
+        {'type': 'list_type', 'loc': (1,), 'msg': 'Input should be a valid list', 'input': ('bar', 'foobar')},
+    ]
+
+
 def test_annotated_use_of_alias():
     @validate_call
     def foo(a: Annotated[int, Field(alias='b')], c: Annotated[int, Field()], d: Annotated[int, Field(alias='')]):

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -504,7 +504,6 @@ def test_config_strict():
     assert foo(1, ['bar', 'foobar']) == '1, bar'
     with pytest.raises(ValidationError) as exc_info:
         foo('foo', ('bar', 'foobar'))
-    # # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'int_type', 'loc': (0,), 'msg': 'Input should be a valid integer', 'input': 'foo'},
         {'type': 'list_type', 'loc': (1,), 'msg': 'Input should be a valid list', 'input': ('bar', 'foobar')},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

Fix #8930

## Change Summary

This PR aims to solve #8930.  Until now, when `strict=True ` is passed in the config dict, only the type of the elements of the sequence fields is forced. Now with this change, both the type of the sequence and the items will be validated strictly. This validation is done perfectly in `pydantic-core`, the problem was that this information was not sent through the json schema to `pydantic-core` for sequence like types. However, the `model_validate_json` method, from what I understand, needs to be fixed in `pydantic-core`.  An example for the last is shown below and also there is test marked with `xfail` in this PR

```python
  class LaxModel(BaseModel):
      x: List[str]
      model_config = ConfigDict(strict=False)
      
 >>> LaxModel.model_validate_json(json.dumps({'x': ('a', 'b', 'c')}), strict=True)
 # No error. 
```
The example has no error, `strict=True` in `model_validate_json` should overwrite config dict `strict=False` (To be honest, I make this statement looking at the numerous examples in the tests, where it is seen that it overwrites)


## Related issue number

#8930

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu