### PR TITLE
#8379: allow for alias enforcement during serialization by setting `serialize_by_alias` on `ConfigDict`

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -49,6 +49,7 @@ class ConfigWrapper:
     extra: ExtraValues | None
     frozen: bool
     populate_by_name: bool
+    serialize_by_alias: bool
     use_enum_values: bool
     validate_assignment: bool
     arbitrary_types_allowed: bool
@@ -227,6 +228,7 @@ config_defaults = ConfigDict(
     extra=None,
     frozen=False,
     populate_by_name=False,
+    serialize_by_alias=False,
     use_enum_values=False,
     validate_assignment=False,
     arbitrary_types_allowed=False,

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -161,6 +161,13 @@ class ConfigDict(TypedDict, total=False):
     3. The model is populated by the field name `'name'`.
     """
 
+    serialize_by_name: bool
+    """
+    counter part to populate_by_name.
+
+    See https://github.com/pydantic/pydantic/issues/8379 for the background discussion.
+    """
+
     use_enum_values: bool
     """
     Whether to populate models with the `value` property of enums, rather than the raw enum.

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -161,7 +161,7 @@ class ConfigDict(TypedDict, total=False):
     3. The model is populated by the field name `'name'`.
     """
 
-    serialize_by_name: bool
+    serialize_by_alias: bool
     """
     counter part to populate_by_name.
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -319,6 +319,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A dictionary representation of the model.
         """
+        if self.model_config.get('serialize_by_name', False):
+            by_alias = True
         return self.__pydantic_serializer__.to_python(
             self,
             mode=mode,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -363,6 +363,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A JSON string representation of the model.
         """
+        if self.model_config.get('serialize_by_name', False):
+            by_alias = True
         return self.__pydantic_serializer__.to_json(
             self,
             indent=indent,

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -319,7 +319,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A dictionary representation of the model.
         """
-        if self.model_config.get('serialize_by_name', False):
+        if self.model_config.get('serialize_by_alias', False):
             by_alias = True
         return self.__pydantic_serializer__.to_python(
             self,
@@ -365,7 +365,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A JSON string representation of the model.
         """
-        if self.model_config.get('serialize_by_name', False):
+        if self.model_config.get('serialize_by_alias', False):
             by_alias = True
         return self.__pydantic_serializer__.to_json(
             self,

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -544,6 +544,18 @@ def test_serialization_by_alias_enforced_with_serialize_by_alias():
     assert 'foo' in m.model_dump_json(by_alias=False)
 
 
+def test_serialization_by_alias_nested():
+    class InnerModel(BaseModel):
+        a: str = Field(alias='a_alias')
+
+    class Model(BaseModel):
+        b: InnerModel = Field(alias='b_alias')
+        model_config = ConfigDict(serialize_by_alias=True)
+
+    example = {'b_alias': {'a_alias': 'a_value'}}
+    assert example == Model(**example).model_dump()
+
+
 @pytest.mark.parametrize(
     'field,expected',
     [

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -533,9 +533,9 @@ def test_serialization_alias_from_alias():
     assert 'foo' in sig.parameters
 
 
-def test_serialization_by_alias_enforced_with_serialize_by_name():
+def test_serialization_by_alias_enforced_with_serialize_by_alias():
     class Model(BaseModel):
-        model_config = {'serialize_by_name': True}
+        model_config = {'serialize_by_alias': True}
         x: str = Field(alias='foo')
 
     m = Model(foo='bar')

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -533,6 +533,17 @@ def test_serialization_alias_from_alias():
     assert 'foo' in sig.parameters
 
 
+def test_serialization_by_alias_enforced_with_serialize_by_name():
+    class Model(BaseModel):
+        model_config = {'serialize_by_name': True}
+        x: str = Field(alias='foo')
+
+    m = Model(foo='bar')
+    assert 'foo' in m.model_dump()
+    assert 'foo' in m.model_dump(by_alias=False)
+    assert 'foo' in m.model_dump_json(by_alias=False)
+
+
 @pytest.mark.parametrize(
     'field,expected',
     [


### PR DESCRIPTION
## Change Summary

this allows for usage of field aliases as aliases - there is a discussion in #8379

## Related issue number

#8379 (it may or may not be considered fully addressed after this PR)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable - admittedly its minimal but at this stage ill propose that its sufficient
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex