### PR TITLE
allow field_serializer('*') (fix #8990)

### DIFF
--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -224,8 +224,8 @@ print(Model(x='test value').model_dump_json())
 #> {"x":"serialized test value"}
 ```
 
-!!! note A single serializer can also be called on all fields by passing the special value '*' to the [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator.
-
+!!! note
+    A single serializer can also be called on all fields by passing the special value '*' to the [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator.
 
 In addition, [`PlainSerializer`][pydantic.functional_serializers.PlainSerializer] and
 [`WrapSerializer`][pydantic.functional_serializers.WrapSerializer] enable you to use a function to modify the output of serialization.

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -224,7 +224,8 @@ print(Model(x='test value').model_dump_json())
 #> {"x":"serialized test value"}
 ```
 
-!!! note A single serializer can also be called on all fields by passing the special value '*' to the [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator.
+!!! note 
+    A single serializer can also be called on all fields by passing the special value '*' to the [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator.
 
 
 In addition, [`PlainSerializer`][pydantic.functional_serializers.PlainSerializer] and

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -224,6 +224,9 @@ print(Model(x='test value').model_dump_json())
 #> {"x":"serialized test value"}
 ```
 
+!!! note A single serializer can also be called on all fields by passing the special value '*' to the [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator.
+
+
 In addition, [`PlainSerializer`][pydantic.functional_serializers.PlainSerializer] and
 [`WrapSerializer`][pydantic.functional_serializers.WrapSerializer] enable you to use a function to modify the output of serialization.
 

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -224,8 +224,7 @@ print(Model(x='test value').model_dump_json())
 #> {"x":"serialized test value"}
 ```
 
-!!! note 
-    A single serializer can also be called on all fields by passing the special value '*' to the [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator.
+!!! note A single serializer can also be called on all fields by passing the special value '*' to the [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator.
 
 
 In addition, [`PlainSerializer`][pydantic.functional_serializers.PlainSerializer] and

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -125,9 +125,8 @@ def check_validator_fields_against_field_name(
     Returns:
         `True` if field name is in validator fields, `False` otherwise.
     """
-    if isinstance(info, (ValidatorDecoratorInfo, FieldValidatorDecoratorInfo)):
-        if '*' in info.fields:
-            return True
+    if '*' in info.fields:
+        return True
     for v_field_name in info.fields:
         if v_field_name == field:
             return True
@@ -148,7 +147,7 @@ def check_decorator_fields_exist(decorators: Iterable[AnyFieldDecorator], fields
     """
     fields = set(fields)
     for dec in decorators:
-        if isinstance(dec.info, (ValidatorDecoratorInfo, FieldValidatorDecoratorInfo)) and '*' in dec.info.fields:
+        if '*' in dec.info.fields:
             continue
         if dec.info.check_fields is False:
             continue

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -560,6 +560,18 @@ def test_field_multiple_serializer_subclass():
     assert MySubModel(x=1234).model_dump() == {'x': '1234'}
 
 
+def test_serialize_all_fields():
+    class MyModel(BaseModel):
+        x: int
+
+        @field_serializer('*')
+        @classmethod
+        def serialize_all(cls, v: Any):
+            return v * 2
+
+    assert MyModel(x=10).model_dump() == {'x': 20}
+
+
 def int_ser_func_without_info1(v: int, expected: int) -> str:
     return f'{v:,}'
 


### PR DESCRIPTION
## Change Summary

allow ``field_serializer('*')`` for defining a serializer for all fields in a model

## Related issue number

fix #8990

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt