### PR TITLE
Handle a case when model_config is defined as a model property

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1089,7 +1089,7 @@ pydantic.errors.PydanticUserError: Dataclass field bar has init=False and init_v
 """
 ```
 
-## `model_config` is used as a model property {#model-config-cannot-be-a-property}
+## `model_config` is used as a model field {#model-config-invalid-field-name}
 This error is raised when `model_config` is used as as property.
 ```py
 from pydantic import BaseModel, PydanticUserError
@@ -1100,7 +1100,7 @@ try:
         model_config: str
 
 except PydanticUserError as exc_info:
-    assert exc_info.code == 'model-config-cannot-be-a-property'
+    assert exc_info.code == 'model-config-invalid-field-name'
 ```
 
 {% endraw %}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1089,4 +1089,18 @@ pydantic.errors.PydanticUserError: Dataclass field bar has init=False and init_v
 """
 ```
 
+## `model_config` is used as a model property {#model-config-cannot-be-a-property}
+This error is raised when `model_config` is used as as property.
+```py
+from pydantic import BaseModel, PydanticUserError
+
+try:
+
+    class Model(BaseModel):
+        model_config: str
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'model-config-cannot-be-a-property'
+```
+
 {% endraw %}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1090,7 +1090,8 @@ pydantic.errors.PydanticUserError: Dataclass field bar has init=False and init_v
 ```
 
 ## `model_config` is used as a model field {#model-config-invalid-field-name}
-This error is raised when `model_config` is used as as property.
+
+This error is raised when `model_config` is used as the name of a field.
 ```py
 from pydantic import BaseModel, PydanticUserError
 

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -119,8 +119,8 @@ class ConfigWrapper:
         raw_annotations = namespace.get('__annotations__', {})
         if raw_annotations.get('model_config') and not config_dict_from_namespace:
             raise PydanticUserError(
-                '"model_config" cannot be used as a model property. Use "model_config" for model configuration',
-                code='model-config-cannot-be-a-property',
+                '"model_config" cannot be used as a model field. Use "model_config" for model configuration',
+                code='model-config-invalid-field-name',
             )
 
         if config_class_from_namespace and config_dict_from_namespace:

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -116,6 +116,13 @@ class ConfigWrapper:
         config_class_from_namespace = namespace.get('Config')
         config_dict_from_namespace = namespace.get('model_config')
 
+        raw_annotations = namespace.get('__annotations__', {})
+        if raw_annotations.get('model_config') and not config_dict_from_namespace:
+            raise PydanticUserError(
+                '"model_config" cannot be used as a model property. Use "model_config" for model configuration',
+                code='model-config-cannot-be-a-property',
+            )
+
         if config_class_from_namespace and config_dict_from_namespace:
             raise PydanticUserError('"Config" and "model_config" cannot be used together', code='config-both')
 

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -119,7 +119,7 @@ class ConfigWrapper:
         raw_annotations = namespace.get('__annotations__', {})
         if raw_annotations.get('model_config') and not config_dict_from_namespace:
             raise PydanticUserError(
-                '"model_config" cannot be used as a model field. Use "model_config" for model configuration',
+                '`model_config` cannot be used as a model field name. Use `model_config` for model configuration.',
                 code='model-config-invalid-field-name',
             )
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -61,7 +61,7 @@ PydanticErrorCodes = Literal[
     'unevaluable-type-annotation',
     'dataclass-init-false-extra-allow',
     'clashing-init-and-init-var',
-    'model-config-cannot-be-a-property',
+    'model-config-invalid-field-name',
 ]
 
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -61,6 +61,7 @@ PydanticErrorCodes = Literal[
     'unevaluable-type-annotation',
     'dataclass-init-false-extra-allow',
     'clashing-init-and-init-var',
+    'model-config-cannot-be-a-property',
 ]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -796,3 +796,16 @@ def test_partial_creation_with_defer_build():
 
     # AssertionError: assert ['a', 'b'] == ['b']
     assert partial.model_json_schema()['required'] == ['b']
+
+
+def test_model_config_use_as_property():
+    """
+    Test: raises PydandicUserError when 'model_config' is used
+    as a property
+    """
+    with pytest.raises(PydanticUserError) as exc_info:
+
+        class MyModel(BaseModel):
+            model_config: str
+
+    assert exc_info.value.code == 'model-config-cannot-be-a-property'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -805,3 +805,17 @@ def test_model_config_as_model_field_raises():
             model_config: str
 
     assert exc_info.value.code == 'model-config-invalid-field-name'
+
+
+def test_dataclass_allowes_model_config_as_model_field():
+    config_title = 'from_config'
+    model_field_title = 'model_field'
+
+    @pydantic_dataclass(config={'title': config_title})
+    class MyDataclass:
+        model_config: dict
+
+    m = MyDataclass(model_config={'title': model_field_title})
+
+    assert m.model_config['title'] == model_field_title
+    assert getattr(m, '__pydantic_config__')['title'] == config_title

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -798,14 +798,10 @@ def test_partial_creation_with_defer_build():
     assert partial.model_json_schema()['required'] == ['b']
 
 
-def test_model_config_use_as_property():
-    """
-    Test: raises PydandicUserError when 'model_config' is used
-    as a property
-    """
+def test_model_config_as_model_field_raises():
     with pytest.raises(PydanticUserError) as exc_info:
 
         class MyModel(BaseModel):
             model_config: str
 
-    assert exc_info.value.code == 'model-config-cannot-be-a-property'
+    assert exc_info.value.code == 'model-config-invalid-field-name'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -809,13 +809,13 @@ def test_model_config_as_model_field_raises():
 
 def test_dataclass_allowes_model_config_as_model_field():
     config_title = 'from_config'
-    model_field_title = 'model_field'
+    field_title = 'from_field'
 
     @pydantic_dataclass(config={'title': config_title})
     class MyDataclass:
         model_config: dict
 
-    m = MyDataclass(model_config={'title': model_field_title})
+    m = MyDataclass(model_config={'title': field_title})
 
-    assert m.model_config['title'] == model_field_title
+    assert m.model_config['title'] == field_title
     assert getattr(m, '__pydantic_config__')['title'] == config_title


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
The PR aims to solve behavior when `pydantic` allows to define `model_config` as a model property with no default value. It leads to confusing behavior:
```py
from pydantic import BaseModel


class MyModel(BaseModel):
    model_config: str


if __name__ == '__main__':
    m = MyModel(model_config='Test')
    print(m.model_config)
    """
    {}
    """
```
The MR offers to raise `PydanticUserError` in this case.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #8469

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle