### PR TITLE
Add support for typing.Self (fix #5992)

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -78,7 +78,7 @@ from ._fields import collect_dataclass_fields, get_type_hints_infer_globalns
 from ._forward_ref import PydanticRecursiveRef
 from ._generics import get_standard_typevars_map, has_instance_in_type, recursively_defined_type_refs, replace_types
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
-from ._typing_extra import is_finalvar
+from ._typing_extra import is_finalvar, is_self_type
 from ._utils import lenient_issubclass
 
 if TYPE_CHECKING:
@@ -640,7 +640,7 @@ class GenerateSchema:
         decide whether to use a `__pydantic_core_schema__` attribute, or generate a fresh schema.
         """
         # avoid calling `__get_pydantic_core_schema__` if we've already visited this object
-        if obj is typing.Self:
+        if is_self_type(obj):
             obj = self.model_type_stack.get()
         with self.defs.get_schema_or_ref(obj) as (_, maybe_schema):
             if maybe_schema is not None:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -859,8 +859,6 @@ class GenerateSchema:
 
         if _typing_extra.is_dataclass(obj):
             return self._dataclass_schema(obj, None)
-        # if _typing_extra.is_self(obj):
-        #     pass
         res = self._get_prepare_pydantic_annotations_for_known_type(obj, ())
         if res is not None:
             source_type, annotations = res

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -467,3 +467,8 @@ else:
 
     def is_generic_alias(type_: type[Any]) -> bool:
         return isinstance(type_, typing._GenericAlias)  # type: ignore
+
+
+def is_self_type(tp: Any) -> bool:
+    """Check if a given class is a Self type (from `typing` or `typing_extensions`)"""
+    return isinstance(tp, typing_base) and tp._name == 'Self'

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -471,4 +471,4 @@ else:
 
 def is_self_type(tp: Any) -> bool:
     """Check if a given class is a Self type (from `typing` or `typing_extensions`)"""
-    return isinstance(tp, typing_base) and tp._name == 'Self'
+    return isinstance(tp, typing_base) and getattr(tp, '_name', None) == 'Self'

--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -2,15 +2,38 @@ import sys
 import typing
 from collections.abc import Callable
 from os import PathLike
-from typing import TYPE_CHECKING, AbstractSet, Any
-from typing import Callable as TypingCallable  # type: ignore
-from typing import (ClassVar, Dict, ForwardRef, Generator, Iterable, List,
-                    Mapping, NewType, Optional, Sequence, Set, Tuple, Type,
-                    TypeVar, Union, _eval_type, cast, get_type_hints)
+from typing import (  # type: ignore
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Callable as TypingCallable,
+    ClassVar,
+    Dict,
+    ForwardRef,
+    Generator,
+    Iterable,
+    List,
+    Mapping,
+    NewType,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    _eval_type,
+    cast,
+    get_type_hints,
+)
 
-from typing_extensions import Annotated, Final, Literal
-from typing_extensions import NotRequired as TypedDictNotRequired
-from typing_extensions import Required as TypedDictRequired
+from typing_extensions import (
+    Annotated,
+    Final,
+    Literal,
+    NotRequired as TypedDictNotRequired,
+    Required as TypedDictRequired,
+)
 
 try:
     from typing import _TypingBase as typing_base  # type: ignore
@@ -294,7 +317,6 @@ __all__ = (
     'is_union',
     'StrPath',
     'MappingIntStrAny',
-    'is_self_type'
 )
 
 

--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -2,38 +2,15 @@ import sys
 import typing
 from collections.abc import Callable
 from os import PathLike
-from typing import (  # type: ignore
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    Callable as TypingCallable,
-    ClassVar,
-    Dict,
-    ForwardRef,
-    Generator,
-    Iterable,
-    List,
-    Mapping,
-    NewType,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    _eval_type,
-    cast,
-    get_type_hints,
-)
+from typing import TYPE_CHECKING, AbstractSet, Any
+from typing import Callable as TypingCallable  # type: ignore
+from typing import (ClassVar, Dict, ForwardRef, Generator, Iterable, List,
+                    Mapping, NewType, Optional, Sequence, Set, Tuple, Type,
+                    TypeVar, Union, _eval_type, cast, get_type_hints)
 
-from typing_extensions import (
-    Annotated,
-    Final,
-    Literal,
-    NotRequired as TypedDictNotRequired,
-    Required as TypedDictRequired,
-)
+from typing_extensions import Annotated, Final, Literal
+from typing_extensions import NotRequired as TypedDictNotRequired
+from typing_extensions import Required as TypedDictRequired
 
 try:
     from typing import _TypingBase as typing_base  # type: ignore
@@ -317,6 +294,7 @@ __all__ = (
     'is_union',
     'StrPath',
     'MappingIntStrAny',
+    'is_self_type'
 )
 
 

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -1,0 +1,15 @@
+def test_recursive_model(create_module):
+    module = create_module(
+        # language=Python
+        """
+from __future__ import annotations
+from typing import Optional, Self
+from pydantic import BaseModel
+
+class SelfRef(BaseModel):
+    data: int
+    ref: Optional[Self] = None
+"""
+    )
+    self_ref = module.SelfRef(data=1, ref={'data': 2})
+    assert self_ref.model_dump() == {'data': 1, 'ref': {'data': 2, 'ref': None}}

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -1,5 +1,6 @@
 import dataclasses
 import typing
+from typing import List, Optional, Union
 
 import pytest
 import typing_extensions
@@ -89,7 +90,7 @@ def test_recursive_model_with_subclass_override(Self):
 
     class SubSelfRef(SelfRef):
         y: int
-        ref: SelfRef | Self | None = None
+        ref: Optional[Union[SelfRef, Self]] = None
 
     assert SubSelfRef(x=1, ref=SubSelfRef(x=3, y=4), y=2).model_dump() == {
         'x': 1,
@@ -114,7 +115,7 @@ def test_self_type_with_field(Self):
 def test_self_type_json_schema(Self):
     class SelfRef(BaseModel):
         x: int
-        refs: typing.List[Self] | None = []
+        refs: List[Self] | None = []
 
     assert SelfRef.model_json_schema() == {
         '$defs': {

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -1,15 +1,40 @@
-def test_recursive_model(create_module):
-    module = create_module(
-        # language=Python
-        """
-from __future__ import annotations
-from typing import Optional, Self
-from pydantic import BaseModel
+import typing
 
-class SelfRef(BaseModel):
-    data: int
-    ref: Optional[Self] = None
-"""
-    )
-    self_ref = module.SelfRef(data=1, ref={'data': 2})
-    assert self_ref.model_dump() == {'data': 1, 'ref': {'data': 2, 'ref': None}}
+import pytest
+import typing_extensions
+
+from pydantic import BaseModel, ValidationError
+
+
+@pytest.fixture(
+    name='Self',
+    params=[
+        pytest.param(typing, id='typing.Self'),
+        pytest.param(typing_extensions, id='t_e.Self'),
+    ],
+)
+def fixture_self_all(request):
+    try:
+        return request.param.Self
+    except AttributeError:
+        pytest.skip(f'Self is not available from {request.param}')
+
+
+def test_recursive_model(Self):
+    class SelfRef(BaseModel):
+        data: int
+        ref: typing.Optional[Self] = None
+
+    assert SelfRef(data=1, ref={'data': 2}).model_dump() == {'data': 1, 'ref': {'data': 2, 'ref': None}}
+
+
+def test_recursive_model_invalid(Self):
+    class SelfRef(BaseModel):
+        data: int
+        ref: typing.Optional[Self] = None
+
+    with pytest.raises(
+        ValidationError,
+        match=r'ref\.ref\s+Input should be a valid dictionary or instance of SelfRef \[type=model_type,',
+    ):
+        SelfRef(data=1, ref={'data': 2, 'ref': 3}).model_dump() == {'data': 1, 'ref': {'data': 2, 'ref': None}}

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -115,7 +115,7 @@ def test_self_type_with_field(Self):
 def test_self_type_json_schema(Self):
     class SelfRef(BaseModel):
         x: int
-        refs: List[Self] | None = []
+        refs: Optional[List[Self]] = []
 
     assert SelfRef.model_json_schema() == {
         '$defs': {


### PR DESCRIPTION
## Change Summary

add support for  `typing.Self` introduced in python3.11 as property annotation.

## Related issue number

fix #5992 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb