### PR TITLE
Fix `test_assert_raises_validation_error` with pytest-8 (#8995)

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1344,20 +1344,20 @@ def test_assert_raises_validation_error():
         @field_validator('a')
         @classmethod
         def check_a(cls, v: Any):
-            assert v == 'a', 'invalid a'
+            if v != 'a':
+                raise AssertionError('invalid a')
             return v
 
     Model(a='a')
 
     with pytest.raises(ValidationError) as exc_info:
         Model(a='snap')
-    injected_by_pytest = "assert 'snap' == 'a'\n  - a\n  + snap"
     assert exc_info.value.errors(include_url=False) == [
         {
-            'ctx': {'error': HasRepr(repr(AssertionError("invalid a\nassert 'snap' == 'a'\n  - a\n  + snap")))},
+            'ctx': {'error': HasRepr(repr(AssertionError('invalid a')))},
             'input': 'snap',
             'loc': ('a',),
-            'msg': f'Assertion failed, invalid a\n{injected_by_pytest}',
+            'msg': 'Assertion failed, invalid a',
             'type': 'assertion_error',
         }
     ]


### PR DESCRIPTION
## Change Summary

Support the different assertion output that is given by pytest >= 8. While at it, simplify the code a bit to reduce the duplicate assertion message.

## Related issue number

fix #8995

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @alexmojaki