### PR TITLE
Fix `PlainSerializer` usage with std type constructor

### DIFF
--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -277,10 +277,16 @@ def get_function_type_hints(
     """Like `typing.get_type_hints`, but doesn't convert `X` to `Optional[X]` if the default value is `None`, also
     copes with `partial`.
     """
-    if isinstance(function, partial):
-        annotations = function.func.__annotations__
-    else:
-        annotations = function.__annotations__
+    try:
+        if isinstance(function, partial):
+            annotations = function.func.__annotations__
+        else:
+            annotations = function.__annotations__
+    except AttributeError:
+        type_hints = get_type_hints(function)
+        if isinstance(function, type):
+            type_hints.setdefault('return', type)
+        return type_hints
 
     globalns = add_module_globals(function)
     type_hints = {}

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1174,7 +1174,7 @@ def test_subclass_support_unions_with_forward_ref() -> None:
 
 
 def test_plain_serializer_with_std_type() -> None:
-    """Ensure that a plain serializer can be used with a standard type constructor, rather than having to use lambda x: std_type(x)"""
+    """Ensure that a plain serializer can be used with a standard type constructor, rather than having to use lambda x: std_type(x)."""
 
     class MyModel(BaseModel):
         x: Annotated[int, PlainSerializer(float)]

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1171,3 +1171,14 @@ def test_subclass_support_unions_with_forward_ref() -> None:
 
     foo_recursive = Foo(items=[Foo(items=[Baz(bar_id=42, baz_id=99)])])
     assert foo_recursive.model_dump() == {'items': [{'items': [{'bar_id': 42}]}]}
+
+
+def test_plain_serializer_with_std_type() -> None:
+    """Ensure that a plain serializer can be used with a standard type constructor, rather than having to use lambda x: std_type(x)"""
+
+    class MyModel(BaseModel):
+        x: Annotated[int, PlainSerializer(float)]
+
+    m = MyModel(x=1)
+    assert m.model_dump() == {'x': 1.0}
+    assert m.model_dump_json() == '{"x":1.0}'


### PR DESCRIPTION
Ensure that you can use `str`, `float`, etc as the argument to `PlainSerializer` instead of the redundant `lambda x: str(x)`, etc. Thanks @dmontagu for the help with the suggested fix!

Fix https://github.com/pydantic/pydantic/issues/8967

Selected Reviewer: @dmontagu