### PR TITLE
[WIP] Fixes for pytest-8 failures related to warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def _create_module_file(code, tmp_path, name):
 def disable_error_urls():
     # Don't add URLs during docs tests when printing
     # Otherwise we'll get version numbers in the URLs that will update frequently
-    os.environ['PYDANTIC_ERRORS_OMIT_URL'] = 'true'
+    os.environ['PYDANTIC_ERRORS_INCLUDE_URL'] = 'false'
 
 
 @pytest.fixture

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -3,6 +3,7 @@ import math
 import re
 import sys
 import typing
+import warnings
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum, IntEnum
@@ -1382,8 +1383,12 @@ def test_callable_fallback_with_non_serializable_default(warning_match):
     class MyGenerator(GenerateJsonSchema):
         ignored_warning_kinds = ()
 
-    with pytest.warns(PydanticJsonSchemaWarning, match=warning_match):
-        model_schema = Model.model_json_schema(schema_generator=MyGenerator)
+    with warnings.catch_warnings():
+        # we need to explicitly ignore the other warning in pytest-8
+        # TODO: rewrite it to use two nested pytest.warns() when pytest-7 is no longer supported
+        warnings.simplefilter("ignore")
+        with pytest.warns(PydanticJsonSchemaWarning, match=warning_match):
+            model_schema = Model.model_json_schema(schema_generator=MyGenerator)
     assert model_schema == {
         'properties': {'callback': {'title': 'Callback', 'type': 'integer'}},
         'title': 'Model',

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2551,6 +2551,7 @@ def test_validator_allow_reuse_different_field_4():
     assert Model(x=1, y=2).model_dump() == {'x': 2, 'y': 3}
 
 
+@pytest.mark.filterwarnings('ignore:Pydantic V1 style `@root_validator` validators are deprecated.*:pydantic.warnings.PydanticDeprecatedSince20')
 def test_root_validator_allow_reuse_same_field():
     with pytest.warns(UserWarning, match='`root_val` overrides an existing Pydantic `@root_validator` decorator'):
 


### PR DESCRIPTION
## Change Summary

This is a work-in-progress of my attempts to fix pytest-8 test failures. I'm opening it early to facilitate discussion whether my approach is correct, particularly whether it's a good idea to ignore implementation-detail warnings from inside `parse_raw()` and `parse_file()`.

## Related issue number

fix #9025 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
