### PR TITLE
Add pydantic.v1 namespace to Pydantic v1

### DIFF
--- a/pydantic/v1.py
+++ b/pydantic/v1.py
@@ -1,0 +1,116 @@
+# NOTE This file aliases the pydantic namespace as pydantic.v1 for smoother v1 -> v2 transition
+# flake8: noqa
+from pydantic import *
+
+# WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
+# please use "from pydantic.errors import ..." instead
+__all__ = [
+    # annotated types utils
+    "create_model_from_namedtuple",
+    "create_model_from_typeddict",
+    # dataclasses
+    "dataclasses",
+    # class_validators
+    "root_validator",
+    "validator",
+    # config
+    "BaseConfig",
+    "ConfigDict",
+    "Extra",
+    # decorator
+    "validate_arguments",
+    # env_settings
+    "BaseSettings",
+    # error_wrappers
+    "ValidationError",
+    # fields
+    "Field",
+    "Required",
+    # main
+    "BaseModel",
+    "create_model",
+    "validate_model",
+    # network
+    "AnyUrl",
+    "AnyHttpUrl",
+    "FileUrl",
+    "HttpUrl",
+    "stricturl",
+    "EmailStr",
+    "NameEmail",
+    "IPvAnyAddress",
+    "IPvAnyInterface",
+    "IPvAnyNetwork",
+    "PostgresDsn",
+    "CockroachDsn",
+    "AmqpDsn",
+    "RedisDsn",
+    "MongoDsn",
+    "KafkaDsn",
+    "validate_email",
+    # parse
+    "Protocol",
+    # tools
+    "parse_file_as",
+    "parse_obj_as",
+    "parse_raw_as",
+    "schema_of",
+    "schema_json_of",
+    # types
+    "NoneStr",
+    "NoneBytes",
+    "StrBytes",
+    "NoneStrBytes",
+    "StrictStr",
+    "ConstrainedBytes",
+    "conbytes",
+    "ConstrainedList",
+    "conlist",
+    "ConstrainedSet",
+    "conset",
+    "ConstrainedFrozenSet",
+    "confrozenset",
+    "ConstrainedStr",
+    "constr",
+    "PyObject",
+    "ConstrainedInt",
+    "conint",
+    "PositiveInt",
+    "NegativeInt",
+    "NonNegativeInt",
+    "NonPositiveInt",
+    "ConstrainedFloat",
+    "confloat",
+    "PositiveFloat",
+    "NegativeFloat",
+    "NonNegativeFloat",
+    "NonPositiveFloat",
+    "FiniteFloat",
+    "ConstrainedDecimal",
+    "condecimal",
+    "ConstrainedDate",
+    "condate",
+    "UUID1",
+    "UUID3",
+    "UUID4",
+    "UUID5",
+    "FilePath",
+    "DirectoryPath",
+    "Json",
+    "JsonWrapper",
+    "SecretField",
+    "SecretStr",
+    "SecretBytes",
+    "StrictBool",
+    "StrictBytes",
+    "StrictInt",
+    "StrictFloat",
+    "PaymentCardNumber",
+    "PrivateAttr",
+    "ByteSize",
+    "PastDate",
+    "FutureDate",
+    # version
+    "compiled",
+    "VERSION",
+]

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -1,0 +1,2 @@
+def test_imports() -> None:
+    from pydantic.v1 import BaseModel, dataclasses

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -1,2 +1,2 @@
 def test_imports() -> None:
-    from pydantic.v1 import BaseModel, dataclasses  # type: ignore
+    from pydantic.v1 import BaseModel, dataclasses  # noqa: F401

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -1,2 +1,2 @@
 def test_imports() -> None:
-    from pydantic.v1 import BaseModel, dataclasses
+    from pydantic.v1 import BaseModel, dataclasses  # type: ignore


### PR DESCRIPTION
## Change Summary

Following jenshnielsen's brilliant idea in https://github.com/pydantic/pydantic/issues/6022, I added a `pydantic.v1` alias to the v1 version of Pydantic. This will enable cross-version Pydantic support and easier migration of expansive v1 codebases by switching all `pydantic` imports to `pydantic.v1` and removing the upper bound.

Fix https://github.com/pydantic/pydantic/issues/6022

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Selected Reviewer: @hramezani

skip change file check