### PR TITLE
Add support `re.Pattern[str]` to `pattern` field

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -64,7 +64,7 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
     strict: bool | None
     min_length: int | None
     max_length: int | None
-    pattern: str | None
+    pattern: str | typing.Pattern[str] | None
     allow_inf_nan: bool | None
     max_digits: int | None
     decimal_places: int | None
@@ -680,7 +680,7 @@ def Field(  # noqa: C901
     init: bool | None = _Unset,
     init_var: bool | None = _Unset,
     kw_only: bool | None = _Unset,
-    pattern: str | None = _Unset,
+    pattern: str | typing.Pattern[str] | None = _Unset,
     strict: bool | None = _Unset,
     gt: float | None = _Unset,
     ge: float | None = _Unset,
@@ -791,6 +791,9 @@ def Field(  # noqa: C901
     regex = extra.pop('regex', None)  # type: ignore
     if regex is not None:
         raise PydanticUserError('`regex` is removed. use `pattern` instead', code='removed-kwargs')
+
+    if isinstance(pattern, typing.Pattern):
+        pattern = pattern.pattern
 
     if extra:
         warn(

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -20,6 +20,7 @@ from typing import (
     Hashable,
     Iterator,
     List,
+    Pattern,
     Set,
     TypeVar,
     Union,
@@ -696,7 +697,7 @@ class StringConstraints(annotated_types.GroupedMetadata):
     strict: bool | None = None
     min_length: int | None = None
     max_length: int | None = None
-    pattern: str | None = None
+    pattern: str | Pattern[str] | None = None
 
     def __iter__(self) -> Iterator[BaseMetadata]:
         if self.min_length is not None:
@@ -715,7 +716,7 @@ class StringConstraints(annotated_types.GroupedMetadata):
                 strip_whitespace=self.strip_whitespace,
                 to_upper=self.to_upper,
                 to_lower=self.to_lower,
-                pattern=self.pattern,
+                pattern=self.pattern.pattern if isinstance(self.pattern, Pattern) else self.pattern,
             )
 
 
@@ -727,7 +728,7 @@ def constr(
     strict: bool | None = None,
     min_length: int | None = None,
     max_length: int | None = None,
-    pattern: str | None = None,
+    pattern: str | Pattern[str] | None = None,
 ) -> type[str]:
     """
     !!! warning "Discouraged"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3936,6 +3936,59 @@ def test_pattern(pattern_type, pattern_value, matching_value, non_matching_value
     }
 
 
+@pytest.mark.parametrize(
+    'use_field',
+    [pytest.param(True, id='Field'), pytest.param(False, id='constr')],
+)
+def test_compiled_pattern_in_field(use_field):
+    """
+    https://github.com/pydantic/pydantic/issues/9052
+    https://github.com/pydantic/pydantic/pull/9053
+    """
+    pattern_value = r'^whatev.r\d$'
+    field_pattern = re.compile(pattern_value)
+
+    if use_field:
+
+        class Foobar(BaseModel):
+            str_regex: str = Field(..., pattern=field_pattern)
+    else:
+
+        class Foobar(BaseModel):
+            str_regex: constr(pattern=field_pattern) = ...
+
+    field_general_metadata = Foobar.model_fields['str_regex'].metadata
+    assert len(field_general_metadata) == 1
+    field_metadata_pattern = field_general_metadata[0].pattern
+
+    if use_field:
+        # In Field re.Pattern is converted to str instantly
+        assert field_metadata_pattern == pattern_value
+        assert isinstance(field_metadata_pattern, str)
+
+    else:
+        # In constr re.Pattern is kept as is
+        assert field_metadata_pattern == field_pattern
+        assert isinstance(field_metadata_pattern, re.Pattern)
+
+    matching_value = 'whatever1'
+    f = Foobar(str_regex=matching_value)
+    assert f.str_regex == matching_value
+
+    with pytest.raises(
+        ValidationError,
+        match=re.escape("String should match pattern '" + pattern_value + "'"),
+    ):
+        Foobar(str_regex=' whatever1')
+
+    assert Foobar.model_json_schema() == {
+        'type': 'object',
+        'title': 'Foobar',
+        'properties': {'str_regex': {'pattern': pattern_value, 'title': 'Str Regex', 'type': 'string'}},
+        'required': ['str_regex'],
+    }
+
+
 def test_pattern_with_invalid_param():
     with pytest.raises(
         PydanticSchemaGenerationError,


### PR DESCRIPTION
## Change Summary

I think it just a simple idea about using already compiled regexp to set in `pattern` field.

Example:

```python diff
import re

from pydantic import BaseModel, Field

TOKEN_RE = re.compile(r"glpat-.{20}")


class ModelWithToken(BaseModel):
    """Token model with secret."""

    token: SecretStr = Field(pattern=TOKEN_RE)  # Instead of `pattern=TOKEN_RE.pattern`
```

## Related issue number

fix #9052

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist — I don't think we need tests for this
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable — I don't think we need docs for this
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt