### PR TITLE
Add a linting integrations section to docs

### DIFF
--- a/docs/integrations/datamodel_code_generator.md
+++ b/docs/integrations/datamodel_code_generator.md
@@ -4,7 +4,7 @@ The [datamodel-code-generator](https://github.com/koxudaxi/datamodel-code-genera
 
 * OpenAPI 3 (YAML/JSON)
 * JSON Schema
-* JSON/YAML/CSV Data (which will converted to JSON Schema)
+* JSON/YAML/CSV Data (which will be converted to JSON Schema)
 * Python dictionary (which will be converted to JSON Schema)
 * GraphQL schema
 

--- a/docs/integrations/linting.md
+++ b/docs/integrations/linting.md
@@ -1,0 +1,16 @@
+## Flake8 plugin
+
+If using Flake8 in your project, a [plugin](https://pypi.org/project/flake8-pydantic/) is available
+and can be installed using the following:
+
+```bash
+pip install flake8-pydantic
+```
+
+The lint errors provided by this plugin are namespaced under the `PYDXXX` code. To ignore some unwanted
+rules, the Flake8 configuration can be adapted:
+
+```ini
+[flake8]
+extend-ignore = PYD001,PYD002
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
   - datamodel-code-generator: integrations/datamodel_code_generator.md
   - devtools: integrations/devtools.md
   - Rich: integrations/rich.md
+  - Linting: integrations/linting.md
 - Blog: https://blog.pydantic.dev/
 - Pydantic People: pydantic_people.md
 
@@ -196,6 +197,7 @@ plugins:
       'usage/model_config.md': 'api/config.md'
       'usage/devtools.md': 'integrations/devtools.md'
       'usage/rich.md': 'integrations/rich.md'
+      'usage/linting.md': 'integrations/linting.md'
       'usage/types.md': 'concepts/types.md'
       'usage/types/secrets.md': 'examples/secrets.md'
       'usage/types/string_types.md': 'api/types.md#pydantic.types.StringConstraints'


### PR DESCRIPTION
Might help having the plugin get some visibility. In the future, I might implement these rules in Ruff itself, so it would also fit under the `Linting` section as well

Selected Reviewer: @adriangb