### PR TITLE
Fix extra fields check in Model.__getattr__()

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -764,7 +764,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 except AttributeError:
                     pydantic_extra = None
 
-                if pydantic_extra is not None:
+                if pydantic_extra:
                     try:
                         return pydantic_extra[item]
                     except KeyError as exc:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fix a check in `Model.__getattr__()` which tries to get an attribute from the `__pydantic_extra__` dict even though its empty.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Fix #9070 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu