### PR TITLE
Fix `ClassVar` forward ref inherited from parent class

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -188,7 +188,11 @@ class ModelMetaclass(ABCMeta):
                 obj.__set_name__(cls, name)
 
             if __pydantic_reset_parent_namespace__:
-                cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
+                parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None) or {}
+                cls.__pydantic_parent_namespace__ = {
+                    **parent_namespace,
+                    **(build_lenient_weakvaluedict(parent_frame_namespace()) or {}),
+                }
             parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None)
             if isinstance(parent_namespace, dict):
                 parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -188,11 +188,7 @@ class ModelMetaclass(ABCMeta):
                 obj.__set_name__(cls, name)
 
             if __pydantic_reset_parent_namespace__:
-                parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None) or {}
-                cls.__pydantic_parent_namespace__ = {
-                    **parent_namespace,
-                    **(build_lenient_weakvaluedict(parent_frame_namespace()) or {}),
-                }
+                cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
             parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None)
             if isinstance(parent_namespace, dict):
                 parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -2,6 +2,7 @@
 from __future__ import annotations as _annotations
 
 import dataclasses
+import re
 import sys
 import types
 import typing
@@ -146,7 +147,10 @@ def is_classvar(ann_type: type[Any]) -> bool:
 
     # this is an ugly workaround for class vars that contain forward references and are therefore themselves
     # forward references, see #3679
-    if ann_type.__class__ == typing.ForwardRef and ann_type.__forward_arg__.startswith('ClassVar['):  # type: ignore
+    if ann_type.__class__ == typing.ForwardRef and re.match(
+        r'(\w+\.)?ClassVar\[',
+        ann_type.__forward_arg__,  # type: ignore
+    ):
         return True
 
     return False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3165,7 +3165,7 @@ def test_eval_type_backport():
     ]
 
 
-def test_inherited_parent_namespace(create_module):
+def test_inherited_class_vars(create_module):
     @create_module
     def module():
         import typing
@@ -3173,9 +3173,11 @@ def test_inherited_parent_namespace(create_module):
         from pydantic import BaseModel
 
         class Base(BaseModel):
-            CONST: 'typing.ClassVar[str]' = 'a'
+            CONST1: 'typing.ClassVar[str]' = 'a'
+            CONST2: 'ClassVar[str]' = 'b'
 
     class Child(module.Base):
         pass
 
-    assert Child.CONST == 'a'
+    assert Child.CONST1 == 'a'
+    assert Child.CONST2 == 'b'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3163,3 +3163,19 @@ def test_eval_type_backport():
             'input': {'not a str or int'},
         },
     ]
+
+
+def test_inherited_parent_namespace(create_module):
+    @create_module
+    def module():
+        import typing
+
+        from pydantic import BaseModel
+
+        class Base(BaseModel):
+            CONST: 'typing.ClassVar[str]' = 'a'
+
+    class Child(module.Base):
+        pass
+
+    assert Child.CONST == 'a'

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -91,7 +91,11 @@ def test_is_literal_with_typing_literal():
     'ann_type,extepcted',
     (
         (None, False),
+        (ForwardRef('Other[int]'), False),
+        (ForwardRef('Other[ClassVar[int]]'), False),
         (ForwardRef('ClassVar[int]'), True),
+        (ForwardRef('t.ClassVar[int]'), True),
+        (ForwardRef('typing.ClassVar[int]'), True),
         (ClassVar[int], True),
     ),
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Make the hack in `is_classvar` work for strings like `'typing.ClassVar[...]'`, not just `'ClassVar[...]'`.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/9069

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
