### PR TITLE
Improve warning message when a field name shadows a field in a parent model

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -193,7 +193,8 @@ def collect_model_fields(  # noqa: C901
                     # on the class instance.
                     continue
                 warnings.warn(
-                    f'Field name "{ann_name}" shadows an attribute in parent "{base.__qualname__}"; ',
+                    f'Field name "{ann_name}" in {cls.__qualname__} shadows an attribute in parent '
+                    f'{base.__qualname__}',
                     UserWarning,
                 )
 

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -193,8 +193,8 @@ def collect_model_fields(  # noqa: C901
                     # on the class instance.
                     continue
                 warnings.warn(
-                    f'Field name "{ann_name}" in {cls.__qualname__} shadows an attribute in parent '
-                    f'{base.__qualname__}',
+                    f'Field name "{ann_name}" in "{cls.__qualname__}" shadows an attribute in parent '
+                    f'"{base.__qualname__}"',
                     UserWarning,
                 )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3131,12 +3131,12 @@ def test_shadow_attribute() -> None:
     class One(Model):
         foo: str = 'abc'
 
-    with pytest.warns(UserWarning, match=r'"foo" shadows an attribute in parent ".*One"'):
+    with pytest.warns(UserWarning, match=r'"foo" in ".*Two" shadows an attribute in parent ".*One"'):
 
         class Two(One):
             foo: str
 
-    with pytest.warns(UserWarning, match=r'"foo" shadows an attribute in parent ".*One"'):
+    with pytest.warns(UserWarning, match=r'"foo" in ".*Three" shadows an attribute in parent ".*One"'):
 
         class Three(One):
             foo: str = 'xyz'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Added in #7193, a helpful warning message is displayed when a subclass contains a field with the same name as the parent class.

If you have many models that inherit from a parent class, it would be helpful to be able to see in the warning message which child model contains the duplicate field name - not just the parent class.

So I've simply tweaked the warning message text to allow the user to easily see which model they should inspect.

Before:

```
UserWarning: Field name "foo" shadows an attribute in parent "ParentModel";
```

After:

```
UserWarning: Field name "foo" in "ChildModel" shadows an attribute in parent "ParentModel"
```

I think this is clearer for cases where you have tens or hundreds of ChildModels.

I also removed the semi-colon because I'm not sure why it's there, but happy to put that back, I may have missed a convention or other warning message or code style rule.

## Related issue number

None

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex