### PR TITLE
Do not warn about shadowed fields if they are not redefined in a child class

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -177,7 +177,7 @@ def collect_model_fields(  # noqa: C901
             )
 
         # when building a generic model with `MyModel[int]`, the generic_origin check makes sure we don't get
-        # "... shadows an attribute" errors
+        # "... shadows an attribute" warnings
         generic_origin = getattr(cls, '__pydantic_generic_metadata__', {}).get('origin')
         for base in bases:
             dataclass_fields = {
@@ -185,11 +185,11 @@ def collect_model_fields(  # noqa: C901
             }
             if hasattr(base, ann_name):
                 if base is generic_origin:
-                    # Don't error when "shadowing" of attributes in parametrized generics
+                    # Don't warn when "shadowing" of attributes in parametrized generics
                     continue
 
                 if ann_name in dataclass_fields:
-                    # Don't error when inheriting stdlib dataclasses whose fields are "shadowed" by defaults being set
+                    # Don't warn when inheriting stdlib dataclasses whose fields are "shadowed" by defaults being set
                     # on the class instance.
                     continue
 

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -192,6 +192,11 @@ def collect_model_fields(  # noqa: C901
                     # Don't error when inheriting stdlib dataclasses whose fields are "shadowed" by defaults being set
                     # on the class instance.
                     continue
+
+                if ann_name not in annotations:
+                    # Don't warn when a field exists in a parent class but has not been defined in the current class
+                    continue
+
                 warnings.warn(
                     f'Field name "{ann_name}" in "{cls.__qualname__}" shadows an attribute in parent '
                     f'"{base.__qualname__}"',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import json
 import platform
 import re
+import warnings
 from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
@@ -3149,6 +3150,33 @@ def test_shadow_attribute() -> None:
     assert getattr(One, 'foo', None) == ' edited!'
     assert getattr(Two, 'foo', None) == ' edited! edited!'
     assert getattr(Three, 'foo', None) == ' edited! edited!'
+
+
+def test_shadow_attribute_warn_for_redefined_fields() -> None:
+    """https://github.com/pydantic/pydantic/issues/9107"""
+
+    # A simple class which defines a field
+    class Parent:
+        foo: bool = False
+
+    # When inheriting from the parent class, as long as the field is not defined at all, there should be no warning
+    # about shadowed fields.
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+
+        class ChildWithoutRedefinedField(BaseModel, Parent):
+            pass
+
+    # But when inheriting from the parent class and a parent field is redefined, a warning should be raised about
+    # shadowed fields irrespective of whether it is defined with a type that is still compatible or narrower, or
+    # with a different default that is still compatible with the type definition.
+    with pytest.warns(
+        UserWarning,
+        match=r'"foo" in ".*ChildWithRedefinedField" shadows an attribute in parent ".*Parent"',
+    ):
+
+        class ChildWithRedefinedField(BaseModel, Parent):
+            foo: bool = True
 
 
 def test_eval_type_backport():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3161,11 +3161,15 @@ def test_shadow_attribute_warn_for_redefined_fields() -> None:
 
     # When inheriting from the parent class, as long as the field is not defined at all, there should be no warning
     # about shadowed fields.
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        # Start capturing all warnings
+        warnings.simplefilter('always')
 
         class ChildWithoutRedefinedField(BaseModel, Parent):
             pass
+
+        # Check that no warnings were captured
+        assert len(captured_warnings) == 0
 
     # But when inheriting from the parent class and a parent field is redefined, a warning should be raised about
     # shadowed fields irrespective of whether it is defined with a type that is still compatible or narrower, or


### PR DESCRIPTION
## Change Summary

Fix for issue #9107.

Adds another early exit condition when evaluating whether to log a warning message during detection for shadowed fields.

In the case where a field is defined in a parent class, but it has not been defined _at all_ in a child class, it is technically not a shadowed field, and so shouldn't be warned as such.

Note this is very different from the case where a child class does redefine a field but with a narrower type or even defined as the same type but with a different default. Conceptually this is probably ok, but checking for that is quite complex and this PR does not attempt to try. So this is about checking if a field is defined or not defined - if it is, regardless of type or default value, the warning message is still logged.

Example of a case where a warning is currently logged, but is now no longer logged:

```python
class MyMixin:
    my_field: bool = False

class MyModel(BaseModel, MyMixin):
    pass
``` 

Example of a case where a warning is still logged, and it is important to do so:


```python
class MyMixin:
    my_field: bool = False

class MyModel(BaseModel, MyMixin):
    my_field: bool = True
```

## Related issue number

fix #9107

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb