### PR TITLE
Remove `update_json_schema` (bad practice func)

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -33,7 +33,7 @@ from pydantic.fields import FieldInfo
 from pydantic.types import Strict
 
 from ..config import ConfigDict
-from ..json_schema import JsonSchemaValue, update_json_schema
+from ..json_schema import JsonSchemaValue
 from . import _known_annotated_metadata, _typing_extra, _validators
 from ._core_utils import get_type_ref
 from ._internal_dataclass import slots_true
@@ -87,7 +87,7 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
         def get_json_schema(schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
             json_schema = handler(schema)
             original_schema = handler.resolve_ref_schema(json_schema)
-            update_json_schema(original_schema, js_updates)
+            original_schema.update(js_updates)
             return json_schema
 
         # we don't want to add the missing to the schema if it's the default one
@@ -113,7 +113,7 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
         def get_json_schema_no_cases(_, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
             json_schema = handler(core_schema.enum_schema(enum_type, cases, sub_type=sub_type, ref=enum_ref))
             original_schema = handler.resolve_ref_schema(json_schema)
-            update_json_schema(original_schema, js_updates)
+            original_schema.update(js_updates)
             return json_schema
 
         # Use an isinstance check for enums with no cases.

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -95,10 +95,13 @@ _MODE_TITLE_MAPPING: dict[JsonSchemaMode, str] = {'validation': 'Input', 'serial
 )
 def update_json_schema(schema: JsonSchemaValue, updates: dict[str, Any]) -> JsonSchemaValue:
     """Update a JSON schema in-place by providing a dictionary of updates.
+
     This function sets the provided key-value pairs in the schema and returns the updated schema.
+
     Args:
         schema: The JSON schema to update.
         updates: A dictionary of key-value pairs to set in the schema.
+
     Returns:
         The updated JSON schema.
     """

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -89,6 +89,23 @@ for validation inputs, or that will be matched by serialization outputs.
 _MODE_TITLE_MAPPING: dict[JsonSchemaMode, str] = {'validation': 'Input', 'serialization': 'Output'}
 
 
+@deprecated(
+    '`update_json_schema` is deprecated, use a simple `my_dict.update(update_dict)` call instead.',
+    category=None,
+)
+def update_json_schema(schema: JsonSchemaValue, updates: dict[str, Any]) -> JsonSchemaValue:
+    """Update a JSON schema in-place by providing a dictionary of updates.
+    This function sets the provided key-value pairs in the schema and returns the updated schema.
+    Args:
+        schema: The JSON schema to update.
+        updates: A dictionary of key-value pairs to set in the schema.
+    Returns:
+        The updated JSON schema.
+    """
+    schema.update(updates)
+    return schema
+
+
 JsonSchemaWarningKind = Literal['skipped-choice', 'non-serializable-default']
 """
 A type alias representing the kinds of warnings that can be emitted during JSON schema generation.

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -89,22 +89,6 @@ for validation inputs, or that will be matched by serialization outputs.
 _MODE_TITLE_MAPPING: dict[JsonSchemaMode, str] = {'validation': 'Input', 'serialization': 'Output'}
 
 
-def update_json_schema(schema: JsonSchemaValue, updates: dict[str, Any]) -> JsonSchemaValue:
-    """Update a JSON schema in-place by providing a dictionary of updates.
-
-    This function sets the provided key-value pairs in the schema and returns the updated schema.
-
-    Args:
-        schema: The JSON schema to update.
-        updates: A dictionary of key-value pairs to set in the schema.
-
-    Returns:
-        The updated JSON schema.
-    """
-    schema.update(updates)
-    return schema
-
-
 JsonSchemaWarningKind = Literal['skipped-choice', 'non-serializable-default']
 """
 A type alias representing the kinds of warnings that can be emitted during JSON schema generation.


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/8381

Removing a function that was minimally used, and was following bad practice. This function was problematic in that it both:

1. Modified an argument in place
2. Returned said modified argument

This is technically a change (bc the `update_json_schema` func was public), but I'm not too concerned about this - it was a think wrapper around the `some_dict.update` function, so it can easily be replaced. I've marked this as `relnotes-change` accordingly, and will draw attention to this in the release notes.

Selected Reviewer: @alexmojaki