### PR TITLE
Ensure json schema generator handles Literal null types

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -751,6 +751,8 @@ class GenerateJsonSchema:
             result['type'] = 'boolean'
         elif types == {list}:
             result['type'] = 'array'
+        elif types == {type(None)}:
+            result['type'] = 'null'
         return result
 
     def enum_schema(self, schema: core_schema.EnumSchema) -> JsonSchemaValue:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR aims to complete #8944 and #8905 by also handling null types when generating a json-schema from a pydantic model.

## Related issue number

fix #8905
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
