### PR TITLE
Import modules/objects directly from v1 namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         exclude:
           # Python 3.7, 3.8, and 3.9 are not available on macOS 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,10 +194,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-latest, macos-13, macos-latest, windows]
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        include:
-        - os: ubuntu
+        exclude:
+          # Python 3.7, 3.8, and 3.9 are not available on macOS 14
+          - os: macos-13
+            python-version: '3.10'
+          - os: macos-latest
+            python-version: '3.7'
+          - os: macos-latest
+            python-version: '3.8'
+          - os: macos-latest
+            python-version: '3.9'
+
+    runs-on: ${{ matrix.os }}
 
     env:
       PYTHON: ${{ matrix.python-version }}
@@ -205,7 +215,6 @@ jobs:
       COMPILED: no
       DEPS: yes
 
-    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
         python-version: '3.8'
 
     - name: install
-      run: pip install -U twine setuptools wheel cibuildwheel
+      run: pip install -U twine setuptools wheel cibuildwheel==2.17.0
 
     - name: build sdist
       if: matrix.os == 'ubuntu' && matrix.python-version == '9'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,10 +194,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        include:
-        - os: ubuntu
+        exclude:
+          # Python 3.7, 3.8, and 3.9 are not available on macOS 14
+          - os: macos-13
+            python-version: '3.10'
+          - os: macos-latest
+            python-version: '3.7'
+          - os: macos-latest
+            python-version: '3.8'
+          - os: macos-latest
+            python-version: '3.9'
+
+    runs-on: ${{ matrix.os }}
 
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,20 +194,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows]
+        os: [ubuntu, macos, windows]
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        exclude:
-          # Python 3.7, 3.8, and 3.9 are not available on macOS 14
-          - os: macos-13
-            python-version: '3.10'
-          - os: macos-latest
-            python-version: '3.7'
-          - os: macos-latest
-            python-version: '3.8'
-          - os: macos-latest
-            python-version: '3.9'
-
-    runs-on: ${{ matrix.os }}
+        include:
+        - os: ubuntu
 
     env:
       PYTHON: ${{ matrix.python-version }}
@@ -215,6 +205,7 @@ jobs:
       COMPILED: no
       DEPS: yes
 
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,6 @@ jobs:
       COMPILED: no
       DEPS: yes
 
-    runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
         exclude:
           # Python 3.7, 3.8, and 3.9 are not available on macOS 14

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,23 +1,23 @@
 # flake8: noqa
-from . import dataclasses
-from .annotated_types import create_model_from_namedtuple, create_model_from_typeddict
-from .class_validators import root_validator, validator
-from .config import BaseConfig, ConfigDict, Extra
-from .decorator import validate_arguments
-from .env_settings import BaseSettings
-from .error_wrappers import ValidationError
-from .errors import *
-from .fields import Field, PrivateAttr, Required
-from .main import *
-from .networks import *
-from .parse import Protocol
-from .tools import *
-from .types import *
-from .version import VERSION, compiled
+from pydantic import dataclasses
+from pydantic.annotated_types import create_model_from_namedtuple, create_model_from_typeddict
+from pydantic.class_validators import root_validator, validator
+from pydantic.config import BaseConfig, ConfigDict, Extra
+from pydantic.decorator import validate_arguments
+from pydantic.env_settings import BaseSettings
+from pydantic.error_wrappers import ValidationError
+from pydantic.errors import *
+from pydantic.fields import Field, PrivateAttr, Required
+from pydantic.main import *
+from pydantic.networks import *
+from pydantic.parse import Protocol
+from pydantic.tools import *
+from pydantic.types import *
+from pydantic.version import VERSION, compiled
 
 __version__ = VERSION
 
-# WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
+# WARNING __all__ from pydantic.errors is not included here, it will be removed as an export here in v2
 # please use "from pydantic.errors import ..." instead
 __all__ = [
     # annotated types utils

--- a/pydantic/annotated_types.py
+++ b/pydantic/annotated_types.py
@@ -1,9 +1,9 @@
 import sys
 from typing import TYPE_CHECKING, Any, Dict, FrozenSet, NamedTuple, Type
 
-from .fields import Required
-from .main import BaseModel, create_model
-from .typing import is_typeddict, is_typeddict_special
+from pydantic.fields import Required
+from pydantic.main import BaseModel, create_model
+from pydantic.typing import is_typeddict, is_typeddict_special
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict

--- a/pydantic/class_validators.py
+++ b/pydantic/class_validators.py
@@ -5,12 +5,12 @@ from itertools import chain
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union, overload
 
-from .errors import ConfigError
-from .typing import AnyCallable
-from .utils import ROOT_KEY, in_ipython
+from pydantic.errors import ConfigError
+from pydantic.typing import AnyCallable
+from pydantic.utils import ROOT_KEY, in_ipython
 
 if TYPE_CHECKING:
-    from .typing import AnyClassMethod
+    from pydantic.typing import AnyClassMethod
 
 
 class Validator:
@@ -36,9 +36,9 @@ class Validator:
 if TYPE_CHECKING:
     from inspect import Signature
 
-    from .config import BaseConfig
-    from .fields import ModelField
-    from .types import ModelOrDc
+    from pydantic.config import BaseConfig
+    from pydantic.fields import ModelField
+    from pydantic.types import ModelOrDc
 
     ValidatorCallable = Callable[[Optional[ModelOrDc], Any, Dict[str, Any], ModelField, Type[BaseConfig]], Any]
     ValidatorsList = List[ValidatorCallable]

--- a/pydantic/color.py
+++ b/pydantic/color.py
@@ -12,11 +12,11 @@ import re
 from colorsys import hls_to_rgb, rgb_to_hls
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast
 
-from .errors import ColorError
-from .utils import Representation, almost_equal_floats
+from pydantic.errors import ColorError
+from pydantic.utils import Representation, almost_equal_floats
 
 if TYPE_CHECKING:
-    from .typing import CallableGenerator, ReprArgs
+    from pydantic.typing import CallableGenerator, ReprArgs
 
 ColorTuple = Union[Tuple[int, int, int], Tuple[int, int, int, float]]
 ColorType = Union[ColorTuple, str]

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -4,15 +4,15 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, ForwardRef, Optional, Tup
 
 from typing_extensions import Literal, Protocol
 
-from .typing import AnyArgTCallable, AnyCallable
-from .utils import GetterDict
-from .version import compiled
+from pydantic.typing import AnyArgTCallable, AnyCallable
+from pydantic.utils import GetterDict
+from pydantic.version import compiled
 
 if TYPE_CHECKING:
     from typing import overload
 
-    from .fields import ModelField
-    from .main import BaseModel
+    from pydantic.fields import ModelField
+    from pydantic.main import BaseModel
 
     ConfigType = Type['BaseConfig']
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -47,17 +47,17 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator, Opti
 
 from typing_extensions import dataclass_transform
 
-from .class_validators import gather_all_validators
-from .config import BaseConfig, ConfigDict, Extra, get_config
-from .error_wrappers import ValidationError
-from .errors import DataclassTypeError
-from .fields import Field, FieldInfo, Required, Undefined
-from .main import create_model, validate_model
-from .utils import ClassAttribute
+from pydantic.class_validators import gather_all_validators
+from pydantic.config import BaseConfig, ConfigDict, Extra, get_config
+from pydantic.error_wrappers import ValidationError
+from pydantic.errors import DataclassTypeError
+from pydantic.fields import Field, FieldInfo, Required, Undefined
+from pydantic.main import create_model, validate_model
+from pydantic.utils import ClassAttribute
 
 if TYPE_CHECKING:
-    from .main import BaseModel
-    from .typing import CallableGenerator, NoArgAnyCallable
+    from pydantic.main import BaseModel
+    from pydantic.typing import CallableGenerator, NoArgAnyCallable
 
     DataclassT = TypeVar('DataclassT', bound='Dataclass')
 

--- a/pydantic/datetime_parse.py
+++ b/pydantic/datetime_parse.py
@@ -18,7 +18,7 @@ import re
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Dict, Optional, Type, Union
 
-from . import errors
+from pydantic import errors
 
 date_expr = r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})'
 time_expr = (

--- a/pydantic/decorator.py
+++ b/pydantic/decorator.py
@@ -1,17 +1,17 @@
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, overload
 
-from . import validator
-from .config import Extra
-from .errors import ConfigError
-from .main import BaseModel, create_model
-from .typing import get_all_type_hints
-from .utils import to_camel
+from pydantic import validator
+from pydantic.config import Extra
+from pydantic.errors import ConfigError
+from pydantic.main import BaseModel, create_model
+from pydantic.typing import get_all_type_hints
+from pydantic.utils import to_camel
 
 __all__ = ('validate_arguments',)
 
 if TYPE_CHECKING:
-    from .typing import AnyCallable
+    from pydantic.typing import AnyCallable
 
     AnyCallableT = TypeVar('AnyCallableT', bound=AnyCallable)
     ConfigType = Union[None, Type[Any], Dict[str, Any]]

--- a/pydantic/env_settings.py
+++ b/pydantic/env_settings.py
@@ -3,12 +3,12 @@ import warnings
 from pathlib import Path
 from typing import AbstractSet, Any, Callable, ClassVar, Dict, List, Mapping, Optional, Tuple, Type, Union
 
-from .config import BaseConfig, Extra
-from .fields import ModelField
-from .main import BaseModel
-from .types import JsonWrapper
-from .typing import StrPath, display_as_type, get_origin, is_union
-from .utils import deep_update, lenient_issubclass, path_type, sequence_like
+from pydantic.config import BaseConfig, Extra
+from pydantic.fields import ModelField
+from pydantic.main import BaseModel
+from pydantic.types import JsonWrapper
+from pydantic.typing import StrPath, display_as_type, get_origin, is_union
+from pydantic.utils import deep_update, lenient_issubclass, path_type, sequence_like
 
 env_file_sentinel = str(object())
 

--- a/pydantic/error_wrappers.py
+++ b/pydantic/error_wrappers.py
@@ -1,15 +1,15 @@
 import json
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Sequence, Tuple, Type, Union
 
-from .json import pydantic_encoder
-from .utils import Representation
+from pydantic.json import pydantic_encoder
+from pydantic.utils import Representation
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from .config import BaseConfig
-    from .types import ModelOrDc
-    from .typing import ReprArgs
+    from pydantic.config import BaseConfig
+    from pydantic.types import ModelOrDc
+    from pydantic.typing import ReprArgs
 
     Loc = Tuple[Union[int, str], ...]
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -2,12 +2,12 @@ from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Sequence, Set, Tuple, Type, Union
 
-from .typing import display_as_type
+from pydantic.typing import display_as_type
 
 if TYPE_CHECKING:
-    from .typing import DictStrAny
+    from pydantic.typing import DictStrAny
 
-# explicitly state exports to avoid "from .errors import *" also importing Decimal, Path etc.
+# explicitly state exports to avoid "from pydantic.errors import *" also importing Decimal, Path etc.
 __all__ = (
     'PydanticTypeError',
     'PydanticValueError',

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -28,12 +28,12 @@ from typing import (
 
 from typing_extensions import Annotated, Final
 
-from . import errors as errors_
-from .class_validators import Validator, make_generic_validator, prep_validators
-from .error_wrappers import ErrorWrapper
-from .errors import ConfigError, InvalidDiscriminator, MissingDiscriminator, NoneIsNotAllowedError
-from .types import Json, JsonWrapper
-from .typing import (
+from pydantic import errors as errors_
+from pydantic.class_validators import Validator, make_generic_validator, prep_validators
+from pydantic.error_wrappers import ErrorWrapper
+from pydantic.errors import ConfigError, InvalidDiscriminator, MissingDiscriminator, NoneIsNotAllowedError
+from pydantic.types import Json, JsonWrapper
+from pydantic.typing import (
     NoArgAnyCallable,
     convert_generics,
     display_as_type,
@@ -48,7 +48,7 @@ from .typing import (
     is_union,
     new_type_supertype,
 )
-from .utils import (
+from pydantic.utils import (
     PyObjectStr,
     Representation,
     ValueItems,
@@ -59,7 +59,7 @@ from .utils import (
     sequence_like,
     smart_deepcopy,
 )
-from .validators import constant_validator, dict_validator, find_validators, validate_json
+from pydantic.validators import constant_validator, dict_validator, find_validators, validate_json
 
 Required: Any = Ellipsis
 
@@ -83,11 +83,11 @@ class UndefinedType:
 Undefined = UndefinedType()
 
 if TYPE_CHECKING:
-    from .class_validators import ValidatorsList
-    from .config import BaseConfig
-    from .error_wrappers import ErrorList
-    from .types import ModelOrDc
-    from .typing import AbstractSetIntStr, MappingIntStrAny, ReprArgs
+    from pydantic.class_validators import ValidatorsList
+    from pydantic.config import BaseConfig
+    from pydantic.error_wrappers import ErrorList
+    from pydantic.types import ModelOrDc
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny, ReprArgs
 
     ValidateReturn = Tuple[Optional[Any], Optional[ErrorList]]
     LocStr = Union[Tuple[Union[int, str], ...], str]
@@ -490,7 +490,7 @@ class ModelField(Representation):
         class_validators: Optional[Dict[str, Validator]],
         config: Type['BaseConfig'],
     ) -> 'ModelField':
-        from .schema import get_annotation_from_field_info
+        from pydantic.schema import get_annotation_from_field_info
 
         field_info, value = cls._get_field_info(name, annotation, value, config)
         required: 'BoolUndefined' = Undefined
@@ -1160,7 +1160,7 @@ class ModelField(Representation):
         """
         Whether the field is "complex" eg. env variables should be parsed as JSON.
         """
-        from .main import BaseModel
+        from pydantic.main import BaseModel
 
         return (
             self.shape != SHAPE_SINGLETON

--- a/pydantic/generics.py
+++ b/pydantic/generics.py
@@ -22,12 +22,12 @@ from weakref import WeakKeyDictionary, WeakValueDictionary
 
 from typing_extensions import Annotated, Literal as ExtLiteral
 
-from .class_validators import gather_all_validators
-from .fields import DeferredType
-from .main import BaseModel, create_model
-from .types import JsonWrapper
-from .typing import display_as_type, get_all_type_hints, get_args, get_origin, typing_base
-from .utils import all_identical, lenient_issubclass
+from pydantic.class_validators import gather_all_validators
+from pydantic.fields import DeferredType
+from pydantic.main import BaseModel, create_model
+from pydantic.types import JsonWrapper
+from pydantic.typing import display_as_type, get_all_type_hints, get_args, get_origin, typing_base
+from pydantic.utils import all_identical, lenient_issubclass
 
 if sys.version_info >= (3, 10):
     from typing import _UnionGenericAlias

--- a/pydantic/json.py
+++ b/pydantic/json.py
@@ -9,9 +9,9 @@ from types import GeneratorType
 from typing import Any, Callable, Dict, Type, Union
 from uuid import UUID
 
-from .color import Color
-from .networks import NameEmail
-from .types import SecretBytes, SecretStr
+from pydantic.color import Color
+from pydantic.networks import NameEmail
+from pydantic.types import SecretBytes, SecretStr
 
 __all__ = 'pydantic_encoder', 'custom_pydantic_encoder', 'timedelta_isoformat'
 
@@ -72,7 +72,7 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
 def pydantic_encoder(obj: Any) -> Any:
     from dataclasses import asdict, is_dataclass
 
-    from .main import BaseModel
+    from pydantic.main import BaseModel
 
     if isinstance(obj, BaseModel):
         return obj.dict()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -26,11 +26,11 @@ from typing import (
 
 from typing_extensions import dataclass_transform
 
-from .class_validators import ValidatorGroup, extract_root_validators, extract_validators, inherit_validators
-from .config import BaseConfig, Extra, inherit_config, prepare_config
-from .error_wrappers import ErrorWrapper, ValidationError
-from .errors import ConfigError, DictError, ExtraError, MissingError
-from .fields import (
+from pydantic.class_validators import ValidatorGroup, extract_root_validators, extract_validators, inherit_validators
+from pydantic.config import BaseConfig, Extra, inherit_config, prepare_config
+from pydantic.error_wrappers import ErrorWrapper, ValidationError
+from pydantic.errors import ConfigError, DictError, ExtraError, MissingError
+from pydantic.fields import (
     MAPPING_LIKE_SHAPES,
     Field,
     ModelField,
@@ -39,11 +39,11 @@ from .fields import (
     Undefined,
     is_finalvar_with_default_val,
 )
-from .json import custom_pydantic_encoder, pydantic_encoder
-from .parse import Protocol, load_file, load_str_bytes
-from .schema import default_ref_template, model_schema
-from .types import PyObject, StrBytes
-from .typing import (
+from pydantic.json import custom_pydantic_encoder, pydantic_encoder
+from pydantic.parse import Protocol, load_file, load_str_bytes
+from pydantic.schema import default_ref_template, model_schema
+from pydantic.types import PyObject, StrBytes
+from pydantic.typing import (
     AnyCallable,
     get_args,
     get_origin,
@@ -53,7 +53,7 @@ from .typing import (
     resolve_annotations,
     update_model_forward_refs,
 )
-from .utils import (
+from pydantic.utils import (
     DUNDER_ATTRIBUTES,
     ROOT_KEY,
     ClassAttribute,
@@ -73,9 +73,9 @@ from .utils import (
 if TYPE_CHECKING:
     from inspect import Signature
 
-    from .class_validators import ValidatorListDict
-    from .types import ModelOrDc
-    from .typing import (
+    from pydantic.class_validators import ValidatorListDict
+    from pydantic.types import ModelOrDc
+    from pydantic.typing import (
         AbstractSetIntStr,
         AnyClassMethod,
         CallableGenerator,
@@ -669,7 +669,7 @@ class BaseModel(Representation, metaclass=ModelMetaclass):
     def schema_json(
         cls, *, by_alias: bool = True, ref_template: str = default_ref_template, **dumps_kwargs: Any
     ) -> str:
-        from .json import pydantic_encoder
+        from pydantic.json import pydantic_encoder
 
         return cls.__config__.json_dumps(
             cls.schema(by_alias=by_alias, ref_template=ref_template), default=pydantic_encoder, **dumps_kwargs

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -65,7 +65,7 @@ from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 from mypy.version import __version__ as mypy_version
 
-from .utils import is_valid_field
+from pydantic.utils import is_valid_field
 
 try:
     from mypy.types import TypeVarDef  # type: ignore[attr-defined]

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -27,17 +27,17 @@ from typing import (
     no_type_check,
 )
 
-from . import errors
-from .utils import Representation, update_not_none
-from .validators import constr_length_validator, str_validator
+from pydantic import errors
+from pydantic.utils import Representation, update_not_none
+from pydantic.validators import constr_length_validator, str_validator
 
 if TYPE_CHECKING:
     import email_validator
     from typing_extensions import TypedDict
 
-    from .config import BaseConfig
-    from .fields import ModelField
-    from .typing import AnyCallable
+    from pydantic.config import BaseConfig
+    from pydantic.fields import ModelField
+    from pydantic.typing import AnyCallable
 
     CallableGenerator = Generator[AnyCallable, None, None]
 

--- a/pydantic/parse.py
+++ b/pydantic/parse.py
@@ -4,7 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Union
 
-from .types import StrBytes
+from pydantic.types import StrBytes
 
 
 class Protocol(str, Enum):

--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -31,7 +31,7 @@ from uuid import UUID
 
 from typing_extensions import Annotated, Literal
 
-from .fields import (
+from pydantic.fields import (
     MAPPING_LIKE_SHAPES,
     SHAPE_DEQUE,
     SHAPE_FROZENSET,
@@ -46,9 +46,9 @@ from .fields import (
     FieldInfo,
     ModelField,
 )
-from .json import pydantic_encoder
-from .networks import AnyUrl, EmailStr
-from .types import (
+from pydantic.json import pydantic_encoder
+from pydantic.networks import AnyUrl, EmailStr
+from pydantic.types import (
     ConstrainedDecimal,
     ConstrainedFloat,
     ConstrainedFrozenSet,
@@ -69,7 +69,7 @@ from .types import (
     conset,
     constr,
 )
-from .typing import (
+from pydantic.typing import (
     all_literal_values,
     get_args,
     get_origin,
@@ -80,11 +80,11 @@ from .typing import (
     is_none_type,
     is_union,
 )
-from .utils import ROOT_KEY, get_model, lenient_issubclass
+from pydantic.utils import ROOT_KEY, get_model, lenient_issubclass
 
 if TYPE_CHECKING:
-    from .dataclasses import Dataclass
-    from .main import BaseModel
+    from pydantic.dataclasses import Dataclass
+    from pydantic.main import BaseModel
 
 default_prefix = '#/definitions/'
 default_ref_template = '#/definitions/{model}'
@@ -378,7 +378,7 @@ def get_flat_models_from_field(field: ModelField, known_models: TypeModelSet) ->
     :param known_models: used to solve circular references
     :return: a set with the model used in the declaration for this field, if any, and all its sub-models
     """
-    from .main import BaseModel
+    from pydantic.main import BaseModel
 
     flat_models: TypeModelSet = set()
 
@@ -445,7 +445,7 @@ def field_type_schema(
     Take a single ``field`` and generate the schema for its type only, not including additional
     information as title, etc. Also return additional schema definitions, from sub-models.
     """
-    from .main import BaseModel  # noqa: F811
+    from pydantic.main import BaseModel  # noqa: F811
 
     definitions = {}
     nested_models: Set[str] = set()
@@ -838,7 +838,7 @@ def field_singleton_schema(  # noqa: C901 (ignore complexity)
 
     Take a single Pydantic ``ModelField``, and return its schema and any additional definitions from sub-models.
     """
-    from .main import BaseModel
+    from pydantic.main import BaseModel
 
     definitions: Dict[str, Any] = {}
     nested_models: Set[str] = set()
@@ -974,7 +974,7 @@ def multitypes_literal_field_for_schema(values: Tuple[Any, ...], field: ModelFie
 
 
 def encode_default(dft: Any) -> Any:
-    from .main import BaseModel
+    from pydantic.main import BaseModel
 
     if isinstance(dft, BaseModel) or is_dataclass(dft):
         dft = cast('dict[str, Any]', pydantic_encoder(dft))

--- a/pydantic/tools.py
+++ b/pydantic/tools.py
@@ -3,16 +3,16 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, Union
 
-from .parse import Protocol, load_file, load_str_bytes
-from .types import StrBytes
-from .typing import display_as_type
+from pydantic.parse import Protocol, load_file, load_str_bytes
+from pydantic.types import StrBytes
+from pydantic.typing import display_as_type
 
 __all__ = ('parse_file_as', 'parse_obj_as', 'parse_raw_as', 'schema_of', 'schema_json_of')
 
 NameFactory = Union[str, Callable[[Type[Any]], str]]
 
 if TYPE_CHECKING:
-    from .typing import DictStrAny
+    from pydantic.typing import DictStrAny
 
 
 def _generate_parsing_type_name(type_: Any) -> str:
@@ -21,7 +21,7 @@ def _generate_parsing_type_name(type_: Any) -> str:
 
 @lru_cache(maxsize=2048)
 def _get_parsing_type(type_: Any, *, type_name: Optional[NameFactory] = None) -> Any:
-    from .main import create_model
+    from pydantic.main import create_model
 
     if type_name is None:
         type_name = _generate_parsing_type_name

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -28,10 +28,10 @@ from typing import (
 from uuid import UUID
 from weakref import WeakSet
 
-from . import errors
-from .datetime_parse import parse_date
-from .utils import import_string, update_not_none
-from .validators import (
+from pydantic import errors
+from pydantic.datetime_parse import parse_date
+from pydantic.utils import import_string, update_not_none
+from pydantic.validators import (
     bytes_validator,
     constr_length_validator,
     constr_lower,
@@ -123,9 +123,9 @@ StrIntFloat = Union[str, int, float]
 if TYPE_CHECKING:
     from typing_extensions import Annotated
 
-    from .dataclasses import Dataclass
-    from .main import BaseModel
-    from .typing import CallableGenerator
+    from pydantic.dataclasses import Dataclass
+    from pydantic.main import BaseModel
+    from pydantic.typing import CallableGenerator
 
     ModelOrDc = Type[Union[BaseModel, Dataclass]]
 

--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -256,7 +256,7 @@ StrPath = Union[str, PathLike]
 
 
 if TYPE_CHECKING:
-    from .fields import ModelField
+    from pydantic.fields import ModelField
 
     TupleGenerator = Generator[Tuple[str, Any], None, None]
     DictStrAny = Dict[str, Any]
@@ -435,7 +435,7 @@ def is_namedtuple(type_: Type[Any]) -> bool:
     Check if a given class is a named tuple.
     It can be either a `typing.NamedTuple` or `collections.namedtuple`
     """
-    from .utils import lenient_issubclass
+    from pydantic.utils import lenient_issubclass
 
     return lenient_issubclass(type_, tuple) and hasattr(type_, '_fields')
 
@@ -445,7 +445,7 @@ def is_typeddict(type_: Type[Any]) -> bool:
     Check if a given class is a typed dict (from `typing` or `typing_extensions`)
     In 3.10, there will be a public method (https://docs.python.org/3.10/library/typing.html#typing.is_typeddict)
     """
-    from .utils import lenient_issubclass
+    from pydantic.utils import lenient_issubclass
 
     return lenient_issubclass(type_, dict) and hasattr(type_, '__total__')
 

--- a/pydantic/utils.py
+++ b/pydantic/utils.py
@@ -28,8 +28,8 @@ from typing import (
 
 from typing_extensions import Annotated
 
-from .errors import ConfigError
-from .typing import (
+from pydantic.errors import ConfigError
+from pydantic.typing import (
     NoneType,
     WithArgsTypes,
     all_literal_values,
@@ -39,17 +39,17 @@ from .typing import (
     is_literal_type,
     is_union,
 )
-from .version import version_info
+from pydantic.version import version_info
 
 if TYPE_CHECKING:
     from inspect import Signature
     from pathlib import Path
 
-    from .config import BaseConfig
-    from .dataclasses import Dataclass
-    from .fields import ModelField
-    from .main import BaseModel
-    from .typing import AbstractSetIntStr, DictIntStrAny, IntStr, MappingIntStrAny, ReprArgs
+    from pydantic.config import BaseConfig
+    from pydantic.dataclasses import Dataclass
+    from pydantic.fields import ModelField
+    from pydantic.main import BaseModel
+    from pydantic.typing import AbstractSetIntStr, DictIntStrAny, IntStr, MappingIntStrAny, ReprArgs
 
     RichReprResult = Iterable[Union[Any, Tuple[Any], Tuple[str, Any], Tuple[str, Any, Any]]]
 
@@ -240,7 +240,7 @@ def generate_model_signature(
     """
     from inspect import Parameter, Signature, signature
 
-    from .config import Extra
+    from pydantic.config import Extra
 
     present_params = signature(init).parameters.values()
     merged_params: Dict[str, Parameter] = {}
@@ -298,7 +298,7 @@ def generate_model_signature(
 
 
 def get_model(obj: Union[Type['BaseModel'], Type['Dataclass']]) -> Type['BaseModel']:
-    from .main import BaseModel
+    from pydantic.main import BaseModel
 
     try:
         model_cls = obj.__pydantic_model__  # type: ignore

--- a/pydantic/v1.py
+++ b/pydantic/v1.py
@@ -16,7 +16,7 @@ def __getattr__(name: str) -> Any:
     return getattr(pydantic, name)
 
 
-# WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
+# WARNING __all__ from pydantic.errors is not included here, it will be removed as an export here in v2
 # please use "from pydantic.errors import ..." instead
 __all__ = [
     # annotated types utils

--- a/pydantic/v1.py
+++ b/pydantic/v1.py
@@ -1,9 +1,8 @@
 # NOTE This file aliases the pydantic namespace as pydantic.v1 for smoother v1 -> v2 transition
 # flake8: noqa
-from pydantic import *
-
-
 import os
+
+from pydantic import *
 
 # allows importing of objects from modules directly
 # i.e. from pydantic.v1.fields import ModelField

--- a/pydantic/v1.py
+++ b/pydantic/v1.py
@@ -1,12 +1,20 @@
 # NOTE This file aliases the pydantic namespace as pydantic.v1 for smoother v1 -> v2 transition
 # flake8: noqa
+import importlib
 import os
+from typing import Any
 
+import pydantic
 from pydantic import *
+
 
 # allows importing of objects from modules directly
 # i.e. from pydantic.v1.fields import ModelField
-__path__ = [os.path.dirname(os.path.abspath(__file__))]
+def __getattr__(name: str) -> Any:
+    """Module level `__getattr__` to allow imports directly from the `pydantic.v1`
+    namespace for all pydantic modules."""
+    return getattr(pydantic, name)
+
 
 # WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
 # please use "from pydantic.errors import ..." instead

--- a/pydantic/v1.py
+++ b/pydantic/v1.py
@@ -2,6 +2,13 @@
 # flake8: noqa
 from pydantic import *
 
+
+import os
+
+# allows importing of objects from modules directly
+# i.e. from pydantic.v1.fields import ModelField
+__path__ = [os.path.dirname(os.path.abspath(__file__))]
+
 # WARNING __all__ from .errors is not included here, it will be removed as an export here in v2
 # please use "from pydantic.errors import ..." instead
 __all__ = [

--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -28,9 +28,9 @@ from typing import (
 )
 from uuid import UUID
 
-from . import errors
-from .datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
-from .typing import (
+from pydantic import errors
+from pydantic.datetime_parse import parse_date, parse_datetime, parse_duration, parse_time
+from pydantic.typing import (
     AnyCallable,
     all_literal_values,
     display_as_type,
@@ -41,14 +41,14 @@ from .typing import (
     is_none_type,
     is_typeddict,
 )
-from .utils import almost_equal_floats, lenient_issubclass, sequence_like
+from pydantic.utils import almost_equal_floats, lenient_issubclass, sequence_like
 
 if TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 
-    from .config import BaseConfig
-    from .fields import ModelField
-    from .types import ConstrainedDecimal, ConstrainedFloat, ConstrainedInt
+    from pydantic.config import BaseConfig
+    from pydantic.fields import ModelField
+    from pydantic.types import ConstrainedDecimal, ConstrainedFloat, ConstrainedInt
 
     ConstrainedNumber = Union[ConstrainedDecimal, ConstrainedFloat, ConstrainedInt]
     AnyOrderedDict = OrderedDict[Any, Any]
@@ -594,7 +594,7 @@ NamedTupleT = TypeVar('NamedTupleT', bound=NamedTuple)
 def make_namedtuple_validator(
     namedtuple_cls: Type[NamedTupleT], config: Type['BaseConfig']
 ) -> Callable[[Tuple[Any, ...]], NamedTupleT]:
-    from .annotated_types import create_model_from_namedtuple
+    from pydantic.annotated_types import create_model_from_namedtuple
 
     NamedTupleModel = create_model_from_namedtuple(
         namedtuple_cls,
@@ -619,7 +619,7 @@ def make_namedtuple_validator(
 def make_typeddict_validator(
     typeddict_cls: Type['TypedDict'], config: Type['BaseConfig']  # type: ignore[valid-type]
 ) -> Callable[[Any], Dict[str, Any]]:
-    from .annotated_types import create_model_from_typeddict
+    from pydantic.annotated_types import create_model_from_typeddict
 
     TypedDictModel = create_model_from_typeddict(
         typeddict_cls,
@@ -698,7 +698,7 @@ _VALIDATORS: List[Tuple[Type[Any], List[Any]]] = [
 def find_validators(  # noqa: C901 (ignore complexity)
     type_: Type[Any], config: Type['BaseConfig']
 ) -> Generator[AnyCallable, None, None]:
-    from .dataclasses import is_builtin_dataclass, make_dataclass_validator
+    from pydantic.dataclasses import is_builtin_dataclass, make_dataclass_validator
 
     if type_ is Any or type_ is object:
         return

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -20,11 +20,7 @@ def test_can_import_modules_from_v1() -> None:
     """That imports from any module in pydantic can be imported through
     ``pydantic.v1.<module>``"""
     for module_fname in os.listdir(pydantic.__path__[0]):
-        if (
-            module_fname.startswith('_')
-            or not module_fname.endswith('.py')
-            or module_fname == 'v1.py'
-        ):
+        if module_fname.startswith('_') or not module_fname.endswith('.py') or module_fname == 'v1.py':
             continue
         module_name = module_fname[:-3]
 

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -1,7 +1,25 @@
 import importlib
 import os
 
+import pytest
+
 import pydantic
+
+try:
+    from mypy import api as mypy_api
+    from mypy.version import __version__ as mypy_version
+
+    from pydantic.mypy import parse_mypy_version
+except ImportError:
+    mypy_api = None
+    mypy_version = None
+    parse_mypy_version = lambda _: (0,)  # noqa: E731
+
+
+try:
+    import dotenv
+except ImportError:
+    dotenv = None
 
 
 def test_imports() -> None:
@@ -16,12 +34,25 @@ def test_imports_from_modules() -> None:
     from pydantic.v1.validators import bool_validator  # noqa: F401
 
 
-def test_can_import_modules_from_v1() -> None:
+@pytest.mark.parametrize(
+    ('module_name'),
+    [
+        (
+            module_name
+            # mypy required for importing the `mypy.py` module.
+            if module_name != 'mypy.py'
+            else pytest.param(
+                module_name,
+                marks=pytest.mark.skipif(not (dotenv and mypy_api), reason='dotenv or mypy are not installed'),
+            )
+        )
+        for module_name in os.listdir(pydantic.__path__[0])
+        if not (module_name.startswith('_') or not module_name.endswith('.py') or module_name == 'v1.py')
+    ],
+)
+def test_can_import_modules_from_v1(module_name: str) -> None:
     """That imports from any module in pydantic can be imported through
     ``pydantic.v1.<module>``"""
-    for module_fname in os.listdir(pydantic.__path__[0]):
-        if module_fname.startswith('_') or not module_fname.endswith('.py') or module_fname == 'v1.py':
-            continue
-        module_name = module_fname[:-3]
+    module_name = module_name[:-3]
 
-        _ = importlib.import_module(f'pydantic.v1.{module_name}')
+    _ = importlib.import_module(f'pydantic.v1.{module_name}')

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -21,11 +21,11 @@ def test_can_import_modules_from_v1() -> None:
     ``pydantic.v1.<module>``"""
     for module_fname in os.listdir(pydantic.__path__[0]):
         if (
-            module_fname.startswith("_")
-            or not module_fname.endswith(".py")
-            or module_fname == "v1.py"
+            module_fname.startswith('_')
+            or not module_fname.endswith('.py')
+            or module_fname == 'v1.py'
         ):
             continue
         module_name = module_fname[:-3]
 
-        _ = importlib.import_module(f"pydantic.v1.{module_name}")
+        _ = importlib.import_module(f'pydantic.v1.{module_name}')

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -1,2 +1,31 @@
+import importlib
+import os
+
+import pydantic
+
+
 def test_imports() -> None:
     from pydantic.v1 import BaseModel, dataclasses  # noqa: F401
+
+
+def test_imports_from_modules() -> None:
+    """That specific objects can be imported from modules directly through the
+    ``v1`` namespace."""
+    from pydantic.v1.fields import ModelField  # noqa: F401
+    from pydantic.v1.generics import GenericModel  # noqa: F401
+    from pydantic.v1.validators import bool_validator  # noqa: F401
+
+
+def test_can_import_modules_from_v1() -> None:
+    """That imports from any module in pydantic can be imported through
+    ``pydantic.v1.<module>``"""
+    for module_fname in os.listdir(pydantic.__path__[0]):
+        if (
+            module_fname.startswith("_")
+            or not module_fname.endswith(".py")
+            or module_fname == "v1.py"
+        ):
+            continue
+        module_name = module_fname[:-3]
+
+        _ = importlib.import_module(f"pydantic.v1.{module_name}")


### PR DESCRIPTION
## Change Summary

Following on from [this PR](https://github.com/pydantic/pydantic/pull/9042) about adding a `v1.py` namespace to pydantic to better follow the v2 syntax of importing v1 objects, imports such as:

```python
from pydantic.fields import ModelField
from pydantic.generics import GenericModel
```

or:
```python
from pydantic import fields
from pydantic import generics
```

cannot be directly swapped for: 

```python
from pydantic.v1.fields import ModelField
from pydantic.v1.generics import GenericModel
```

or:
```python
from pydantic.v1 import fields
from pydantic.v1 import generics
```
imports. If this was the case, this would make unpinning from v1 --> v2 much simpler as a simple find and replace would be all that is needed to convert `from pydantic` --> `from pydantic.v1` instead (ofc still using v1 types and models).

One caveat with this approach is if this happens:

```python
from pydantic.fields import ModelField
from pydantic.v1.fields import ModelField as ModelFieldFromV1

ModelField is ModelFieldFromV1 # False
```

but ideally the import syntax should be changed across a codebase rather than only in some places. Note that anything in the ``__init__.py`` pydantic namespace is still imported wholesale:

```python
from pydantic import dataclasses
from pydantic.v1 import v1_dataclasses

dataclasses is v1_dataclasses # True
```
since these modules are imported directly from the underlying submodules. This also means that for the former import block, the `ModelField` in this case **is** imported twice.

Additionally, things like `Pylance` can't directly resolve the import path for `pydantic.v1.fields` imports using this syntax, but ideally that will be very transient since as soon as the find and replace is executed, any `pydantic<2` pins should be able to be removed wholesale and the import will be resolved in pydantic v2.

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Selected reviewer: @sydney-runkle 

skip change file check

Fix https://github.com/pydantic/pydantic/issues/9357

Selected Reviewer: @PrettyWood