### PR TITLE
Address case where model_construct on a class which defines model_post_init fails with AttributeError: __pydantic_private__ when subsequently model_copy'd

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -721,7 +721,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         _object_setattr(m, '__pydantic_extra__', copy(self.__pydantic_extra__))
         _object_setattr(m, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
 
-        if self.__pydantic_private__ is None:
+        if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:
             _object_setattr(m, '__pydantic_private__', None)
         else:
             _object_setattr(
@@ -742,7 +742,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # and attempting a deepcopy would be marginally slower.
         _object_setattr(m, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
 
-        if self.__pydantic_private__ is None:
+        if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:
             _object_setattr(m, '__pydantic_private__', None)
         else:
             _object_setattr(
@@ -902,7 +902,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 # Perform common checks first
                 if not (
                     self_type == other_type
-                    and self.__pydantic_private__ == other.__pydantic_private__
+                    and getattr(self, '__pydantic_private__', None) == getattr(other, '__pydantic_private__', None)
                     and self.__pydantic_extra__ == other.__pydantic_extra__
                 ):
                     return False

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -250,7 +250,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             private: dict[str, Any] | None = getattr(m, '__pydantic_private__', None)
             if private is not None:
                 for k, v in values.items():
-                    if k in private:
+                    if k in m.__private_attributes__:
                         private[k] = v
 
         elif not cls.__pydantic_root_model__:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -247,11 +247,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         if cls.__pydantic_post_init__:
             m.model_post_init(None)
             # update private attributes with values set
-            private: dict[str, Any] | None = getattr(m, '__pydantic_private__', None)
-            if private is not None:
+            if hasattr(m, '__pydantic_private__') and m.__pydantic_private__ is not None:
                 for k, v in values.items():
                     if k in m.__private_attributes__:
-                        private[k] = v
+                        m.__pydantic_private__[k] = v
 
         elif not cls.__pydantic_root_model__:
             # Note: if there are any private attributes, cls.__pydantic_post_init__ would exist
@@ -722,14 +721,13 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         _object_setattr(m, '__pydantic_extra__', copy(self.__pydantic_extra__))
         _object_setattr(m, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
 
-        private: dict[str, Any] | None = getattr(self, '__pydantic_private__', None)
-        if private is None:
+        if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:
             _object_setattr(m, '__pydantic_private__', None)
         else:
             _object_setattr(
                 m,
                 '__pydantic_private__',
-                {k: v for k, v in private.items() if v is not PydanticUndefined},
+                {k: v for k, v in self.__pydantic_private__.items() if v is not PydanticUndefined},
             )
 
         return m
@@ -744,14 +742,13 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # and attempting a deepcopy would be marginally slower.
         _object_setattr(m, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
 
-        private: dict[str, Any] | None = getattr(self, '__pydantic_private__', None)
-        if private is None:
+        if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:
             _object_setattr(m, '__pydantic_private__', None)
         else:
             _object_setattr(
                 m,
                 '__pydantic_private__',
-                deepcopy({k: v for k, v in private.items() if v is not PydanticUndefined}, memo=memo),
+                deepcopy({k: v for k, v in self.__pydantic_private__.items() if v is not PydanticUndefined}, memo=memo),
             )
 
         return m

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -247,10 +247,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         if cls.__pydantic_post_init__:
             m.model_post_init(None)
             # update private attributes with values set
-            if hasattr(m, '__pydantic_private__') and m.__pydantic_private__ is not None:
+            private: dict[str, Any] | None = getattr(m, '__pydantic_private__', None)
+            if private is not None:
                 for k, v in values.items():
-                    if k in m.__private_attributes__:
-                        m.__pydantic_private__[k] = v
+                    if k in private:
+                        private[k] = v
 
         elif not cls.__pydantic_root_model__:
             # Note: if there are any private attributes, cls.__pydantic_post_init__ would exist
@@ -721,13 +722,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         _object_setattr(m, '__pydantic_extra__', copy(self.__pydantic_extra__))
         _object_setattr(m, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
 
-        if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:
+        private: dict[str, Any] | None = getattr(self, '__pydantic_private__', None)
+        if private is None:
             _object_setattr(m, '__pydantic_private__', None)
         else:
             _object_setattr(
                 m,
                 '__pydantic_private__',
-                {k: v for k, v in self.__pydantic_private__.items() if v is not PydanticUndefined},
+                {k: v for k, v in private.items() if v is not PydanticUndefined},
             )
 
         return m
@@ -742,13 +744,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # and attempting a deepcopy would be marginally slower.
         _object_setattr(m, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
 
-        if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:
+        private: dict[str, Any] | None = getattr(self, '__pydantic_private__', None)
+        if private is None:
             _object_setattr(m, '__pydantic_private__', None)
         else:
             _object_setattr(
                 m,
                 '__pydantic_private__',
-                deepcopy({k: v for k, v in self.__pydantic_private__.items() if v is not PydanticUndefined}, memo=memo),
+                deepcopy({k: v for k, v in private.items() if v is not PydanticUndefined}, memo=memo),
             )
 
         return m

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3280,3 +3280,17 @@ def test_validation_works_for_cyclical_forward_refs() -> None:
         x: Union[X, None]
 
     assert Y(x={'y': None}).x.y is None
+
+
+def test_model_construct_with_model_post_init_and_model_copy() -> None:
+    class Model(BaseModel):
+        id: int
+
+        def model_post_init(self, context: Any) -> None:
+            super().model_post_init(context)
+
+    m = Model.model_construct(id=1)
+    copy = m.model_copy(deep=True)
+
+    assert m == copy
+    assert id(m) != id(copy)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

See detail as reported in Issue #9122

Note: this patch specifically addresses the handling of `__pydantic_private__` in `__copy__`, `__deepcopy__` and `__eq__`. It does not address usage in several other places in main.py including: `__{get,set,del}attr__`, `__{get,set}state__`. It was unclear whether these were required, as eventually the model created by `model_construct` will in fact have `__pydantic_private__` set (possibly to `None`).

:## Related issue number: #9122 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable [N/A]
* [x] My PR is ready to review

Please Review

Fix https://github.com/pydantic/pydantic/issues/9122


Selected Reviewer: @alexmojaki