### PR TITLE
Add warning when set "alias" in low level annontated field

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -226,7 +226,7 @@ def collect_model_fields(  # noqa: C901
                     # Nothing stops us from just creating a new FieldInfo for this type hint, so we do this.
                     field_info = FieldInfo.from_annotation(ann_type)
         else:
-            _warning_if_annotate_have_low_level_alias(ann_type, ann_name)
+            _warn_on_nested_alias_in_annotation(ann_type, ann_name)
             field_info = FieldInfo.from_annotated_attribute(ann_type, default)
             # attributes which are fields are removed from the class namespace:
             # 1. To match the behaviour of annotation-only fields
@@ -252,7 +252,7 @@ def collect_model_fields(  # noqa: C901
     return fields, class_vars
 
 
-def _warning_if_annotate_have_low_level_alias(ann_type: type[Any], ann_name: str):
+def _warn_on_nested_alias_in_annotation(ann_type: type[Any], ann_name: str):
     from ..fields import FieldInfo
 
     if hasattr(ann_type, '__args__'):
@@ -261,7 +261,7 @@ def _warning_if_annotate_have_low_level_alias(ann_type: type[Any], ann_name: str
                 for anno_type_arg in _typing_extra.get_args(anno_arg):
                     if isinstance(anno_type_arg, FieldInfo) and anno_type_arg.alias is not None:
                         warnings.warn(
-                            f'Field "{ann_name}" has `alias` should be set at higher level to have affect',
+                            f'`alias` specification on field "{ann_name}" must be set on outermost annotation to take effect.',
                             UserWarning,
                         )
                         break

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -226,17 +226,7 @@ def collect_model_fields(  # noqa: C901
                     # Nothing stops us from just creating a new FieldInfo for this type hint, so we do this.
                     field_info = FieldInfo.from_annotation(ann_type)
         else:
-            if hasattr(ann_type, '__args__'):
-                for anno_arg in ann_type.__args__:
-                    if _typing_extra.is_annotated(anno_arg):
-                        for anno_type_arg in _typing_extra.get_args(anno_arg):
-                            if isinstance(anno_type_arg, FieldInfo) and anno_type_arg.alias is not None:
-                                warnings.warn(
-                                    f'Field "{ann_name}" has `alias` should be set at higher level to have affect',
-                                    UserWarning,
-                                )
-                                break
-                        break
+            _warning_if_annotate_have_low_level_alias(ann_type, ann_name)
             field_info = FieldInfo.from_annotated_attribute(ann_type, default)
             # attributes which are fields are removed from the class namespace:
             # 1. To match the behaviour of annotation-only fields
@@ -260,6 +250,21 @@ def collect_model_fields(  # noqa: C901
     _update_fields_from_docstrings(cls, fields, config_wrapper)
 
     return fields, class_vars
+
+
+def _warning_if_annotate_have_low_level_alias(ann_type: type[Any], ann_name: str):
+    from ..fields import FieldInfo
+
+    if hasattr(ann_type, '__args__'):
+        for anno_arg in ann_type.__args__:
+            if _typing_extra.is_annotated(anno_arg):
+                for anno_type_arg in _typing_extra.get_args(anno_arg):
+                    if isinstance(anno_type_arg, FieldInfo) and anno_type_arg.alias is not None:
+                        warnings.warn(
+                            f'Field "{ann_name}" has `alias` should be set at higher level to have affect',
+                            UserWarning,
+                        )
+                        break
 
 
 def _is_finalvar_with_default_val(type_: type[Any], val: Any) -> bool:

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -226,6 +226,17 @@ def collect_model_fields(  # noqa: C901
                     # Nothing stops us from just creating a new FieldInfo for this type hint, so we do this.
                     field_info = FieldInfo.from_annotation(ann_type)
         else:
+            if hasattr(ann_type, '__args__'):
+                for anno_arg in ann_type.__args__:
+                    if _typing_extra.is_annotated(anno_arg):
+                        for anno_type_arg in _typing_extra.get_args(anno_arg):
+                            if isinstance(anno_type_arg, FieldInfo) and anno_type_arg.alias is not None:
+                                warnings.warn(
+                                    f'Field "{ann_name}" has `alias` should be set at higher level to have affect',
+                                    UserWarning,
+                                )
+                                break
+                        break
             field_info = FieldInfo.from_annotated_attribute(ann_type, default)
             # attributes which are fields are removed from the class namespace:
             # 1. To match the behaviour of annotation-only fields

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -234,7 +234,7 @@ def test_modify_get_schema_annotated() -> None:
 
 def test_annotated_alias_at_low_level() -> None:
     with pytest.warns(
-        UserWarning, match=r'Field "low_level_alias_field" has `alias` should be set at higher level to have affect'
+        UserWarning, match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.
     ):
 
         class Model(BaseModel):

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -234,7 +234,7 @@ def test_modify_get_schema_annotated() -> None:
 
 def test_annotated_alias_at_low_level() -> None:
     with pytest.warns(
-        UserWarning, 
+        UserWarning,
         match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.'
     ):
 

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -234,7 +234,8 @@ def test_modify_get_schema_annotated() -> None:
 
 def test_annotated_alias_at_low_level() -> None:
     with pytest.warns(
-        UserWarning, match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.'
+        UserWarning, 
+        match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.'
     ):
 
         class Model(BaseModel):

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -234,7 +234,7 @@ def test_modify_get_schema_annotated() -> None:
 
 def test_annotated_alias_at_low_level() -> None:
     with pytest.warns(
-        UserWarning, match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.
+        UserWarning, match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.'
     ):
 
         class Model(BaseModel):

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -235,7 +235,7 @@ def test_modify_get_schema_annotated() -> None:
 def test_annotated_alias_at_low_level() -> None:
     with pytest.warns(
         UserWarning,
-        match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.'
+        match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.',
     ):
 
         class Model(BaseModel):

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Generic, Iterator, List, Set, TypeVar
+from typing import Any, Generic, Iterator, List, Optional, Set, TypeVar
 
 import pytest
 from annotated_types import BaseMetadata, GroupedMetadata, Gt, Lt, Predicate
@@ -230,6 +230,17 @@ def test_modify_get_schema_annotated() -> None:
     ]
 
     calls.clear()
+
+
+def test_annotated_alias_at_low_level() -> None:
+    with pytest.warns(
+        UserWarning, match=r'Field "low_level_alias_field" have `alias` should be set at higher level to have affect'
+    ):
+
+        class Model(BaseModel):
+            low_level_alias_field: Optional[Annotated[int, Field(alias='field_alias')]] = None
+
+    assert Model(field_alias=1).low_level_alias_field is None
 
 
 def test_get_pydantic_core_schema_source_type() -> None:

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -234,7 +234,7 @@ def test_modify_get_schema_annotated() -> None:
 
 def test_annotated_alias_at_low_level() -> None:
     with pytest.warns(
-        UserWarning, match=r'Field "low_level_alias_field" have `alias` should be set at higher level to have affect'
+        UserWarning, match=r'Field "low_level_alias_field" has `alias` should be set at higher level to have affect'
     ):
 
         class Model(BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add warning message when user setup annotated field with `alias` kwarg at low level. #7828.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Fix #7828


Selected Reviewer: @adriangb