### PR TITLE
Use field description for RootModel schema description when there is …

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -215,6 +215,7 @@ def modify_model_json_schema(
         JsonSchemaValue: The updated JSON schema.
     """
     from ..main import BaseModel
+    from ..root_model import RootModel
 
     json_schema = handler(schema_or_field)
     original_schema = handler.resolve_ref_schema(json_schema)
@@ -229,6 +230,8 @@ def modify_model_json_schema(
     docstring = None if cls is BaseModel else cls.__doc__
     if docstring and 'description' not in original_schema:
         original_schema['description'] = inspect.cleandoc(docstring)
+    elif issubclass(cls, RootModel) and cls.model_fields['root'].description:
+        original_schema['description'] = cls.model_fields['root'].description
     return json_schema
 
 

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -657,3 +657,25 @@ def test_model_construction_with_invalid_generic_specification() -> None:
 
         class GenericRootModel(RootModel, Generic[T_]):
             root: Union[T_, int]
+
+
+def test_model_with_field_description() -> None:
+    class AModel(RootModel):
+        root: int = Field(description='abc')
+
+    assert AModel.model_json_schema() == {'title': 'AModel', 'type': 'integer', 'description': 'abc'}
+
+
+def test_model_with_both_docstring_and_field_description() -> None:
+    """Check if the docstring is used as the description when both are present."""
+
+    class AModel(RootModel):
+        """More detailed description"""
+
+        root: int = Field(description='abc')
+
+    assert AModel.model_json_schema() == {
+        'title': 'AModel',
+        'type': 'integer',
+        'description': 'More detailed description',
+    }


### PR DESCRIPTION
Use field description or root for RootModel schema description when there is no docstring

## Related issue number

 fix #9160

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin