### PR TITLE
Fix `validation_alias` behavior with `model_construct` for `AliasChoices` and `AliasPath`

### DIFF
--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -42,16 +42,10 @@ class AliasPath:
         """
         v = d
         for k in self.path:
-            if isinstance(k, str):
-                if k not in v:
-                    return PydanticUndefined
+            try:
                 v = v[k]
-            elif isinstance(k, int):
-                try:
-                    v = v[k]
-                except (IndexError, TypeError):
-                    return PydanticUndefined
-
+            except (KeyError, IndexError, TypeError):
+                return PydanticUndefined
         return v
 
 

--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -40,18 +40,19 @@ class AliasPath:
         Returns:
             The value at the specified path, or `PydanticUndefined` if the path is not found.
         """
-        v = PydanticUndefined
+        v = d
         for k in self.path:
             if isinstance(k, str):
-                v = d.get(k, PydanticUndefined)
-            if isinstance(k, int):
+                if k not in v:
+                    return PydanticUndefined
+                v = v[k]
+            elif isinstance(k, int):
                 try:
-                    v = d[k]
-                except IndexError:
-                    v = PydanticUndefined
+                    v = v[k]
+                except (IndexError, TypeError):
+                    return PydanticUndefined
 
         return v
-
 
 
 @dataclasses.dataclass(**_internal_dataclass.slots_true)

--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Callable, Literal
+from typing import Any, Callable, Literal
+
+from pydantic_core import PydanticUndefined
 
 from ._internal import _internal_dataclass
 
@@ -31,6 +33,25 @@ class AliasPath:
             The list of aliases.
         """
         return self.path
+
+    def search_dict_for_path(self, d: dict) -> Any:
+        """Searches a dictionary for the path specified by the alias.
+
+        Returns:
+            The value at the specified path, or `PydanticUndefined` if the path is not found.
+        """
+        v = PydanticUndefined
+        for k in self.path:
+            if isinstance(k, str):
+                v = d.get(k, PydanticUndefined)
+            if isinstance(k, int):
+                try:
+                    v = d[k]
+                except IndexError:
+                    v = PydanticUndefined
+
+        return v
+
 
 
 @dataclasses.dataclass(**_internal_dataclass.slots_true)

--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -42,6 +42,9 @@ class AliasPath:
         """
         v = d
         for k in self.path:
+            if isinstance(v, str):
+                # disallow indexing into a str, like for AliasPath('x', 0) and x='abc'
+                return PydanticUndefined
             try:
                 v = v[k]
             except (KeyError, IndexError, TypeError):

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -246,12 +246,12 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                             fields_set.add(name)
                             break
 
-            if (name not in fields_set) and name in values:
-                fields_values[name] = values.pop(name)
-                fields_set.add(name)
-
-            if (name not in fields_set) and not field.is_required():
-                fields_values[name] = field.get_default(call_default_factory=True)
+            if name not in fields_set:
+                if name in values:
+                    fields_values[name] = values.pop(name)
+                    fields_set.add(name)
+                elif not field.is_required():
+                    fields_values[name] = field.get_default(call_default_factory=True)
         if _fields_set is None:
             _fields_set = fields_set
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -198,7 +198,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return self.__pydantic_fields_set__
 
     @classmethod
-    def model_construct(cls: type[Model], _fields_set: set[str] | None = None, **values: Any) -> Model:
+    def model_construct(cls: type[Model], _fields_set: set[str] | None = None, **values: Any) -> Model:  # noqa: C901
         """Creates a new instance of the `Model` class with validated data.
 
         Creates a new model setting `__dict__` and `__pydantic_fields_set__` from trusted or pre-validated data.
@@ -223,11 +223,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         fields_set = set()
 
         for name, field in cls.model_fields.items():
-
             if field.alias is not None and field.alias in values:
                 fields_values[name] = values.pop(field.alias)
                 fields_set.add(name)
-            
+
             if (name not in fields_set) and (field.validation_alias is not None):
                 validation_aliases: list[str | AliasPath] = (
                     field.validation_alias.choices

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -27,7 +27,7 @@ from ._internal import (
     _utils,
 )
 from ._migration import getattr_migration
-from aliases import AliasChoices, AliasPath
+from .aliases import AliasChoices, AliasPath
 from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from .config import ConfigDict
 from .errors import PydanticUndefinedAnnotation, PydanticUserError

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -223,10 +223,12 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         fields_set = set()
 
         for name, field in cls.model_fields.items():
+
             if field.alias is not None and field.alias in values:
                 fields_values[name] = values.pop(field.alias)
                 fields_set.add(name)
-            elif field.validation_alias is not None:
+            
+            if (name not in fields_set) and (field.validation_alias is not None):
                 validation_aliases: list[str | AliasPath] = (
                     field.validation_alias.choices
                     if isinstance(field.validation_alias, AliasChoices)
@@ -245,10 +247,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                             fields_set.add(name)
                             break
 
-            elif name in values:
+            if (name not in fields_set) and name in values:
                 fields_values[name] = values.pop(name)
                 fields_set.add(name)
-            elif not field.is_required():
+
+            if (name not in fields_set) and not field.is_required():
                 fields_values[name] = field.get_default(call_default_factory=True)
         if _fields_set is None:
             _fields_set = fields_set

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 import pytest
 from pydantic_core import PydanticUndefined, ValidationError
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, PydanticDeprecatedSince20
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, PrivateAttr, PydanticDeprecatedSince20
 
 
 class Model(BaseModel):
@@ -561,3 +561,12 @@ def test_initialize_with_private_attr():
 
     assert m._a == 'a'
     assert '_a' in m.__pydantic_private__
+
+
+def test_model_construct_with_alias_choices() -> None:
+    class MyModel(BaseModel):
+        a: str = Field(validation_alias=AliasChoices('aaa', 'AAA'))
+
+    assert MyModel.model_construct(a='a_value').a == 'a_value'
+    assert MyModel.model_construct(aaa='a_value').a == 'a_value'
+    assert MyModel.model_construct(AAA='a_value').a == 'a_value'

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 import pytest
 from pydantic_core import PydanticUndefined, ValidationError
 
-from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, PrivateAttr, PydanticDeprecatedSince20
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, PrivateAttr, PydanticDeprecatedSince20
 
 
 class Model(BaseModel):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 import pytest
 from pydantic_core import PydanticUndefined, ValidationError
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, PrivateAttr, PydanticDeprecatedSince20
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, PrivateAttr, PydanticDeprecatedSince20
 
 
 class Model(BaseModel):
@@ -570,3 +570,20 @@ def test_model_construct_with_alias_choices() -> None:
     assert MyModel.model_construct(a='a_value').a == 'a_value'
     assert MyModel.model_construct(aaa='a_value').a == 'a_value'
     assert MyModel.model_construct(AAA='a_value').a == 'a_value'
+
+
+def test_model_construct_with_alias_path() -> None:
+    class MyModel(BaseModel):
+        a: str = Field(validation_alias=AliasPath('aaa', 'AAA'))
+
+    assert MyModel.model_construct(a='a_value').a == 'a_value'
+    assert MyModel.model_construct(aaa={'AAA': 'a_value'}).a == 'a_value'
+
+
+def test_model_construct_with_alias_choices_and_path() -> None:
+    class MyModel(BaseModel):
+        a: str = Field(validation_alias=AliasChoices('aaa', AliasPath('AAA', 'aaa')))
+
+    assert MyModel.model_construct(a='a_value').a == 'a_value'
+    assert MyModel.model_construct(aaa='a_value').a == 'a_value'
+    assert MyModel.model_construct(AAA={'aaa': 'a_value'}).a == 'a_value'


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9216
Fix https://github.com/pydantic/pydantic/issues/9220

Initially introduced in https://github.com/pydantic/pydantic/pull/9144 because we forgot to account for `AliasPath` and `AliasChoices` validation aliases!

Selected Reviewer: @adriangb