### PR TITLE
Revert typing.Literal and import it outside the TYPE_CHECKING block

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -15,7 +15,7 @@ from enum import Enum
 from functools import partial
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from operator import attrgetter
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Any, Callable, Iterable, Literal, TypeVar
 
 import typing_extensions
 from pydantic_core import (
@@ -67,7 +67,7 @@ def get_enum_core_schema(enum_type: type[Enum], config: ConfigDict) -> CoreSchem
     js_updates = {'title': enum_type.__name__, 'description': description}
     js_updates = {k: v for k, v in js_updates.items() if v is not None}
 
-    sub_type: typing_extensions.Literal['str', 'int', 'float'] | None = None
+    sub_type: Literal['str', 'int', 'float'] | None = None
     if issubclass(enum_type, int):
         sub_type = 'int'
         value_ser_type: core_schema.SerSchema = core_schema.simple_ser_schema('int')

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -124,7 +124,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         __pydantic_decorators__: ClassVar[_decorators.DecoratorInfos]
         __pydantic_generic_metadata__: ClassVar[_generics.PydanticGenericMetadata]
         __pydantic_parent_namespace__: ClassVar[dict[str, Any] | None]
-        __pydantic_post_init__: ClassVar[None | typing_extensions.Literal['model_post_init']]
+        __pydantic_post_init__: ClassVar[None | Literal['model_post_init']]
         __pydantic_root_model__: ClassVar[bool]
         __pydantic_serializer__: ClassVar[SchemaSerializer]
         __pydantic_validator__: ClassVar[SchemaValidator]
@@ -290,7 +290,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     def model_dump(
         self,
         *,
-        mode: typing_extensions.Literal['json', 'python'] | str = 'python',
+        mode: Literal['json', 'python'] | str = 'python',
         include: IncEx = None,
         exclude: IncEx = None,
         context: dict[str, Any] | None = None,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

In PR #7680 the `typing.Literal` was replaced with `typing_extensions.Literal`. I was curious enough to double-check the origin and found that the error was caused by importing `from typing import Literal` inside the TYPE_CHECKING block but then using it outside the scope.

I suggest to revert `typing.Literal` back, but importing it correctly at the module level. This meets the required Python 3.8+ limitation and works well with the example from the original issue:

```python
import typing
from pydantic import BaseModel
typing.get_type_hints(BaseModel.model_copy)
typing.get_type_hints(BaseModel.model_dump)
typing.get_type_hints(BaseModel.dict)
```

## Related issue number

refs #7623

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu