### PR TITLE
Ensure BaseModel behaves alike with annotated types as TypeAdapter

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -439,7 +439,16 @@ class FieldInfo(_repr.Representation):
         new_kwargs: dict[str, Any] = {}
         metadata = {}
         for field_info in field_infos:
-            new_kwargs.update(field_info._attributes_set)
+            for key in field_info._attributes_set:
+                if (
+                    key in new_kwargs.keys()
+                    and key == 'json_schema_extra'
+                    and not callable(field_info._attributes_set[key])
+                ):
+                    # Merge the fields if not callable, making the schema for BaseModel consistent with TypeAdapter
+                    new_kwargs[key].update(field_info._attributes_set[key])
+                else:
+                    new_kwargs[key] = field_info._attributes_set[key]
             for x in field_info.metadata:
                 if not isinstance(x, FieldInfo):
                     metadata[type(x)] = x

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -470,3 +470,10 @@ def test_min_length_field_info_not_lost():
             'type': 'string_too_short',
         }
     ]
+
+
+def test_combine_annonated_fields():
+    class Foo(BaseModel):
+        v: Annotated[str, Field(json_schema_extra={'key1': 'value1'}), Field(json_schema_extra={'key2': 'value2'})]
+
+    assert {'key1': 'value1', 'key2': 'value2'}.items() <= Foo.model_json_schema()['properties']['v'].items()


### PR DESCRIPTION
## Change Summary

Make a special case for non callable,`json_schema_extra` to combine them instead of override them. I feel like there should be a better way, but I definitely couldn't figure that out by myself. Please review.


## Related issue number

Fixes #9210 

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
