### PR TITLE
Fix `Secret` serialization schema, applicable for unions

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1561,14 +1561,22 @@ class Secret(_SecretBase[SecretType]):
             validated_inner = handler(value)
             return cls(validated_inner)
 
+        def serialize(value: Secret[SecretType], info: core_schema.SerializationInfo) -> str | Secret[SecretType]:
+            if info.mode == 'json':
+                return str(value)
+            else:
+                return value
+
         return core_schema.json_or_python_schema(
             python_schema=core_schema.no_info_wrap_validator_function(
                 validate_secret_value,
                 inner_schema,
-                serialization=core_schema.plain_serializer_function_ser_schema(lambda x: x),
             ),
-            json_schema=core_schema.no_info_after_validator_function(
-                lambda x: cls(x), inner_schema, serialization=core_schema.to_string_ser_schema(when_used='json')
+            json_schema=core_schema.no_info_after_validator_function(lambda x: cls(x), inner_schema),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                serialize,
+                info_arg=True,
+                when_used='always',
             ),
         )
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4463,6 +4463,15 @@ def test_secretdate_idempotent():
     assert m.value.get_secret_value() == date(2017, 1, 1)
 
 
+def test_secret_union_serializable() -> None:
+    class Base(BaseModel):
+        x: Secret[int] | Secret[str]
+
+    model = Base(x=1)
+    assert model.model_dump() == {'x': Secret[int](1)}
+    assert model.model_dump_json() == '{"x":"**********"}'
+
+
 @pytest.mark.parametrize(
     'pydantic_type',
     [

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4465,7 +4465,7 @@ def test_secretdate_idempotent():
 
 def test_secret_union_serializable() -> None:
     class Base(BaseModel):
-        x: Secret[int] | Secret[str]
+        x: Union[Secret[int], Secret[str]]
 
     model = Base(x=1)
     assert model.model_dump() == {'x': Secret[int](1)}


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9231

Selected Reviewer: @hramezani