### PR TITLE
docs(performance): remove section on literal vs enum performance

### DIFF
--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -140,35 +140,6 @@ class Html(BaseModel):
 
 See [Discriminated Unions] for more details.
 
-## Use `Literal` not `Enum`
-
-Instead of using `Enum`, use `Literal` to define the structure of the data.
-
-??? info "Performance comparison"
-    With a simple benchmark, `Literal` is about ~3x faster than `Enum`:
-
-    ```py test="skip"
-    import enum
-    from timeit import timeit
-
-    from typing_extensions import Literal
-
-    from pydantic import TypeAdapter
-
-    ta = TypeAdapter(Literal['a', 'b'])
-    result1 = timeit(lambda: ta.validate_python('a'), number=10000)
-
-
-    class AB(str, enum.Enum):
-        a = 'a'
-        b = 'b'
-
-
-    ta = TypeAdapter(AB)
-    result2 = timeit(lambda: ta.validate_python('a'), number=10000)
-    print(result2 / result1)
-    ```
-
 ## Use `TypedDict` over nested models
 
 Instead of using nested models, use `TypedDict` to define the structure of the data.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I've removed the docs on the performance differences between using a literal or an enum. It seems the performance improvements made in 2.7 have made them perform nearly identically in the previous example, so unless theres a case missing, it doesn't seem worth promoting this tip anymore.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt