### PR TITLE
Fix `strict` application to `function-after` with `use_enum_values`

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -196,8 +196,8 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         allowed_schemas = CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint]
 
         # if it becomes necessary to handle more than one constraint
-        # in this recursive case with function-after, we should refactor
-        if schema_type == 'function-after' and constraint == 'strict':
+        # in this recursive case with function-after or function-wrap, we should refactor
+        if schema_type in ['function-after', 'function-wrap'] and constraint == 'strict':
             schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function-after schema
             continue
 

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -199,7 +199,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         # in this recursive case with function-after or function-wrap, we should refactor
         if schema_type in ['function-before', 'function-wrap', 'function-after'] and constraint == 'strict':
             schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function-after schema
-            continue
+            return schema
 
         if schema_type in allowed_schemas:
             if constraint == 'union_mode' and schema_type == 'union':

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -197,7 +197,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
 
         # if it becomes necessary to handle more than one constraint
         # in this recursive case with function-after or function-wrap, we should refactor
-        if schema_type in ['function-before', 'function-wrap', 'function-after'] and constraint == 'strict':
+        if schema_type in {'function-before', 'function-wrap', 'function-after'} and constraint == 'strict':
             schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function-after schema
             return schema
 

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -195,6 +195,9 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             raise ValueError(f'Unknown constraint {constraint}')
         allowed_schemas = CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint]
 
+        if schema_type == 'function-after' and constraint == 'strict':
+            schema['schema']['strict'] = value  # type: ignore  # schema is function-after schema, 'schema' key is present
+
         if schema_type in allowed_schemas:
             if constraint == 'union_mode' and schema_type == 'union':
                 schema['mode'] = value  # type: ignore  # schema is UnionSchema

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -197,6 +197,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
 
         if schema_type == 'function-after' and constraint == 'strict':
             schema['schema']['strict'] = value  # type: ignore  # schema is function-after schema, 'schema' key is present
+            return schema
 
         if schema_type in allowed_schemas:
             if constraint == 'union_mode' and schema_type == 'union':

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -197,7 +197,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
 
         # if it becomes necessary to handle more than one constraint
         # in this recursive case with function-after or function-wrap, we should refactor
-        if schema_type in ['function-after', 'function-wrap'] and constraint == 'strict':
+        if schema_type in ['function-before', 'function-wrap', 'function-after'] and constraint == 'strict':
             schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function-after schema
             continue
 

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -195,9 +195,11 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             raise ValueError(f'Unknown constraint {constraint}')
         allowed_schemas = CONSTRAINTS_TO_ALLOWED_SCHEMAS[constraint]
 
+        # if it becomes necessary to handle more than one constraint
+        # in this recursive case with function-after, we should refactor
         if schema_type == 'function-after' and constraint == 'strict':
-            schema['schema']['strict'] = value  # type: ignore  # schema is function-after schema, 'schema' key is present
-            return schema
+            schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function-after schema
+            continue
 
         if schema_type in allowed_schemas:
             if constraint == 'union_mode' and schema_type == 'union':

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6658,3 +6658,19 @@ def test_can_serialize_deque_passed_to_sequence() -> None:
 
     assert ta.dump_python(my_dec) == my_dec
     assert ta.dump_json(my_dec) == b'[1,2,3]'
+
+
+def test_strict_enum_with_use_enum_values() -> None:
+    class SomeEnum(int, Enum):
+        SOME_KEY = 1
+
+    class Foo(BaseModel):
+        model_config = ConfigDict(strict=False, use_enum_values=True)
+        foo: Annotated[SomeEnum, Strict(strict=True)]
+
+    f = Foo(foo=SomeEnum.SOME_KEY)
+    assert f.foo == 1
+
+    # validation error raised bc foo field uses strict mode
+    with pytest.raises(ValidationError):
+        Foo(foo='1')


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9257

Selected Reviewer: @samuelcolvin