### PR TITLE
Fix model json schema with config types

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2037,13 +2037,13 @@ class GenerateJsonSchema:
         Returns:
             The encoded default value.
         """
-        from .type_adapter import TypeAdapter
+        from .type_adapter import TypeAdapter, _type_has_config
 
         config = self._config
         try:
             default = (
                 dft
-                if hasattr(dft, '__pydantic_serializer__')
+                if _type_has_config(type(dft))
                 else TypeAdapter(type(dft), config=config.config_dict).dump_python(dft, mode='json')
             )
         except PydanticSchemaGenerationError:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import math
 import re
@@ -6030,3 +6031,108 @@ def test_default_value_encoding(field_type, default_value, expected_schema):
 
     schema = Model.model_json_schema()
     assert schema == expected_schema
+
+
+@dataclasses.dataclass
+class BuiltinDataclassParent:
+    name: str
+
+
+@pydantic.dataclasses.dataclass
+class PydanticDataclassParent:
+    name: str
+
+
+class TypedDictParent(TypedDict):
+    name: str
+
+
+class ModelParent(BaseModel):
+    name: str
+
+
+@pytest.mark.parametrize(
+    'pydantic_type,expected_json_schema',
+    [
+        pytest.param(
+            BuiltinDataclassParent,
+            {
+                '$defs': {
+                    'BuiltinDataclassParent': {
+                        'properties': {'name': {'title': 'Name', 'type': 'string'}},
+                        'required': ['name'],
+                        'title': 'BuiltinDataclassParent',
+                        'type': 'object',
+                    }
+                },
+                'properties': {
+                    'parent': {'allOf': [{'$ref': '#/$defs/BuiltinDataclassParent'}], 'default': {'name': 'Jon Doe'}}
+                },
+                'title': 'child',
+                'type': 'object',
+            },
+            id='builtin-dataclass',
+        ),
+        pytest.param(
+            PydanticDataclassParent,
+            {
+                '$defs': {
+                    'PydanticDataclassParent': {
+                        'properties': {'name': {'title': 'Name', 'type': 'string'}},
+                        'required': ['name'],
+                        'title': 'PydanticDataclassParent',
+                        'type': 'object',
+                    }
+                },
+                'properties': {
+                    'parent': {'allOf': [{'$ref': '#/$defs/PydanticDataclassParent'}], 'default': {'name': 'Jon Doe'}}
+                },
+                'title': 'child',
+                'type': 'object',
+            },
+            id='pydantic-dataclass',
+        ),
+        pytest.param(
+            TypedDictParent,
+            {
+                '$defs': {
+                    'TypedDictParent': {
+                        'properties': {'name': {'title': 'Name', 'type': 'string'}},
+                        'required': ['name'],
+                        'title': 'TypedDictParent',
+                        'type': 'object',
+                    }
+                },
+                'properties': {
+                    'parent': {'allOf': [{'$ref': '#/$defs/TypedDictParent'}], 'default': {'name': 'Jon Doe'}}
+                },
+                'title': 'child',
+                'type': 'object',
+            },
+            id='typeddict',
+        ),
+        pytest.param(
+            ModelParent,
+            {
+                '$defs': {
+                    'ModelParent': {
+                        'properties': {'name': {'title': 'Name', 'type': 'string'}},
+                        'required': ['name'],
+                        'title': 'ModelParent',
+                        'type': 'object',
+                    }
+                },
+                'properties': {'parent': {'allOf': [{'$ref': '#/$defs/ModelParent'}], 'default': {'name': 'Jon Doe'}}},
+                'title': 'child',
+                'type': 'object',
+            },
+            id='model',
+        ),
+    ],
+)
+def test_pydantic_types_as_default_values(pydantic_type, expected_json_schema):
+    class Child(BaseModel):
+        model_config = ConfigDict(title='child')
+        parent: pydantic_type = pydantic_type(name='Jon Doe')
+
+    assert Child.model_json_schema() == expected_json_schema


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Fixing an issue where a model would have a field with a default value being a pydantic type (`BaseModel`, `datacalass`, `TypedDict`), then generating the parent model's json schema would fail.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Fix #9253

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu