### PR TITLE
Fixes loss when serializing/deserializing large decimals #9180

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -192,6 +192,7 @@ class DecimalValidator:
                 # but if it's not make it a string
                 # we don't use JSON -> float because parsing to any float will cause
                 # loss of precision
+                core_schema.float_schema(),
                 core_schema.int_schema(strict=True),
                 core_schema.str_schema(strict=True, strip_whitespace=True),
                 core_schema.no_info_plain_validator_function(str),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -248,6 +248,47 @@ def test_con_decimal_encode() -> None:
     assert Obj.model_validate_json(json_data) == Obj(id=1)
 
 
+@pytest.mark.parametrize(
+    ('json_data', 'expected'),
+    [
+        pytest.param(
+            '{"value": 1.234567890123456789012345678901234567890}',
+            Decimal(1.234567890123456789012345678901234567890),
+            id='many decimal places',
+        ),
+        pytest.param(
+            '{"value": 12345678901234567890123456789012345678.9}',
+            Decimal(12345678901234567890123456789012345678.9),
+            id='large number with a single decimal place',
+        ),
+        pytest.param(
+            '{"value": 12345678901234567890123456789012345678}',
+            12345678901234567890123456789012345678,
+            id='large number, no decimal places',
+        ),
+    ],
+)
+def test_long_decimal_decoding(json_data: str, expected: Decimal) -> None:
+    """
+    Really large decimal values should lose their precision when encoding or decoding
+    from json.
+
+    Note: Test case data is supplied as a raw string since python can be lossy with large floats
+
+    ToDo: Possible use flag `check_digits`?
+    """
+
+    class Obj(BaseModel):
+        value: Decimal
+
+    # parse from json
+    m = Obj.model_validate_json(json_data)
+    m_json_data = m.model_dump_json()
+
+    # test encoding and decoding in 1 go
+    assert (m.value, m_json_data) == (expected, json_data)
+
+
 def test_json_encoder_simple_inheritance():
     class Parent(BaseModel):
         dt: datetime = datetime.now()


### PR DESCRIPTION
## Change Summary
Serializing/deserializing large decimal values is lossy. These changes enable expected behavior - no loss in information with large decimals.

### Help Needed
I was able to solve the deserialization part. But I'm having trouble identifying how/where to control for model export to json _(serialization is still lossy)_. 

## Related issue number
fix #9180

## Checklist

* [X ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
