### PR TITLE
Fixes loss when serializing/deserializing large decimals #9180 (take 2)

### DIFF
--- a/tests/test_decimal.py
+++ b/tests/test_decimal.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+
+import pytest
+
+from pydantic import BaseModel, ValidationError
+
+from .conftest import Err
+
+
+@pytest.fixture(scope='module', name='DecimalModel')
+def decimal_model_fixture():
+    class DecimalModel(BaseModel):
+        v: Decimal
+
+    return DecimalModel
+
+
+@pytest.mark.parametrize(
+    'value,result',
+    [
+        # Valid inputs
+        ('1.234567890123456789012345678901234567890', Decimal(1.234567890123456789012345678901234567890)),
+        (Decimal(1.234567890123456789012345678901234567890), Decimal(1.234567890123456789012345678901234567890)),
+        ('12345678901234567890123456789012345678.9', Decimal(12345678901234567890123456789012345678.9)),
+        (Decimal(12345678901234567890123456789012345678.9), Decimal(12345678901234567890123456789012345678.9)),
+        (12345678901234567890123456789012345678, 12345678901234567890123456789012345678),
+        (12345678901234567890123456789012345678, Decimal(12345678901234567890123456789012345678)),
+        (float('inf'), Err('Input should be a finite number')),
+        (float('-inf'), Err('Input should be a finite number')),
+        (float('nan'), Err('Input should be a finite number')),
+    ],
+)
+def test_decimal_parsing(DecimalModel, value, result):
+    if isinstance(result, Err):
+        with pytest.raises(ValidationError, match=result.message_escaped()):
+            DecimalModel(v=value)
+    else:
+        assert DecimalModel(v=value).v == result


### PR DESCRIPTION
## Change Summary
Serializing/deserializing large decimal values is lossy. These changes enable expected behavior - no loss in information with large decimals.

> **Note:** This PR replaces work done by https://github.com/pydantic/pydantic/pull/9291

### Help Needed
~I was able to solve the deserialization part. But I'm having trouble identifying how/where to control for model export to json _(serialization is still lossy)_.~ <-- that message was on my work in the previous PR. Presently, am not sure where the interface to control serialization/deserialization. Could someone point me in the direction?

## Related issue number
fix #9180

## Checklist

* [X ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
