### PR TITLE
Hide private attributes (`PrivateAttr`) from `__init__` signature in type checkers

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -40,6 +40,7 @@ else:
     # and https://youtrack.jetbrains.com/issue/PY-51428
     DeprecationWarning = PydanticDeprecatedSince20
     PydanticModelField = object()
+    PydanticModelPrivateAttr = object()
 
 object_setattr = object.__setattr__
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -33,6 +33,7 @@ from ._validate_call import ValidateCallWrapper
 if typing.TYPE_CHECKING:
     from ..fields import Field as PydanticModelField
     from ..fields import FieldInfo, ModelPrivateAttr
+    from ..fields import PrivateAttr as PydanticModelPrivateAttr
     from ..main import BaseModel
 else:
     # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
@@ -56,7 +57,7 @@ class _ModelNamespaceDict(dict):
         return super().__setitem__(k, v)
 
 
-@dataclass_transform(kw_only_default=True, field_specifiers=(PydanticModelField,))
+@dataclass_transform(kw_only_default=True, field_specifiers=(PydanticModelField, PydanticModelPrivateAttr))
 class ModelMetaclass(ABCMeta):
     def __new__(
         mcs,

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -12,7 +12,7 @@ from ._internal import _config, _decorators, _typing_extra
 from ._internal import _dataclasses as _pydantic_dataclasses
 from ._migration import getattr_migration
 from .config import ConfigDict
-from .fields import Field, FieldInfo
+from .fields import Field, FieldInfo, PrivateAttr
 
 if TYPE_CHECKING:
     from ._internal._dataclasses import PydanticDataclass
@@ -23,7 +23,7 @@ _T = TypeVar('_T')
 
 if sys.version_info >= (3, 10):
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    @dataclass_transform(field_specifiers=(dataclasses.field, Field, PrivateAttr))
     @overload
     def dataclass(
         *,
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 10):
     ) -> Callable[[type[_T]], type[PydanticDataclass]]:  # type: ignore
         ...
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    @dataclass_transform(field_specifiers=(dataclasses.field, Field, PrivateAttr))
     @overload
     def dataclass(
         _cls: type[_T],  # type: ignore
@@ -60,7 +60,7 @@ if sys.version_info >= (3, 10):
 
 else:
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    @dataclass_transform(field_specifiers=(dataclasses.field, Field, PrivateAttr))
     @overload
     def dataclass(
         *,
@@ -75,7 +75,7 @@ else:
     ) -> Callable[[type[_T]], type[PydanticDataclass]]:  # type: ignore
         ...
 
-    @dataclass_transform(field_specifiers=(dataclasses.field, Field))
+    @dataclass_transform(field_specifiers=(dataclasses.field, Field, PrivateAttr))
     @overload
     def dataclass(
         _cls: type[_T],  # type: ignore
@@ -92,7 +92,7 @@ else:
         ...
 
 
-@dataclass_transform(field_specifiers=(dataclasses.field, Field))
+@dataclass_transform(field_specifiers=(dataclasses.field, Field, PrivateAttr))
 def dataclass(  # noqa: C901
     _cls: type[_T] | None = None,
     *,

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -934,6 +934,7 @@ def PrivateAttr(
     default: Any = PydanticUndefined,
     *,
     default_factory: typing.Callable[[], Any] | None = None,
+    init: Literal[False] = False,
 ) -> Any:
     """Usage docs: https://docs.pydantic.dev/2.7/concepts/models/#private-model-attributes
 
@@ -948,6 +949,7 @@ def PrivateAttr(
         default_factory: Callable that will be
             called when a default value is needed for this attribute.
             If both `default` and `default_factory` are set, an error will be raised.
+        init: Whether the attribute should be included in the constructor of the dataclass. Always `False`.
 
     Returns:
         An instance of [`ModelPrivateAttr`][pydantic.fields.ModelPrivateAttr] class.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -131,8 +131,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         __pydantic_validator__: ClassVar[SchemaValidator]
 
         # Instance attributes
-        # Note: we use the non-existent kwarg `init=False` in pydantic.fields.Field below so that @dataclass_transform
-        # doesn't think these are valid as keyword arguments to the class initializer.
         __pydantic_extra__: dict[str, Any] | None = _Field(init=False)  # type: ignore
         __pydantic_fields_set__: set[str] = _Field(init=False)  # type: ignore
         __pydantic_private__: dict[str, Any] | None = _Field(init=False)  # type: ignore

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -52,7 +52,7 @@ if typing.TYPE_CHECKING:
     from ._internal._utils import AbstractSetIntStr, MappingIntStrAny
     from .deprecated.parse import Protocol as DeprecatedParseProtocol
     from .fields import ComputedFieldInfo, FieldInfo, ModelPrivateAttr
-    from .fields import Field as _Field
+    from .fields import PrivateAttr as _PrivateAttr
 else:
     # See PyCharm issues https://youtrack.jetbrains.com/issue/PY-21915
     # and https://youtrack.jetbrains.com/issue/PY-51428
@@ -131,9 +131,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         __pydantic_validator__: ClassVar[SchemaValidator]
 
         # Instance attributes
-        __pydantic_extra__: dict[str, Any] | None = _Field(init=False)  # type: ignore
-        __pydantic_fields_set__: set[str] = _Field(init=False)  # type: ignore
-        __pydantic_private__: dict[str, Any] | None = _Field(init=False)  # type: ignore
+        __pydantic_extra__: dict[str, Any] | None = _PrivateAttr()
+        __pydantic_fields_set__: set[str] = _PrivateAttr()
+        __pydantic_private__: dict[str, Any] | None = _PrivateAttr()
 
     else:
         # `model_fields` and `__pydantic_decorators__` must be set for

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -17,11 +17,12 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Literal, dataclass_transform
 
     from .fields import Field as PydanticModelField
+    from .fields import PrivateAttr as PydanticModelPrivateAttr
 
     # dataclass_transform could be applied to RootModel directly, but `ModelMetaclass`'s dataclass_transform
     # takes priority (at least with pyright). We trick type checkers into thinking we apply dataclass_transform
     # on a new metaclass.
-    @dataclass_transform(kw_only_default=False, field_specifiers=(PydanticModelField,))
+    @dataclass_transform(kw_only_default=False, field_specifiers=(PydanticModelField, PydanticModelPrivateAttr))
     class _RootModelMetaclass(_model_construction.ModelMetaclass):
         ...
 else:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR:
* adds `PrivateAttr` to the list of [field specifiers](https://typing.readthedocs.io/en/latest/spec/dataclasses.html#field-specifiers) passed to `dataclass_transform` by Pydantic.
* adapts these changes in `BaseModel`  for instance (private) attributes.

## Related issue number

fix #9234.

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @hramezani