### PR TITLE
Fix bullets in Strict Mode docs

### DIFF
--- a/docs/concepts/strict_mode.md
+++ b/docs/concepts/strict_mode.md
@@ -37,6 +37,7 @@ except ValidationError as exc:
 ```
 
 There are various ways to get strict-mode validation while using Pydantic, which will be discussed in more detail below:
+
 * [Passing `strict=True` to the validation methods](#strict-mode-in-method-calls), such as `BaseModel.model_validate`,
   `TypeAdapter.validate_python`, and similar for JSON
 * [Using `Field(strict=True)`](#strict-mode-with-field) with fields of a `BaseModel`, `dataclass`, or `TypedDict`


### PR DESCRIPTION
Current StrictMode documentation does not show this as a bulleted list. This should fix it.

![image](https://github.com/pydantic/pydantic/assets/55868530/b302983b-6fb4-4e6a-a2ed-b5ce89ac5dd2)

Needed a blank line...
