### PR TITLE
Change CI to use `macos-13` for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,22 +98,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           # no pydantic-core binaries for pypy on windows, so tests take absolute ages
           # macos tests with pypy take ages (>10mins) since pypy is very slow
           # so we only test pypy on ubuntu
-          - os: ubuntu
+          - os: ubuntu-latest
             python-version: 'pypy3.9'
-          - os: ubuntu
+          - os: ubuntu-latest
             python-version: 'pypy3.10'
+        exclude:
+          # Python 3.8 and 3.9 are not available on macOS 14
+          - os: macos-13
+            python-version: '3.10'
+          - os: macos-13
+            python-version: '3.11'
+          - os: macos-13
+            python-version: '3.12'
+          - os: macos-latest
+            python-version: '3.8'
+          - os: macos-latest
+            python-version: '3.9'
 
     env:
       OS: ${{ matrix.os }}
       DEPS: yes
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes the CI error `The version '3.8' with architecture 'arm64' was not found for macOS 14.4.1.`
https://github.com/pydantic/pydantic/actions/runs/8797954784/job/24143937686?pr=9303


Selected Reviewer: @sydney-runkle