### PR TITLE
Make ImportString json schema compatible

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -990,6 +990,10 @@ else:
                     function=_validators.import_string, schema=handler(source), serialization=serializer
                 )
 
+        @classmethod
+        def __get_pydantic_json_schema__(cls, cs: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+            return handler(core_schema.str_schema())
+
         @staticmethod
         def _serialize(v: Any) -> str:
             if isinstance(v, ModuleType):

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -992,7 +992,7 @@ else:
 
         @classmethod
         def __get_pydantic_json_schema__(cls, cs: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            return handler(core_schema.str_schema())
+            return core_schema.str_schema() if (cls is source) else handler(core_schema.str_schema())
 
         @staticmethod
         def _serialize(v: Any) -> str:

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -992,7 +992,7 @@ else:
 
         @classmethod
         def __get_pydantic_json_schema__(cls, cs: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-            return core_schema.str_schema() if (cls is source) else handler(core_schema.str_schema())
+            return handler(core_schema.str_schema())
 
         @staticmethod
         def _serialize(v: Any) -> str:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1392,12 +1392,16 @@ def test_callable_fallback_with_non_serializable_default(warning_match):
     }
 
 
-def test_error_non_supported_types():
+def test_importstring_json_schema():
     class Model(BaseModel):
         a: ImportString
 
-    with pytest.raises(PydanticInvalidForJsonSchema):
-        Model.model_json_schema()
+    assert Model.model_json_schema() == {
+        'title': 'Model',
+        'type': 'object',
+        'properties': {'a': {'title': 'A', 'type': 'string'}},
+        'required': ['a'],
+    }
 
 
 def test_schema_overrides():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Adds JSON-Schema handler for ImportString which failed to schematize prior to this change. The schema type of importstring is simply string (which gets imported on validation).

There was a test specifically for an exception for this type, which was changed to validate a model containing an importstring type - there is another test already exercising a bad json schema using the same exception type (see https://github.com/pydantic/pydantic/blob/main/tests/test_types.py#L6155), so there does not look to be loss here. 


_Note_: There could be an opportunity to use a regex validation on the string to match something importable, but I left that out of scope here.

<!-- Please give a short summary of the changes. -->

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/9327

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable - _I think the documentation currently implies json schema should work (by omission that it explicitly should not)_
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @dmontagu