### PR TITLE
Link to Type Adapter documentation in migration guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -691,7 +691,7 @@ adapter: TypeAdapter[str | int] = TypeAdapter(str | int)
 ...
 ```
 
-[TODO: Add link to TypeAdapter documentation. For now, you can find example usage in `tests/test_type_adapter.py`.]
+See [Type Adapter](concepts/type_adapter.md) for more information.
 
 ### Defining custom types
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This links to the Type Adapter concept docs, since they now exist. This addresses a TODO in the V1 -> V2 migration guide.

## Related issue number

N/A

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Manual test: docs seem to render correctly locally, and the link goes to the right place:

![image](https://github.com/pydantic/pydantic/assets/1203825/20e4f93a-084f-422e-9175-7ca2e9ba5b47)


Selected Reviewer: @adriangb