### PR TITLE
Logfire annoucement

### DIFF
--- a/docs/theme/announce.html
+++ b/docs/theme/announce.html
@@ -1,3 +1,5 @@
 <!-- the following line is displayed in the announcement bar -->
 <!-- keep length under 164 characters (less HTML tags) to fit on 1280px desktop window -->
-<a href="https://docs.pydantic.dev/2.0/blog/pydantic-v2-final/">Pydantic V2</a> is here 🚀! Upgrading an existing app? See the <a href="https://docs.pydantic.dev/2.0/migration/">Migration Guide</a> for tips on essential changes from Pydantic V1!
+<b>We're live!</b> <a href="https://pydantic.dev/logfire">Pydantic Logfire</a> is out in open beta! 🎉<br>
+Logfire is a new observability tool for Python, from the creators of Pydantic, with great Pydantic support.
+Please try it, and tell us <a href="https://docs.pydantic.dev/logfire/help/">what you think</a>!


### PR DESCRIPTION
Change the announcement at the top of the docs to talk about [Pydantic Logfire](https://pydantic.dev/logfire).

Because of the branch name, this should get deployed automatically. It's based off the `2.7` branch which I just (re)created off the `v2.7.1` tag. We should merge this into 2.7 so it gets included in any other 2.7.x release, and also cherry-pick it onto main so it gets included in 2.8 etc.