### PR TITLE
Disallow usage of `with_config` on a Pydantic model

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1117,4 +1117,20 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'model-config-invalid-field-name'
 ```
 
+## [`with_config`][pydantic.config.with_config] is used on a `BaseModel` subclass {#with-config-on-model}
+
+This error is raised when the [`with_config`][pydantic.config.with_config]  decorator is used on a class which is already a Pydantic model (use the `model_config` attribute instead).
+
+```py
+from pydantic import BaseModel, PydanticUserError, with_config
+
+try:
+
+    @with_config({"allow_inf_nan": True})
+    class Model(BaseModel):
+        bar: str
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'with-config-on-model'
+
 {% endraw %}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1127,7 +1127,7 @@ from pydantic import BaseModel, PydanticUserError, with_config
 
 try:
 
-    @with_config({"allow_inf_nan": True})
+    @with_config({'allow_inf_nan': True})
     class Model(BaseModel):
         bar: str
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type, TypeVar, Unio
 
 from typing_extensions import Literal, TypeAlias, TypedDict
 
-from ._internal._utils import is_model_class
 from ._migration import getattr_migration
 from .aliases import AliasGenerator
 from .errors import PydanticUserError
@@ -1023,6 +1022,8 @@ def with_config(config: ConfigDict) -> Callable[[_TypeT], _TypeT]:
         # Ideally, we would check for `class_` to either be a `TypedDict` or a stdlib dataclass.
         # However, the `@with_config` decorator can be applied *after* `@dataclass`. To avoid
         # common mistakes, we at least check for `class_` to not be a Pydantic model.
+        from ._internal._utils import is_model_class
+
         if is_model_class(class_):
             raise PydanticUserError(
                 f'Cannot use `with_config` on {class_.__name__} as it is a Pydantic model',

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1026,7 +1026,7 @@ def with_config(config: ConfigDict) -> Callable[[_TypeT], _TypeT]:
         if is_model_class(class_):
             raise PydanticUserError(
                 f'Cannot use `with_config` on {class_.__name__} as it is a Pydantic model',
-                code=None,
+                code='with-config-on-model',
             )
         class_.__pydantic_config__ = config
         return class_

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -315,13 +315,13 @@ def rebuild_dataclass(
         )
 
 
-def is_pydantic_dataclass(__cls: type[Any]) -> TypeGuard[type[PydanticDataclass]]:
+def is_pydantic_dataclass(class_: type[Any], /) -> TypeGuard[type[PydanticDataclass]]:
     """Whether a class is a pydantic dataclass.
 
     Args:
-        __cls: The class.
+        class_: The class.
 
     Returns:
         `True` if the class is a pydantic dataclass, `False` otherwise.
     """
-    return dataclasses.is_dataclass(__cls) and '__pydantic_validator__' in __cls.__dict__
+    return dataclasses.is_dataclass(class_) and '__pydantic_validator__' in class_.__dict__

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -62,6 +62,7 @@ PydanticErrorCodes = Literal[
     'dataclass-init-false-extra-allow',
     'clashing-init-and-init-var',
     'model-config-invalid-field-name',
+    'with-config-on-model',
 ]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ from pydantic import (
     create_model,
     field_validator,
     validate_call,
+    with_config,
 )
 from pydantic._internal._config import ConfigWrapper, config_defaults
 from pydantic._internal._mock_val_ser import MockValSer
@@ -899,3 +900,13 @@ def test_dataclass_allowes_model_config_as_model_field():
 
     assert m.model_config['title'] == field_title
     assert getattr(m, '__pydantic_config__')['title'] == config_title
+
+
+def test_with_config_disallowed_with_model():
+    msg = 'Cannot use `with_config` on Model as it is a Pydantic model'
+
+    with pytest.raises(PydanticUserError, match=msg):
+
+        @with_config({'coerce_numbers_to_str': True})
+        class Model(BaseModel):
+            pass


### PR DESCRIPTION
Additionally, make `is_pydantic_dataclass` argument pos only, this was missed from a previous PR.

Fixes https://github.com/pydantic/pydantic/issues/9397