### PR TITLE
Remove redundant `relnotes-fix`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,10 +3,6 @@ relnotes-fix:
 - changed-files:
   - any-glob-to-any-file: '**'
 
-# Add 'relnotes-fix' label to any PR where the head branch name starts with `fix` or has a `fix` section in the name
-relnotes-fix:
- - head-branch: ['^fix', 'fix']
-
 relnotes-feature:
  - head-branch: ['^feature', 'feature']
 


### PR DESCRIPTION
As we already defined `relnotes-fix` in top of the file and it adds the fix label by default to all the PRs we don't need the second one.
 https://github.com/pydantic/pydantic/blob/4d7bef62aeff10985fe67d13477fe666b13ba070/.github/labeler.yml#L2


Also, it breaks the labeler
https://github.com/pydantic/pydantic/actions/runs/8941662878/job/24641654672?pr=9387