### PR TITLE
added @classmethod to @model_validator(mode='before') in docs and acr…

### DIFF
--- a/docs/concepts/dataclasses.md
+++ b/docs/concepts/dataclasses.md
@@ -412,6 +412,7 @@ class User:
     birth: Birth
 
     @model_validator(mode='before')
+    @classmethod
     def pre_root(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         print(f'First: {values}')
         """

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1836,6 +1836,7 @@ def test_model_validator_before():
         b: float
 
         @model_validator(mode='before')
+        @classmethod
         def double_b(cls, v: ArgsKwargs):
             v.kwargs['b'] *= 2
             return v

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -213,6 +213,7 @@ def test_assignment():
 def test_model_validator_before():
     class Model(RootModel[int]):
         @model_validator(mode='before')
+        @classmethod
         def words(cls, v):
             if v == 'one':
                 return 1

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1786,6 +1786,7 @@ def test_overridden_root_validators():
         x: str
 
         @model_validator(mode='before')
+        @classmethod
         def pre_root(cls, values: Dict[str, Any]) -> Dict[str, Any]:
             validate_stub('A', 'pre')
             return values
@@ -1797,6 +1798,7 @@ def test_overridden_root_validators():
 
     class B(A):
         @model_validator(mode='before')
+        @classmethod
         def pre_root(cls, values: Dict[str, Any]) -> Dict[str, Any]:
             validate_stub('B', 'pre')
             return values
@@ -1851,6 +1853,7 @@ def test_validating_assignment_model_validator_before_fail():
         model_config = ConfigDict(validate_assignment=True)
 
         @model_validator(mode='before')
+        @classmethod
         def values_are_not_string(cls, values: Dict[str, Any]) -> Dict[str, Any]:
             assert isinstance(values, dict)
             if any(isinstance(x, str) for x in values.values()):


### PR DESCRIPTION
…oss app

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- For clarity/consistency, added the @classmethod decorator to methods with @model_validate(mode="before"), as described in the docs.

"Before model validators should be class methods. The first argument should be cls (and we also recommend you use @classmethod below @model_validator for proper type checking),"

https://docs.pydantic.dev/latest/concepts/validators/#model-validators

## Related issue number

#9407

## Checklist

* [ x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ x] Unit tests for the changes exist
* [ x] Tests pass on CI
* [ x] Documentation reflects the changes where applicable
* [ x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt