### PR TITLE
Support `pip install pydantic[settings]`

### DIFF
--- a/docs/concepts/pydantic_settings.md
+++ b/docs/concepts/pydantic_settings.md
@@ -4,6 +4,6 @@ description: Support for loading a settings or config class from environment var
 
 # Settings Management
 
-[Pydantic Settings](https://github.com/pydantic/pydantic-settings) provides optional Pydantic features for loading a settings or config class from environment variables or secrets files. It can be conveniently installed via `pip install pydantic[settings]`.
+[Pydantic Settings](https://github.com/pydantic/pydantic-settings) provides optional Pydantic features for loading a settings or config class from environment variables or secrets files.
 
 {{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/main/docs/index.md', '') }}

--- a/docs/concepts/pydantic_settings.md
+++ b/docs/concepts/pydantic_settings.md
@@ -4,6 +4,6 @@ description: Support for loading a settings or config class from environment var
 
 # Settings Management
 
-[Pydantic Settings](https://github.com/pydantic/pydantic-settings) provides optional Pydantic features for loading a settings or config class from environment variables or secrets files.
+[Pydantic Settings](https://github.com/pydantic/pydantic-settings) provides optional Pydantic features for loading a settings or config class from environment variables or secrets files. It can be conveniently installed via `pip install pydantic[settings]`.
 
 {{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/main/docs/index.md', '') }}

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
+groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra", "settings"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:1f3f711d35fa13627c92e663011e3ca007476b79f4bc440570cccbf517fd3521"
+content_hash = "sha256:6f8cf7444b8cfc9e87cc49918d2ddff02cddcab97c0142769855ad6b5c284921"
 
 [[package]]
 name = "annotated-types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 dynamic = ['version', 'readme']
 
 [project.optional-dependencies]
+settings = ['pydantic-settings>=2.0.0']
 email = ['email-validator>=2.0.0']
 
 [project.urls]


### PR DESCRIPTION
## Change Summary

I have added a line to `[project.optional-dependencies]` in `pyproject.toml` to support the use of `pip install pydantic[settings]` to install both `pydantic` and `pydantic-settings`.

If/when this is merged, we should update the `pydantic-settings` docs [here](https://github.com/pydantic/pydantic-settings/blob/main/docs/index.md) to mention this convenience method of installation.

## Related issue number

N/A

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [X] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
