### PR TITLE
Fix labeler permission problem

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,7 @@ name: release notes
 
 on:
   pull_request_target:
+    types: [opened]
 
 jobs:
   auto-labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,7 @@
 name: release notes
 
 on:
-  pull_request:
-    types: [opened]
+  pull_request_target:
 
 jobs:
   auto-labeler:


### PR DESCRIPTION
It is failing for PR from a fork: https://github.com/pydantic/pydantic/actions/runs/8992867651/job/24766726818?pr=9410

This is the fix based on this doc: https://github.com/actions/labeler?tab=readme-ov-file#permissions