### PR TITLE
docs(fields): fix link to union modes

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -750,7 +750,7 @@ def Field(  # noqa: C901
         max_digits: Maximum number of allow digits for strings.
         decimal_places: Maximum number of decimal places allowed for numbers.
         union_mode: The strategy to apply when validating a union. Can be `smart` (the default), or `left_to_right`.
-            See [Union Mode](standard_library_types.md#union-mode) for details.
+            See [Union Mode](../concepts/unions.md#union-modes) for details.
         extra: (Deprecated) Extra fields that will be included in the JSON schema.
 
             !!! warning Deprecated


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The description of the `union_mode` parameter of the [Field](https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.Field) function is provided with a link to a nonexistent paragraph on the [Standard Library Types](https://docs.pydantic.dev/latest/api/standard_library_types/) page: https://docs.pydantic.dev/latest/api/standard_library_types/#union-mode

I believe that the correct link is: https://docs.pydantic.dev/latest/concepts/unions/#union-modes. It has been changed in this PR.

<!-- Please give a short summary of the changes. -->

## Related issue number

There is none.

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
