### PR TITLE
[Docs] Fix ModuleNotFoundError in Pydantic Extra Types

### DIFF
--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -76,14 +76,23 @@ def add_changelog() -> None:
 
 
 def add_mkdocs_run_deps() -> None:
-    # set the pydantic and pydantic-core versions to configure for running examples in the browser
+    # set the pydantic, pydantic-core, and pydantic-extra-types versions to configure for running examples in the browser
     pyproject_toml = (PROJECT_ROOT / 'pyproject.toml').read_text()
     pydantic_core_version = re.search(r'pydantic-core==(.+?)["\']', pyproject_toml).group(1)
 
     version_py = (PROJECT_ROOT / 'pydantic' / 'version.py').read_text()
     pydantic_version = re.search(r'^VERSION ?= (["\'])(.+)\1', version_py, flags=re.M).group(2)
 
-    mkdocs_run_deps = json.dumps([f'pydantic=={pydantic_version}', f'pydantic-core=={pydantic_core_version}'])
+    pdm_lock = (PROJECT_ROOT / 'pdm.lock').read_text()
+    pydantic_extra_types_version = re.search(r'name = "pydantic-extra-types"\nversion = "(.+?)"', pdm_lock).group(1)
+
+    mkdocs_run_deps = json.dumps(
+        [
+            f'pydantic=={pydantic_version}',
+            f'pydantic-core=={pydantic_core_version}',
+            f'pydantic-extra-types=={pydantic_extra_types_version}',
+        ]
+    )
     logger.info('Setting mkdocs_run_deps=%s', mkdocs_run_deps)
 
     html = f"""\

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -76,7 +76,7 @@ def add_changelog() -> None:
 
 
 def add_mkdocs_run_deps() -> None:
-    # set the pydantic, pydantic-core, and pydantic-extra-types versions to configure for running examples in the browser
+    # set the pydantic, pydantic-core, pydantic-extra-types versions to configure for running examples in the browser
     pyproject_toml = (PROJECT_ROOT / 'pyproject.toml').read_text()
     pydantic_core_version = re.search(r'pydantic-core==(.+?)["\']', pyproject_toml).group(1)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The Pydantic Extra Types docs have several examples to run in the browser but `ModuleNotFoundError: No module named 'pydantic_extra_types'` error is raised because `pydantic-extra-types` is not installed. An example with `Latitude`: https://docs.pydantic.dev/latest/api/pydantic_extra_types_coordinate/#pydantic_extra_types.coordinate.Latitude.

I have updated `add_mkdocs_run_deps` to include this dependency with its version. Documentation is built and served correctly. I have verified the `Latitude` example (and others) and its docstring runs as expected.

For the sake of consistency on the output, the corresponding script is updated as well at https://github.com/samuelcolvin/mkdocs-run-code/pull/6.

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [X] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
