### PR TITLE
Remove unneeded check for `CoreSchema` or `CoreSchemaField` in `handler_func` in `GenerateJsonSchema.generate_inner`

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -503,11 +503,8 @@ class GenerateJsonSchema:
                 ser_schema = schema_or_field['serialization']  # type: ignore
                 json_schema = self.ser_schema(ser_schema)
             if json_schema is None:
-                if _core_utils.is_core_schema(schema_or_field) or _core_utils.is_core_schema_field(schema_or_field):
-                    generate_for_schema_type = self._schema_type_to_method[schema_or_field['type']]
-                    json_schema = generate_for_schema_type(schema_or_field)
-                else:
-                    raise TypeError(f'Unexpected schema type: schema={schema_or_field}')
+                generate_for_schema_type = self._schema_type_to_method[schema_or_field['type']]
+                json_schema = generate_for_schema_type(schema_or_field)
             if _core_utils.is_core_schema(schema_or_field):
                 json_schema = populate_defs(schema_or_field, json_schema)
                 json_schema = convert_to_all_of(json_schema)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR removes the check for `CoreSchema` or `CoreSchemaField` in `handler_func` in `GenerateJsonSchema.generate_inner`. The check is always true.

This PR is not what is needed if the code before the change in this PR doesn't implement what is intended.


<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin