### PR TITLE
Fix a bug when setting StringConstraint(strict=False)

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -705,7 +705,7 @@ class StringConstraints(annotated_types.GroupedMetadata):
         if self.max_length is not None:
             yield MaxLen(self.max_length)
         if self.strict is not None:
-            yield Strict()
+            yield Strict(self.strict)
         if (
             self.strip_whitespace is not None
             or self.pattern is not None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6421,6 +6421,15 @@ def test_string_constraints() -> None:
     assert ta.validate_python(' ABC ') == 'abcabc'
 
 
+def test_string_constraints_strict() -> None:
+    ta = TypeAdapter(Annotated[str, StringConstraints(strict=False)])
+    assert ta.validate_python(b'123') == '123'
+
+    ta = TypeAdapter(Annotated[str, StringConstraints(strict=True)])
+    with pytest.raises(ValidationError):
+        ta.validate_python(b'123')
+
+
 def test_decimal_float_precision() -> None:
     """https://github.com/pydantic/pydantic/issues/6807"""
     ta = TypeAdapter(Decimal)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

This PR fixes a bug when setting `StringConstraint(strict=False)`. It was in fact setting the schema to `strict=True`.

This change was initiated as a test code coverage improvement, but while creating the test, I spotted this bug.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Contributes to #7656 .

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex