### PR TITLE
Do not alter `RootModel.model_construct` signature in the mypy plugin

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -480,7 +480,8 @@ class PydanticModelTransformer:
 
         is_settings = any(base.fullname == BASESETTINGS_FULLNAME for base in info.mro[:-1])
         self.add_initializer(fields, config, is_settings, is_root_model)
-        self.add_model_construct_method(fields, config, is_settings)
+        if not is_root_model:
+            self.add_model_construct_method(fields, config, is_settings)
         self.set_frozen(fields, self._api, frozen=config.frozen is True)
 
         self.adjust_decorator_signatures()

--- a/tests/mypy/modules/root_models.py
+++ b/tests/mypy/modules/root_models.py
@@ -7,6 +7,8 @@ class Pets1(RootModel[List[str]]):
     pass
 
 
+pets_construct = Pets1.model_construct(['dog'])
+
 Pets2 = RootModel[List[str]]
 
 

--- a/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin_ini/root_models.py
@@ -7,6 +7,8 @@ class Pets1(RootModel[List[str]]):
     pass
 
 
+pets_construct = Pets1.model_construct(['dog'])
+
 Pets2 = RootModel[List[str]]
 
 

--- a/tests/mypy/outputs/1.1.1/mypy-default_ini/root_models.py
+++ b/tests/mypy/outputs/1.1.1/mypy-default_ini/root_models.py
@@ -7,6 +7,8 @@ class Pets1(RootModel[List[str]]):
     pass
 
 
+pets_construct = Pets1.model_construct(['dog'])
+
 Pets2 = RootModel[List[str]]
 
 

--- a/tests/mypy/outputs/1.1.1/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/1.1.1/mypy-plugin_ini/root_models.py
@@ -7,6 +7,8 @@ class Pets1(RootModel[List[str]]):
     pass
 
 
+pets_construct = Pets1.model_construct(['dog'])
+
 Pets2 = RootModel[List[str]]
 
 

--- a/tests/mypy/outputs/1.1.1/pyproject-default_toml/root_models.py
+++ b/tests/mypy/outputs/1.1.1/pyproject-default_toml/root_models.py
@@ -7,6 +7,8 @@ class Pets1(RootModel[List[str]]):
     pass
 
 
+pets_construct = Pets1.model_construct(['dog'])
+
 Pets2 = RootModel[List[str]]
 
 

--- a/tests/mypy/outputs/1.4.1/mypy-default_ini/root_models.py
+++ b/tests/mypy/outputs/1.4.1/mypy-default_ini/root_models.py
@@ -7,6 +7,8 @@ class Pets1(RootModel[List[str]]):
     pass
 
 
+pets_construct = Pets1.model_construct(['dog'])
+
 Pets2 = RootModel[List[str]]
 
 

--- a/tests/mypy/outputs/1.4.1/pyproject-default_toml/root_models.py
+++ b/tests/mypy/outputs/1.4.1/pyproject-default_toml/root_models.py
@@ -7,6 +7,8 @@ class Pets1(RootModel[List[str]]):
     pass
 
 
+pets_construct = Pets1.model_construct(['dog'])
+
 Pets2 = RootModel[List[str]]
 
 


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/9461.

No need to tweak the signature as no `**values` argument is present