### PR TITLE
Fix missing `description` field in callable json schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1651,6 +1651,7 @@ class GenerateJsonSchema:
                 json_schema['additionalProperties'] = additional_properties_schema
         else:
             json_schema['additionalProperties'] = False
+
         return json_schema
 
     def p_arguments_schema(

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -2,8 +2,9 @@ import sys
 from typing import Callable
 
 import pytest
+from typing_extensions import Annotated
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 collection_callable_types = [Callable, Callable[[int], int]]
 if sys.version_info >= (3, 9):
@@ -28,3 +29,14 @@ def test_non_callable(annotation):
 
     with pytest.raises(ValidationError):
         Model(callback=1)
+
+
+def test_description_in_callable_schema() -> None:
+    FooType = Annotated[int, Field(default=1, description='foo type description')]
+
+    def func(foo: FooType):
+        ...
+
+    # Description is lost 🤔
+    json_schema = TypeAdapter(func).json_schema()
+    assert json_schema['properties']['foo']['description'] == 'foo type description'


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9404

Note, I don't think we should go with this solution, but I wanted to document one workaround.

Instead, I think we should refactor how we apply JSON schema from annotations, because the current method is quite confusing.