### PR TITLE
Updates type signature for Field() constructor

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -60,10 +60,10 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
     ge: annotated_types.SupportsGe | None
     lt: annotated_types.SupportsLt | None
     le: annotated_types.SupportsLe | None
-    multiple_of: annotated_types.MultipleOf | None
+    multiple_of: float | None
     strict: bool | None
-    min_length: annotated_types.MinLen | None
-    max_length: annotated_types.MaxLen | None
+    min_length: int | None
+    max_length: int | None
     pattern: str | typing.Pattern[str] | None
     allow_inf_nan: bool | None
     max_digits: int | None
@@ -690,12 +690,12 @@ def Field(  # noqa: C901
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: annotated_types.MultipleOf | None = _Unset,
+    multiple_of: float | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
-    min_length: annotated_types.MinLen | None = _Unset,
-    max_length: annotated_types.MaxLen | None = _Unset,
+    min_length: int | None = _Unset,
+    max_length: int | None = _Unset,
     union_mode: Literal['smart', 'left_to_right'] = _Unset,
     **extra: Unpack[_EmptyKwargs],
 ) -> Any:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -56,14 +56,14 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
     description: str | None
     examples: list[Any] | None
     exclude: bool | None
-    gt: float | None
-    ge: float | None
-    lt: float | None
-    le: float | None
-    multiple_of: float | None
+    gt: annotated_types.SupportsGt | None
+    ge: annotated_types.SupportsGe | None
+    lt: annotated_types.SupportsLt | None
+    le: annotated_types.SupportsLe | None
+    multiple_of: annotated_types.MultipleOf | None
     strict: bool | None
-    min_length: int | None
-    max_length: int | None
+    min_length: annotated_types.MinLen | None
+    max_length: annotated_types.MaxLen | None
     pattern: str | typing.Pattern[str] | None
     allow_inf_nan: bool | None
     max_digits: int | None
@@ -686,16 +686,16 @@ def Field(  # noqa: C901
     pattern: str | typing.Pattern[str] | None = _Unset,
     strict: bool | None = _Unset,
     coerce_numbers_to_str: bool | None = _Unset,
-    gt: float | None = _Unset,
-    ge: float | None = _Unset,
-    lt: float | None = _Unset,
-    le: float | None = _Unset,
-    multiple_of: float | None = _Unset,
+    gt: annotated_types.SupportsGt | None = _Unset,
+    ge: annotated_types.SupportsGe | None = _Unset,
+    lt: annotated_types.SupportsLt | None = _Unset,
+    le: annotated_types.SupportsLe | None = _Unset,
+    multiple_of: annotated_types.MultipleOf | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
-    min_length: int | None = _Unset,
-    max_length: int | None = _Unset,
+    min_length: annotated_types.MinLen | None = _Unset,
+    max_length: annotated_types.MaxLen | None = _Unset,
     union_mode: Literal['smart', 'left_to_right'] = _Unset,
     **extra: Unpack[_EmptyKwargs],
 ) -> Any:


### PR DESCRIPTION
Replaces `float` in `lt`/`gt`/`le`/`ge`, arguments with the appropriate Protocol from `annotated_types`.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Related to #9472 updates the type signatures in `Field()` to be less restrictive, using the appropriate protocols from `annotated_types` instead of strict `float` or `int` types. This should be a nonbreaking change.

## Related issue number

fixes #9472

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
