### PR TITLE
test_pretty_print - ignore `FORCE_COLOR`

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -669,7 +669,10 @@ def test_handle_call_schema():
     assert schema['return_schema'] == {'type': 'int'}
 
 
-def test_pretty_print(capfd):
+def test_pretty_print(capfd, monkeypatch):
+    # This can break the test by adding color to the output streams
+    monkeypatch.delenv('FORCE_COLOR', raising=False)
+
     # 1. Included metadata
     schema = core_schema.AnySchema(
         type='any',


### PR DESCRIPTION
## Change Summary

Making life better for the `typing_extensions` folks - https://github.com/python/typing_extensions/issues/415

I can reproduce - running `FORCE_COLOR=1 pytest tests/test_utils.py` fails without this patch.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
