### PR TITLE
2.7: Support context being passed to TypeAdapter's dump_json/dump_python 

### DIFF
--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -316,6 +316,7 @@ class TypeAdapter(Generic[T]):
         round_trip: bool = False,
         warnings: bool | Literal['none', 'warn', 'error'] = True,
         serialize_as_any: bool = False,
+        context: dict[str, Any] | None = None,
     ) -> Any:
         """Dump an instance of the adapted type to a Python object.
 
@@ -332,6 +333,7 @@ class TypeAdapter(Generic[T]):
             warnings: How to handle serialization errors. False/"none" ignores them, True/"warn" logs errors,
                 "error" raises a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError].
             serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
+            context: Additional context to pass to the serializer.
 
         Returns:
             The serialized object.
@@ -348,6 +350,7 @@ class TypeAdapter(Generic[T]):
             round_trip=round_trip,
             warnings=warnings,
             serialize_as_any=serialize_as_any,
+            context=context,
         )
 
     def dump_json(
@@ -365,6 +368,7 @@ class TypeAdapter(Generic[T]):
         round_trip: bool = False,
         warnings: bool | Literal['none', 'warn', 'error'] = True,
         serialize_as_any: bool = False,
+        context: dict[str, Any] | None = None,
     ) -> bytes:
         """Usage docs: https://docs.pydantic.dev/2.7/concepts/json/#json-serialization
 
@@ -383,6 +387,7 @@ class TypeAdapter(Generic[T]):
             warnings: How to handle serialization errors. False/"none" ignores them, True/"warn" logs errors,
                 "error" raises a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError].
             serialize_as_any: Whether to serialize fields with duck-typing serialization behavior.
+            context: Additional context to pass to the serializer.
 
         Returns:
             The JSON representation of the given instance as bytes.
@@ -399,6 +404,7 @@ class TypeAdapter(Generic[T]):
             round_trip=round_trip,
             warnings=warnings,
             serialize_as_any=serialize_as_any,
+            context=context,
         )
 
     def json_schema(


### PR DESCRIPTION
## Change Summary

Identical change to https://github.com/pydantic/pydantic/pull/9495, but targeted at a 2.7 release.

Support passing in of context to TypeAdapter's dump_python and dump_json functions, allowing context to be present during TypeAdapter serialization.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
Issue I'm solving for is that I want to be able to serialize an object in different contexts (using fastapi), so this piece is needed to support context based serialization of type adapters.

The upstream problem this solves (in fastapi) is illustrated here: https://github.com/tiangolo/fastapi/pull/11634

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin