### PR TITLE
Replace `_defer_build_mode` with `experimental_defer_build_mode`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,7 +196,7 @@ plugins:
         options:
           members_order: source
           separate_signature: true
-          filters: ["!^_(?!defer_build_mode)"]
+          filters: ["!^_"]
           docstring_options:
             ignore_init_summary: true
           merge_init_into_class: true

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -75,7 +75,7 @@ class ConfigWrapper:
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
     defer_build: bool
-    _defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
+    experimental_defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
     plugin_settings: dict[str, object] | None
     schema_generator: type[GenerateSchema] | None
     json_schema_serialization_defaults_required: bool
@@ -257,7 +257,7 @@ config_defaults = ConfigDict(
     hide_input_in_errors=False,
     json_encoders=None,
     defer_build=False,
-    _defer_build_mode=('model',),
+    experimental_defer_build_mode=('model',),
     plugin_settings=None,
     schema_generator=None,
     json_schema_serialization_defaults_required=False,

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -525,7 +525,7 @@ def complete_model_class(
         ref_mode='unpack',
     )
 
-    if config_wrapper.defer_build and 'model' in config_wrapper._defer_build_mode:
+    if config_wrapper.defer_build and 'model' in config_wrapper.experimental_defer_build_mode:
         set_model_mocks(cls, cls_name)
         return False
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -716,28 +716,28 @@ class ConfigDict(TypedDict, total=False):
     used nested within other models, or when you want to manually define type namespace via
     [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild].
 
-    See also [`_defer_build_mode`][pydantic.config.ConfigDict._defer_build_mode].
+    See also [`experimental_defer_build_mode`][pydantic.config.ConfigDict.experimental_defer_build_mode].
 
     !!! note
         `defer_build` does not work by default with FastAPI Pydantic models. By default, the validator and serializer
         for said models is constructed immediately for FastAPI routes. You also need to define
-        [`_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict._defer_build_mode] with FastAPI
+        [`experimental_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict.experimental_defer_build_mode] with FastAPI
         models in order for `defer_build=True` to take effect. This additional (experimental) parameter is required for
         the deferred building due to FastAPI relying on `TypeAdapter`s.
     """
 
-    _defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
+    experimental_defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
     """
     Controls when [`defer_build`][pydantic.config.ConfigDict.defer_build] is applicable. Defaults to `('model',)`.
 
     Due to backwards compatibility reasons [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] does not by default
-    respect `defer_build`. Meaning when `defer_build` is `True` and `_defer_build_mode` is the default `('model',)`
+    respect `defer_build`. Meaning when `defer_build` is `True` and `experimental_defer_build_mode` is the default `('model',)`
     then `TypeAdapter` immediately constructs its validator and serializer instead of postponing said construction until
     the first model validation. Set this to `('model', 'type_adapter')` to make `TypeAdapter` respect the `defer_build`
     so it postpones validator and serializer construction until the first validation or serialization.
 
     !!! note
-        The `_defer_build_mode` parameter is named with an underscore to suggest this is an experimental feature. It may
+        The `experimental_defer_build_mode` parameter is named with an underscore to suggest this is an experimental feature. It may
         be removed or changed in the future in a minor release.
     """
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -159,7 +159,7 @@ class TypeAdapter(Generic[T]):
     **Note:** By default, `TypeAdapter` does not respect the
     [`defer_build=True`][pydantic.config.ConfigDict.defer_build] setting in the
     [`model_config`][pydantic.BaseModel.model_config] or in the `TypeAdapter` constructor `config`. You need to also
-    explicitly set [`_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict._defer_build_mode] of the
+    explicitly set [`experimental_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict.experimental_defer_build_mode] of the
     config to defer the model validator and serializer construction. Thus, this feature is opt-in to ensure backwards
     compatibility.
 
@@ -341,8 +341,10 @@ class TypeAdapter(Generic[T]):
     @staticmethod
     def _is_defer_build_config(config: ConfigDict) -> bool:
         # TODO reevaluate this logic when we have a better understanding of how defer_build should work with TypeAdapter
-        # Should we drop the special _defer_build_mode check?
-        return config.get('defer_build', False) is True and 'type_adapter' in config.get('_defer_build_mode', tuple())
+        # Should we drop the special experimental_defer_build_mode check?
+        return config.get('defer_build', False) is True and 'type_adapter' in config.get(
+            'experimental_defer_build_mode', tuple()
+        )
 
     @_frame_depth(1)
     def validate_python(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -710,7 +710,7 @@ def test_config_model_defer_build(
 ):
     config = ConfigDict(defer_build=True)
     if defer_build_mode is not None:
-        config['_defer_build_mode'] = defer_build_mode
+        config['experimental_defer_build_mode'] = defer_build_mode
 
     class MyModel(BaseModel):
         model_config = config
@@ -719,11 +719,11 @@ def test_config_model_defer_build(
     if defer_build_mode is None or 'model' in defer_build_mode:
         assert isinstance(MyModel.__pydantic_validator__, MockValSer)
         assert isinstance(MyModel.__pydantic_serializer__, MockValSer)
-        assert generate_schema_calls.count == 0, 'Should respect _defer_build_mode'
+        assert generate_schema_calls.count == 0, 'Should respect experimental_defer_build_mode'
     else:
         assert isinstance(MyModel.__pydantic_validator__, SchemaValidator)
         assert isinstance(MyModel.__pydantic_serializer__, SchemaSerializer)
-        assert generate_schema_calls.count == 1, 'Should respect _defer_build_mode'
+        assert generate_schema_calls.count == 1, 'Should respect experimental_defer_build_mode'
 
     m = MyModel(x=1)
     assert m.x == 1
@@ -742,7 +742,7 @@ def test_config_model_type_adapter_defer_build(
 ):
     config = ConfigDict(defer_build=True)
     if defer_build_mode is not None:
-        config['_defer_build_mode'] = defer_build_mode
+        config['experimental_defer_build_mode'] = defer_build_mode
 
     class MyModel(BaseModel):
         model_config = config
@@ -770,7 +770,7 @@ def test_config_plain_type_adapter_defer_build(
 ):
     config = ConfigDict(defer_build=True)
     if defer_build_mode is not None:
-        config['_defer_build_mode'] = defer_build_mode
+        config['experimental_defer_build_mode'] = defer_build_mode
     is_deferred = defer_build_mode is not None and 'type_adapter' in defer_build_mode
 
     ta = TypeAdapter(Dict[str, int], config=config)
@@ -792,7 +792,7 @@ def test_config_model_defer_build_nested(
 ):
     config = ConfigDict(defer_build=True)
     if defer_build_mode:
-        config['_defer_build_mode'] = defer_build_mode
+        config['experimental_defer_build_mode'] = defer_build_mode
 
     assert generate_schema_calls.count == 0
 
@@ -807,7 +807,7 @@ def test_config_model_defer_build_nested(
     assert isinstance(MyModel.__pydantic_serializer__, SchemaSerializer)
 
     expected_schema_count = 1 if defer_build_mode is None or 'model' in defer_build_mode else 2
-    assert generate_schema_calls.count == expected_schema_count, 'Should respect _defer_build_mode'
+    assert generate_schema_calls.count == expected_schema_count, 'Should respect experimental_defer_build_mode'
 
     if defer_build_mode is None or 'model' in defer_build_mode:
         assert isinstance(MyNestedModel.__pydantic_validator__, MockValSer)

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -73,7 +73,7 @@ OuterDict = Dict[str, 'IntList']
 @pytest.mark.parametrize('defer_build', [False, True])
 @pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
 def test_global_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
-    config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
     ta = TypeAdapter(OuterDict, config=config)
 
     assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
@@ -94,7 +94,9 @@ def test_global_namespace_variables(defer_build: bool, method: str, generate_sch
 @pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
 def test_model_global_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
     class MyModel(BaseModel):
-        model_config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+        model_config = (
+            ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+        )
         x: OuterDict
 
     ta = TypeAdapter(MyModel)
@@ -119,7 +121,7 @@ def test_local_namespace_variables(defer_build: bool, method: str, generate_sche
     IntList = List[int]  # noqa: F841
     OuterDict = Dict[str, 'IntList']
 
-    config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
     ta = TypeAdapter(OuterDict, config=config)
 
     assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
@@ -142,7 +144,9 @@ def test_model_local_namespace_variables(defer_build: bool, method: str, generat
     IntList = List[int]  # noqa: F841
 
     class MyModel(BaseModel):
-        model_config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+        model_config = (
+            ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+        )
         x: Dict[str, 'IntList']
 
     ta = TypeAdapter(MyModel)
@@ -165,7 +169,7 @@ def test_model_local_namespace_variables(defer_build: bool, method: str, generat
 @pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="ForwardRef doesn't accept module as a parameter in Python < 3.9")
 def test_top_level_fwd_ref(defer_build: bool, method: str, generate_schema_calls):
-    config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
 
     FwdRef = ForwardRef('OuterDict', module=__name__)
     ta = TypeAdapter(FwdRef, config=config)
@@ -393,7 +397,7 @@ def test_validate_python_from_attributes() -> None:
 def test_validate_strings(
     field_type, input_value, expected, raises_match, strict, defer_build: bool, generate_schema_calls
 ):
-    config = ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
     ta = TypeAdapter(field_type, config=config)
 
     assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
@@ -514,10 +518,10 @@ def defer_build_test_models(config: ConfigDict) -> List[Any]:
 
 
 CONFIGS = [
-    ConfigDict(defer_build=False, _defer_build_mode=('model',)),
-    ConfigDict(defer_build=False, _defer_build_mode=DEFER_ENABLE_MODE),
-    ConfigDict(defer_build=True, _defer_build_mode=('model',)),
-    ConfigDict(defer_build=True, _defer_build_mode=DEFER_ENABLE_MODE),
+    ConfigDict(defer_build=False, experimental_defer_build_mode=('model',)),
+    ConfigDict(defer_build=False, experimental_defer_build_mode=DEFER_ENABLE_MODE),
+    ConfigDict(defer_build=True, experimental_defer_build_mode=('model',)),
+    ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE),
 ]
 MODELS_CONFIGS: List[Tuple[Any, ConfigDict]] = [
     (model, config) for config in CONFIGS for model in defer_build_test_models(config)
@@ -533,7 +537,7 @@ def test_core_schema_respects_defer_build(model: Any, config: ConfigDict, method
 
     type_adapter = TypeAdapter(model) if _type_has_config(model) else TypeAdapter(model, config=config)
 
-    if config['defer_build'] and 'type_adapter' in config['_defer_build_mode']:
+    if config['defer_build'] and 'type_adapter' in config['experimental_defer_build_mode']:
         assert generate_schema_calls.count == 0, 'Should be built deferred'
         assert type_adapter._core_schema is None, 'Should be initialized deferred'
         assert type_adapter._validator is None, 'Should be initialized deferred'


### PR DESCRIPTION
Follow up to https://github.com/pydantic/pydantic/pull/8939

Replace the "private" `_defer_build_mode` setting with `experimental_defer_build_mode` to be consistent with the new experimental API that we're going to introduce, where experimental new features are either:
* Prefixed with `experimental_`
* Located in the `experimental` module

@MarkusSintonen just wanted to ping you to notify you of this change -- hoping to do the 2.8 release around the end of June, and I'll add some docs explaining our new experimental feature policy here shortly :).

Selected Reviewer: @hramezani