### PR TITLE
Fix typing of `TypeAdapter`

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -687,7 +687,7 @@ may need to explicitly specify the generic parameter:
 ```python test="skip"
 from pydantic import TypeAdapter
 
-adapter: TypeAdapter[str | int] = TypeAdapter(str | int)
+adapter = TypeAdapter[str | int](str | int)
 ...
 ```
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -171,7 +171,7 @@ class TypeAdapter(Generic[T]):
 
     @overload
     def __init__(
-        self: TypeAdapter[T],
+        self,
         type: type[T],
         *,
         config: ConfigDict | None = ...,
@@ -185,7 +185,7 @@ class TypeAdapter(Generic[T]):
     # See https://github.com/python/typing/pull/1618
     @overload
     def __init__(
-        self: TypeAdapter[Any],
+        self,
         type: Any,
         *,
         config: ConfigDict | None = ...,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/9532

Dirty playgrounds if you want to play with it: [pyright](https://pyright-play.net/?strict=true&code=GYJw9gtgBALgngBwJYDsDmUkQWEMoBUAUEQCpQC8UpiApgGoCGIAFAESlsCUJAxgDaMAzkKgBBFgHFaKWiCS8A2qQC6XAFxEo2qAAEwANzn8wjACZadZ2sCgB9O6iQwHLIbX7AANFEbrYdMpq-gB0YZba%2BkYgJuYRUNa2Dk4udm4e3r7%2BYihwGlBhISSMlOKKQjAgUAA%2BmCgwKiw5KGAwjDC0ZuWVNXUwPoVqJCC0Roz8dvAItCyMPEQjYxNTMxKoMFzz5owIHSDZ3VW16yqlEhVHfTzbu3Jnh70nbj3H9TxAA), [mypy](https://mypy-play.net/?mypy=latest&python=3.12&gist=009d6511b198b92c85d498440ada4c28).

The only drawback is this is allowed:

```python
ta = TypeAdapter[int](str)
```

As type checkers will fallback to the second overload. However, the following works as expected:

```python
TypeAdapter(int)  # TypeAdapter[int], no type errors
TypeAdapter[int](int)  # TypeAdapter[int], no type errors
TypeAdapter[str | int](str | int)  # TypeAdapter[str | int], no type errors
TypeAdapter[int](Annotated[int, ...])  # TypeAdapter[int], no type errors
```

I think the TypeForm PEP is just around the corner, so this is really only a temporary fix until we get something working as expected for all use cases.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @davidhewitt