### PR TITLE
Add support for regex flags inside the Pattern

### DIFF
--- a/pydantic/_internal/_regex.py
+++ b/pydantic/_internal/_regex.py
@@ -1,0 +1,28 @@
+import re
+import typing
+
+# Reversed regex inline flag mappings
+# https://docs.rs/regex/latest/regex/#grouping-and-flags
+# https://github.com/python/cpython/blob/376c734216f54bb0f6676f60d0c771e24efe0824/Lib/re/_parser.py#L55
+INLINE_FLAG_MAPPING = {
+    re.IGNORECASE: 'i',
+    re.MULTILINE: 'm',
+    re.DOTALL: 's',
+    re.VERBOSE: 'x',
+    re.UNICODE: 'u',
+    # extended: not supported by rust regex engine
+    re.ASCII: 'a',
+}
+
+flag_clean_regex = re.compile(rf"^\(\?[{''.join(INLINE_FLAG_MAPPING.values())}]+\)")
+
+
+def extract_flagged_pattern(pattern: typing.Pattern[str]) -> str:
+    """Extract the regex string with embedded flags from a regex object"""
+    # Remove embedded flags at the beginning of the pattern, e.g. (?i)
+    # these flags are stored in the pattern.flags attribute
+    cleaned_pattern = re.sub(flag_clean_regex, '', pattern.pattern)
+
+    flags_str = ''.join(INLINE_FLAG_MAPPING[flag] for flag in INLINE_FLAG_MAPPING if pattern.flags & flag)
+
+    return f'(?{flags_str}){cleaned_pattern}' if flags_str else pattern.pattern

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -17,7 +17,7 @@ from pydantic_core import PydanticUndefined
 from typing_extensions import Literal, TypeAlias, Unpack, deprecated
 
 from . import types
-from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra, _utils
+from ._internal import _decorators, _fields, _generics, _internal_dataclass, _regex, _repr, _typing_extra, _utils
 from .aliases import AliasChoices, AliasPath
 from .config import JsonDict
 from .errors import PydanticUserError
@@ -798,7 +798,7 @@ def Field(  # noqa: C901
         raise PydanticUserError('`regex` is removed. use `pattern` instead', code='removed-kwargs')
 
     if isinstance(pattern, typing.Pattern):
-        pattern = pattern.pattern
+        pattern = _regex.extract_flagged_pattern(pattern)
 
     if extra:
         warn(

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -39,6 +39,7 @@ from ._internal import (
     _core_utils,
     _fields,
     _internal_dataclass,
+    _regex,
     _typing_extra,
     _utils,
     _validators,
@@ -716,7 +717,9 @@ class StringConstraints(annotated_types.GroupedMetadata):
                 strip_whitespace=self.strip_whitespace,
                 to_upper=self.to_upper,
                 to_lower=self.to_lower,
-                pattern=self.pattern.pattern if isinstance(self.pattern, Pattern) else self.pattern,
+                pattern=(
+                    _regex.extract_flagged_pattern(self.pattern) if isinstance(self.pattern, Pattern) else self.pattern
+                ),
             )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I've updated the extraction logic for `Field.pattern` to inplace `flags` for instances of Pattern. The previous logic directly accessed the pattern attribute, which ignores all passed flags.



<!-- Please give a short summary of the changes. -->

## Related issue number

fix #9568

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @samuelcolvin