### PR TITLE
Add fallback default value for private fields in __setstate__ of BaseModel

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -920,10 +920,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         }
 
     def __setstate__(self, state: dict[Any, Any]) -> None:
-        _object_setattr(self, '__pydantic_fields_set__', state['__pydantic_fields_set__'])
-        _object_setattr(self, '__pydantic_extra__', state['__pydantic_extra__'])
-        _object_setattr(self, '__pydantic_private__', state['__pydantic_private__'])
-        _object_setattr(self, '__dict__', state['__dict__'])
+        _object_setattr(self, '__pydantic_fields_set__', state.get('__pydantic_fields_set__', {}))
+        _object_setattr(self, '__pydantic_extra__', state.get('__pydantic_extra__', {}))
+        _object_setattr(self, '__pydantic_private__', state.get('__pydantic_private__', {}))
+        _object_setattr(self, '__dict__', state.get('__dict__', {}))
 
     if not TYPE_CHECKING:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

- Instead of dictionary access, it's safe to use `.get` for private model attributes with empty dictionary fallback value.
- This allows compatibility to v1 BaseModel when using pickle with reference to data class as well.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @adriangb