### PR TITLE
Fix mypy v1 plugin for upcoming mypy release

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -57,6 +57,7 @@ from mypy.types import (
     Type,
     TypeOfAny,
     TypeType,
+    TypeVarId,
     TypeVarType,
     UnionType,
     get_proper_type,
@@ -498,7 +499,7 @@ class PydanticModelTransformer:
             tvd = TypeVarType(
                 self_tvar_name,
                 tvar_fullname,
-                -1,
+                TypeVarId(-1),
                 [],
                 obj_type,
                 AnyType(TypeOfAny.from_omitted_generics),  # type: ignore[arg-type]


### PR DESCRIPTION
## Change Summary
In https://github.com/python/mypy/pull/17311 the signature of `TypeVarType` was changed to only accept `TypeVarId`. Previously it accepted `TypeVarId | int` and did an auto-conversion if an int was passed.
```py
if isinstance(id, int):
    id = TypeVarId(id)
```

This will break with the next release of mypy. Thus a new pydantic release would be much appreciated.


## Related issue number

--

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
