### PR TITLE
Extend path types that are automatically converted during validation

### DIFF
--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -39,6 +39,7 @@ from . import _known_annotated_metadata, _typing_extra, _validators
 from ._core_utils import get_type_ref
 from ._internal_dataclass import slots_true
 from ._schema_generation_shared import GetCoreSchemaHandler, GetJsonSchemaHandler
+from ._utils import lenient_issubclass
 
 if typing.TYPE_CHECKING:
     from ._generate_schema import GenerateSchema
@@ -207,14 +208,7 @@ def path_schema_prepare_pydantic_annotations(
 ) -> tuple[Any, list[Any]] | None:
     import pathlib
 
-    if source_type not in {
-        os.PathLike,
-        pathlib.Path,
-        pathlib.PurePath,
-        pathlib.PosixPath,
-        pathlib.PurePosixPath,
-        pathlib.PureWindowsPath,
-    }:
+    if not lenient_issubclass(source_type, os.PathLike):
         return None
 
     metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2776,37 +2776,6 @@ def test_tuple_with_extra_schema():
     }
 
 
-def test_path_modify_schema():
-    class MyPath(Path):
-        @classmethod
-        def __get_pydantic_core_schema__(cls, _source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
-            return handler(Path)
-
-        @classmethod
-        def __get_pydantic_json_schema__(
-            cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
-        ) -> JsonSchemaValue:
-            schema = handler(core_schema)
-            schema.update(foobar=123)
-            return schema
-
-    class Model(BaseModel):
-        path1: Path
-        path2: MyPath
-        path3: List[MyPath]
-
-    assert Model.model_json_schema() == {
-        'title': 'Model',
-        'type': 'object',
-        'properties': {
-            'path1': {'title': 'Path1', 'type': 'string', 'format': 'path'},
-            'path2': {'title': 'Path2', 'type': 'string', 'format': 'path', 'foobar': 123},
-            'path3': {'title': 'Path3', 'type': 'array', 'items': {'type': 'string', 'format': 'path', 'foobar': 123}},
-        },
-        'required': ['path1', 'path2', 'path3'],
-    }
-
-
 def test_frozen_set():
     class Model(BaseModel):
         a: FrozenSet[int] = frozenset({1, 2, 3})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR extends [the automatic conversion during validation for paths](https://docs.pydantic.dev/latest/concepts/conversion_table/) to support any subclass of `os.PathLike` class. This is to support easy serialisation of other path types like [`etils.epath.Path`](https://etils.readthedocs.io/en/latest/epath.html).

<!-- Please give a short summary of the changes. -->

## Related issue number

A PR was directly created, instead of an issue, as the initial suggested diff is small and straightforward. 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @tiangolo