### PR TITLE
Fix missing recursive_guard parameter in Pydantic v1 for python 3.12.4+

### DIFF
--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -63,7 +63,7 @@ else:
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
-        return cast(Any, type_)._evaluate(globalns, localns, set())
+        return cast(Any, type_)._evaluate(globalns, localns, set(), recursive_guard=set())
 
 
 if sys.version_info < (3, 9):

--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -54,23 +54,21 @@ except ImportError:
 
 
 if sys.version_info < (3, 9):
-
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         return type_._evaluate(globalns, localns)
     
-elif sys.version_info <= (3, 12, 3):
-    
-    def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
-        # For Python 3.9 to 3.12.3 and fix the error below
-        # TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
-        return cast(Any, type_)._evaluate(globalns, localns, set(), recursive_guard=set())
-    
-else:
-
+elif sys.version_info < (3, 12, 4):
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
         return cast(Any, type_)._evaluate(globalns, localns, set())
+    
+else:
+    def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
+        # For 3.12.4+ provide a default `recursive_guard` to resolve:
+        # TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
+        
+        return cast(Any, type_)._evaluate(globalns, localns, set(), recursive_guard=set())
 
 
 if sys.version_info < (3, 9):

--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -57,13 +57,20 @@ if sys.version_info < (3, 9):
 
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         return type_._evaluate(globalns, localns)
-
+    
+elif sys.version_info <= (3, 12, 3):
+    
+    def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
+        # For Python 3.9 to 3.12.3 and fix the error below
+        # TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
+        return cast(Any, type_)._evaluate(globalns, localns, set(), recursive_guard=set())
+    
 else:
 
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
-        return cast(Any, type_)._evaluate(globalns, localns, set(), recursive_guard=set())
+        return cast(Any, type_)._evaluate(globalns, localns, set())
 
 
 if sys.version_info < (3, 9):

--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -57,17 +57,13 @@ if sys.version_info < (3, 9):
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         return type_._evaluate(globalns, localns)
 
-elif sys.version_info < (3, 12, 4):
+else:
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
-        return cast(Any, type_)._evaluate(globalns, localns, set())
-
-else:
-    def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
-        # For 3.12.4+ provide a default `recursive_guard` to resolve:
+        # Note 3.13/3.12.4+ made `recursive_guard` a kwarg, so name it explicitly to avoid:
         # TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
-        return cast(Any, type_)._evaluate(globalns, localns, set(), recursive_guard=set())
+        return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set())
 
 
 if sys.version_info < (3, 9):

--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -56,18 +56,17 @@ except ImportError:
 if sys.version_info < (3, 9):
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         return type_._evaluate(globalns, localns)
-    
+
 elif sys.version_info < (3, 12, 4):
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
         return cast(Any, type_)._evaluate(globalns, localns, set())
-    
+
 else:
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # For 3.12.4+ provide a default `recursive_guard` to resolve:
         # TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
-        
         return cast(Any, type_)._evaluate(globalns, localns, set(), recursive_guard=set())
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I add args recursive guard=set() when calling evaluate function because in python 3.12 they don't add default value for this params. You can [see that here](https://github.com/sobolevn/cpython/commit/d7483de262e53059671946b147c1fe62986582c7).

While waiting for this merge request to be accepted, you can quickly fix it by using python version 3.12.3

## Related issue number

fix https://github.com/pydantic/pydantic/issues/9609 and fix https://github.com/pydantic/pydantic/issues/9607

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Skip change file check
