### PR TITLE
Specify recursive_guard as kwarg in FutureRef._evaluate

### DIFF
--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -63,7 +63,9 @@ else:
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
-        return cast(Any, type_)._evaluate(globalns, localns, set())
+        # Python 3.13/3.12.4+ made `recursive_guard` a kwarg, so name it explicitly to avoid:
+        # TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
+        return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set())
 
 
 if sys.version_info < (3, 9):


### PR DESCRIPTION
In CPython 3.12.4/3.13, the function signature of `FutureRef._evaluate` changed such that `recursive_guard` is no longer a positional argument; it is now keyword only [0] [1].

To accommodate this, specify `recursive_guard` as a kwarg. This syntax is backwards compatible with earlier versions of the function signature.

[0]: https://github.com/python/cpython/pull/118104
[1]: https://github.com/python/cpython/pull/118009

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
Fix #9607 #9609 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

skip change file check