### PR TITLE
setup: remove upper bound from python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
     license='MIT',
     packages=['pydantic'],
     package_data={'pydantic': ['py.typed']},
-    python_requires='>=3.7, <3.13',
+    python_requires='>=3.7',
     zip_safe=False,  # https://mypy.readthedocs.io/en/latest/installed_packages.html
     install_requires=[
         'typing-extensions>=4.2.0'


### PR DESCRIPTION
A cap was recently added to denote the upper bound of python support for pydantic v1.

Further research, however, has determined that `python_requires` was not developed with an upper bound in mind [^0] and may actually cause some dependency solvers to silently fall back to older versions where there is no cap, and thus presumed support for the user's python.

For now, remove the upper bound.

[^0]: https://discuss.python.org/t/requires-python-upper-limits/12663

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
fix #9663 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

skip change file check