### PR TITLE
docs: update migration docs

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -96,16 +96,16 @@ Imports for `pydantic` v1 features for different versions of pydantic.
 
 === "`pydantic>2,<3`"
 
-    ```py
+    ```python test="skip" lint="skip" upgrade="skip"
     try:
         from pydantic.v1.fields import ModelField
     except ImportError:
         from pydantic.fields import ModelField
     ```
 
-=== "pydantic>=1.10.17,<3"
+=== "`pydantic>=1.10.17,<3`"
 
-    ```py
+    ```python test="skip" lint="skip" upgrade="skip"
     from pydantic.v1.fields import ModelField
     ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -90,29 +90,29 @@ features, take the following steps:
 from pydantic.<module> import <object>
 ```
 
-to:
+with:
 
 ```python test="skip" lint="skip" upgrade="skip"
 from pydantic.v1.<module> import <object>
 ```
 
-Imports for `pydantic` v1 features for different versions of pydantic.
+Here's how you can import `pydantic`'s v1 features based on your version of `pydantic`:
 
-=== "`pydantic<3`"
+=== "`pydantic>=1.10.17,<3`"
+    As of `1.10.17` the `.v1` namespace is usable, allowing imports as below:
 
     ```python test="skip" lint="skip" upgrade="skip"
-    # Try/except usable for multiple versions of pydantic.
+    from pydantic.v1.fields import ModelField
+    ```
+
+=== "`pydantic<3`"
+    Try/except usable for multiple versions of pydantic:
+
+    ```python test="skip" lint="skip" upgrade="skip"
     try:
         from pydantic.v1.fields import ModelField
     except ImportError:
         from pydantic.fields import ModelField
-    ```
-
-=== "`pydantic>=1.10.17,<3`"
-
-    ```python test="skip" lint="skip" upgrade="skip"
-    # as of `1.10.17` the `.v1` namespace is usable, allowing imports as below
-    from pydantic.v1.fields import ModelField
     ```
 
 !!! note

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -48,7 +48,8 @@ See more about it on the [Bump Pydantic](https://github.com/pydantic/bump-pydant
 
 ## Continue using Pydantic V1 features
 
-Pydantic V1 is still available when you need it, though we recommend migrating to Pydantic V2 for its improvements and new features.
+Pydantic V1 is still available when you need it, though we recommend migrating to
+Pydantic V2 for its improvements and new features.
 
 If you need to use latest Pydantic V1, you can install it with:
 
@@ -56,8 +57,11 @@ If you need to use latest Pydantic V1, you can install it with:
 pip install "pydantic==1.*"
 ```
 
-The Pydantic V2 package also continues to provide access to the Pydantic V1 API by importing through `pydantic.v1`.
-For example, you can use the `BaseModel` class from Pydantic V1 instead of the Pydantic V2 `pydantic.BaseModel` class:
+The Pydantic V2 package also continues to provide access to the Pydantic V1 API
+by importing through `pydantic.v1`.
+
+For example, you can use the `BaseModel` class from Pydantic V1 instead of the
+Pydantic V2 `pydantic.BaseModel` class:
 
 ```python test="skip" lint="skip" upgrade="skip"
 from pydantic.v1 import BaseModel
@@ -70,6 +74,47 @@ from pydantic.v1.utils import lenient_isinstance
 ```
 
 Pydantic V1 documentation is available at [https://docs.pydantic.dev/1.10/](https://docs.pydantic.dev/1.10/).
+
+
+#### Using Pydantic v1 features in a v1/v2 environment
+
+As of `pydantic>=1.10.17` the `pydantic.v1` namespace is available to use within v1,
+meaning that in order to unpin a `pydantic<2` dependency to allow using `v1` features,
+simply replace `pydantic<2` with `pydantic>=1.10.17,<3` and find and replace all:
+
+```python test="skip" lint="skip" upgrade="skip"
+from pydantic.<module> import <object>
+```
+
+to:
+
+```python test="skip" lint="skip" upgrade="skip"
+from pydantic.v1.<module> import <object>
+```
+
+Imports for `pydantic` v1 features for different versions of pydantic.
+
+=== "`pydantic>2,<3`"
+
+    ```py
+    try:
+        from pydantic.v1.fields import ModelField
+    except ImportError:
+        from pydantic.fields import ModelField
+    ```
+
+=== "pydantic>=1.10.17,<3"
+
+    ```py
+    from pydantic.v1.fields import ModelField
+    ```
+
+!!! note
+    When importing modules using `pydantic>=1.10.17,<2` with the `.v1` namespace
+    these modules will *not* be the same module as the same import without the `.v1`
+    namespace, but the symbols imported *will* be. For example ``pydantic.v1.fields is not pydantic.fields``
+    but ``pydantic.v1.fields.ModelField is pydantic.fields.ModelField``.
+
 
 ## Migration guide
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -78,9 +78,13 @@ Pydantic V1 documentation is available at [https://docs.pydantic.dev/1.10/](http
 
 #### Using Pydantic v1 features in a v1/v2 environment
 
-As of `pydantic>=1.10.17` the `pydantic.v1` namespace is available to use within v1,
-meaning that in order to unpin a `pydantic<2` dependency to allow using `v1` features,
-simply replace `pydantic<2` with `pydantic>=1.10.17,<3` and find and replace all:
+As of `pydantic>=1.10.17`, the `pydantic.v1` namespace can be used within V1.
+This makes it easier to migrate to V2, which also supports the `pydantic.v1`
+namespace. In order to unpin a `pydantic<2` dependency and continue using V1
+features, take the following steps:
+
+1. Replace `pydantic<2` with `pydantic>=1.10.17`
+2. Find and replace all occurrences of:
 
 ```python test="skip" lint="skip" upgrade="skip"
 from pydantic.<module> import <object>
@@ -94,9 +98,10 @@ from pydantic.v1.<module> import <object>
 
 Imports for `pydantic` v1 features for different versions of pydantic.
 
-=== "`pydantic>2,<3`"
+=== "`pydantic<3`"
 
     ```python test="skip" lint="skip" upgrade="skip"
+    # Try/except usable for multiple versions of pydantic.
     try:
         from pydantic.v1.fields import ModelField
     except ImportError:
@@ -106,14 +111,17 @@ Imports for `pydantic` v1 features for different versions of pydantic.
 === "`pydantic>=1.10.17,<3`"
 
     ```python test="skip" lint="skip" upgrade="skip"
+    # as of `1.10.17` the `.v1` namespace is usable, allowing imports as below
     from pydantic.v1.fields import ModelField
     ```
 
 !!! note
     When importing modules using `pydantic>=1.10.17,<2` with the `.v1` namespace
-    these modules will *not* be the same module as the same import without the `.v1`
+    these modules will *not* be the **same** module as the same import without the `.v1`
     namespace, but the symbols imported *will* be. For example ``pydantic.v1.fields is not pydantic.fields``
-    but ``pydantic.v1.fields.ModelField is pydantic.fields.ModelField``.
+    but ``pydantic.v1.fields.ModelField is pydantic.fields.ModelField``. However
+    this is not likely to be relevant in 99% of cases, and is an unfortunate
+    consequence of providing a smoother migration experience.
 
 
 ## Migration guide
@@ -873,6 +881,33 @@ Read more about it in the [Composing types via `Annotated`](concepts/types.md#co
 docs.
 
 For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringConstraints] instead.
+
+#### Mypy Plugins
+
+Pydantic V2 contains a [mypy](https://mypy.readthedocs.io/en/stable/extending_mypy.html#configuring-mypy-to-use-plugins) plugin in
+`pydantic.mypy`.
+
+When using [V1 features](migration.md#continue-using-pydantic-v1-features) the
+`pydantic.v1.mypy` plugin might need to also be enabled.
+
+To configure the `mypy` plugins:
+
+=== `mypy.ini`
+
+    ```ini
+    [mypy]
+    plugins = pydantic.mypy, pydantic.v1.mypy # include `.v1.mypy` if required.
+    ```
+
+=== `pyproject.toml`
+
+    ```toml
+    [tool.mypy]
+    plugins = [
+        "pydantic.mypy",
+        "pydantic.v1.mypy",
+    ]
+    ```
 
 ## Other changes
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Updates the migration docs in preparation of the `1.10.17` release of `pydantic` that includes the `pydantic.v1` subpackage to assist with v2 migration.

Note not sure if we want `pydantic>=1.10.16` in the docs (given the typing issues and potential `python>=3.12` incompatibilities raised) hence I've opted for when the `1.10.17` is released. 

Additionally I have a change to `update_v1.sh` as well that should remove the `v1` sub directory, but will need to be included post `1.10.17` release, because the shell script installs the highest tagged `v1` version (which currently is `1.10.16`). 

So I believe we need to:
- release `1.10.17`, 
- update `update_v1.sh`, 
- run `update_v1.sh`, 
- add that (in a separate PR?)

## Related issue number


## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @PrettyWood

@sydney-runkle tagging you given our discussion on this!