### PR TITLE
test: increase `pydantic\aliases.py` coverage to 100%

### DIFF
--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -587,10 +587,9 @@ def test_validation_alias_path(value):
 
 
 def test_search_dict_for_alias_path():
-    class Model(BaseModel):
-        ap = AliasPath('a', 1)
-        assert ap.search_dict_for_path({'a': ['hello', 'world']}) == 'world'
-        assert ap.search_dict_for_path({'a': 'hello'}) is PydanticUndefined
+    ap = AliasPath('a', 1)
+    assert ap.search_dict_for_path({'a': ['hello', 'world']}) == 'world'
+    assert ap.search_dict_for_path({'a': 'hello'}) is PydanticUndefined
 
 
 def test_validation_alias_invalid_value_type():

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -4,6 +4,7 @@ from typing import Any, ContextManager, List, Optional
 
 import pytest
 from dirty_equals import IsStr
+from pydantic_core import PydanticUndefined
 
 from pydantic import (
     AliasChoices,
@@ -611,6 +612,10 @@ def test_validation_alias_parse_data():
             'input': {'b': ['hello']},
         }
     ]
+    assert (
+        Model.model_fields['x'].validation_alias.choices[1].search_dict_for_path({'b': ['hello', 'world']}) == 'world'
+    )
+    assert Model.model_fields['x'].validation_alias.choices[1].search_dict_for_path({'b': 'hello'}) is PydanticUndefined
 
 
 def test_alias_generator_class() -> None:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -588,10 +588,9 @@ def test_validation_alias_path(value):
 
 def test_search_dict_for_alias_path():
     class Model(BaseModel):
-        x: str = Field(validation_alias=AliasPath('a', 1))
-
-    assert Model.model_fields['x'].validation_alias.search_dict_for_path({'a': ['hello', 'world']}) == 'world'
-    assert Model.model_fields['x'].validation_alias.search_dict_for_path({'a': 'hello'}) is PydanticUndefined
+        ap = AliasPath('a', 1)
+        assert ap.search_dict_for_path({'a': ['hello', 'world']}) == 'world'
+        assert ap.search_dict_for_path({'a': 'hello'}) is PydanticUndefined
 
 
 def test_validation_alias_invalid_value_type():

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -586,6 +586,14 @@ def test_validation_alias_path(value):
     assert Model.model_fields['x'].validation_alias == value
 
 
+def test_search_dict_for_alias_path():
+    class Model(BaseModel):
+        x: str = Field(validation_alias=AliasPath('a', 1))
+
+    assert Model.model_fields['x'].validation_alias.search_dict_for_path({'a': ['hello', 'world']}) == 'world'
+    assert Model.model_fields['x'].validation_alias.search_dict_for_path({'a': 'hello'}) is PydanticUndefined
+
+
 def test_validation_alias_invalid_value_type():
     m = 'Invalid `validation_alias` type. it should be `str`, `AliasChoices`, or `AliasPath`'
     with pytest.raises(TypeError, match=m):
@@ -612,10 +620,6 @@ def test_validation_alias_parse_data():
             'input': {'b': ['hello']},
         }
     ]
-    assert (
-        Model.model_fields['x'].validation_alias.choices[1].search_dict_for_path({'b': ['hello', 'world']}) == 'world'
-    )
-    assert Model.model_fields['x'].validation_alias.choices[1].search_dict_for_path({'b': 'hello'}) is PydanticUndefined
 
 
 def test_alias_generator_class() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add a tiny case to increase coverage of `pydantic\aliases.py` to 100%.
Tests for forbidden string indexing of `AliasPath` argument via the `search_dict_for_path` utility. 

note: I thought that the newly added assertions could fit into the existing `test_validation_alias_parse_data`, therefore I didn't add a new test function. Happy to change if you think otherwise (or get guidance in any case)!

## Related issue number

Contributes to https://github.com/pydantic/pydantic/issues/7656.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
