### PR TITLE
Fix Python version check for `_eval_type`

### DIFF
--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -256,7 +256,7 @@ def eval_type_backport(
     if the original syntax is not supported in the current Python version.
     """
     try:
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 13):
             return typing._eval_type(  # type: ignore
                 value, globalns, localns, type_params=type_params
             )


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9780