### PR TITLE
Respect use_enum_values on Literal types

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -111,13 +111,6 @@ FROZEN_SET_TYPES: list[type] = [frozenset, typing.FrozenSet, collections.abc.Set
 DICT_TYPES: list[type] = [dict, typing.Dict, collections.abc.MutableMapping, collections.abc.Mapping]
 
 
-def enum_or_var_gettr(obj):
-    if isinstance(obj, Enum):
-        return obj.value
-
-    return obj
-
-
 def check_validator_fields_against_field_name(
     info: FieldDecoratorInfo,
     field: str,

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1258,7 +1258,9 @@ class GenerateSchema:
         schema = core_schema.literal_schema(expected)
 
         if self._config_wrapper.use_enum_values:
-            schema = core_schema.no_info_after_validator_function(enum_or_var_gettr, schema)
+            schema = core_schema.no_info_after_validator_function(
+                lambda v: v.value if isinstance(v, Enum) else v, schema
+            )
 
         return schema
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1250,7 +1250,7 @@ class GenerateSchema:
         assert expected, f'literal "expected" cannot be empty, obj={literal_type}'
         schema = core_schema.literal_schema(expected)
 
-        if self._config_wrapper.use_enum_values:
+        if self._config_wrapper.use_enum_values and any(isinstance(v, Enum) for v in expected):
             schema = core_schema.no_info_after_validator_function(
                 lambda v: v.value if isinstance(v, Enum) else v, schema
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -802,7 +802,7 @@ class StrFoo(str, Enum):
 
 
 @pytest.mark.parametrize('value', [StrFoo.FOO, StrFoo.FOO.value, 'foo', 'hello'])
-def test_literal_use_enum_values_multi_type(value):
+def test_literal_use_enum_values_multi_type(value) -> None:
     class Model(BaseModel):
         baz: Literal[StrFoo.FOO, 'hello']
         model_config = ConfigDict(use_enum_values=True)
@@ -810,18 +810,22 @@ def test_literal_use_enum_values_multi_type(value):
     assert isinstance(Model(baz=value).baz, str)
 
 
-def test_literal_use_enum_values_with_default():
+def test_literal_use_enum_values_with_default() -> None:
     class Model(BaseModel):
         baz: Literal[StrFoo.FOO] = Field(default=StrFoo.FOO)
-        model_config = ConfigDict(use_enum_values=True)
+        model_config = ConfigDict(use_enum_values=True, validate_default=True)
 
-    assert isinstance(Model().baz, str)
+    validated = Model()
+    assert type(validated.baz) is str
+    assert type(validated.model_dump()['baz']) is str
 
     validated = Model.model_validate_json('{"baz": "foo"}')
-    assert isinstance(validated.baz, str)
+    assert type(validated.baz) is str
+    assert type(validated.model_dump()['baz']) is str
 
     validated = Model.model_validate({'baz': StrFoo.FOO})
-    assert isinstance(validated.baz, str)
+    assert type(validated.baz) is str
+    assert type(validated.model_dump()['baz']) is str
 
 
 def test_strict_enum_values():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Following the logic for enum schema generation, I added `no_info_after_validator_function` to the literal schema when `use_enum_values` is set.

To be fair, I don't really have a clue what I'm doing, so I haven't fixed the test yet. Would like to know if this change makes sense and if I should continue this way. Thanks! 

<!-- Please give a short summary of the changes. -->

## Related issue number
fix #9738 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Kludex