### PR TITLE
Option to exclude `model_extra` from `repr`

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -48,6 +48,7 @@ class ConfigWrapper:
     str_min_length: int
     str_max_length: int | None
     extra: ExtraValues | None
+    extra_repr: bool
     frozen: bool
     populate_by_name: bool
     use_enum_values: bool
@@ -238,6 +239,7 @@ config_defaults = ConfigDict(
     str_max_length=None,
     # let the model / dataclass decide how to handle it
     extra=None,
+    extra_repr=True,
     frozen=False,
     populate_by_name=False,
     use_enum_values=False,

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -128,6 +128,48 @@ class ConfigDict(TypedDict, total=False):
     ```
     """
 
+    extra_repr: bool
+    """
+    Whether to include the `model_extra` in the model repr. Defaults to `True`.
+    If `extra = 'allow'` and `extra_repr = True`, all extra values will be included in the model's repr.
+
+    ```py
+    from pydantic import BaseModel, ConfigDict
+
+
+    class User(BaseModel):
+        model_config = ConfigDict(extra='allow', extra_repr=True)
+
+        name: str
+
+
+    user = User(name='John Doe', age=20)  # (1)!
+    print(user)
+    #> name='John Doe' age=20
+    ```
+
+    But, if `extra_repr = False`, none of the extra values will be included in the model's repr.
+
+    ```py
+    from pydantic import BaseModel, ConfigDict
+
+
+    class User(BaseModel):
+        model_config = ConfigDict(extra='allow', extra_repr=False)
+
+        name: str
+
+
+    user = User(name='John Doe', age=20)  # (1)!
+    print(user)
+    #> name='John Doe'
+    print(user.model_extra)  # Still present, but hidden from repr.
+    #> {'age': 20}
+    ```
+
+    There is no effect if `extra` is set to anything besides `"allow"`.
+    """
+
     frozen: bool
     """
     Whether models are faux-immutable, i.e. whether `__setattr__` is allowed, and also generates

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1027,17 +1027,19 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             if field and field.repr:
                 yield k, v
 
-        # `__pydantic_extra__` can fail to be set if the model is not yet fully initialized.
-        # This can happen if a `ValidationError` is raised during initialization and the instance's
-        # repr is generated as part of the exception handling. Therefore, we use `getattr` here
-        # with a fallback, even though the type hints indicate the attribute will always be present.
-        try:
-            pydantic_extra = object.__getattribute__(self, '__pydantic_extra__')
-        except AttributeError:
-            pydantic_extra = None
+        if self.model_config.get('extra_repr', True):
+            # `__pydantic_extra__` can fail to be set if the model is not yet fully initialized.
+            # This can happen if a `ValidationError` is raised during initialization and the instance's
+            # repr is generated as part of the exception handling. Therefore, we use `getattr` here
+            # with a fallback, even though the type hints indicate the attribute will always be present.
+            try:
+                pydantic_extra = object.__getattribute__(self, '__pydantic_extra__')
+            except AttributeError:
+                pydantic_extra = None
 
-        if pydantic_extra is not None:
-            yield from ((k, v) for k, v in pydantic_extra.items())
+            if pydantic_extra is not None:
+                yield from ((k, v) for k, v in pydantic_extra.items())
+
         yield from ((k, getattr(self, k)) for k, v in self.model_computed_fields.items() if v.repr)
 
     # take logic from `_repr.Representation` without the side effects of inheritance, see #5740

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -269,6 +269,24 @@ def test_allow_extra_repr():
     assert str(Model(a='10.2', b=12)) == 'a=10.2 b=12'
 
 
+@pytest.mark.parametrize(
+    'extra_repr,expected',
+    [
+        (True, "Model(a=1.0, foo='bar')"),
+        pytest.param(False, 'Model(a=1.0)', marks=pytest.mark.xfail(reason='``extra_repr`` not implemented yet.')),
+    ],
+)
+def test_allow_extra_no_repr(extra_repr: bool, expected: str):
+    class Model(BaseModel):
+        model_config = ConfigDict(extra='allow', extra_repr=extra_repr)
+        a: float = ...
+
+    extra = {'foo': 'bar'}
+    actual = Model(a=1.0, **extra)
+    assert repr(actual) == expected
+    assert actual.model_extra == extra
+
+
 def test_forbidden_extra_success():
     class ForbiddenExtra(BaseModel):
         model_config = ConfigDict(extra='forbid')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -269,13 +269,7 @@ def test_allow_extra_repr():
     assert str(Model(a='10.2', b=12)) == 'a=10.2 b=12'
 
 
-@pytest.mark.parametrize(
-    'extra_repr,expected',
-    [
-        (True, "Model(a=1.0, foo='bar')"),
-        pytest.param(False, 'Model(a=1.0)', marks=pytest.mark.xfail(reason='``extra_repr`` not implemented yet.')),
-    ],
-)
+@pytest.mark.parametrize('extra_repr,expected', [(True, "Model(a=1.0, foo='bar')"), (False, 'Model(a=1.0)')])
 def test_allow_extra_no_repr(extra_repr: bool, expected: str):
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow', extra_repr=extra_repr)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Added `extra_repr` to the `ConfiDict` (and other necessary spots) + unit tests and docstrings.

<!-- Please give a short summary of the changes. -->

## Related issue number
fix #9732 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @PrettyWood