### PR TITLE
fix(secrets): keep the same type of secret field on json serialization

### DIFF
--- a/docs/examples/secrets.md
+++ b/docs/examples/secrets.md
@@ -1,10 +1,57 @@
 !!! warning "🚧 Work in Progress"
     This page is a work in progress.
 
+## Default serialization to python
+
+By default, when serializing [`Secret`][pydatic.types.Secret] to python,
+secret values are kept as `Secret` objects.
+
+```py
+from pydantic import BaseModel, Secret
+class Foo(BaseModel):
+    secret_bool: Secret[bool]
+    secret_str: Secret[str]
+    secret_float: Secret[float]
+
+foo = Foo(secret_bool=True, secret_str='secret', secret_float=3.14)
+print(foo)
+#> secret_bool=Secret('**********') secret_str=Secret('**********') secret_float=Secret('**********')
+
+print(foo.model_dump())
+#> {'secret_bool': Secret('**********'), 'secret_str': Secret('**********'), 'secret_float': Secret('**********')}
+```
+
+## Default serialization to json
+
+By default, when serializing [`Secret`][pydatic.types.Secret] to JSON,
+secret values are always serialized to their 'nullable' value.
+
+For example, secret bool is always serialized to `false`,
+secret str is always serialized to empty string, etc.
+
+```py
+from pydantic import BaseModel, Secret
+
+class Foo(BaseModel):
+    secret_bool: Secret[bool]
+    secret_str: Secret[str]
+    secret_float: Secret[float]
+
+foo = Foo(secret_bool=True, secret_str='secret', secret_float=3.14)
+print(foo)
+#> secret_bool=Secret('**********') secret_str=Secret('**********') secret_float=Secret('**********')
+
+print(foo.model_dump(mode='json'))
+#> {'secret_bool': 'false', 'secret_str': '', 'secret_float': '0.0'}
+
+print(foo.model_dump_json())
+#> {"secret_bool":"false","secret_str":"","secret_float":"0.0"}
+```
+
 ## Serialize `SecretStr` and `SecretBytes` as plain-text
 
 By default, [`SecretStr`][pydantic.types.SecretStr] and [`SecretBytes`][pydantic.types.SecretBytes]
-will be serialized as `**********` when serializing to json.
+will be serialized as empty string when serializing to json.
 
 You can use the [`field_serializer`][pydantic.functional_serializers.field_serializer] to dump the
 secret as plain-text when serializing to json.


### PR DESCRIPTION
## Change Summary

Change `Secret` (including `SecretStr` and `SecretBytes`) serialization to json to keep original type.
Also, add `bool(secret)` for convinience.

Before:
```python
from pydantic import BaseModel, Secret
class Foo(BaseModel):
    secret_data: Secret[dict]
foo = Foo(secret_data={"bar": "bar_value"})
print(foo.model_dump(mode='json'))
#> {'secret_data': '**********'}
```

After:
```python
from pydantic import BaseModel, Secret
class Foo(BaseModel):
    secret_data: Secret[dict]
foo = Foo(secret_data={"bar": "bar_value"})
print(foo.model_dump(mode='json'))
#> {'secret_data': '{}'}
```

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review
