### PR TITLE
Update functional_serializers.py Typo in Docs Example Simple Fix

### DIFF
--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -239,7 +239,7 @@ def field_serializer(
         courses: Set[str]
 
         @field_serializer('courses', when_used='json')
-        def serialize_courses_in_order(courses: Set[str]):
+        def serialize_courses_in_order(self, courses: Set[str]):
             return sorted(courses)
 
     student = StudentModel(courses={'Math', 'Chemistry', 'English'})


### PR DESCRIPTION
Missing self as first argument in an @field_serializer decorated method. This had me confused for a while and may confuse others too. Simple fix.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add 'self' as first argument to wrapped method

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
