### PR TITLE
Allow `WithJsonSchema` to inject `$ref`s w/ `http` or `https` links

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2042,10 +2042,16 @@ class GenerateJsonSchema:
         return json_schema
 
     def get_schema_from_definitions(self, json_ref: JsonRef) -> JsonSchemaValue | None:
-        def_ref = self.json_to_defs_refs[json_ref]
-        if def_ref in self._core_defs_invalid_for_json_schema:
-            raise self._core_defs_invalid_for_json_schema[def_ref]
-        return self.definitions.get(def_ref, None)
+        try:
+            def_ref = self.json_to_defs_refs[json_ref]
+            if def_ref in self._core_defs_invalid_for_json_schema:
+                raise self._core_defs_invalid_for_json_schema[def_ref]
+            return self.definitions.get(def_ref, None)
+        except KeyError as e:
+            if json_ref.startswith('http://') or json_ref.startswith('https://'):
+                return None
+            else:
+                raise e
 
     def encode_default(self, dft: Any) -> Any:
         """Encode a default value to a JSON-serializable value.
@@ -2155,10 +2161,14 @@ class GenerateJsonSchema:
                     json_refs[json_ref] += 1
                     if already_visited:
                         return  # prevent recursion on a definition that was already visited
-                    defs_ref = self.json_to_defs_refs[json_ref]
-                    if defs_ref in self._core_defs_invalid_for_json_schema:
-                        raise self._core_defs_invalid_for_json_schema[defs_ref]
-                    _add_json_refs(self.definitions[defs_ref])
+                    try:
+                        defs_ref = self.json_to_defs_refs[json_ref]
+                        if defs_ref in self._core_defs_invalid_for_json_schema:
+                            raise self._core_defs_invalid_for_json_schema[defs_ref]
+                        _add_json_refs(self.definitions[defs_ref])
+                    except KeyError as e:
+                        if not (json_ref.startswith('http://') or json_ref.startswith('https://')):
+                            raise e
 
                 for v in schema.values():
                     _add_json_refs(v)
@@ -2215,11 +2225,15 @@ class GenerateJsonSchema:
         unvisited_json_refs = _get_all_json_refs(schema)
         while unvisited_json_refs:
             next_json_ref = unvisited_json_refs.pop()
-            next_defs_ref = self.json_to_defs_refs[next_json_ref]
-            if next_defs_ref in visited_defs_refs:
-                continue
-            visited_defs_refs.add(next_defs_ref)
-            unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
+            try:
+                next_defs_ref = self.json_to_defs_refs[next_json_ref]
+                if next_defs_ref in visited_defs_refs:
+                    continue
+                visited_defs_refs.add(next_defs_ref)
+                unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
+            except KeyError as e:
+                if not (next_json_ref.startswith('http://') or next_json_ref.startswith('https://')):
+                    raise e
 
         self.definitions = {k: v for k, v in self.definitions.items() if k in visited_defs_refs}
 

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2055,11 +2055,10 @@ class GenerateJsonSchema:
             if def_ref in self._core_defs_invalid_for_json_schema:
                 raise self._core_defs_invalid_for_json_schema[def_ref]
             return self.definitions.get(def_ref, None)
-        except KeyError as e:
+        except KeyError:
             if json_ref.startswith(('http://', 'https://')):
                 return None
-            else:
-                raise e
+            raise
 
     def encode_default(self, dft: Any) -> Any:
         """Encode a default value to a JSON-serializable value.
@@ -2174,9 +2173,9 @@ class GenerateJsonSchema:
                         if defs_ref in self._core_defs_invalid_for_json_schema:
                             raise self._core_defs_invalid_for_json_schema[defs_ref]
                         _add_json_refs(self.definitions[defs_ref])
-                    except KeyError as e:
+                    except KeyError:
                         if not json_ref.startswith(('http://', 'https://')):
-                            raise e
+                            raise
 
                 for v in schema.values():
                     _add_json_refs(v)
@@ -2239,9 +2238,9 @@ class GenerateJsonSchema:
                     continue
                 visited_defs_refs.add(next_defs_ref)
                 unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
-            except KeyError as e:
+            except KeyError:
                 if not next_json_ref.startswith(('http://', 'https://')):
-                    raise e
+                    raise
 
         self.definitions = {k: v for k, v in self.definitions.items() if k in visited_defs_refs}
 

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2048,7 +2048,7 @@ class GenerateJsonSchema:
                 raise self._core_defs_invalid_for_json_schema[def_ref]
             return self.definitions.get(def_ref, None)
         except KeyError as e:
-            if json_ref.startswith('http://') or json_ref.startswith('https://'):
+            if json_ref.startswith(('http://', 'https://')):
                 return None
             else:
                 raise e
@@ -2167,7 +2167,7 @@ class GenerateJsonSchema:
                             raise self._core_defs_invalid_for_json_schema[defs_ref]
                         _add_json_refs(self.definitions[defs_ref])
                     except KeyError as e:
-                        if not (json_ref.startswith('http://') or json_ref.startswith('https://')):
+                        if not json_ref.startswith(('http://', 'https://')):
                             raise e
 
                 for v in schema.values():
@@ -2232,7 +2232,7 @@ class GenerateJsonSchema:
                 visited_defs_refs.add(next_defs_ref)
                 unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
             except KeyError as e:
-                if not (next_json_ref.startswith('http://') or next_json_ref.startswith('https://')):
+                if not next_json_ref.startswith(('http://', 'https://')):
                     raise e
 
         self.definitions = {k: v for k, v in self.definitions.items() if k in visited_defs_refs}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1668,7 +1668,7 @@ def test_external_ref():
     """https://github.com/pydantic/pydantic/issues/9783"""
 
     class Model(BaseModel):
-        json_schema: typing.Annotated[
+        json_schema: Annotated[
             dict,
             WithJsonSchema({'$ref': 'https://json-schema.org/draft/2020-12/schema'}),
         ]

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1674,9 +1674,7 @@ def test_external_ref():
         ]
 
     assert Model.model_json_schema() == {
-        'properties': {
-            'json_schema': {'$ref': 'https://json-schema.org/draft/2020-12/schema', 'title': 'Json Schema'}
-        },
+        'properties': {'json_schema': {'$ref': 'https://json-schema.org/draft/2020-12/schema', 'title': 'Json Schema'}},
         'required': ['json_schema'],
         'title': 'Model',
         'type': 'object',

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1675,7 +1675,7 @@ def test_external_ref():
 
     assert Model.model_json_schema() == {
         'properties': {
-            'json_schema': {'allOf': [{'$ref': 'https://json-schema.org/draft/2020-12/schema'}], 'title': 'Json Schema'}
+            'json_schema': {'$ref': 'https://json-schema.org/draft/2020-12/schema', 'title': 'Json Schema'}
         },
         'required': ['json_schema'],
         'title': 'Model',

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1641,6 +1641,25 @@ def test_schema_ref_template_key_error():
         models_json_schema([(Bar, 'validation'), (Baz, 'validation')], ref_template='/schemas/{bad_name}.json#/')
 
 
+def test_external_ref():
+    """https://github.com/pydantic/pydantic/issues/9783"""
+
+    class Model(BaseModel):
+        json_schema: typing.Annotated[
+            dict,
+            WithJsonSchema({'$ref': 'https://json-schema.org/draft/2020-12/schema'}),
+        ]
+
+    assert Model.model_json_schema() == {
+        'properties': {
+            'json_schema': {'allOf': [{'$ref': 'https://json-schema.org/draft/2020-12/schema'}], 'title': 'Json Schema'}
+        },
+        'required': ['json_schema'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
 def test_schema_no_definitions():
     keys_map, model_schema = models_json_schema([], title='Schema without definitions')
     assert keys_map == {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
- Problem: Pydantic throws a KeyError when WithJsonSchema is used with a $ref that defines an external JSON Schema via an https link.
- Fix: Add try-excepts to skip lookup if it is failing for a link that begins w/ https or http (suggested by Adrian). 

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
fix #9783 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
