### PR TITLE
Replace str type annotation with Any in validator factories in documentation on validators

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -155,7 +155,7 @@ class Context(TypedDict):
     logs: List[str]
 
 
-def make_validator(label: str) -> Callable[[str, ValidationInfo], str]:
+def make_validator(label: str) -> Callable[[Any, ValidationInfo], Any]:
     def validator(v: Any, info: ValidationInfo) -> Any:
         context = cast(Context, info.context)
         context['logs'].append(label)
@@ -166,7 +166,7 @@ def make_validator(label: str) -> Callable[[str, ValidationInfo], str]:
 
 def make_wrap_validator(
     label: str,
-) -> Callable[[str, ValidatorFunctionWrapHandler, ValidationInfo], str]:
+) -> Callable[[Any, ValidatorFunctionWrapHandler, ValidationInfo], Any]:
     def validator(
         v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
     ) -> Any:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The (wrap) validator functions in the validators section of the documentation have a return type indicating that the validator takes a string as input and returns a string when this is actually not known. Also this way the types of the factory and the inner function do not match.
This is a very minor issue but had me confused when reading it.

## Related issue number

None

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle