### PR TITLE
Fix `ComputedFieldInfo.wrapped_property` pointer when a property setter is assigned

### DIFF
--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -178,6 +178,9 @@ class PydanticDescriptorProxy(Generic[ReturnType]):
 
     def _call_wrapped_attr(self, func: Callable[[Any], None], *, name: str) -> PydanticDescriptorProxy[ReturnType]:
         self.wrapped = getattr(self.wrapped, name)(func)
+        # update ComputedFieldInfo.wrapped_property
+        if isinstance(self.wrapped, property) and hasattr(self.decorator_info, 'wrapped_property'):
+            self.decorator_info.wrapped_property = self.wrapped
         return self
 
     def __get__(self, obj: object | None, obj_type: type[object] | None = None) -> PydanticDescriptorProxy[ReturnType]:

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -178,9 +178,12 @@ class PydanticDescriptorProxy(Generic[ReturnType]):
 
     def _call_wrapped_attr(self, func: Callable[[Any], None], *, name: str) -> PydanticDescriptorProxy[ReturnType]:
         self.wrapped = getattr(self.wrapped, name)(func)
-        # update ComputedFieldInfo.wrapped_property
-        if isinstance(self.wrapped, property) and hasattr(self.decorator_info, 'wrapped_property'):
-            self.decorator_info.wrapped_property = self.wrapped
+        if isinstance(self.wrapped, property):
+            # update ComputedFieldInfo.wrapped_property
+            from ..fields import ComputedFieldInfo
+
+            if isinstance(self.decorator_info, ComputedFieldInfo):
+                self.decorator_info.wrapped_property = self.wrapped
         return self
 
     def __get__(self, obj: object | None, obj_type: type[object] | None = None) -> PydanticDescriptorProxy[ReturnType]:

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -151,6 +151,7 @@ def test_computed_fields_set():
     assert s.model_dump() == {'side': 10.0, 'area': 100.0, 'area_string': '100.0 SQUARE UNITS'}
     s.area = 64
     assert s.model_dump() == {'side': 8.0, 'area': 64.0, 'area_string': '64.0 SQUARE UNITS'}
+    assert Square.model_computed_fields['area'].wrapped_property is Square.area
 
 
 def test_computed_fields_del():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

```python
from pydantic import BaseModel, computed_field

class Thing(BaseModel):
    x: int

    @computed_field
    def y(self) -> bool: ...

    @y.setter
    def y(self, value: bool) -> None: ...

# this statement is True on `main` *only* if a setter is not used, otherwise it returns False
# this PR fixes the pointer when a setter is used.
print(Thing.model_computed_fields["y"].wrapped_property is Thing.y)
```
## Change Summary

<!-- Please give a short summary of the changes. -->
Fixes the pointer in `ComputedFieldInfo.wrapped_property` when a property setter is used

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle