### PR TITLE
chore(ci): remove `{{ matrix.os }}` from names of coverage artifacts pertaining to `test-mypy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
     - name: store coverage files
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-${{ matrix.os }}-${{ matrix.python-version }}-mypy${{ matrix.mypy-version }}
+        name: coverage-${{ matrix.python-version }}-mypy${{ matrix.mypy-version }}
         path: coverage
 
   coverage-combine:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
The PR removes the `{{ matrix.os }}` reference from the `mypy`-related coverage file names as no `os` attribute is available on `matrix` within `test-mypy` (as, in turn, they do run on `ubuntu-latest` only).

Please see a complete example of the mistyped coverage file names pertaining to the `mypy` tests at https://api.github.com/repos/pydantic/pydantic/actions/runs/9830032671/artifacts and a single example below (where `{{ matrix.os }}` results in a redundant `-`). 

<pre><code>
  {
    "id": 1675502690,
    "node_id": "MDg6QXJ0aWZhY3QxNjc1NTAyNjkw",
    <b>
    "name": "coverage--3.13-mypy1.5.1",
    </b>
    "size_in_bytes": 144792,
    "url": "https://api.github.com/repos/pydantic/pydantic/actions/artifacts/1675502690",
    "archive_download_url": "https://api.github.com/repos/pydantic/pydantic/actions/artifacts/1675502690/zip",
    "expired": false,
    "created_at": "2024-07-07T20:26:23Z",
    "updated_at": "2024-07-07T20:26:23Z",
    "expires_at": "2024-10-05T20:15:19Z",
    "workflow_run": {
      "id": 9830032671,
      "repository_id": 90194616,
      "head_repository_id": 803823737,
      "head_branch": "json-schema-external-link",
      "head_sha": "34fbdf67d41718829fccbdf7955c1b0f1cba2161"
    }
  }
</pre></code>

#### EDIT: 
strange error (for me, at least) on `CI / mypy 1.2.0 / 3.10 (pull_request)`. Perhaps, only a matter of triggering the build again?

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
