### PR TITLE
Fix a typo on Validators doc page

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -459,7 +459,7 @@ except ValidationError as e:
     Methods decorated with `@model_validator` should return the self instance at the end of the method.
     For type checking purposes, you can use `Self` from either `typing` or the `typing_extensions` backport as the
     return type of the decorated method.
-    In the context of the above example, you could also use `def check_passwords_match(self: 'UserModel)' -> 'UserModel'` to indicate that
+    In the context of the above example, you could also use `def check_passwords_match(self: 'UserModel') -> 'UserModel'` to indicate that
     the method returns an instance of the model.
 
 !!! note "On Inheritance"


### PR DESCRIPTION
## Change Summary

This PR fixes a typo on [_Validators_](https://docs.pydantic.dev/latest/concepts/validators/) doc page

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] ~Unit tests for the changes exist~ (not sure, doc-only change)
* [x] Tests pass on CI
* [ ] ~Documentation reflects the changes where applicable~ (doc-only change)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle