### PR TITLE
Add class name to "has conflict" warnings

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -159,7 +159,7 @@ def collect_model_fields(  # noqa: C901
                         x for x in config_wrapper.protected_namespaces if not ann_name.startswith(x)
                     )
                     warnings.warn(
-                        f'Field "{ann_name}" has conflict with protected namespace "{protected_namespace}".'
+                        f'Field "{ann_name}" in {cls.__name__} has conflict with protected namespace "{protected_namespace}".'
                         '\n\nYou may be able to resolve this warning by setting'
                         f" `model_config['protected_namespaces'] = {valid_namespaces}`.",
                         UserWarning,

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -620,7 +620,7 @@ class ConfigDict(TypedDict, total=False):
     except UserWarning as e:
         print(e)
         '''
-        Field "model_prefixed_field" has conflict with protected namespace "model_".
+        Field "model_prefixed_field" in Model has conflict with protected namespace "model_".
 
         You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
         '''
@@ -648,7 +648,7 @@ class ConfigDict(TypedDict, total=False):
     except UserWarning as e:
         print(e)
         '''
-        Field "also_protect_field" has conflict with protected namespace "also_protect_".
+        Field "also_protect_field" in Model has conflict with protected namespace "also_protect_".
 
         You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ('protect_me_',)`.
         '''

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -557,7 +557,9 @@ def test_create_model_tuple_3():
 
 
 def test_create_model_protected_namespace_default():
-    with pytest.warns(UserWarning, match='Field "model_prefixed_field" has conflict with protected namespace "model_"'):
+    with pytest.warns(
+        UserWarning, match='Field "model_prefixed_field" in Model has conflict with protected namespace "model_"'
+    ):
         create_model('Model', model_prefixed_field=(str, ...))
 
 
@@ -567,7 +569,7 @@ def test_create_model_protected_namespace_real_conflict():
 
 
 def test_create_model_custom_protected_namespace():
-    with pytest.warns(UserWarning, match='Field "test_field" has conflict with protected namespace "test_"'):
+    with pytest.warns(UserWarning, match='Field "test_field" in Model has conflict with protected namespace "test_"'):
         create_model(
             'Model',
             __config__=ConfigDict(protected_namespaces=('test_',)),
@@ -578,7 +580,7 @@ def test_create_model_custom_protected_namespace():
 
 def test_create_model_multiple_protected_namespace():
     with pytest.warns(
-        UserWarning, match='Field "also_protect_field" has conflict with protected namespace "also_protect_"'
+        UserWarning, match='Field "also_protect_field" in Model has conflict with protected namespace "also_protect_"'
     ):
         create_model(
             'Model',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2586,7 +2586,9 @@ def test_recursion_loop_error():
 
 
 def test_protected_namespace_default():
-    with pytest.warns(UserWarning, match='Field "model_prefixed_field" has conflict with protected namespace "model_"'):
+    with pytest.warns(
+        UserWarning, match='Field "model_prefixed_field" in Model has conflict with protected namespace "model_"'
+    ):
 
         class Model(BaseModel):
             model_prefixed_field: str
@@ -2602,7 +2604,7 @@ def test_protected_namespace_real_conflict():
 
 
 def test_custom_protected_namespace():
-    with pytest.warns(UserWarning, match='Field "test_field" has conflict with protected namespace "test_"'):
+    with pytest.warns(UserWarning, match='Field "test_field" in Model has conflict with protected namespace "test_"'):
 
         class Model(BaseModel):
             # this field won't raise error because we changed the default value for the
@@ -2615,7 +2617,7 @@ def test_custom_protected_namespace():
 
 def test_multiple_protected_namespace():
     with pytest.warns(
-        UserWarning, match='Field "also_protect_field" has conflict with protected namespace "also_protect_"'
+        UserWarning, match='Field "also_protect_field" in Model has conflict with protected namespace "also_protect_"'
     ):
 
         class Model(BaseModel):


### PR DESCRIPTION
## Change Summary

Make it easier to identify which class has the conflict when multiple classes are involved.

Before:

```
.../site-packages/pydantic/_internal/_fields.py:160:
UserWarning: Field "model_max_budget"
has conflict with protected namespace "model_".
```

After:

```
.../site-packages/pydantic/_internal/_fields.py:160:
UserWarning: Field "model_max_budget" in LiteLLM_BudgetTable
has conflict with protected namespace "model_".
```

## Related issue number

#9962 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
