### PR TITLE
Fix dataclass ignoring default_factory passed in Annotated

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -488,7 +488,7 @@ class FieldInfo(_repr.Representation):
         """
         default = dc_field.default
         if default is dataclasses.MISSING:
-            default = PydanticUndefined
+            default = _Unset
 
         if dc_field.default_factory is dataclasses.MISSING:
             default_factory: typing.Callable[[], Any] | None = _Unset

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -491,7 +491,7 @@ class FieldInfo(_repr.Representation):
             default = PydanticUndefined
 
         if dc_field.default_factory is dataclasses.MISSING:
-            default_factory: typing.Callable[[], Any] | None = None
+            default_factory: typing.Callable[[], Any] | None = _Unset
         else:
             default_factory = dc_field.default_factory
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2945,16 +2945,17 @@ def test_validation_works_for_cyclical_forward_refs() -> None:
 
     assert Y(x={'y': None}).x.y is None
 
-@pytest.mark.parametrize("field_fn_unset", [Field, dataclasses.field])
-@pytest.mark.parametrize("field_fn2", [Field, dataclasses.field])
-def test_annotated_with_field_default_factory( field_fn_unset, field_fn2) -> None:
+
+@pytest.mark.parametrize('field_fn_unset', [Field, dataclasses.field])
+@pytest.mark.parametrize('field_fn2', [Field, dataclasses.field])
+def test_annotated_with_field_default_factory(field_fn_unset, field_fn2) -> None:
     """
     https://github.com/pydantic/pydantic/issues/9947
     """
 
     # wrap in lambda to create new instance for different fields
-    field1 =lambda: pydantic.Field(default_factory=lambda: 1)  # `Annotated` only works with pydantic field
-    field2 = lambda:field_fn2(default_factory=lambda: 2)
+    field1 = lambda: pydantic.Field(default_factory=lambda: 1)  # `Annotated` only works with pydantic field
+    field2 = lambda: field_fn2(default_factory=lambda: 2)
 
     @pydantic.dataclasses.dataclass()
     class A:
@@ -2966,7 +2967,7 @@ def test_annotated_with_field_default_factory( field_fn_unset, field_fn2) -> Non
         f: Annotated[int, field1()] = field2()
 
     instance = A()
-    field_names = ("a", "b", "c", "d", "e", "f")
+    field_names = ('a', 'b', 'c', 'd', 'e', 'f')
     results = (1, 1, 1, 2, 2, 2)
-    for field_name,result in zip(field_names, results):
+    for field_name, result in zip(field_names, results):
         assert getattr(instance, field_name) == result


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This is a fix for bug reported in #9947. When using `pydantic.dataclass` with `Annotated` and `Field(default_factory=...)`, the generated field does not have correct `default_factory`. 

The only change I made was changing
```py
if dc_field.default_factory is dataclasses.MISSING:
    default_factory: typing.Callable[[], Any] | None = None
```
to
```py
if dc_field.default_factory is dataclasses.MISSING:
    default_factory: typing.Callable[[], Any] | None = _Unset
```
in `FieldInfo._from_dataclass_field` function.

The original assignment of `None` will cause `default_factory` to be override in `FieldInfo.merge_field_infos` method, which is called in `collect_dataclass_fields`.

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #9947 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
