### PR TITLE
Changed `BaseModel.model_validate_json` raises docstring to mention `ValidationError` instead of `ValueError`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -589,7 +589,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             The validated Pydantic model.
 
         Raises:
-            ValueError: If `json_data` is not a JSON string.
+            ValidationError: If `json_data` is not a JSON string or the object could not be validated.
         """
         # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
         __tracebackhide__ = True


### PR DESCRIPTION
## Change Summary

Changed the `raises` documentation of `BaseModel.model_validate_json` to be more specific as it raises a `ValidationError` and not a generic `ValueError`.

## Related issue number

fix #9944

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
