### PR TITLE
Simplify schema generation for uuid, url, and ip types

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -14,6 +14,7 @@ from copy import copy, deepcopy
 from enum import Enum
 from functools import partial
 from inspect import Parameter, _ParameterKind, signature
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from itertools import chain
 from operator import attrgetter
 from types import FunctionType, LambdaType, MethodType
@@ -33,9 +34,18 @@ from typing import (
     cast,
     overload,
 )
+from uuid import UUID
 from warnings import warn
 
-from pydantic_core import CoreSchema, PydanticCustomError, PydanticUndefined, core_schema, to_jsonable_python
+from pydantic_core import (
+    CoreSchema,
+    MultiHostUrl,
+    PydanticCustomError,
+    PydanticUndefined,
+    Url,
+    core_schema,
+    to_jsonable_python,
+)
 from typing_extensions import Annotated, Literal, TypeAliasType, TypedDict, get_args, get_origin, is_typeddict
 
 from ..aliases import AliasGenerator
@@ -109,6 +119,7 @@ LIST_TYPES: list[type] = [list, typing.List, collections.abc.MutableSequence]
 SET_TYPES: list[type] = [set, typing.Set, collections.abc.MutableSet]
 FROZEN_SET_TYPES: list[type] = [frozenset, typing.FrozenSet, collections.abc.Set]
 DICT_TYPES: list[type] = [dict, typing.Dict, collections.abc.MutableMapping, collections.abc.Mapping]
+IP_TYPES: list[type] = [IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network]
 
 
 def check_validator_fields_against_field_name(
@@ -470,6 +481,30 @@ class GenerateSchema:
                 enum_type,
                 metadata={'pydantic_js_functions': [get_json_schema_no_cases]},
             )
+
+    def _ip_schema(self, tp: Any) -> CoreSchema:
+        from ._validators import IP_VALIDATOR_LOOKUP
+
+        ip_type_json_schema_format = {
+            IPv4Address: 'ipv4',
+            IPv4Network: 'ipv4network',
+            IPv4Interface: 'ipv4interface',
+            IPv6Address: 'ipv6',
+            IPv6Network: 'ipv6network',
+            IPv6Interface: 'ipv6interface',
+        }
+
+        return core_schema.lax_or_strict_schema(
+            lax_schema=core_schema.no_info_plain_validator_function(IP_VALIDATOR_LOOKUP[tp]),
+            strict_schema=core_schema.json_or_python_schema(
+                json_schema=core_schema.no_info_after_validator_function(tp, core_schema.str_schema()),
+                python_schema=core_schema.is_instance_schema(tp),
+            ),
+            serialization=core_schema.to_string_ser_schema(),
+            metadata=build_metadata_dict(
+                js_functions=[lambda _1, _2: {'type': 'string', 'format': ip_type_json_schema_format[tp]}]
+            ),
+        )
 
     def _arbitrary_type_schema(self, tp: Any) -> CoreSchema:
         if not isinstance(tp, type):
@@ -883,8 +918,16 @@ class GenerateSchema:
             return core_schema.bool_schema()
         elif obj is Any or obj is object:
             return core_schema.any_schema()
+        elif obj is UUID:
+            return core_schema.uuid_schema()
+        elif obj is Url:
+            return core_schema.url_schema()
+        elif obj is MultiHostUrl:
+            return core_schema.multi_host_url_schema()
         elif obj is None or obj is _typing_extra.NoneType:
             return core_schema.none_schema()
+        elif obj in IP_TYPES:
+            return self._ip_schema(obj)
         elif obj in TUPLE_TYPES:
             return self._tuple_schema(obj)
         elif obj in LIST_TYPES:

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -12,16 +12,13 @@ import decimal
 import os
 import typing
 from functools import partial
-from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import Any, Callable, Iterable, Tuple, TypeVar
 
 import typing_extensions
 from pydantic_core import (
     CoreSchema,
-    MultiHostUrl,
     PydanticCustomError,
     PydanticOmit,
-    Url,
     core_schema,
 )
 from typing_extensions import get_args, get_origin
@@ -40,18 +37,6 @@ if typing.TYPE_CHECKING:
     from ._generate_schema import GenerateSchema
 
     StdSchemaFunction = Callable[[GenerateSchema, type[Any]], core_schema.CoreSchema]
-
-
-@dataclasses.dataclass(**slots_true)
-class SchemaTransformer:
-    get_core_schema: Callable[[Any, GetCoreSchemaHandler], CoreSchema]
-    get_json_schema: Callable[[CoreSchema, GetJsonSchemaHandler], JsonSchemaValue]
-
-    def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
-        return self.get_core_schema(source_type, handler)
-
-    def __get_pydantic_json_schema__(self, schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-        return self.get_json_schema(schema, handler)
 
 
 @dataclasses.dataclass(**slots_true)
@@ -112,19 +97,6 @@ def datetime_prepare_pydantic_annotations(
     # check now that we know the source type is correct
     _known_annotated_metadata.check_metadata(metadata, _known_annotated_metadata.DATE_TIME_CONSTRAINTS, source_type)
     return (source_type, [sv, *remaining_annotations])
-
-
-def uuid_prepare_pydantic_annotations(
-    source_type: Any, annotations: Iterable[Any], _config: ConfigDict
-) -> tuple[Any, list[Any]] | None:
-    # UUIDs have no constraints - they are fixed length, constructing a UUID instance checks the length
-
-    from uuid import UUID
-
-    if source_type is not UUID:
-        return None
-
-    return (source_type, [InnerSchemaValidator(core_schema.uuid_schema()), *annotations])
 
 
 def path_schema_prepare_pydantic_annotations(
@@ -545,67 +517,10 @@ def mapping_like_prepare_pydantic_annotations(
     )
 
 
-def ip_prepare_pydantic_annotations(
-    source_type: Any, annotations: Iterable[Any], _config: ConfigDict
-) -> tuple[Any, list[Any]] | None:
-    from ._validators import IP_VALIDATOR_LOOKUP
-
-    if source_type not in [IPv4Address, IPv4Network, IPv4Interface, IPv6Address, IPv6Network, IPv6Interface]:
-        return None
-
-    ip_type_json_schema_format = {
-        IPv4Address: 'ipv4',
-        IPv4Network: 'ipv4network',
-        IPv4Interface: 'ipv4interface',
-        IPv6Address: 'ipv6',
-        IPv6Network: 'ipv6network',
-        IPv6Interface: 'ipv6interface',
-    }
-
-    return source_type, [
-        SchemaTransformer(
-            lambda _1, _2: core_schema.lax_or_strict_schema(
-                lax_schema=core_schema.no_info_plain_validator_function(IP_VALIDATOR_LOOKUP[source_type]),
-                strict_schema=core_schema.json_or_python_schema(
-                    json_schema=core_schema.no_info_after_validator_function(source_type, core_schema.str_schema()),
-                    python_schema=core_schema.is_instance_schema(source_type),
-                ),
-                serialization=core_schema.to_string_ser_schema(),
-            ),
-            lambda _1, _2: {'type': 'string', 'format': ip_type_json_schema_format[source_type]},
-        ),
-        *annotations,
-    ]
-
-
-def url_prepare_pydantic_annotations(
-    source_type: Any, annotations: Iterable[Any], _config: ConfigDict
-) -> tuple[Any, list[Any]] | None:
-    if source_type is Url:
-        return source_type, [
-            SchemaTransformer(
-                lambda _1, _2: core_schema.url_schema(),
-                lambda cs, handler: handler(cs),
-            ),
-            *annotations,
-        ]
-    if source_type is MultiHostUrl:
-        return source_type, [
-            SchemaTransformer(
-                lambda _1, _2: core_schema.multi_host_url_schema(),
-                lambda cs, handler: handler(cs),
-            ),
-            *annotations,
-        ]
-
-
 PREPARE_METHODS: tuple[Callable[[Any, Iterable[Any], ConfigDict], tuple[Any, list[Any]] | None], ...] = (
     decimal_prepare_pydantic_annotations,
     sequence_like_prepare_pydantic_annotations,
     datetime_prepare_pydantic_annotations,
-    uuid_prepare_pydantic_annotations,
     path_schema_prepare_pydantic_annotations,
     mapping_like_prepare_pydantic_annotations,
-    ip_prepare_pydantic_annotations,
-    url_prepare_pydantic_annotations,
 )


### PR DESCRIPTION
Some std types, including `uuid.UUID`, various IP address types, and `core_schema.Url`/ `core_schema.MultiHostUrl` had complicated schema application patterns, jumping through annotation hoops that weren't needed.

This moves the generation of those schemas to the `_generate_schema.py` file directly!

This results in a minor improvement to the schema build time: https://codspeed.io/pydantic/pydantic/branches/uuid-move