### PR TITLE
Move date schemas to `_generate_schema.py`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -11,6 +11,7 @@ import typing
 import warnings
 from contextlib import ExitStack, contextmanager
 from copy import copy, deepcopy
+from datetime import date, datetime, time, timedelta
 from enum import Enum
 from functools import partial
 from inspect import Parameter, _ParameterKind, signature
@@ -883,6 +884,14 @@ class GenerateSchema:
             return core_schema.bool_schema()
         elif obj is Any or obj is object:
             return core_schema.any_schema()
+        elif obj is date:
+            return core_schema.date_schema()
+        elif obj is datetime:
+            return core_schema.datetime_schema()
+        elif obj is time:
+            return core_schema.time_schema()
+        elif obj is timedelta:
+            return core_schema.timedelta_schema()
         elif obj is None or obj is _typing_extra.NoneType:
             return core_schema.none_schema()
         elif obj in TUPLE_TYPES:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import collections.abc
 import dataclasses
+import datetime
 import inspect
 import re
 import sys
@@ -11,7 +12,6 @@ import typing
 import warnings
 from contextlib import ExitStack, contextmanager
 from copy import copy, deepcopy
-from datetime import date, datetime, time, timedelta
 from enum import Enum
 from functools import partial
 from inspect import Parameter, _ParameterKind, signature
@@ -884,13 +884,13 @@ class GenerateSchema:
             return core_schema.bool_schema()
         elif obj is Any or obj is object:
             return core_schema.any_schema()
-        elif obj is date:
+        elif obj is datetime.date:
             return core_schema.date_schema()
-        elif obj is datetime:
+        elif obj is datetime.datetime:
             return core_schema.datetime_schema()
-        elif obj is time:
+        elif obj is datetime.time:
             return core_schema.time_schema()
-        elif obj is timedelta:
+        elif obj is datetime.timedelta:
             return core_schema.timedelta_schema()
         elif obj is None or obj is _typing_extra.NoneType:
             return core_schema.none_schema()

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -76,9 +76,7 @@ constraint_schema_pairings: list[tuple[set[str], tuple[str, ...]]] = [
     (GENERATOR_CONSTRAINTS, ('generator',)),
     (FLOAT_CONSTRAINTS, ('float',)),
     (INT_CONSTRAINTS, ('int',)),
-    (DATE_TIME_CONSTRAINTS, ('date', 'time', 'datetime')),
-    (TIMEDELTA_CONSTRAINTS, ('timedelta',)),
-    (TIME_CONSTRAINTS, ('time',)),
+    (DATE_TIME_CONSTRAINTS, ('date', 'time', 'datetime', 'timedelta')),
     # TODO: this is a bit redundant, we could probably avoid some of these
     (STRICT, (*TEXT_SCHEMA_TYPES, *SEQUENCE_SCHEMA_TYPES, *NUMERIC_SCHEMA_TYPES, 'typed-dict', 'model')),
     (UNION_CONSTRAINTS, ('union',)),

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -93,27 +93,6 @@ def decimal_prepare_pydantic_annotations(
     return source, [InnerSchemaValidator(core_schema.decimal_schema(**metadata)), *remaining_annotations]
 
 
-def datetime_prepare_pydantic_annotations(
-    source_type: Any, annotations: Iterable[Any], _config: ConfigDict
-) -> tuple[Any, list[Any]] | None:
-    import datetime
-
-    metadata, remaining_annotations = _known_annotated_metadata.collect_known_metadata(annotations)
-    if source_type is datetime.date:
-        sv = InnerSchemaValidator(core_schema.date_schema(**metadata))
-    elif source_type is datetime.datetime:
-        sv = InnerSchemaValidator(core_schema.datetime_schema(**metadata))
-    elif source_type is datetime.time:
-        sv = InnerSchemaValidator(core_schema.time_schema(**metadata))
-    elif source_type is datetime.timedelta:
-        sv = InnerSchemaValidator(core_schema.timedelta_schema(**metadata))
-    else:
-        return None
-    # check now that we know the source type is correct
-    _known_annotated_metadata.check_metadata(metadata, _known_annotated_metadata.DATE_TIME_CONSTRAINTS, source_type)
-    return (source_type, [sv, *remaining_annotations])
-
-
 def uuid_prepare_pydantic_annotations(
     source_type: Any, annotations: Iterable[Any], _config: ConfigDict
 ) -> tuple[Any, list[Any]] | None:
@@ -602,7 +581,6 @@ def url_prepare_pydantic_annotations(
 PREPARE_METHODS: tuple[Callable[[Any, Iterable[Any], ConfigDict], tuple[Any, list[Any]] | None], ...] = (
     decimal_prepare_pydantic_annotations,
     sequence_like_prepare_pydantic_annotations,
-    datetime_prepare_pydantic_annotations,
     uuid_prepare_pydantic_annotations,
     path_schema_prepare_pydantic_annotations,
     mapping_like_prepare_pydantic_annotations,


### PR DESCRIPTION
Similar to https://github.com/pydantic/pydantic/pull/9975, moving some schema generation that doesn't need to directly handle metadata to `_generate_schema.py`

Also provides a nice little performance bump: https://codspeed.io/pydantic/pydantic/branches/move-date-stuff