### PR TITLE
Fix Sequence ignoring discriminator

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1605,6 +1605,9 @@ class GenerateSchema:
         item_type_schema = self.generate_schema(item_type)
         list_schema = core_schema.list_schema(item_type_schema)
 
+        from ._utils import smart_deepcopy
+
+        json_schema = smart_deepcopy(list_schema)
         python_schema = core_schema.is_instance_schema(typing.Sequence, cls_repr='Sequence')
         if item_type != Any:
             from ._validators import sequence_validator
@@ -1617,7 +1620,7 @@ class GenerateSchema:
             serialize_sequence_via_list, schema=item_type_schema, info_arg=True
         )
         return core_schema.json_or_python_schema(
-            json_schema=list_schema, python_schema=python_schema, serialization=serialization
+            json_schema=json_schema, python_schema=python_schema, serialization=serialization
         )
 
     def _iterable_schema(self, type_: Any) -> core_schema.GeneratorSchema:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -80,7 +80,7 @@ from ._generics import get_standard_typevars_map, has_instance_in_type, recursiv
 from ._mock_val_ser import MockCoreSchema
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._typing_extra import is_finalvar, is_self_type, is_zoneinfo_type
-from ._utils import lenient_issubclass
+from ._utils import lenient_issubclass, smart_deepcopy
 
 if TYPE_CHECKING:
     from ..fields import ComputedFieldInfo, FieldInfo
@@ -1604,8 +1604,6 @@ class GenerateSchema:
         item_type = self._get_first_arg_or_any(sequence_type)
         item_type_schema = self.generate_schema(item_type)
         list_schema = core_schema.list_schema(item_type_schema)
-
-        from ._utils import smart_deepcopy
 
         json_schema = smart_deepcopy(list_schema)
         python_schema = core_schema.is_instance_schema(typing.Sequence, cls_repr='Sequence')

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -2,7 +2,7 @@ import re
 import sys
 from enum import Enum, IntEnum
 from types import SimpleNamespace
-from typing import Any, Callable, Generic, List, Optional, Self, Sequence, TypeVar, Union
+from typing import Any, Callable, Generic, List, Optional, Sequence, TypeVar, Union
 
 import pytest
 from dirty_equals import HasRepr, IsStr
@@ -1430,7 +1430,7 @@ def test_sequence_discriminated_union_validation_with_validator():
         a_field: str
 
         @model_validator(mode='after')
-        def check_a(self) -> Self:
+        def check_a(self):
             return self
 
     class B(BaseModel):
@@ -1438,7 +1438,7 @@ def test_sequence_discriminated_union_validation_with_validator():
         b_field: str
 
         @model_validator(mode='after')
-        def check_b(self) -> Self:
+        def check_b(self):
             return self
 
     class Model(BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
This is a fix for bug #9872. The annotation `Sequence` ignores `discriminator` metadata in certain cases. The generated schema has not correct `python_schema` where a `union` is presented rather than expected `tagged-union`. `json_schema` is normal.

The bug occurs in `GenerateSchema._sequence_schema`. In the `json-or-python` schema created, the underling reference of `item_type_schema` is the same, therefore the `metadata` dict is also shared. When calling `apply_discriminators` on the model schema, because `json_schema` is walked first, it has correct conversion from `union` to `tagged-union`. But the walk will pop the discriminator from `metadata`. Therefore when `python_schema` is walked, `metadata` is already empty, resulting in `union`, not `tagged-union` schema.  
```py
# `metadata` object has the same memory location
metadata = s.get('metadata', {})
discriminator = metadata.pop(CORE_SCHEMA_METADATA_DISCRIMINATOR_PLACEHOLDER_KEY, None)
```

I suspect there are more of these kinds of reference sharing problems in other parts of schema generation process.  🤔

Note the author mentioned that the bug disappears when adding `model_validator` to both models. This is because the procedure for applying discriminators is different. It is `GenerateSchema._apply_discriminator_to_union` that generates `tagged-union` in this case.

## Related issue number

fix #9872 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
