### PR TITLE
chore: fix entry in `.gitignore` to let `make format` work correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ _build/
 /codecov.sh
 /coverage.lcov
 .coverage
-test*.py
+/test*.py
 run_mypy_on_file.py
 
 # Documentation files


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
This PR fixes `make format` not running on `tests` (but only on `pydantic` and on `docs/plugins`) as per comment https://github.com/pydantic/pydantic/pull/9971#discussion_r1691217255.
Upon investigation, I ensured that the issue was not related to `pdm` nor `ruff` themselves and not even to the use of multiple arguments with `ruff format`.

In particular, both `pdm run ruff format tests --verbose` and `ruff format tests --verbose` did return the following (only 9 files subjected to formatting)

    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/__init__.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/pyright/pipeline_api.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/pyright/pyright_example.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/conftest.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/benchmarks/generate_north_star_data.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/benchmarks/basemodel_eq_performance.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/benchmarks/__init__.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/plugin/example_plugin.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] format_path; path=/home/ales/projects/pydantic/pydantic/tests/check_usage_docs.py
    [2024-07-27][13:49:50][ruff::commands::format][DEBUG] Formatted 9 files in 1.71ms

as specification of the files on which `ruff format tests` was being run and a bunch of annotations as the one below 

    [2024-07-27][13:49:50][ignore::walk][DEBUG] ignoring /home/ales/projects/pydantic/pydantic/tests/test_decorators.py: Ignore(IgnoreMatch(Gitignore(Glob { from: Some("/home/ales/projects/pydantic/pydantic/.gitignore"), original: "test*.py", actual: "**/test*.py", is_whitelist: false, is_only_dir: false })))

related to the files on which it was not running. 

Besides the patterns on which - given the `.gitignore` - `ruff format` is not running on purpose (see `original: "*.py[cod]`), you can find lines as the one above where the pattern which is preventing `ruff` to format correctly is `original: "test*.py"`.

Then, I saw that the change (from `test.py` to `test*.py` in `.gitignore`) was recently added in https://github.com/pydantic/pydantic/pull/9948 (guess it should reference `./.venv/lib/python3.12/site-packages/setuptools/command/test.py` as `find . -name "test.py"` says), which made me think that
removing the line from `.gitignore` could have affected other stuff elsewhere. 

Adding `/` to the considered line (so `/test*.py` in lieu of `test*.py`) should work best as it would leave things as is (namely ignore `test*.py` files in the root directory) while helping `ruff` work correctly.

## Related issue number

Addresses https://github.com/pydantic/pydantic/pull/9971#discussion_r1691217255.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
