### PR TITLE
model_config respects the MRO in repeated keys

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -113,7 +113,7 @@ class ConfigWrapper:
             A `ConfigWrapper` instance for `BaseModel`.
         """
         config_new = ConfigDict()
-        for base in bases:
+        for base in reversed(bases):
             config = getattr(base, 'model_config', None)
             if config:
                 config_new.update(config.copy())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -493,33 +493,43 @@ def test_invalid_config_keys():
 
 def test_multiple_inheritance_config():
     class Parent(BaseModel):
-        model_config = ConfigDict(frozen=True, extra='forbid')
+        model_config = ConfigDict(frozen=True, extra='forbid', title='parent_title', revalidate_instances='always')
 
     class Mixin(BaseModel):
-        model_config = ConfigDict(use_enum_values=True)
+        model_config = ConfigDict(
+            use_enum_values=True, title='this_should_be_the_childs_title_due_mro', revalidate_instances='never'
+        )
 
     class Child(Mixin, Parent):
-        model_config = ConfigDict(populate_by_name=True)
+        model_config = ConfigDict(populate_by_name=True, revalidate_instances='subclass-instances')
 
     assert BaseModel.model_config.get('frozen') is None
     assert BaseModel.model_config.get('populate_by_name') is None
     assert BaseModel.model_config.get('extra') is None
     assert BaseModel.model_config.get('use_enum_values') is None
+    assert BaseModel.model_config.get('title') is None
+    assert BaseModel.model_config.get('revalidate_instances') is None
 
     assert Parent.model_config.get('frozen') is True
     assert Parent.model_config.get('populate_by_name') is None
     assert Parent.model_config.get('extra') == 'forbid'
     assert Parent.model_config.get('use_enum_values') is None
+    assert Parent.model_config.get('title') == 'parent_title'
+    assert Parent.model_config.get('revalidate_instances') == 'always'
 
     assert Mixin.model_config.get('frozen') is None
     assert Mixin.model_config.get('populate_by_name') is None
     assert Mixin.model_config.get('extra') is None
     assert Mixin.model_config.get('use_enum_values') is True
+    assert Mixin.model_config.get('title') == 'this_should_be_the_childs_title_due_mro'
+    assert Mixin.model_config.get('revalidate_instances') == 'never'
 
     assert Child.model_config.get('frozen') is True
     assert Child.model_config.get('populate_by_name') is True
     assert Child.model_config.get('extra') == 'forbid'
     assert Child.model_config.get('use_enum_values') is True
+    assert Child.model_config.get('title') == 'this_should_be_the_childs_title_due_mro'
+    assert Child.model_config.get('revalidate_instances') == 'subclass-instances'
 
 
 def test_config_wrapper_match():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
This PR tries to fix https://github.com/pydantic/pydantic/issues/9992.  According to the logic of `ConfigWrapper.for_model`, in multiple inheritance, it does not completely overwrite `model_config` but rather successively updates its fields using the bases. The bases are provided using the MRO, and by using reversed, it ensures that repeated keys are always set according to the MRO.


<!-- Please give a short summary of the changes. -->

## Related issue number
#9992 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle