### PR TITLE
Fix `model_config` overrided order

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -113,7 +113,7 @@ class ConfigWrapper:
             A `ConfigWrapper` instance for `BaseModel`.
         """
         config_new = ConfigDict()
-        for base in bases:
+        for base in bases[::-1]:
             config = getattr(base, 'model_config', None)
             if config:
                 config_new.update(config.copy())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -522,6 +522,24 @@ def test_multiple_inheritance_config():
     assert Child.model_config.get('use_enum_values') is True
 
 
+def test_multiple_inheritance_config_override():
+    class Parent1(BaseModel):
+        model_config = {'frozen': True, 'extra': 'forbid', 'strict': True}
+
+    class Parent2(BaseModel):
+        model_config = {'use_enum_values': True, 'extra': 'allow', 'strict': False}
+
+    class Mixin1(Parent1, Parent2):
+        pass
+
+    class Mixin2(Parent2, Parent1):
+        pass
+
+    # Closest parent wins
+    assert Mixin1.model_config == Parent2.model_config | Parent1.model_config
+    assert Mixin2.model_config == Parent1.model_config | Parent2.model_config
+
+
 def test_config_wrapper_match():
     localns = {
         '_GenerateSchema': GenerateSchema,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -536,8 +536,8 @@ def test_multiple_inheritance_config_override():
         pass
 
     # Closest parent wins
-    assert Mixin1.model_config == Parent2.model_config | Parent1.model_config
-    assert Mixin2.model_config == Parent1.model_config | Parent2.model_config
+    assert Mixin1.model_config == {**Parent2.model_config, **Parent1.model_config}
+    assert Mixin2.model_config == {**Parent1.model_config, **Parent2.model_config}
 
 
 def test_config_wrapper_match():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Change 
```py
for base in bases:
```
to 
```py
for base in bases[::-1]:
```
for correct `model_config` overrided order.

<!-- Please give a short summary of the changes. -->

## Related issue number
fix #9992 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
