### PR TITLE
Apply `strict=True` to `__init__` in mypy plugin

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -285,9 +285,6 @@ class PydanticPluginConfig:
             for key in self.__slots__:
                 setting = plugin_config.getboolean(CONFIGFILE_KEY, key, fallback=False)
                 setattr(self, key, setting)
-        # self.init_typed = True
-        # self.init_forbid_extra = True
-        # print(self.init_typed, self.init_forbid_extra)
 
     def to_data(self) -> dict[str, Any]:
         """Returns a dict of config names to their values."""

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -285,6 +285,9 @@ class PydanticPluginConfig:
             for key in self.__slots__:
                 setting = plugin_config.getboolean(CONFIGFILE_KEY, key, fallback=False)
                 setattr(self, key, setting)
+        # self.init_typed = True
+        # self.init_forbid_extra = True
+        # print(self.init_typed, self.init_forbid_extra)
 
     def to_data(self) -> dict[str, Any]:
         """Returns a dict of config names to their values."""
@@ -324,6 +327,7 @@ class PydanticModelField:
         is_frozen: bool,
         has_dynamic_alias: bool,
         has_default: bool,
+        strict: bool | None,
         line: int,
         column: int,
         type: Type | None,
@@ -334,6 +338,7 @@ class PydanticModelField:
         self.is_frozen = is_frozen
         self.has_dynamic_alias = has_dynamic_alias
         self.has_default = has_default
+        self.strict = strict
         self.line = line
         self.column = column
         self.type = type
@@ -343,6 +348,7 @@ class PydanticModelField:
         self,
         current_info: TypeInfo,
         typed: bool,
+        model_strict: bool,
         force_optional: bool,
         use_alias: bool,
         api: SemanticAnalyzerPluginInterface,
@@ -351,7 +357,13 @@ class PydanticModelField:
     ) -> Argument:
         """Based on mypy.plugins.dataclasses.DataclassAttribute.to_argument."""
         variable = self.to_var(current_info, api, use_alias, force_typevars_invariant)
-        type_annotation = self.expand_type(current_info, api) if typed else AnyType(TypeOfAny.explicit)
+
+        strict = model_strict if self.strict is None else self.strict
+        if typed or strict:
+            type_annotation = self.expand_type(current_info, api)
+        else:
+            type_annotation = AnyType(TypeOfAny.explicit)
+
         return Argument(
             variable=variable,
             type_annotation=type_annotation,
@@ -414,6 +426,7 @@ class PydanticModelField:
             'is_frozen': self.is_frozen,
             'has_dynamic_alias': self.has_dynamic_alias,
             'has_default': self.has_default,
+            'strict': self.strict,
             'line': self.line,
             'column': self.column,
             'type': self.type.serialize(),
@@ -473,6 +486,7 @@ class PydanticModelTransformer:
         'from_attributes',
         'populate_by_name',
         'alias_generator',
+        'strict',
     }
 
     def __init__(
@@ -796,6 +810,7 @@ class PydanticModelTransformer:
             )
 
         has_default = self.get_has_default(stmt)
+        strict = self.get_strict(stmt)
 
         if sym.type is None and node.is_final and node.is_inferred:
             # This follows the logic from the dataclasses plugin. The following comment is taken verbatim:
@@ -825,6 +840,7 @@ class PydanticModelTransformer:
             name=lhs.name,
             has_dynamic_alias=has_dynamic_alias,
             has_default=has_default,
+            strict=strict,
             alias=alias,
             is_frozen=is_frozen,
             line=stmt.line,
@@ -882,11 +898,13 @@ class PydanticModelTransformer:
             return  # Don't generate an __init__ if one already exists
 
         typed = self.plugin_config.init_typed
+        model_strict = bool(config.strict)
         use_alias = config.populate_by_name is not True
         requires_dynamic_aliases = bool(config.has_alias_generator and not config.populate_by_name)
         args = self.get_field_arguments(
             fields,
             typed=typed,
+            model_strict=model_strict,
             requires_dynamic_aliases=requires_dynamic_aliases,
             use_alias=use_alias,
             is_settings=is_settings,
@@ -937,6 +955,7 @@ class PydanticModelTransformer:
             args = self.get_field_arguments(
                 fields,
                 typed=True,
+                model_strict=bool(config.strict),
                 requires_dynamic_aliases=False,
                 use_alias=False,
                 is_settings=is_settings,
@@ -1046,6 +1065,22 @@ class PydanticModelTransformer:
         return not isinstance(expr, EllipsisExpr)
 
     @staticmethod
+    def get_strict(stmt: AssignmentStmt) -> bool | None:
+        """Returns a the `strict` value of a field if defined, otherwise `None`."""
+        expr = stmt.rvalue
+        if isinstance(expr, CallExpr) and isinstance(expr.callee, RefExpr) and expr.callee.fullname == FIELD_FULLNAME:
+            for arg, name in zip(expr.args, expr.arg_names):
+                if name != 'strict':
+                    continue
+                if isinstance(arg, NameExpr):
+                    if arg.fullname == 'builtins.True':
+                        return True
+                    elif arg.fullname == 'builtins.False':
+                        return False
+                return None
+        return None
+
+    @staticmethod
     def get_alias_info(stmt: AssignmentStmt) -> tuple[str | None, bool]:
         """Returns a pair (alias, has_dynamic_alias), extracted from the declaration of the field defined in `stmt`.
 
@@ -1102,6 +1137,7 @@ class PydanticModelTransformer:
         self,
         fields: list[PydanticModelField],
         typed: bool,
+        model_strict: bool,
         use_alias: bool,
         requires_dynamic_aliases: bool,
         is_settings: bool,
@@ -1117,6 +1153,7 @@ class PydanticModelTransformer:
             field.to_argument(
                 info,
                 typed=typed,
+                model_strict=model_strict,
                 force_optional=requires_dynamic_aliases or is_settings,
                 use_alias=use_alias,
                 api=self._api,
@@ -1166,12 +1203,14 @@ class ModelConfigData:
         from_attributes: bool | None = None,
         populate_by_name: bool | None = None,
         has_alias_generator: bool | None = None,
+        strict: bool | None = None,
     ):
         self.forbid_extra = forbid_extra
         self.frozen = frozen
         self.from_attributes = from_attributes
         self.populate_by_name = populate_by_name
         self.has_alias_generator = has_alias_generator
+        self.strict = strict
 
     def get_values_dict(self) -> dict[str, Any]:
         """Returns a dict of Pydantic model config names to their values.

--- a/tests/mypy/modules/plugin_strict_fields.py
+++ b/tests/mypy/modules/plugin_strict_fields.py
@@ -1,0 +1,49 @@
+from pydantic import BaseModel, Field
+
+
+class Model(BaseModel):
+    a: int
+    b: int = Field(strict=True)
+    c: int = Field(strict=False)
+
+
+# expected error: b
+Model(a='1', b='2', c='3')
+
+
+class ModelStrictMode(BaseModel):
+    model_config = {'strict': True}
+
+    a: int
+    b: int = Field(strict=True)
+    c: int = Field(strict=False)
+
+
+# expected error: a, b
+ModelStrictMode(a='1', b='2', c='3')
+
+
+class ModelOverride1(Model):
+    b: int = Field(strict=False)
+    c: int = Field(strict=True)
+
+
+# expected error: c
+ModelOverride1(a='1', b='2', c='3')
+
+
+class ModelOverride2(ModelStrictMode):
+    b: int = Field(strict=False)
+    c: int = Field(strict=True)
+
+
+# expected error: a, c
+ModelOverride2(a='1', b='2', c='3')
+
+
+class ModelOverrideStrictMode(ModelStrictMode):
+    model_config = {'strict': False}
+
+
+# expected error: b
+ModelOverrideStrictMode(a='1', b='2', c='3')

--- a/tests/mypy/outputs/1.0.1/mypy-plugin_ini/plugin_strict_fields.py
+++ b/tests/mypy/outputs/1.0.1/mypy-plugin_ini/plugin_strict_fields.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel, Field
+
+
+class Model(BaseModel):
+    a: int
+    b: int = Field(strict=True)
+    c: int = Field(strict=False)
+
+
+# expected error: b
+Model(a='1', b='2', c='3')
+# MYPY: error: Argument "b" to "Model" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelStrictMode(BaseModel):
+    model_config = {'strict': True}
+
+    a: int
+    b: int = Field(strict=True)
+    c: int = Field(strict=False)
+
+
+# expected error: a, b
+ModelStrictMode(a='1', b='2', c='3')
+# MYPY: error: Argument "a" to "ModelStrictMode" has incompatible type "str"; expected "int"  [arg-type]
+# MYPY: error: Argument "b" to "ModelStrictMode" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelOverride1(Model):
+    b: int = Field(strict=False)
+    c: int = Field(strict=True)
+
+
+# expected error: c
+ModelOverride1(a='1', b='2', c='3')
+# MYPY: error: Argument "c" to "ModelOverride1" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelOverride2(ModelStrictMode):
+    b: int = Field(strict=False)
+    c: int = Field(strict=True)
+
+
+# expected error: a, c
+ModelOverride2(a='1', b='2', c='3')
+# MYPY: error: Argument "a" to "ModelOverride2" has incompatible type "str"; expected "int"  [arg-type]
+# MYPY: error: Argument "c" to "ModelOverride2" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelOverrideStrictMode(ModelStrictMode):
+    model_config = {'strict': False}
+
+
+# expected error: b
+ModelOverrideStrictMode(a='1', b='2', c='3')
+# MYPY: error: Argument "b" to "ModelOverrideStrictMode" has incompatible type "str"; expected "int"  [arg-type]

--- a/tests/mypy/outputs/1.1.1/mypy-plugin_ini/plugin_strict_fields.py
+++ b/tests/mypy/outputs/1.1.1/mypy-plugin_ini/plugin_strict_fields.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel, Field
+
+
+class Model(BaseModel):
+    a: int
+    b: int = Field(strict=True)
+    c: int = Field(strict=False)
+
+
+# expected error: b
+Model(a='1', b='2', c='3')
+# MYPY: error: Argument "b" to "Model" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelStrictMode(BaseModel):
+    model_config = {'strict': True}
+
+    a: int
+    b: int = Field(strict=True)
+    c: int = Field(strict=False)
+
+
+# expected error: a, b
+ModelStrictMode(a='1', b='2', c='3')
+# MYPY: error: Argument "a" to "ModelStrictMode" has incompatible type "str"; expected "int"  [arg-type]
+# MYPY: error: Argument "b" to "ModelStrictMode" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelOverride1(Model):
+    b: int = Field(strict=False)
+    c: int = Field(strict=True)
+
+
+# expected error: c
+ModelOverride1(a='1', b='2', c='3')
+# MYPY: error: Argument "c" to "ModelOverride1" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelOverride2(ModelStrictMode):
+    b: int = Field(strict=False)
+    c: int = Field(strict=True)
+
+
+# expected error: a, c
+ModelOverride2(a='1', b='2', c='3')
+# MYPY: error: Argument "a" to "ModelOverride2" has incompatible type "str"; expected "int"  [arg-type]
+# MYPY: error: Argument "c" to "ModelOverride2" has incompatible type "str"; expected "int"  [arg-type]
+
+
+class ModelOverrideStrictMode(ModelStrictMode):
+    model_config = {'strict': False}
+
+
+# expected error: b
+ModelOverrideStrictMode(a='1', b='2', c='3')
+# MYPY: error: Argument "b" to "ModelOverrideStrictMode" has incompatible type "str"; expected "int"  [arg-type]

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -110,6 +110,7 @@ cases = (
         ('mypy-plugin.ini', 'plugin_optional_inheritance.py'),
         ('mypy-plugin.ini', 'generics.py'),
         ('mypy-plugin.ini', 'root_models.py'),
+        ('mypy-plugin.ini', 'plugin_strict_fields.py'),
         ('mypy-plugin-strict.ini', 'plugin_default_factory.py'),
         ('mypy-plugin-strict-no-any.ini', 'dataclass_no_any.py'),
         ('mypy-plugin-very-strict.ini', 'metaclass_args.py'),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I've added a feature to `pydantic-mypy` where type annotations for `__init__` will apply to fields with `strict=True`, even when `init_typed` set to `False`. Additionally, if `model_config['strict'] = True` is set for a model, then all fields will be typed in `__init__` unless overridden with `Field(strict=True)`.

Currently, this feature only works with `a: int = Field(strict=True)` and not with `a: Annotated[int, Field(strict=True)]` or `a: Annotated[int, Strict(strict=True)]`. It is also implemented only for `__init__` and not for `validate_call` or other methods.

### Example Code

```python
class Model(BaseModel):
    a: int
    b: int = Field(strict=True)
    c: int = Field(strict=False)

# expected mypy error: b
Model(a='1', b='2', c='3')


class ModelStrictMode(BaseModel):
    model_config = {'strict': True}

    a: int
    b: int = Field(strict=True)
    c: int = Field(strict=False)

# expected mypy error: a, b
ModelStrictMode(a='1', b='2', c='3')
```

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #9997 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->


## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
