### PR TITLE
Move annotation compatibility errors to validation phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
           pdm install -G testing
 
       - name: install example plugin
-        run: pdm add ./tests/plugin
+        run: pdm add ./tests/plugin -v
 
       - run: pdm run pytest ./tests/plugin
         env:

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -264,7 +264,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         else:
             # It's rare that we'd get here, but it's possible if we add a new constraint and forget to handle it
             # Most constraint errors are caught at runtime during attempted application
-            raise ValueError(f"Unable to apply constraint '{constraint}' to schema of type '{schema_type}'")
+            raise RuntimeError(f"Unable to apply constraint '{constraint}' to schema of type '{schema_type}'")
 
     for annotation in other_metadata:
         if (annotation_type := type(annotation)) in (at_to_constraint_map := _get_at_to_constraint_map()):

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -223,9 +223,10 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         # this is a bit challenging because we sometimes want to apply constraints to the inner schema,
         # whereas other times we want to wrap the existing schema with a new one that enforces a new constraint.
         if schema_type in {'function-before', 'function-wrap', 'function-after'} and constraint == 'strict':
-            schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function-after schema
+            schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function schema
             return schema
 
+        # if we're allowed to apply constraint directly to the schema, like le to int, do that
         if schema_type in allowed_schemas:
             if constraint == 'union_mode' and schema_type == 'union':
                 schema['mode'] = value  # type: ignore  # schema is UnionSchema
@@ -233,34 +234,47 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
                 schema[constraint] = value
             continue
 
-        if constraint in chain_schema_constraints:
-            chain_schema_steps.append(cs.str_schema(**{constraint: value}))
-        elif constraint in {*NUMERIC_CONSTRAINTS, *LENGTH_CONSTRAINTS}:
-            if constraint in NUMERIC_CONSTRAINTS:
-                json_schema_constraint = constraint
-            elif constraint in LENGTH_CONSTRAINTS:
-                inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
-                inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
-                ):
-                    json_schema_constraint = 'minItems' if constraint == 'min_length' else 'maxItems'
-                else:
-                    json_schema_constraint = 'minLength' if constraint == 'min_length' else 'maxLength'
+        #  else if we recognize the type of the schema as one of the common wrapper types,
+        #  apply a function after to the schema to enforce the corresponding constraint, if
+        if schema_type in [
+            'function-before',
+            'function-wrap',
+            'function-after',
+            'function-plain',
+            'json-or-python',
+            'lax-or-strict',
+            'isinstance',
+        ]:
+            if constraint in chain_schema_constraints:
+                chain_schema_steps.append(cs.str_schema(**{constraint: value}))
+            elif constraint in {*NUMERIC_CONSTRAINTS, *LENGTH_CONSTRAINTS}:
+                if constraint in NUMERIC_CONSTRAINTS:
+                    json_schema_constraint = constraint
+                elif constraint in LENGTH_CONSTRAINTS:
+                    inner_schema = schema
+                    while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
+                        inner_schema = inner_schema['schema']  # type: ignore
+                    inner_schema_type = inner_schema['type']
+                    if inner_schema_type == 'list' or (
+                        inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
+                    ):
+                        json_schema_constraint = 'minItems' if constraint == 'min_length' else 'maxItems'
+                    else:
+                        json_schema_constraint = 'minLength' if constraint == 'min_length' else 'maxLength'
 
-            schema = cs.no_info_after_validator_function(
-                partial(get_constraint_validator(constraint), **{constraint: value}), schema
-            )
-            add_js_update_schema(schema, lambda: {json_schema_constraint: as_jsonable_value(value)})
-        elif constraint == 'allow_inf_nan' and value is False:
-            schema = cs.no_info_after_validator_function(
-                forbid_inf_nan_check,
-                schema,
-            )
+                schema = cs.no_info_after_validator_function(
+                    partial(get_constraint_validator(constraint), **{constraint: value}), schema
+                )
+                add_js_update_schema(schema, lambda: {json_schema_constraint: as_jsonable_value(value)})
+            elif constraint == 'allow_inf_nan' and value is False:
+                schema = cs.no_info_after_validator_function(
+                    forbid_inf_nan_check,
+                    schema,
+                )
+            else:
+                raise TypeError(f"Unable to apply constraint '{constraint}' to schema of type '{schema_type}'")
         else:
-            raise RuntimeError(f'Unable to apply constraint {constraint} to schema {schema_type}')
+            raise TypeError(f"Unable to apply constraint '{constraint}' to schema of type '{schema_type}'")
 
     for annotation in other_metadata:
         if (annotation_type := type(annotation)) in (at_to_constraint_map := _get_at_to_constraint_map()):

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -235,7 +235,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             continue
 
         #  else if we recognize the type of the schema as one of the common wrapper types,
-        #  apply a function after to the schema to enforce the corresponding constraint, if
+        #  apply a function after to the schema to enforce the corresponding constraint
         if schema_type in [
             'function-before',
             'function-wrap',

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -251,6 +251,15 @@ def create_constraint_validator(
     error_type: ErrorType,
     context_gen: Callable[[Any, Any], dict[str, Any]] | None = None,
 ) -> Callable[[_InputType, Any], _InputType]:
+    """Create a validator function for a given constraint.
+
+    Args:
+        constraint_id: The constraint identifier, used to identify the constraint in error messages, ex 'gt'.
+        predicate: The predicate function to apply to the input value, ex `lambda x, gt: x > gt`.
+        error_type: The error type to raise if the predicate fails.
+        context_gen: A function to generate the error context from the constraint value and the input value.
+    """
+
     def validator(x: _InputType, constraint_value: Any) -> _InputType:
         try:
             if not predicate(x, constraint_value):

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -418,7 +418,6 @@ class Account(BaseModel):
     }
 
 
-@pytest.mark.xfail(reason='needs more strict annotation checks, see https://github.com/pydantic/pydantic/issues/9988')
 def test_forward_ref_with_field(create_module):
     @create_module
     def module():
@@ -430,7 +429,7 @@ def test_forward_ref_with_field(create_module):
 
         Foo = ForwardRef('Foo')
 
-        with pytest.raises(TypeError, match=r'The following constraints cannot be applied.*\'gt\''):
+        with pytest.raises(TypeError, match=r"Unable to apply constraint 'gt' to schema of type 'list'"):
 
             class Foo(BaseModel):
                 c: List[Foo] = Field(..., gt=0)

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -421,6 +421,7 @@ class Account(BaseModel):
 def test_forward_ref_with_field(create_module):
     @create_module
     def module():
+        import re
         from typing import ForwardRef, List
 
         import pytest
@@ -429,10 +430,11 @@ def test_forward_ref_with_field(create_module):
 
         Foo = ForwardRef('Foo')
 
-        with pytest.raises(TypeError, match=r"Unable to apply constraint 'gt' to schema of type 'list'"):
+        class Foo(BaseModel):
+            c: List[Foo] = Field(..., gt=0)
 
-            class Foo(BaseModel):
-                c: List[Foo] = Field(..., gt=0)
+        with pytest.raises(TypeError, match=re.escape("Unable to apply constraint 'gt' to supplied value []")):
+            Foo(c=[Foo(c=[])])
 
 
 def test_forward_ref_optional(create_module):

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5947,7 +5947,7 @@ def test_description_not_included_for_basemodel() -> None:
     assert 'description' not in Model.model_json_schema()['$defs']['BaseModel']
 
 
-@pytest.mark.xfail('should we allow max_length on enum?')
+@pytest.mark.xfail(reason='should we allow max_length on enum?')
 def test_recursive_json_schema_build() -> None:
     """
     Schema build for this case is a bit complicated due to the recursive nature of the models.

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5947,6 +5947,7 @@ def test_description_not_included_for_basemodel() -> None:
     assert 'description' not in Model.model_json_schema()['$defs']['BaseModel']
 
 
+@pytest.mark.xfail('should we allow max_length on enum?')
 def test_recursive_json_schema_build() -> None:
     """
     Schema build for this case is a bit complicated due to the recursive nature of the models.

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5947,7 +5947,6 @@ def test_description_not_included_for_basemodel() -> None:
     assert 'description' not in Model.model_json_schema()['$defs']['BaseModel']
 
 
-@pytest.mark.xfail(reason='should we allow max_length on enum?')
 def test_recursive_json_schema_build() -> None:
     """
     Schema build for this case is a bit complicated due to the recursive nature of the models.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1812,7 +1812,7 @@ def test_invalid_decimal_constraint():
             a: Decimal = Field('foo', title='A title', description='A description', max_length=5)
 
 
-@pytest.mark.xfail('should we allow gt on str?')
+@pytest.mark.xfail(reason='should we allow gt on str?')
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 def test_string_success():
     class MoreStringsModel(BaseModel):
@@ -6009,7 +6009,7 @@ def test_transform_schema_for_first_party_class():
     ]
 
 
-@pytest.mark.xfail('currently raising a TypeError for constraints on dataclasses')
+@pytest.mark.xfail(reason='currently raising a TypeError for constraints on dataclasses')
 def test_constraint_dataclass() -> None:
     @dataclass(order=True)
     # need to make it inherit from int so that
@@ -6224,7 +6224,7 @@ def test_instanceof_serialization():
     }
 
 
-@pytest.mark.xfail('hmm, we should probably allow this...')
+@pytest.mark.xfail(reason='hmm, we should probably allow this - do we check for corresponding functions like __lt__?')
 def test_constraints_arbitrary_type() -> None:
     class CustomType:
         def __init__(self, v: Any) -> None:

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -104,9 +104,8 @@ def test_recursive_model_with_subclass_override(Self):
     }
 
 
-@pytest.mark.xfail(reason='needs more strict annotation checks, see https://github.com/pydantic/pydantic/issues/9988')
 def test_self_type_with_field(Self):
-    with pytest.raises(TypeError, match=r'The following constraints cannot be applied.*\'gt\''):
+    with pytest.raises(TypeError, match=r"Unable to apply constraint 'gt' to schema of type 'list'"):
 
         class SelfRef(BaseModel):
             x: int

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -1,4 +1,5 @@
 import dataclasses
+import re
 import typing
 from typing import List, Optional, Union
 
@@ -105,11 +106,12 @@ def test_recursive_model_with_subclass_override(Self):
 
 
 def test_self_type_with_field(Self):
-    with pytest.raises(TypeError, match=r"Unable to apply constraint 'gt' to schema of type 'list'"):
+    class SelfRef(BaseModel):
+        x: int
+        refs: typing.List[Self] = Field(..., gt=0)
 
-        class SelfRef(BaseModel):
-            x: int
-            refs: typing.List[Self] = Field(..., gt=0)
+    with pytest.raises(TypeError, match=re.escape("Unable to apply constraint 'gt' to supplied value []")):
+        SelfRef(x=1, refs=[SelfRef(x=2, refs=[])])
 
 
 def test_self_type_json_schema(Self):


### PR DESCRIPTION
An attempt at addressing https://github.com/pydantic/pydantic/issues/9988

We apply annotations in 2 ways, in order of preference:
1. Directly to the type, like `le` to `int`
2. As an after validator wrapper that enforces a given constraint, like `le` around an arbitrary function after around an `int`. This ensures we respect annotation order.

We try to be pretty lax with #2, but this can cause problems if even a functional validator applying the given constraint isn't compatible with the inner type. Thus, I've added some support to our builtin functional validators to raise informative error messages when applying a constraint raises a `TypeError`.

Fix https://github.com/pydantic/pydantic/issues/9988