### PR TITLE
Fix `Hashable` not working with `model_validate_json`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1805,14 +1805,15 @@ class GenerateSchema:
         )
 
         # Try to convert a `BaseModel` to `dict`
-        def get_frozendict(x: Any, handler):
-            try:
-                x = dict(x)
-            except TypeError as exc:
-                raise ValueError from exc
+        def get_frozendict(x: Any, handler: core_schema.ValidatorFunctionWrapHandler, info: core_schema.ValidationInfo):
+            if not info.config or not info.config.get('strict', False):
+                try:
+                    x = dict(x)
+                except TypeError as exc:
+                    raise ValueError from exc
             return frozendict(handler(x))
 
-        python_frozen_dict_schema = core_schema.no_info_wrap_validator_function(
+        python_frozen_dict_schema = core_schema.with_info_wrap_validator_function(
             get_frozendict,
             core_schema.dict_schema(json_ref, json_ref),
         )

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1741,8 +1741,21 @@ class GenerateSchema:
             raise PydanticSchemaGenerationError(f'Unable to generate pydantic-core schema for {pattern_type!r}.')
 
     def _hashable_schema(self) -> core_schema.CoreSchema:
+        # json cannot be validated by isinstance, so we manually construct a schema
+        json_schema = core_schema.union_schema(
+            [
+                core_schema.str_schema(),
+                core_schema.int_schema(),
+                core_schema.float_schema(),
+                core_schema.bool_schema(),
+                core_schema.none_schema(),
+            ]
+        )
         return core_schema.custom_error_schema(
-            core_schema.is_instance_schema(collections.abc.Hashable),
+            core_schema.json_or_python_schema(
+                json_schema=json_schema,
+                python_schema=core_schema.is_instance_schema(collections.abc.Hashable),
+            ),
             custom_error_type='is_hashable',
             custom_error_message='Input should be hashable',
         )

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1826,7 +1826,7 @@ class GenerateSchema:
                         core_schema.is_instance_schema(collections.abc.Hashable),
                         tuple_schema,
                         python_frozen_dict_schema,
-                        core_schema.frozenset_schema(core_schema.any_schema()),
+                        core_schema.frozenset_schema(python_ref),
                     ],
                     mode='left_to_right',
                     ref='python-hashable',

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -718,12 +718,8 @@ def test_hashable_required():
     class MyDataclass:
         v: Hashable
 
-    MyDataclass(v=None)
-    with pytest.raises(ValidationError) as exc_info:
-        MyDataclass(v=[])
-    assert exc_info.value.errors(include_url=False) == [
-        {'input': [], 'loc': ('v',), 'msg': 'Input should be hashable', 'type': 'is_hashable'}
-    ]
+    hash(MyDataclass(v=None).v)
+    hash(MyDataclass(v=[]).v)
 
     with pytest.raises(ValidationError) as exc_info:
         # Should this raise a TypeError instead? https://github.com/pydantic/pydantic/issues/5487

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2161,7 +2161,7 @@ def test_hashable_json_schema():
                 ]
             }
         },
-        'properties': {'v': {'allOf': [{'$ref': '#/$defs/json-hashable'}], 'title': 'V'}},
+        'properties': {'v': {'$ref': '#/$defs/json-hashable', 'title': 'V'}},
         'required': ['v'],
         'title': 'Model',
         'type': 'object',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Wrap a `json-or-python` schema for `Hashable` type. This allows `validate_json` to work consistently with validating Python objects.

This breaks some existing tests, though. Currently my concern is about `model_dump_json`: when a hashable field has type other than `Union[str, int, float, bool, none]` (e.g. `tuple`), the model can still be serialized (with warning), but the dumped json cannot be validated by the model, which seems inconsistent. I am thinking just raising error when serializing such fields; but I couldn't find a way to do it.

### Example
```py
class A(BaseModel):
    x: Hashable

a = A.model_validate_json('{"x": "1"}')
```

## Related issue number

fix #9567
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
