### PR TITLE
Clarify `model_serializer(mode="wrap")` usage in documentation

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -931,6 +931,28 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'model-serializer-signature'
 ```
 
+Valid model serializer signatures are:
+
+```py test="skip" lint="skip" upgrade="skip"
+from pydantic import model_serializer, SerializerFunctionWrapHandler, SerializationInfo
+
+# an instance method with the default mode or `mode='plain'`
+@model_serializer  # or model_serializer(mode='plain')
+def mod_ser(self, info: SerializationInfo): ...
+
+# an instance method with `mode='wrap'`
+@model_serializer(mode='wrap')
+def mod_ser(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo):
+
+For all of these, you can also choose to omit the `info` argument, for example:
+
+@model_serializer(mode='plain')
+def mod_ser(self): ...
+
+@model_serializer(mode='wrap')
+def mod_ser(self, handler: SerializerFunctionWrapHandler): ...
+```
+
 ## Multiple field serializers {#multiple-field-serializers}
 
 This error is raised when multiple `model_serializer` functions are defined for a field.

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -873,17 +873,17 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'field-serializer-signature'
 ```
 
-Valid serializer signatures are:
+Valid field serializer signatures are:
 
 ```py test="skip" lint="skip" upgrade="skip"
-from pydantic import model_serializer
+from pydantic import field_serializer
 
 # an instance method with the default mode or `mode='plain'`
-@model_serializer('x')  # or @serialize('x', mode='plain')
+@field_serializer('x')  # or @serialize('x', mode='plain')
 def ser_x(self, value: Any, info: pydantic.FieldSerializationInfo): ...
 
 # a static method or free-standing function with the default mode or `mode='plain'`
-@model_serializer('x')  # or @serialize('x', mode='plain')
+@field_serializer('x')  # or @serialize('x', mode='plain')
 @staticmethod
 def ser_x(value: Any, info: pydantic.FieldSerializationInfo): ...
 # equivalent to
@@ -891,11 +891,11 @@ def ser_x(value: Any, info: pydantic.FieldSerializationInfo): ...
 serializer('x')(ser_x)
 
 # an instance method with `mode='wrap'`
-@model_serializer('x', mode='wrap')
+@field_serializer('x', mode='wrap')
 def ser_x(self, value: Any, nxt: pydantic.SerializerFunctionWrapHandler, info: pydantic.FieldSerializationInfo): ...
 
 # a static method or free-standing function with `mode='wrap'`
-@model_serializer('x', mode='wrap')
+@field_serializer('x', mode='wrap')
 @staticmethod
 def ser_x(value: Any, nxt: pydantic.SerializerFunctionWrapHandler, info: pydantic.FieldSerializationInfo): ...
 # equivalent to
@@ -904,10 +904,10 @@ serializer('x')(ser_x)
 
 For all of these, you can also choose to omit the `info` argument, for example:
 
-@model_serializer('x')
+@field_serializer('x')
 def ser_x(self, value: Any): ...
 
-@model_serializer('x', mode='wrap')
+@field_serializer('x', mode='wrap')
 def ser_x(self, value: Any, handler: pydantic.SerializerFunctionWrapHandler): ...
 ```
 

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -127,7 +127,7 @@ class ModelValidatorDecoratorInfo:
     while building the pydantic-core schema.
 
     Attributes:
-        decorator_repr: A class variable representing the decorator string, '@model_serializer'.
+        decorator_repr: A class variable representing the decorator string, '@model_validator'.
         mode: The proposed serializer mode.
     """
 

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -339,6 +339,16 @@ def model_serializer(
 
     See [Custom serializers](../concepts/serialization.md#custom-serializers) for more information.
 
+    Two signatures are supported for `mode='plain'`, which is the default:
+
+    - `(self)`
+    - `(self, info: SerializationInfo)`
+
+    And two other signatures for `mode='wrap'`:
+
+    - `(self, nxt: SerializerFunctionWrapHandler)`
+    - `(self, nxt: SerializerFunctionWrapHandler, info: SerializationInfo)`
+
     Args:
         f: The function to be decorated.
         mode: The serialization mode.

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -337,8 +337,6 @@ def model_serializer(
     #> {'unit': 'C', 'value': 100}
     ```
 
-    See [Custom serializers](../concepts/serialization.md#custom-serializers) for more information.
-
     Two signatures are supported for `mode='plain'`, which is the default:
 
     - `(self)`
@@ -348,6 +346,8 @@ def model_serializer(
 
     - `(self, nxt: SerializerFunctionWrapHandler)`
     - `(self, nxt: SerializerFunctionWrapHandler, info: SerializationInfo)`
+
+        See [Custom serializers](../concepts/serialization.md#custom-serializers) for more information.
 
     Args:
         f: The function to be decorated.

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -99,7 +99,8 @@ class WrapSerializer:
         end: datetime
 
     def convert_to_utc(value: Any, handler, info) -> Dict[str, datetime]:
-        # Note that `helper` can actually help serialize the `value` for further custom serialization in case it's a subclass.
+        # Note that `handler` can actually help serialize the `value` for
+        # further custom serialization in case it's a subclass.
         partial_result = handler(value, info)
         if info.mode == 'json':
             return {

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -389,7 +389,7 @@ _ModelTypeCo = TypeVar('_ModelTypeCo', covariant=True)
 
 
 class ModelWrapValidatorHandler(_core_schema.ValidatorFunctionWrapHandler, Protocol[_ModelTypeCo]):
-    """@model_validator decorated function handler argument type. This is used when `mode='wrap'`."""
+    """`@model_validator` decorated function handler argument type. This is used when `mode='wrap'`."""
 
     def __call__(  # noqa: D102
         self,
@@ -401,7 +401,7 @@ class ModelWrapValidatorHandler(_core_schema.ValidatorFunctionWrapHandler, Proto
 
 
 class ModelWrapValidatorWithoutInfo(Protocol[_ModelType]):
-    """A @model_validator decorated function signature.
+    """A `@model_validator` decorated function signature.
     This is used when `mode='wrap'` and the function does not have info argument.
     """
 
@@ -418,7 +418,7 @@ class ModelWrapValidatorWithoutInfo(Protocol[_ModelType]):
 
 
 class ModelWrapValidator(Protocol[_ModelType]):
-    """A @model_validator decorated function signature. This is used when `mode='wrap'`."""
+    """A `@model_validator` decorated function signature. This is used when `mode='wrap'`."""
 
     def __call__(  # noqa: D102
         self,
@@ -434,7 +434,7 @@ class ModelWrapValidator(Protocol[_ModelType]):
 
 
 class FreeModelBeforeValidatorWithoutInfo(Protocol):
-    """A @model_validator decorated function signature.
+    """A `@model_validator` decorated function signature.
     This is used when `mode='before'` and the function does not have info argument.
     """
 
@@ -449,7 +449,7 @@ class FreeModelBeforeValidatorWithoutInfo(Protocol):
 
 
 class ModelBeforeValidatorWithoutInfo(Protocol):
-    """A @model_validator decorated function signature.
+    """A `@model_validator` decorated function signature.
     This is used when `mode='before'` and the function does not have info argument.
     """
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I'm trying to fix a few issues with regard to the documentation of the `model_serializer(mode="wrap")` case. I *think* there was a few typo. I've also wrapped a line in a python example in order to avoid an horizontal scrollbar.

I've tried to respect the style, but please feel free to comment. Also, I'm not native-english, so a grammar error is still possible.

I think the branch lacks a meaningful example to add to model_serializer docstring, but we can still discuss that, either here or in another PR.

## Related issue number

fix #9987 

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle