### PR TITLE
Using cached internal import for `BaseModel`

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -17,7 +17,6 @@ from pydantic_core import (
 from typing_extensions import TypeGuard
 
 from ..errors import PydanticUndefinedAnnotation
-from ..fields import FieldInfo
 from ..plugin._schema_validator import PluggableSchemaValidator, create_schema_validator
 from ..warnings import PydanticDeprecatedSince20
 from . import _config, _decorators, _typing_extra
@@ -30,6 +29,7 @@ from ._signature import generate_pydantic_signature
 
 if typing.TYPE_CHECKING:
     from ..config import ConfigDict
+    from ..fields import FieldInfo
 
     class StandardDataclass(typing.Protocol):
         __dataclass_fields__: ClassVar[dict[str, Any]]

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -16,6 +16,7 @@ from pydantic.errors import PydanticUserError
 from . import _typing_extra
 from ._config import ConfigWrapper
 from ._docs_extraction import extract_docstrings_from_cls
+from ._import_utils import import_manager
 from ._repr import Representation
 from ._typing_extra import get_cls_type_hints_lenient, get_type_hints, is_classvar, is_finalvar
 
@@ -147,7 +148,7 @@ def collect_model_fields(  # noqa: C901
             if ann_name.startswith(protected_namespace):
                 for b in bases:
                     if hasattr(b, ann_name):
-                        from ..main import BaseModel
+                        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
                         if not (issubclass(b, BaseModel) and ann_name in b.model_fields):
                             raise NameError(

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -16,7 +16,6 @@ from pydantic.errors import PydanticUserError
 from . import _typing_extra
 from ._config import ConfigWrapper
 from ._docs_extraction import extract_docstrings_from_cls
-from ._import_utils import import_manager
 from ._repr import Representation
 from ._typing_extra import get_cls_type_hints_lenient, get_type_hints, is_classvar, is_finalvar
 
@@ -129,6 +128,7 @@ def collect_model_fields(  # noqa: C901
             - If a field shadows an attribute in the parent model.
     """
     from ..fields import FieldInfo
+    from ._import_utils import import_cached_base_model
 
     type_hints = get_cls_type_hints_lenient(cls, types_namespace)
 
@@ -148,7 +148,7 @@ def collect_model_fields(  # noqa: C901
             if ann_name.startswith(protected_namespace):
                 for b in bases:
                     if hasattr(b, ann_name):
-                        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+                        BaseModel = import_cached_base_model()
 
                         if not (issubclass(b, BaseModel) and ann_name in b.model_fields):
                             raise NameError(

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -16,7 +16,7 @@ from pydantic.errors import PydanticUserError
 from . import _typing_extra
 from ._config import ConfigWrapper
 from ._docs_extraction import extract_docstrings_from_cls
-from ._import_utils import import_cached_base_model
+from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._repr import Representation
 from ._typing_extra import get_cls_type_hints_lenient, get_type_hints, is_classvar, is_finalvar
 
@@ -128,7 +128,7 @@ def collect_model_fields(  # noqa: C901
             - If there is a field other than `root` in `RootModel`.
             - If a field shadows an attribute in the parent model.
     """
-    from ..fields import FieldInfo
+    FieldInfo_ = import_cached_field_info()
 
     type_hints = get_cls_type_hints_lenient(cls, types_namespace)
 
@@ -211,7 +211,7 @@ def collect_model_fields(  # noqa: C901
                 raise AttributeError
         except AttributeError:
             if ann_name in annotations:
-                field_info = FieldInfo.from_annotation(ann_type)
+                field_info = FieldInfo_.from_annotation(ann_type)
             else:
                 # if field has no default value and is not in __annotations__ this means that it is
                 # defined in a base class and we can take it from there
@@ -226,10 +226,10 @@ def collect_model_fields(  # noqa: C901
                     # The field was not found on any base classes; this seems to be caused by fields not getting
                     # generated thanks to models not being fully defined while initializing recursive models.
                     # Nothing stops us from just creating a new FieldInfo for this type hint, so we do this.
-                    field_info = FieldInfo.from_annotation(ann_type)
+                    field_info = FieldInfo_.from_annotation(ann_type)
         else:
             _warn_on_nested_alias_in_annotation(ann_type, ann_name)
-            field_info = FieldInfo.from_annotated_attribute(ann_type, default)
+            field_info = FieldInfo_.from_annotated_attribute(ann_type, default)
             # attributes which are fields are removed from the class namespace:
             # 1. To match the behaviour of annotation-only fields
             # 2. To avoid false positives in the NameError check above
@@ -255,7 +255,7 @@ def collect_model_fields(  # noqa: C901
 
 
 def _warn_on_nested_alias_in_annotation(ann_type: type[Any], ann_name: str):
-    from ..fields import FieldInfo
+    FieldInfo = import_cached_field_info()
 
     if hasattr(ann_type, '__args__'):
         for anno_arg in ann_type.__args__:
@@ -270,7 +270,7 @@ def _warn_on_nested_alias_in_annotation(ann_type: type[Any], ann_name: str):
 
 
 def _is_finalvar_with_default_val(type_: type[Any], val: Any) -> bool:
-    from ..fields import FieldInfo
+    FieldInfo = import_cached_field_info()
 
     if not is_finalvar(type_):
         return False
@@ -300,7 +300,7 @@ def collect_dataclass_fields(
     Returns:
         The dataclass fields.
     """
-    from ..fields import FieldInfo
+    FieldInfo_ = import_cached_field_info()
 
     fields: dict[str, FieldInfo] = {}
     dataclass_fields: dict[str, dataclasses.Field] = cls.__dataclass_fields__
@@ -324,7 +324,7 @@ def collect_dataclass_fields(
             #   Issue: https://github.com/pydantic/pydantic/issues/5470
             continue
 
-        if isinstance(dataclass_field.default, FieldInfo):
+        if isinstance(dataclass_field.default, FieldInfo_):
             if dataclass_field.default.init_var:
                 if dataclass_field.default.init is False:
                     raise PydanticUserError(
@@ -334,13 +334,13 @@ def collect_dataclass_fields(
 
                 # TODO: same note as above re validate_assignment
                 continue
-            field_info = FieldInfo.from_annotated_attribute(ann_type, dataclass_field.default)
+            field_info = FieldInfo_.from_annotated_attribute(ann_type, dataclass_field.default)
         else:
-            field_info = FieldInfo.from_annotated_attribute(ann_type, dataclass_field)
+            field_info = FieldInfo_.from_annotated_attribute(ann_type, dataclass_field)
 
         fields[ann_name] = field_info
 
-        if field_info.default is not PydanticUndefined and isinstance(getattr(cls, ann_name, field_info), FieldInfo):
+        if field_info.default is not PydanticUndefined and isinstance(getattr(cls, ann_name, field_info), FieldInfo_):
             # We need this to fix the default when the "default" from __dataclass_fields__ is a pydantic.FieldInfo
             setattr(cls, ann_name, field_info.default)
 

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -148,7 +148,7 @@ def collect_model_fields(  # noqa: C901
             if ann_name.startswith(protected_namespace):
                 for b in bases:
                     if hasattr(b, ann_name):
-                        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+                        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
                         if not (issubclass(b, BaseModel) and ann_name in b.model_fields):
                             raise NameError(

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -16,6 +16,7 @@ from pydantic.errors import PydanticUserError
 from . import _typing_extra
 from ._config import ConfigWrapper
 from ._docs_extraction import extract_docstrings_from_cls
+from ._import_utils import import_cached_base_model
 from ._repr import Representation
 from ._typing_extra import get_cls_type_hints_lenient, get_type_hints, is_classvar, is_finalvar
 
@@ -128,7 +129,6 @@ def collect_model_fields(  # noqa: C901
             - If a field shadows an attribute in the parent model.
     """
     from ..fields import FieldInfo
-    from ._import_utils import import_cached_base_model
 
     type_hints = get_cls_type_hints_lenient(cls, types_namespace)
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -92,7 +92,7 @@ from ._docs_extraction import extract_docstrings_from_cls
 from ._fields import collect_dataclass_fields, get_type_hints_infer_globalns
 from ._forward_ref import PydanticRecursiveRef
 from ._generics import get_standard_typevars_map, has_instance_in_type, recursively_defined_type_refs, replace_types
-from ._import_utils import import_cached_base_model
+from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._mock_val_ser import MockCoreSchema
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._typing_extra import is_finalvar, is_self_type, is_zoneinfo_type
@@ -1255,7 +1255,8 @@ class GenerateSchema:
     ) -> _CommonField:
         # Update FieldInfo annotation if appropriate:
         from .. import AliasChoices, AliasPath
-        from ..fields import FieldInfo
+
+        FieldInfo = import_cached_field_info()
 
         if has_instance_in_type(field_info.annotation, (ForwardRef, str)):
             types_namespace = self._types_namespace
@@ -1433,7 +1434,7 @@ class GenerateSchema:
         Hence to avoid creating validators that do not do what users expect we only
         support typing.TypedDict on Python >= 3.12 or typing_extension.TypedDict on all versions
         """
-        from ..fields import FieldInfo
+        FieldInfo = import_cached_field_info()
 
         with self.model_type_stack.push(typed_dict_cls), self.defs.get_schema_or_ref(typed_dict_cls) as (
             typed_dict_ref,
@@ -1569,7 +1570,7 @@ class GenerateSchema:
         mode: Literal['positional_only', 'positional_or_keyword', 'keyword_only'] | None = None,
     ) -> core_schema.ArgumentsParameter:
         """Prepare a ArgumentsParameter to represent a field in a namedtuple or function signature."""
-        from ..fields import FieldInfo
+        FieldInfo = import_cached_field_info()
 
         if default is Parameter.empty:
             field = FieldInfo.from_annotation(annotation)
@@ -2006,7 +2007,7 @@ class GenerateSchema:
 
     def _annotated_schema(self, annotated_type: Any) -> core_schema.CoreSchema:
         """Generate schema for an Annotated type, e.g. `Annotated[int, Field(...)]` or `Annotated[int, Gt(0)]`."""
-        from ..fields import FieldInfo
+        FieldInfo = import_cached_field_info()
 
         source_type, *annotations = self._get_args_resolving_forward_refs(
             annotated_type,
@@ -2098,7 +2099,7 @@ class GenerateSchema:
         return _add_custom_serialization_from_json_encoders(self._config_wrapper.json_encoders, source_type, schema)
 
     def _apply_single_annotation(self, schema: core_schema.CoreSchema, metadata: Any) -> core_schema.CoreSchema:
-        from ..fields import FieldInfo
+        FieldInfo = import_cached_field_info()
 
         if isinstance(metadata, FieldInfo):
             for field_metadata in metadata.metadata:
@@ -2142,7 +2143,7 @@ class GenerateSchema:
     def _apply_single_annotation_json_schema(
         self, schema: core_schema.CoreSchema, metadata: Any
     ) -> core_schema.CoreSchema:
-        from ..fields import FieldInfo
+        FieldInfo = import_cached_field_info()
 
         if isinstance(metadata, FieldInfo):
             for field_metadata in metadata.metadata:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -92,7 +92,7 @@ from ._docs_extraction import extract_docstrings_from_cls
 from ._fields import collect_dataclass_fields, get_type_hints_infer_globalns
 from ._forward_ref import PydanticRecursiveRef
 from ._generics import get_standard_typevars_map, has_instance_in_type, recursively_defined_type_refs, replace_types
-from ._import_utils import get_cached_component
+from ._import_utils import import_manager
 from ._mock_val_ser import MockCoreSchema
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._typing_extra import is_finalvar, is_self_type, is_zoneinfo_type
@@ -263,7 +263,7 @@ def modify_model_json_schema(
     from ..root_model import RootModel
     from ._dataclasses import is_builtin_dataclass
 
-    BaseModel = get_cached_component('pydantic.main', 'BaseModel')
+    BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
     json_schema = handler(schema_or_field)
     original_schema = handler.resolve_ref_schema(json_schema)
@@ -911,7 +911,7 @@ class GenerateSchema:
         if isinstance(obj, ForwardRef):
             return self.generate_schema(self._resolve_forward_ref(obj))
 
-        BaseModel = get_cached_component('pydantic.main', 'BaseModel')
+        BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
         if lenient_issubclass(obj, BaseModel):
             with self.model_type_stack.push(obj):
@@ -2418,7 +2418,7 @@ def _extract_get_pydantic_json_schema(tp: Any, schema: CoreSchema) -> GetJsonSch
     js_modify_function = getattr(tp, '__get_pydantic_json_schema__', None)
 
     if hasattr(tp, '__modify_schema__'):
-        BaseModel = get_cached_component('pydantic.main', 'BaseModel')
+        BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
         has_custom_v2_modify_js_func = (
             js_modify_function is not None

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -53,7 +53,7 @@ from pydantic_core import (
 )
 from typing_extensions import Annotated, Literal, TypeAliasType, TypedDict, get_args, get_origin, is_typeddict
 
-from ..aliases import AliasGenerator
+from ..aliases import AliasChoices, AliasGenerator, AliasPath
 from ..annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ..config import ConfigDict, JsonDict, JsonEncoder
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
@@ -1254,8 +1254,6 @@ class GenerateSchema:
         self, name: str, field_info: FieldInfo, decorators: DecoratorInfos
     ) -> _CommonField:
         # Update FieldInfo annotation if appropriate:
-        from .. import AliasChoices, AliasPath
-
         FieldInfo = import_cached_field_info()
 
         if has_instance_in_type(field_info.annotation, (ForwardRef, str)):

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -263,7 +263,7 @@ def modify_model_json_schema(
     from ..root_model import RootModel
     from ._dataclasses import is_builtin_dataclass
 
-    BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+    BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
     json_schema = handler(schema_or_field)
     original_schema = handler.resolve_ref_schema(json_schema)
@@ -911,7 +911,7 @@ class GenerateSchema:
         if isinstance(obj, ForwardRef):
             return self.generate_schema(self._resolve_forward_ref(obj))
 
-        BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
         if lenient_issubclass(obj, BaseModel):
             with self.model_type_stack.push(obj):
@@ -2418,7 +2418,7 @@ def _extract_get_pydantic_json_schema(tp: Any, schema: CoreSchema) -> GetJsonSch
     js_modify_function = getattr(tp, '__get_pydantic_json_schema__', None)
 
     if hasattr(tp, '__modify_schema__'):
-        BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
         has_custom_v2_modify_js_func = (
             js_modify_function is not None

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -263,7 +263,7 @@ def modify_model_json_schema(
     from ..root_model import RootModel
     from ._dataclasses import is_builtin_dataclass
 
-    BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+    BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
     json_schema = handler(schema_or_field)
     original_schema = handler.resolve_ref_schema(json_schema)
@@ -911,7 +911,7 @@ class GenerateSchema:
         if isinstance(obj, ForwardRef):
             return self.generate_schema(self._resolve_forward_ref(obj))
 
-        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
         if lenient_issubclass(obj, BaseModel):
             with self.model_type_stack.push(obj):
@@ -2418,7 +2418,7 @@ def _extract_get_pydantic_json_schema(tp: Any, schema: CoreSchema) -> GetJsonSch
     js_modify_function = getattr(tp, '__get_pydantic_json_schema__', None)
 
     if hasattr(tp, '__modify_schema__'):
-        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
         has_custom_v2_modify_js_func = (
             js_modify_function is not None

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -92,7 +92,7 @@ from ._docs_extraction import extract_docstrings_from_cls
 from ._fields import collect_dataclass_fields, get_type_hints_infer_globalns
 from ._forward_ref import PydanticRecursiveRef
 from ._generics import get_standard_typevars_map, has_instance_in_type, recursively_defined_type_refs, replace_types
-from ._import_utils import import_manager
+from ._import_utils import import_cached_base_model
 from ._mock_val_ser import MockCoreSchema
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._typing_extra import is_finalvar, is_self_type, is_zoneinfo_type
@@ -263,7 +263,7 @@ def modify_model_json_schema(
     from ..root_model import RootModel
     from ._dataclasses import is_builtin_dataclass
 
-    BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+    BaseModel = import_cached_base_model()
 
     json_schema = handler(schema_or_field)
     original_schema = handler.resolve_ref_schema(json_schema)
@@ -911,7 +911,7 @@ class GenerateSchema:
         if isinstance(obj, ForwardRef):
             return self.generate_schema(self._resolve_forward_ref(obj))
 
-        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+        BaseModel = import_cached_base_model()
 
         if lenient_issubclass(obj, BaseModel):
             with self.model_type_stack.push(obj):
@@ -2418,7 +2418,7 @@ def _extract_get_pydantic_json_schema(tp: Any, schema: CoreSchema) -> GetJsonSch
     js_modify_function = getattr(tp, '__get_pydantic_json_schema__', None)
 
     if hasattr(tp, '__modify_schema__'):
-        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+        BaseModel = import_cached_base_model()
 
         has_custom_v2_modify_js_func = (
             js_modify_function is not None

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -1,14 +1,14 @@
 from importlib import import_module
-from typing import Any
+from typing import Any, Dict, Tuple
 
 
 class CachedImportManager:
     def __init__(self) -> None:
-        self._attr_cache = {}
-        self._module_cache = {}
+        self._attr_cache: Dict[Tuple[str, str], Any] = {}
+        self._module_cache: Dict[str, Any] = {}
 
     def get_cached_attr(self, attr_name: str, module_name: str) -> Any:
-        if key := (module_name, attr_name) in self._attr_cache:
+        if (key := (module_name, attr_name)) in self._attr_cache:
             return self._attr_cache[key]
 
         if module_name in self._module_cache:

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -1,11 +1,23 @@
 from importlib import import_module
 from typing import Any
 
-_cache = {}
+
+class CachedImportManager:
+    def __init__(self) -> None:
+        self._attr_cache = {}
+        self._module_cache = {}
+
+    def get_cached_attr(self, attr_name: str, module_name: str) -> Any:
+        if key := (module_name, attr_name) in self._attr_cache:
+            return self._attr_cache[key]
+
+        if module_name in self._module_cache:
+            module = self._module_cache[module_name]
+        else:
+            module = import_module(module_name)
+            self._module_cache[module_name] = module
+        self._attr_cache[key] = getattr(module, attr_name)
+        return self._attr_cache[key]
 
 
-def get_cached_component(module_name: str, component_name: str) -> Any:
-    if key := (module_name, component_name) not in _cache:
-        module = import_module(module_name)
-        _cache[key] = getattr(module, component_name)
-    return _cache[key]
+import_manager = CachedImportManager()

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -1,11 +1,9 @@
-from functools import cache
 from importlib import import_module
 from typing import Any
 
 _cache = {}
 
 
-@cache
 def get_cached_component(module_name: str, component_name: str) -> Any:
     if key := (module_name, component_name) not in _cache:
         module = import_module(module_name)

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -1,0 +1,13 @@
+from functools import cache
+from importlib import import_module
+from typing import Any
+
+_cache = {}
+
+
+@cache
+def get_cached_component(module_name: str, component_name: str) -> Any:
+    if key := (module_name, component_name) not in _cache:
+        module = import_module(module_name)
+        _cache[key] = getattr(module, component_name)
+    return _cache[key]

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -1,30 +1,15 @@
-from importlib import import_module
-from typing import Any, Dict, Tuple
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+_type_cache = {}
 
 
-class CachedImportManager:
-    def __init__(self) -> None:
-        self._attr_cache: Dict[Tuple[str, str], Any] = {}
-        self._module_cache: Dict[str, Any] = {}
+def import_cached_base_model() -> type['BaseModel']:
+    if 'BaseModel' not in _type_cache:
+        from pydantic import BaseModel
 
-    def get_attr(self, attr_name: str, module_name: str) -> Any:
-        if (key := (module_name, attr_name)) in self._attr_cache:
-            return self._attr_cache[key]
-
-        if module_name in self._module_cache:
-            module = self._module_cache[module_name]
-        else:
-            module = import_module(module_name)
-            self._module_cache[module_name] = module
-        self._attr_cache[key] = getattr(module, attr_name)
-        return self._attr_cache[key]
-
-    def get_module(self, module_name: str) -> Any:
-        if module_name in self._module_cache:
-            return self._module_cache[module_name]
-        module = import_module(module_name)
-        self._module_cache[module_name] = module
-        return module
-
-
-import_manager = CachedImportManager()
+        _type_cache['BaseModel'] = BaseModel
+        return BaseModel
+    return _type_cache['BaseModel']

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -7,7 +7,7 @@ class CachedImportManager:
         self._attr_cache: Dict[Tuple[str, str], Any] = {}
         self._module_cache: Dict[str, Any] = {}
 
-    def get_cached_attr(self, attr_name: str, module_name: str) -> Any:
+    def get_attr(self, attr_name: str, module_name: str) -> Any:
         if (key := (module_name, attr_name)) in self._attr_cache:
             return self._attr_cache[key]
 
@@ -18,6 +18,13 @@ class CachedImportManager:
             self._module_cache[module_name] = module
         self._attr_cache[key] = getattr(module, attr_name)
         return self._attr_cache[key]
+
+    def get_module(self, module_name: str) -> Any:
+        if module_name in self._module_cache:
+            return self._module_cache[module_name]
+        module = import_module(module_name)
+        self._module_cache[module_name] = module
+        return module
 
 
 import_manager = CachedImportManager()

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -7,9 +7,10 @@ _type_cache = {}
 
 
 def import_cached_base_model() -> type['BaseModel']:
-    if 'BaseModel' not in _type_cache:
+    if 'BaseModel' in _type_cache:
+        return _type_cache['BaseModel']
+    else:
         from pydantic import BaseModel
 
         _type_cache['BaseModel'] = BaseModel
         return BaseModel
-    return _type_cache['BaseModel']

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -1,12 +1,20 @@
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
+    from pydantic.fields import FieldInfo
 
 
 @lru_cache(maxsize=None)
-def import_cached_base_model() -> type['BaseModel']:
+def import_cached_base_model() -> Type['BaseModel']:
     from pydantic import BaseModel
 
     return BaseModel
+
+
+@lru_cache(maxsize=None)
+def import_cached_field_info() -> Type['FieldInfo']:
+    from pydantic.fields import FieldInfo
+
+    return FieldInfo

--- a/pydantic/_internal/_import_utils.py
+++ b/pydantic/_internal/_import_utils.py
@@ -1,16 +1,12 @@
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
-_type_cache = {}
 
-
+@lru_cache(maxsize=None)
 def import_cached_base_model() -> type['BaseModel']:
-    if 'BaseModel' in _type_cache:
-        return _type_cache['BaseModel']
-    else:
-        from pydantic import BaseModel
+    from pydantic import BaseModel
 
-        _type_cache['BaseModel'] = BaseModel
-        return BaseModel
+    return BaseModel

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -9,6 +9,7 @@ from pydantic_core import CoreSchema, PydanticCustomError, to_jsonable_python
 from pydantic_core import core_schema as cs
 
 from ._fields import PydanticMetadata
+from ._import_utils import import_cached_field_info
 
 if TYPE_CHECKING:
     from ..annotated_handlers import GetJsonSchemaHandler
@@ -136,7 +137,7 @@ def expand_grouped_metadata(annotations: Iterable[Any]) -> Iterable[Any]:
     """
     import annotated_types as at
 
-    from pydantic.fields import FieldInfo  # circular import
+    FieldInfo = import_cached_field_info()
 
     for annotation in annotations:
         if isinstance(annotation, at.GroupedMetadata):

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -118,7 +118,7 @@ class ModelMetaclass(ABCMeta):
 
             cls: type[BaseModel] = super().__new__(mcs, cls_name, bases, namespace, **kwargs)  # type: ignore
 
-            BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+            BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
             mro = cls.__mro__
             if Generic in mro and mro.index(Generic) < mro.index(BaseModel):
@@ -250,7 +250,7 @@ class ModelMetaclass(ABCMeta):
 
     @staticmethod
     def _collect_bases_data(bases: tuple[type[Any], ...]) -> tuple[set[str], set[str], dict[str, ModelPrivateAttr]]:
-        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
         field_names: set[str] = set()
         class_vars: set[str] = set()
@@ -301,7 +301,7 @@ def get_model_post_init(namespace: dict[str, Any], bases: tuple[type[Any], ...])
     if 'model_post_init' in namespace:
         return namespace['model_post_init']
 
-    BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+    BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
     model_post_init = get_attribute_from_bases(bases, 'model_post_init')
     if model_post_init is not BaseModel.model_post_init:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -8,7 +8,7 @@ import typing
 import warnings
 import weakref
 from abc import ABCMeta
-from functools import partial
+from functools import lru_cache, partial
 from types import FunctionType
 from typing import Any, Callable, Generic, NoReturn
 
@@ -24,7 +24,7 @@ from ._decorators import DecoratorInfos, PydanticDescriptorProxy, get_attribute_
 from ._fields import collect_model_fields, is_valid_field_name, is_valid_privateattr_name
 from ._generate_schema import GenerateSchema
 from ._generics import PydanticGenericMetadata, get_model_typevars_map
-from ._import_utils import import_cached_base_model
+from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._mock_val_ser import set_model_mocks
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
@@ -334,7 +334,9 @@ def inspect_namespace(  # noqa C901
             - If a field does not have a type annotation.
             - If a field on base class was overridden by a non-annotated attribute.
     """
-    from ..fields import FieldInfo, ModelPrivateAttr, PrivateAttr
+    from ..fields import ModelPrivateAttr, PrivateAttr
+
+    FieldInfo = import_cached_field_info()
 
     all_ignored_types = ignored_types + default_ignored_types()
 
@@ -695,6 +697,7 @@ def unpack_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | N
     return result
 
 
+@lru_cache(maxsize=None)
 def default_ignored_types() -> tuple[type[Any], ...]:
     from ..fields import ComputedFieldInfo
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -24,6 +24,7 @@ from ._decorators import DecoratorInfos, PydanticDescriptorProxy, get_attribute_
 from ._fields import collect_model_fields, is_valid_field_name, is_valid_privateattr_name
 from ._generate_schema import GenerateSchema
 from ._generics import PydanticGenericMetadata, get_model_typevars_map
+from ._import_utils import import_manager
 from ._mock_val_ser import set_model_mocks
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
@@ -117,7 +118,7 @@ class ModelMetaclass(ABCMeta):
 
             cls: type[BaseModel] = super().__new__(mcs, cls_name, bases, namespace, **kwargs)  # type: ignore
 
-            from ..main import BaseModel
+            BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
             mro = cls.__mro__
             if Generic in mro and mro.index(Generic) < mro.index(BaseModel):
@@ -249,7 +250,7 @@ class ModelMetaclass(ABCMeta):
 
     @staticmethod
     def _collect_bases_data(bases: tuple[type[Any], ...]) -> tuple[set[str], set[str], dict[str, ModelPrivateAttr]]:
-        from ..main import BaseModel
+        BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
         field_names: set[str] = set()
         class_vars: set[str] = set()
@@ -300,7 +301,7 @@ def get_model_post_init(namespace: dict[str, Any], bases: tuple[type[Any], ...])
     if 'model_post_init' in namespace:
         return namespace['model_post_init']
 
-    from ..main import BaseModel
+    BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
     model_post_init = get_attribute_from_bases(bases, 'model_post_init')
     if model_post_init is not BaseModel.model_post_init:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -24,7 +24,7 @@ from ._decorators import DecoratorInfos, PydanticDescriptorProxy, get_attribute_
 from ._fields import collect_model_fields, is_valid_field_name, is_valid_privateattr_name
 from ._generate_schema import GenerateSchema
 from ._generics import PydanticGenericMetadata, get_model_typevars_map
-from ._import_utils import import_manager
+from ._import_utils import import_cached_base_model
 from ._mock_val_ser import set_model_mocks
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
@@ -118,7 +118,7 @@ class ModelMetaclass(ABCMeta):
 
             cls: type[BaseModel] = super().__new__(mcs, cls_name, bases, namespace, **kwargs)  # type: ignore
 
-            BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+            BaseModel = import_cached_base_model()
 
             mro = cls.__mro__
             if Generic in mro and mro.index(Generic) < mro.index(BaseModel):
@@ -250,7 +250,7 @@ class ModelMetaclass(ABCMeta):
 
     @staticmethod
     def _collect_bases_data(bases: tuple[type[Any], ...]) -> tuple[set[str], set[str], dict[str, ModelPrivateAttr]]:
-        BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+        BaseModel = import_cached_base_model()
 
         field_names: set[str] = set()
         class_vars: set[str] = set()
@@ -301,7 +301,7 @@ def get_model_post_init(namespace: dict[str, Any], bases: tuple[type[Any], ...])
     if 'model_post_init' in namespace:
         return namespace['model_post_init']
 
-    BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+    BaseModel = import_cached_base_model()
 
     model_post_init = get_attribute_from_bases(bases, 'model_post_init')
     if model_post_init is not BaseModel.model_post_init:

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -23,13 +23,15 @@ from pydantic_core import (
 from typing_extensions import get_args, get_origin
 
 from pydantic.errors import PydanticSchemaGenerationError
-from pydantic.fields import FieldInfo
 from pydantic.types import Strict
 
 from ..json_schema import JsonSchemaValue
 from . import _known_annotated_metadata, _typing_extra
+from ._import_utils import import_cached_field_info
 from ._internal_dataclass import slots_true
 from ._schema_generation_shared import GetCoreSchemaHandler, GetJsonSchemaHandler
+
+FieldInfo = import_cached_field_info()
 
 if typing.TYPE_CHECKING:
     from ._generate_schema import GenerateSchema

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -18,6 +18,7 @@ from typing import Any, Mapping, TypeVar
 from typing_extensions import TypeAlias, TypeGuard
 
 from . import _repr, _typing_extra
+from ._import_utils import import_manager
 
 if typing.TYPE_CHECKING:
     MappingIntStrAny: TypeAlias = 'typing.Mapping[int, Any] | typing.Mapping[str, Any]'
@@ -85,7 +86,7 @@ def is_model_class(cls: Any) -> TypeGuard[type[BaseModel]]:
     """Returns true if cls is a _proper_ subclass of BaseModel, and provides proper type-checking,
     unlike raw calls to lenient_issubclass.
     """
-    from ..main import BaseModel
+    BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
     return lenient_issubclass(cls, BaseModel) and cls is not BaseModel
 

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -86,7 +86,7 @@ def is_model_class(cls: Any) -> TypeGuard[type[BaseModel]]:
     """Returns true if cls is a _proper_ subclass of BaseModel, and provides proper type-checking,
     unlike raw calls to lenient_issubclass.
     """
-    BaseModel: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+    BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
 
     return lenient_issubclass(cls, BaseModel) and cls is not BaseModel
 

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -18,7 +18,7 @@ from typing import Any, Mapping, TypeVar
 from typing_extensions import TypeAlias, TypeGuard
 
 from . import _repr, _typing_extra
-from ._import_utils import import_manager
+from ._import_utils import import_cached_base_model
 
 if typing.TYPE_CHECKING:
     MappingIntStrAny: TypeAlias = 'typing.Mapping[int, Any] | typing.Mapping[str, Any]'
@@ -86,7 +86,7 @@ def is_model_class(cls: Any) -> TypeGuard[type[BaseModel]]:
     """Returns true if cls is a _proper_ subclass of BaseModel, and provides proper type-checking,
     unlike raw calls to lenient_issubclass.
     """
-    BaseModel: type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+    BaseModel = import_cached_base_model()
 
     return lenient_issubclass(cls, BaseModel) and cls is not BaseModel
 

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, 
 from typing_extensions import deprecated
 
 from .._internal import _config, _typing_extra
-from .._internal._import_utils import import_manager
 from ..alias_generators import to_pascal
 from ..errors import PydanticUserError
 from ..functional_validators import field_validator
+from ..main import BaseModel, create_model
 from ..warnings import PydanticDeprecatedSince20
 
 if not TYPE_CHECKING:
@@ -19,8 +19,6 @@ if not TYPE_CHECKING:
 __all__ = ('validate_arguments',)
 
 if TYPE_CHECKING:
-    from ..main import BaseModel
-
     AnyCallable = Callable[..., Any]
 
     AnyCallableT = TypeVar('AnyCallableT', bound=AnyCallable)
@@ -224,9 +222,6 @@ class ValidatedFunction:
             return self.raw_function(**d, **var_kwargs)
 
     def create_model(self, fields: Dict[str, Any], takes_args: bool, takes_kwargs: bool, config: 'ConfigType') -> None:
-        BaseModel_: Type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
-        create_model_ = import_manager.get_attr('create_model', 'pydantic.main')
-
         pos_args = len(self.arg_mapping)
 
         config_wrapper = _config.ConfigWrapper(config)
@@ -240,7 +235,7 @@ class ValidatedFunction:
         if config_wrapper.extra is None:
             config_wrapper.config_dict['extra'] = 'forbid'
 
-        class DecoratorBaseModel(BaseModel_):
+        class DecoratorBaseModel(BaseModel):
             @field_validator(self.v_args_name, check_fields=False)
             @classmethod
             def check_args(cls, v: Optional[List[Any]]) -> Optional[List[Any]]:
@@ -281,4 +276,4 @@ class ValidatedFunction:
 
             model_config = config_wrapper.config_dict
 
-        self.model = create_model_(to_pascal(self.raw_function.__name__), __base__=DecoratorBaseModel, **fields)
+        self.model = create_model(to_pascal(self.raw_function.__name__), __base__=DecoratorBaseModel, **fields)

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -224,8 +224,8 @@ class ValidatedFunction:
             return self.raw_function(**d, **var_kwargs)
 
     def create_model(self, fields: Dict[str, Any], takes_args: bool, takes_kwargs: bool, config: 'ConfigType') -> None:
-        BaseModel_: type[BaseModel] = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
-        create_model_ = import_manager.get_cached_attr('create_model', 'pydantic.main')
+        BaseModel_: Type[BaseModel] = import_manager.get_attr('BaseModel', 'pydantic.main')
+        create_model_ = import_manager.get_attr('create_model', 'pydantic.main')
 
         pos_args = len(self.arg_mapping)
 

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 from typing_extensions import deprecated
 
-from .._internal._import_utils import import_manager
+from .._internal._import_utils import import_cached_base_model
 from ..color import Color
 from ..networks import NameEmail
 from ..types import SecretBytes, SecretStr
@@ -91,7 +91,7 @@ def pydantic_encoder(obj: Any) -> Any:
     )
     from dataclasses import asdict, is_dataclass
 
-    BaseModel = import_manager.get_attr('BaseModel', 'pydantic.main')
+    BaseModel = import_cached_base_model()
 
     if isinstance(obj, BaseModel):
         return obj.model_dump()

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -91,7 +91,7 @@ def pydantic_encoder(obj: Any) -> Any:
     )
     from dataclasses import asdict, is_dataclass
 
-    BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
+    BaseModel = import_manager.get_attr('BaseModel', 'pydantic.main')
 
     if isinstance(obj, BaseModel):
         return obj.model_dump()

--- a/pydantic/deprecated/json.py
+++ b/pydantic/deprecated/json.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 from typing_extensions import deprecated
 
+from .._internal._import_utils import import_manager
 from ..color import Color
 from ..networks import NameEmail
 from ..types import SecretBytes, SecretStr
@@ -90,7 +91,7 @@ def pydantic_encoder(obj: Any) -> Any:
     )
     from dataclasses import asdict, is_dataclass
 
-    from ..main import BaseModel
+    BaseModel = import_manager.get_cached_attr('BaseModel', 'pydantic.main')
 
     if isinstance(obj, BaseModel):
         return obj.model_dump()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -35,6 +35,7 @@ from ._internal import (
     _fields,
     _forward_ref,
     _generics,
+    _import_utils,
     _mock_val_ser,
     _model_construction,
     _repr,
@@ -1533,7 +1534,7 @@ def create_model(  # noqa: C901
             (f_annotation, f_value, *_) = typing_extensions.get_args(
                 f_def
             )  # first two input are expected from Annotated, refer to https://docs.python.org/3/library/typing.html#typing.Annotated
-            from .fields import FieldInfo
+            FieldInfo = _import_utils.import_cached_field_info()
 
             if not isinstance(f_value, FieldInfo):
                 raise PydanticUserError(


### PR DESCRIPTION
Similar to how we use a custom `__getattr__` in `__init__.py` to lazily import attributes, and cache the results, I've added logic to manually cache the `BaseModel` import in our internal operations.