### PR TITLE
Refactor application of deque annotations

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1685,7 +1685,7 @@ class GenerateSchema:
 
     def _sequence_schema(self, items_type: Any) -> core_schema.CoreSchema:
         """Generate schema for a Sequence, e.g. `Sequence[int]`."""
-        from ._std_types_schema import serialize_sequence_via_list
+        from ._serializers import serialize_sequence_via_list
 
         item_type_schema = self.generate_schema(items_type)
         list_schema = core_schema.list_schema(item_type_schema)
@@ -2022,9 +2022,9 @@ class GenerateSchema:
         self, obj: Any, annotations: tuple[Any, ...]
     ) -> tuple[Any, list[Any]] | None:
         from ._std_types_schema import (
+            deque_schema_prepare_pydantic_annotations,
             mapping_like_prepare_pydantic_annotations,
             path_schema_prepare_pydantic_annotations,
-            sequence_like_prepare_pydantic_annotations,
         )
 
         # Check for hashability
@@ -2042,7 +2042,7 @@ class GenerateSchema:
         if obj_origin in PATH_TYPES:
             return path_schema_prepare_pydantic_annotations(obj, annotations)
         elif obj_origin in DEQUE_TYPES:
-            return sequence_like_prepare_pydantic_annotations(obj, annotations)
+            return deque_schema_prepare_pydantic_annotations(obj, annotations)
         elif obj_origin in MAPPING_TYPES:
             return mapping_like_prepare_pydantic_annotations(obj, annotations)
         else:

--- a/pydantic/_internal/_serializers.py
+++ b/pydantic/_internal/_serializers.py
@@ -1,11 +1,11 @@
 import collections
 import collections.abc
 import typing
-from typing import Any
+from typing import Any, Dict
 
 from pydantic_core import PydanticOmit, core_schema
 
-SEQUENCE_ORIGIN_MAP: dict[Any, Any] = {
+SEQUENCE_ORIGIN_MAP: Dict[Any, Any] = {
     typing.Deque: collections.deque,
     collections.deque: collections.deque,
     list: list,

--- a/pydantic/_internal/_serializers.py
+++ b/pydantic/_internal/_serializers.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import collections
 import collections.abc
 import typing
-from typing import Any, Dict
+from typing import Any
 
 from pydantic_core import PydanticOmit, core_schema
 
-SEQUENCE_ORIGIN_MAP: Dict[Any, Any] = {
+SEQUENCE_ORIGIN_MAP: dict[Any, Any] = {
     typing.Deque: collections.deque,
     collections.deque: collections.deque,
     list: list,

--- a/pydantic/_internal/_serializers.py
+++ b/pydantic/_internal/_serializers.py
@@ -1,0 +1,49 @@
+import collections
+import collections.abc
+import typing
+from typing import Any
+
+from pydantic_core import PydanticOmit, core_schema
+
+SEQUENCE_ORIGIN_MAP: dict[Any, Any] = {
+    typing.Deque: collections.deque,
+    collections.deque: collections.deque,
+    list: list,
+    typing.List: list,
+    set: set,
+    typing.AbstractSet: set,
+    typing.Set: set,
+    frozenset: frozenset,
+    typing.FrozenSet: frozenset,
+    typing.Sequence: list,
+    typing.MutableSequence: list,
+    typing.MutableSet: set,
+    # this doesn't handle subclasses of these
+    # parametrized typing.Set creates one of these
+    collections.abc.MutableSet: set,
+    collections.abc.Set: frozenset,
+}
+
+
+def serialize_sequence_via_list(
+    v: Any, handler: core_schema.SerializerFunctionWrapHandler, info: core_schema.SerializationInfo
+) -> Any:
+    items: list[Any] = []
+
+    mapped_origin = SEQUENCE_ORIGIN_MAP.get(type(v), None)
+    if mapped_origin is None:
+        # we shouldn't hit this branch, should probably add a serialization error or something
+        return v
+
+    for index, item in enumerate(v):
+        try:
+            v = handler(item, index)
+        except PydanticOmit:
+            pass
+        else:
+            items.append(v)
+
+    if info.mode_is_json():
+        return items
+    else:
+        return mapped_origin(items)


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/9340

Simplify the injection of annotations for deque types. Calling this the end of the sequence validator refactor - we've restructured significantly, and I think the next step is moving things to `pydantic-core`, which wasn't within the original scope of the issue.