### PR TITLE
Remove `__pydantic_parent_namespace__` caching logic with weakrefs

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -18,7 +18,7 @@ from ._config import ConfigWrapper
 from ._docs_extraction import extract_docstrings_from_cls
 from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._repr import Representation
-from ._typing_extra import get_cls_type_hints_lenient, get_type_hints, is_classvar, is_finalvar
+from ._typing_extra import get_cls_type_hints_lenient, is_classvar, is_finalvar
 
 if TYPE_CHECKING:
     from annotated_types import BaseMetadata
@@ -27,35 +27,6 @@ if TYPE_CHECKING:
     from ..main import BaseModel
     from ._dataclasses import StandardDataclass
     from ._decorators import DecoratorInfos
-
-
-def get_type_hints_infer_globalns(
-    obj: Any,
-    localns: dict[str, Any] | None = None,
-    include_extras: bool = False,
-) -> dict[str, Any]:
-    """Gets type hints for an object by inferring the global namespace.
-
-    It uses the `typing.get_type_hints`, The only thing that we do here is fetching
-    global namespace from `obj.__module__` if it is not `None`.
-
-    Args:
-        obj: The object to get its type hints.
-        localns: The local namespaces.
-        include_extras: Whether to recursively include annotation metadata.
-
-    Returns:
-        The object type hints.
-    """
-    module_name = getattr(obj, '__module__', None)
-    globalns: dict[str, Any] | None = None
-    if module_name:
-        try:
-            globalns = sys.modules[module_name].__dict__
-        except KeyError:
-            # happens occasionally, see https://github.com/pydantic/pydantic/issues/2363
-            pass
-    return get_type_hints(obj, globalns=globalns, localns=localns, include_extras=include_extras)
 
 
 class PydanticMetadata(Representation):

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1539,7 +1539,12 @@ class GenerateSchema:
             if not annotations:
                 # annotations is empty, happens if namedtuple_cls defined via collections.namedtuple(...)
                 annotations = {k: Any for k in namedtuple_cls._fields}
-            annotations = replace_types(annotations, typevars_map)
+
+            if typevars_map:
+                annotations = {
+                    field_name: replace_types(annotation, typevars_map)
+                    for field_name, annotation in annotations.items()
+                }
 
             arguments_schema = core_schema.arguments_schema(
                 [

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1472,7 +1472,8 @@ class GenerateSchema:
                 else:
                     field_docstrings = None
 
-                for field_name, annotation in get_cls_type_hints_lenient(typed_dict_cls, self._types_namespace).items():
+                type_hints = get_cls_type_hints_lenient(typed_dict_cls, self._types_namespace) or {}
+                for field_name, annotation in type_hints.items():
                     annotation = replace_types(annotation, typevars_map)
                     required = field_name in required_keys
 
@@ -1538,12 +1539,7 @@ class GenerateSchema:
             if not annotations:
                 # annotations is empty, happens if namedtuple_cls defined via collections.namedtuple(...)
                 annotations = {k: Any for k in namedtuple_cls._fields}
-
-            if typevars_map:
-                annotations = {
-                    field_name: replace_types(annotation, typevars_map)
-                    for field_name, annotation in annotations.items()
-                }
+            annotations = replace_types(annotations, typevars_map)
 
             arguments_schema = core_schema.arguments_schema(
                 [

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -89,13 +89,13 @@ from ._decorators import (
     inspect_validator,
 )
 from ._docs_extraction import extract_docstrings_from_cls
-from ._fields import collect_dataclass_fields, get_type_hints_infer_globalns
+from ._fields import collect_dataclass_fields
 from ._forward_ref import PydanticRecursiveRef
 from ._generics import get_standard_typevars_map, has_instance_in_type, recursively_defined_type_refs, replace_types
 from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._mock_val_ser import MockCoreSchema
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
-from ._typing_extra import is_finalvar, is_self_type, is_zoneinfo_type
+from ._typing_extra import get_cls_type_hints_lenient, is_finalvar, is_self_type, is_zoneinfo_type
 from ._utils import lenient_issubclass, smart_deepcopy
 
 if TYPE_CHECKING:
@@ -1472,9 +1472,7 @@ class GenerateSchema:
                 else:
                     field_docstrings = None
 
-                for field_name, annotation in get_type_hints_infer_globalns(
-                    typed_dict_cls, localns=self._types_namespace, include_extras=True
-                ).items():
+                for field_name, annotation in get_cls_type_hints_lenient(typed_dict_cls, self._types_namespace).items():
                     annotation = replace_types(annotation, typevars_map)
                     required = field_name in required_keys
 
@@ -1536,9 +1534,7 @@ class GenerateSchema:
             if origin is not None:
                 namedtuple_cls = origin
 
-            annotations: dict[str, Any] = get_type_hints_infer_globalns(
-                namedtuple_cls, include_extras=True, localns=self._types_namespace
-            )
+            annotations: dict[str, Any] = get_cls_type_hints_lenient(namedtuple_cls, self._types_namespace)
             if not annotations:
                 # annotations is empty, happens if namedtuple_cls defined via collections.namedtuple(...)
                 annotations = {k: Any for k in namedtuple_cls._fields}

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -192,12 +192,9 @@ class ModelMetaclass(ABCMeta):
                 obj.__set_name__(cls, name)
 
             if __pydantic_reset_parent_namespace__:
-                # cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
-                cls.__pydantic_parent_namespace__ = parent_frame_namespace()
-            parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None)
-            # if isinstance(parent_namespace, dict):
-            #     parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
-
+                parent_namespace = parent_frame_namespace() or {}
+            else:
+                parent_namespace = {}
             types_namespace = get_cls_types_namespace(cls, parent_namespace)
             set_model_fields(cls, bases, config_wrapper, types_namespace)
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -192,10 +192,11 @@ class ModelMetaclass(ABCMeta):
                 obj.__set_name__(cls, name)
 
             if __pydantic_reset_parent_namespace__:
-                cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
+                # cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
+                cls.__pydantic_parent_namespace__ = parent_frame_namespace()
             parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None)
-            if isinstance(parent_namespace, dict):
-                parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
+            # if isinstance(parent_namespace, dict):
+            #     parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
 
             types_namespace = get_cls_types_namespace(cls, parent_namespace)
             set_model_fields(cls, bases, config_wrapper, types_namespace)

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -696,7 +696,7 @@ def unpack_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | N
 
     result = {}
     for k, v in d.items():
-        if getattr(v, '_is_weakref', False):
+        if getattr(v, '_is_pydantic_weakref', False):
             v = v()
             if v is not None:
                 result[k] = v

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -6,7 +6,6 @@ import builtins
 import operator
 import typing
 import warnings
-import weakref
 from abc import ABCMeta
 from functools import lru_cache, partial
 from types import FunctionType
@@ -191,10 +190,7 @@ class ModelMetaclass(ABCMeta):
             for name, obj in private_attributes.items():
                 obj.__set_name__(cls, name)
 
-            if __pydantic_reset_parent_namespace__:
-                parent_namespace = parent_frame_namespace() or {}
-            else:
-                parent_namespace = {}
+            parent_namespace = parent_frame_namespace() or {} if __pydantic_reset_parent_namespace__ else {}
             types_namespace = get_cls_types_namespace(cls, parent_namespace)
             set_model_fields(cls, bases, config_wrapper, types_namespace)
 
@@ -622,77 +618,6 @@ class _DeprecatedFieldDescriptor:
     # as `BaseModel.__setattr__` is defined and takes priority.
     def __set__(self, obj: Any, value: Any) -> NoReturn:
         raise AttributeError(self.field_name)
-
-
-class _PydanticWeakRef:
-    """Wrapper for `weakref.ref` that enables `pickle` serialization.
-
-    Cloudpickle fails to serialize `weakref.ref` objects due to an arcane error related
-    to abstract base classes (`abc.ABC`). This class works around the issue by wrapping
-    `weakref.ref` instead of subclassing it.
-
-    See https://github.com/pydantic/pydantic/issues/6763 for context.
-
-    Semantics:
-        - If not pickled, behaves the same as a `weakref.ref`.
-        - If pickled along with the referenced object, the same `weakref.ref` behavior
-          will be maintained between them after unpickling.
-        - If pickled without the referenced object, after unpickling the underlying
-          reference will be cleared (`__call__` will always return `None`).
-    """
-
-    def __init__(self, obj: Any):
-        if obj is None:
-            # The object will be `None` upon deserialization if the serialized weakref
-            # had lost its underlying object.
-            self._wr = None
-        else:
-            self._wr = weakref.ref(obj)
-
-    def __call__(self) -> Any:
-        if self._wr is None:
-            return None
-        else:
-            return self._wr()
-
-    def __reduce__(self) -> tuple[Callable, tuple[weakref.ReferenceType | None]]:
-        return _PydanticWeakRef, (self(),)
-
-
-def build_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Takes an input dictionary, and produces a new value that (invertibly) replaces the values with weakrefs.
-
-    We can't just use a WeakValueDictionary because many types (including int, str, etc.) can't be stored as values
-    in a WeakValueDictionary.
-
-    The `unpack_lenient_weakvaluedict` function can be used to reverse this operation.
-    """
-    if d is None:
-        return None
-    result = {}
-    for k, v in d.items():
-        try:
-            proxy = _PydanticWeakRef(v)
-        except TypeError:
-            proxy = v
-        result[k] = proxy
-    return result
-
-
-def unpack_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Inverts the transform performed by `build_lenient_weakvaluedict`."""
-    if d is None:
-        return None
-
-    result = {}
-    for k, v in d.items():
-        if isinstance(v, _PydanticWeakRef):
-            v = v()
-            if v is not None:
-                result[k] = v
-        else:
-            result[k] = v
-    return result
 
 
 @lru_cache(maxsize=None)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -518,19 +518,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             else:
                 if _parent_namespace_depth > 0:
                     frame_parent_ns = _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth) or {}
-                    cls_parent_ns = cls.__pydantic_parent_namespace__ or {}
-                    cls.__pydantic_parent_namespace__ = {**cls_parent_ns, **frame_parent_ns}
-
-                types_namespace = cls.__pydantic_parent_namespace__
-                #     cls_parent_ns = (
-                #         _model_construction.unpack_lenient_weakvaluedict(cls.__pydantic_parent_namespace__) or {}
-                #     )
-                #     types_namespace = {**cls_parent_ns, **frame_parent_ns}
-                #     cls.__pydantic_parent_namespace__ = _model_construction.build_lenient_weakvaluedict(types_namespace)
-                # else:
-                #     types_namespace = _model_construction.unpack_lenient_weakvaluedict(
-                #         cls.__pydantic_parent_namespace__
-                #     )
+                    types_namespace = frame_parent_ns
+                else:
+                    types_namespace = {}
 
                 types_namespace = _typing_extra.get_cls_types_namespace(cls, types_namespace)
 
@@ -1575,8 +1565,8 @@ def create_model(  # noqa: C901
         model_name,
         resolved_bases,
         namespace,
-        __pydantic_reset_parent_namespace__=False,
         _create_model_module=__module__,
+        __pydantic_reset_parent_namespace__=False,
         **kwds,
     )
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -518,15 +518,19 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             else:
                 if _parent_namespace_depth > 0:
                     frame_parent_ns = _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth) or {}
-                    cls_parent_ns = (
-                        _model_construction.unpack_lenient_weakvaluedict(cls.__pydantic_parent_namespace__) or {}
-                    )
-                    types_namespace = {**cls_parent_ns, **frame_parent_ns}
-                    cls.__pydantic_parent_namespace__ = _model_construction.build_lenient_weakvaluedict(types_namespace)
-                else:
-                    types_namespace = _model_construction.unpack_lenient_weakvaluedict(
-                        cls.__pydantic_parent_namespace__
-                    )
+                    cls_parent_ns = cls.__pydantic_parent_namespace__ or {}
+                    cls.__pydantic_parent_namespace__ = {**cls_parent_ns, **frame_parent_ns}
+
+                types_namespace = cls.__pydantic_parent_namespace__
+                #     cls_parent_ns = (
+                #         _model_construction.unpack_lenient_weakvaluedict(cls.__pydantic_parent_namespace__) or {}
+                #     )
+                #     types_namespace = {**cls_parent_ns, **frame_parent_ns}
+                #     cls.__pydantic_parent_namespace__ = _model_construction.build_lenient_weakvaluedict(types_namespace)
+                # else:
+                #     types_namespace = _model_construction.unpack_lenient_weakvaluedict(
+                #         cls.__pydantic_parent_namespace__
+                #     )
 
                 types_namespace = _typing_extra.get_cls_types_namespace(cls, types_namespace)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1565,8 +1565,8 @@ def create_model(  # noqa: C901
         model_name,
         resolved_bases,
         namespace,
-        _create_model_module=__module__,
         __pydantic_reset_parent_namespace__=False,
+        _create_model_module=__module__,
         **kwds,
     )
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1438,7 +1438,7 @@ else:
             return hash(type(self))
 
         def __eq__(self, other: Any) -> bool:
-            return type(other) == type(self)
+            return type(other) is type(self)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SECRET TYPES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2232,8 +2232,9 @@ def test_model_rebuild_zero_depth():
     with pytest.raises(NameError, match='X_Type'):
         Model.model_rebuild(_parent_namespace_depth=0)
 
-    Model.__pydantic_parent_namespace__.update({'X_Type': int})
-    Model.model_rebuild(_parent_namespace_depth=0)
+    X_Type = int
+
+    Model.model_rebuild(_parent_namespace_depth=2)
 
     m = Model(x=42)
     assert m.model_dump() == {'x': 42}

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,5 +1,4 @@
 import dataclasses
-import gc
 import pickle
 from typing import Optional, Type
 
@@ -8,7 +7,6 @@ import pytest
 
 import pydantic
 from pydantic import BaseModel, PositiveFloat, ValidationError
-from pydantic._internal._model_construction import _PydanticWeakRef
 from pydantic.config import ConfigDict
 
 
@@ -21,43 +19,6 @@ class IntWrapper:
 
     def __eq__(self, other: 'IntWrapper') -> bool:
         return self.get() == other.get()
-
-
-def test_pickle_pydantic_weakref():
-    obj1 = IntWrapper(1)
-    ref1 = _PydanticWeakRef(obj1)
-    assert ref1() is obj1
-
-    obj2 = IntWrapper(2)
-    ref2 = _PydanticWeakRef(obj2)
-    assert ref2() is obj2
-
-    ref3 = _PydanticWeakRef(IntWrapper(3))
-    gc.collect()  # PyPy does not use reference counting and always relies on GC.
-    assert ref3() is None
-
-    d = {
-        # Hold a hard reference to the underlying object for ref1 that will also
-        # be pickled.
-        'hard_ref': obj1,
-        # ref1's underlying object has a hard reference in the pickled object so it
-        # should maintain the reference after deserialization.
-        'has_hard_ref': ref1,
-        # ref2's underlying object has no hard reference in the pickled object so it
-        # should be `None` after deserialization.
-        'has_no_hard_ref': ref2,
-        # ref3's underlying object had already gone out of scope before pickling so it
-        # should be `None` after deserialization.
-        'ref_out_of_scope': ref3,
-    }
-
-    loaded = pickle.loads(pickle.dumps(d))
-    gc.collect()  # PyPy does not use reference counting and always relies on GC.
-
-    assert loaded['hard_ref'] == IntWrapper(1)
-    assert loaded['has_hard_ref']() is loaded['hard_ref']
-    assert loaded['has_no_hard_ref']() is None
-    assert loaded['ref_out_of_scope']() is None
 
 
 class ImportableModel(BaseModel):

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -611,6 +611,8 @@ def test_recursive_generic_typeddict_in_module(create_module):
 
 
 def test_recursive_generic_typeddict_in_function_1():
+    from pydantic._internal._core_utils import pretty_print_core_schema
+
     T = TypeVar('T')
 
     # First ordering: typed dict first
@@ -623,6 +625,8 @@ def test_recursive_generic_typeddict_in_function_1():
 
     # Note: no model_rebuild() necessary here
     # RecursiveGenTypedDictModel.model_rebuild()
+
+    pretty_print_core_schema(RecursiveGenTypedDictModel[int].__pydantic_core_schema__)
 
     int_data: RecursiveGenTypedDict[int] = {'foo': {'foo': None, 'ls': [1]}, 'ls': [1]}
     assert RecursiveGenTypedDictModel[int](rec=int_data).rec == int_data


### PR DESCRIPTION
In https://github.com/pydantic/pydantic/pull/6681, we introduced an approach to fixing a memory leak with generic models in V2. Unfortunately, this fix results in a memory usage blowup as well as a significant performance hit for cases with lots of models.

This PR seeks to come up with an alternative fix to https://github.com/pydantic/pydantic/issues/6672, while also significantly decreasing the build time and memory usage for cases with lots of models.

Fix https://github.com/pydantic/pydantic/issues/8652
Fix https://github.com/pydantic/pydantic/issues/9905

My current approach: remove caching of parent namespace on each model. This fixes the generic memory leak, but potentially introduces some new problems with generics and typevars that I'm trying to troubleshoot.

Currently causing problems based on changes made in https://github.com/pydantic/pydantic/pull/5305 and maybe https://github.com/pydantic/pydantic/pull/5274

Note, this will make model rebuilds slower (but not that slow).