### PR TITLE
Raise a better user error when failing to evaluate a forward reference

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:cb33d970d4571653960055944e59cc5a8aab70c8e0890a66f9b0036a261985be"
+content_hash = "sha256:d2e639b55bbc844c3114751df53b3b9f6c808273f1146eaf783463932233a720"
 
 [[metadata.targets]]
 requires_python = ">=3.8"

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -265,19 +265,23 @@ def eval_type_backport(
                 value, globalns, localns
             )
     except TypeError as e:
-        if not (isinstance(value, typing.ForwardRef) and is_backport_fixable_error(e)):
-            raise
-        try:
-            from eval_type_backport import eval_type_backport
-        except ImportError:
-            raise TypeError(
-                f'You have a type annotation {value.__forward_arg__!r} '
-                f'which makes use of newer typing features than are supported in your version of Python. '
-                f'To handle this error, you should either remove the use of new syntax '
-                f'or install the `eval_type_backport` package.'
-            ) from e
+        if isinstance(value, typing.ForwardRef):
+            if is_backport_fixable_error(e):
+                try:
+                    from eval_type_backport import eval_type_backport
+                except ImportError:
+                    raise TypeError(
+                        f'You have a type annotation {value.__forward_arg__!r} '
+                        f'which makes use of newer typing features than are supported in your version of Python. '
+                        f'To handle this error, you should either remove the use of new syntax '
+                        f'or install the `eval_type_backport` package.'
+                    ) from e
 
-        return eval_type_backport(value, globalns, localns, try_default=False)
+                return eval_type_backport(value, globalns, localns, try_default=False)
+
+            raise TypeError(f'Unable to evaluate type annotation {value.__forward_arg__!r}.') from e
+
+        raise e
 
 
 def is_backport_fixable_error(e: TypeError) -> bool:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -261,7 +261,10 @@ def eval_type_backport(
     try:
         return _eval_type_backport(value, globalns, localns, type_params)
     except TypeError as e:
-        # If it is a `TypeError` and value isn't a `ForwardRef`, it would have failed during class definition.
+        if 'Unable to evaluate type annotation' in str(e):
+            raise
+
+        # If it is a `TypeError` and value isn't a `ForwardRef`, it would have failed during annotation definition.
         # Thus we assert here for type checking purposes:
         assert isinstance(value, typing.ForwardRef)
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -270,10 +270,10 @@ def eval_type_backport(
                 from eval_type_backport import eval_type_backport
             except ImportError:
                 raise TypeError(
-                    f'Unable to evaluate type annotation {value.__forward_arg__!r}. '
-                    'If you are making use of the new typing syntax (unions using `|` or builtins subscripting), '
-                    'you should either replace the use of new syntax with the existing `typing` constructs '
-                    'or install the `eval_type_backport` package. Otherwise, it might be '
+                    f'Unable to evaluate type annotation {value.__forward_arg__!r}. If you are making use '
+                    'of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting '
+                    'since Python 3.9), you should either replace the use of new syntax with the existing '
+                    '`typing` constructs or install the `eval_type_backport` package. Otherwise, it might be '
                     "that the type being used isn't subscriptable."
                 ) from e
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -274,16 +274,12 @@ def eval_type_backport(
                         f'Unable to evaluate type annotation {value.__forward_arg__!r}. If you are making use '
                         'of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting '
                         'since Python 3.9), you should either replace the use of new syntax with the existing '
-                        '`typing` constructs or install the `eval_type_backport` package. Otherwise, it might be '
-                        "that the type being used isn't subscriptable."
+                        '`typing` constructs or install the `eval_type_backport` package.'
                     ) from e
 
                 return eval_type_backport(value, globalns, localns, try_default=False)
 
-            raise TypeError(
-                f'Unable to evaluate type annotation {value.__forward_arg__!r}. '
-                "It might be that the type being used isn't subscriptable."
-            ) from e
+            raise TypeError(f'Unable to evaluate type annotation {value.__forward_arg__!r}.') from e
 
         raise e
 
@@ -292,9 +288,9 @@ def is_backport_fixable_error(e: TypeError) -> bool:
     msg = str(e)
 
     return (
-        sys.version_info <= (3, 8)
+        sys.version_info < (3, 10)
         and msg.startswith('unsupported operand type(s) for |: ')
-        or sys.version_info <= (3, 9)
+        or sys.version_info < (3, 9)
         and "' object is not subscriptable" in msg
     )
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -272,6 +272,7 @@ def eval_type_backport(
         else:
             raise TypeError(message) from e
 
+
 def _eval_type_backport(
     value: Any,
     globalns: dict[str, Any] | None = None,
@@ -311,6 +312,7 @@ def _eval_type(
         return typing._eval_type(  # type: ignore
             value, globalns, localns
         )
+
 
 def is_backport_fixable_error(e: TypeError) -> bool:
     msg = str(e)

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -266,26 +266,37 @@ def eval_type_backport(
             )
     except TypeError as e:
         if isinstance(value, typing.ForwardRef):
-            try:
-                from eval_type_backport import eval_type_backport
-            except ImportError:
-                raise TypeError(
-                    f'Unable to evaluate type annotation {value.__forward_arg__!r}. If you are making use '
-                    'of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting '
-                    'since Python 3.9), you should either replace the use of new syntax with the existing '
-                    '`typing` constructs or install the `eval_type_backport` package. Otherwise, it might be '
-                    "that the type being used isn't subscriptable."
-                ) from e
+            if is_backport_fixable_error(e):
+                try:
+                    from eval_type_backport import eval_type_backport
+                except ImportError:
+                    raise TypeError(
+                        f'Unable to evaluate type annotation {value.__forward_arg__!r}. If you are making use '
+                        'of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting '
+                        'since Python 3.9), you should either replace the use of new syntax with the existing '
+                        '`typing` constructs or install the `eval_type_backport` package. Otherwise, it might be '
+                        "that the type being used isn't subscriptable."
+                    ) from e
 
-            try:
                 return eval_type_backport(value, globalns, localns, try_default=False)
-            except TypeError as e:
-                raise TypeError(
-                    f'Unable to evaluate type annotation {value.__forward_arg__!r}. '
-                    "It might be that the type being used isn't subscriptable."
-                ) from e
+
+            raise TypeError(
+                f'Unable to evaluate type annotation {value.__forward_arg__!r}. '
+                "It might be that the type being used isn't subscriptable."
+            ) from e
 
         raise e
+
+
+def is_backport_fixable_error(e: TypeError) -> bool:
+    msg = str(e)
+
+    return (
+        sys.version_info <= (3, 8)
+        and msg.startswith('unsupported operand type(s) for |: ')
+        or sys.version_info <= (3, 9)
+        and "' object is not subscriptable" in msg
+    )
 
 
 def get_function_type_hints(

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1087,7 +1087,9 @@ def test_invalid_forward_ref() -> None:
     class CustomType:
         """A custom type that isn't subscriptable."""
 
-    with pytest.raises(TypeError, match=re.escape("Unable to evaluate type annotation 'CustomType[int]'.")):
+    msg = "Unable to evaluate type annotation 'CustomType[int]'. It might be that the type being used isn't subscriptable."
+
+    with pytest.raises(TypeError, match=re.escape(msg)):
 
         class Model(BaseModel):
             foo: 'CustomType[int]'

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1081,3 +1081,13 @@ def test_forward_ref_in_generic_separate_modules(create_module: Any) -> None:
     Bar = module_2.Bar
     Foo.model_rebuild(_types_namespace={'tp': typing, 'Bar': Bar})
     assert Foo(x={Bar: Bar}).x[Bar] is Bar
+
+
+def test_invalid_forward_ref() -> None:
+    class CustomType:
+        """A custom type that isn't subscriptable."""
+
+    with pytest.raises(TypeError, match=re.escape("Unable to evaluate type annotation 'CustomType[int]'.")):
+
+        class Model(BaseModel):
+            foo: 'CustomType[int]'

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1087,7 +1087,7 @@ def test_invalid_forward_ref() -> None:
     class CustomType:
         """A custom type that isn't subscriptable."""
 
-    msg = "Unable to evaluate type annotation 'CustomType[int]'. It might be that the type being used isn't subscriptable."
+    msg = "Unable to evaluate type annotation 'CustomType[int]'."
 
     with pytest.raises(TypeError, match=re.escape(msg)):
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -133,10 +133,10 @@ def test_eval_type_backport_not_installed():
                 foo: 'int | str'
 
         assert str(exc_info.value) == (
-            "Unable to evaluate type annotation 'int | str' which makes use of newer typing. "
-            'If you are making use of the new typing syntax (unions using `|` or builtins subscripting), '
-            'you should either replace the use of new syntax with the existing `typing` constructs '
-            'or install the `eval_type_backport` package. Otherwise, it might be '
+            "Unable to evaluate type annotation 'int | str'. If you are making use "
+            'of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting '
+            'since Python 3.9), you should either replace the use of new syntax with the existing '
+            '`typing` constructs or install the `eval_type_backport` package. Otherwise, it might be '
             "that the type being used isn't subscriptable."
         )
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -136,8 +136,7 @@ def test_eval_type_backport_not_installed():
             "Unable to evaluate type annotation 'int | str'. If you are making use "
             'of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting '
             'since Python 3.9), you should either replace the use of new syntax with the existing '
-            '`typing` constructs or install the `eval_type_backport` package. Otherwise, it might be '
-            "that the type being used isn't subscriptable."
+            '`typing` constructs or install the `eval_type_backport` package.'
         )
 
     finally:

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -133,10 +133,11 @@ def test_eval_type_backport_not_installed():
                 foo: 'int | str'
 
         assert str(exc_info.value) == (
-            "You have a type annotation 'int | str' which makes use of newer typing "
-            'features than are supported in your version of Python. To handle this error, '
-            'you should either remove the use of new syntax or install the '
-            '`eval_type_backport` package.'
+            "Unable to evaluate type annotation 'int | str' which makes use of newer typing. "
+            'If you are making use of the new typing syntax (unions using `|` or builtins subscripting), '
+            'you should either replace the use of new syntax with the existing `typing` constructs '
+            'or install the `eval_type_backport` package. Otherwise, it might be '
+            "that the type being used isn't subscriptable."
         )
 
     finally:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Fixes https://github.com/pydantic/pydantic/issues/8291.

I first wanted to have the actual field name displayed (and possibly line number). This could be done in `get_cls_type_hints_lenient` (which calls `eval_type_lenient` for each annotation) where we have access to the field names, but this is only used by `BaseModel`, not Pydantic dataclasses, `validate_call`, etc.

But I think at least providing the bad annotation string repr as it is done in this PR could be sufficient: users just need to <kbd>Ctrl</kbd> + <kbd>F</kbd> through the code to find where it is coming from

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
