### PR TITLE
Simplify internal generics logic - remove generator overhead

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -6,7 +6,6 @@ import typing
 from collections import ChainMap
 from contextlib import contextmanager
 from contextvars import ContextVar
-from functools import lru_cache
 from types import prepare_class
 from typing import TYPE_CHECKING, Any, Iterator, List, Mapping, MutableMapping, Tuple, TypeVar
 from weakref import WeakValueDictionary
@@ -335,7 +334,6 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
     return type_map.get(type_, type_)
 
 
-@lru_cache(maxsize=None)
 def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
     """Checks if the type, or any of its arbitrary nested args, satisfy
     `isinstance(<type>, isinstance_target)`.

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -350,14 +350,16 @@ def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
 
     # Having type args is a good indicator that this is a typing module
     # class instantiation or a generic alias of some sort.
-    if any(has_instance_in_type(a, isinstance_target) for a in type_args):
-        return True
+    for arg in type_args:
+        if has_instance_in_type(arg, isinstance_target):
+            return True
 
     # Handle special case for typehints that can have lists as arguments.
     # `typing.Callable[[int, str], int]` is an example for this.
     if isinstance(type_, (List, list)) and not isinstance(type_, typing_extensions.ParamSpec):
-        if any(has_instance_in_type(element, isinstance_target) for element in type_):
-            return True
+        for element in type_:
+            if has_instance_in_type(element, isinstance_target):
+                return True
 
     return False
 

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -6,6 +6,7 @@ import typing
 from collections import ChainMap
 from contextlib import contextmanager
 from contextvars import ContextVar
+from functools import lru_cache
 from types import prepare_class
 from typing import TYPE_CHECKING, Any, Iterator, List, Mapping, MutableMapping, Tuple, TypeVar
 from weakref import WeakValueDictionary
@@ -334,6 +335,7 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
     return type_map.get(type_, type_)
 
 
+@lru_cache(maxsize=None)
 def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
     """Checks if the type, or any of its arbitrary nested args, satisfy
     `isinstance(<type>, isinstance_target)`.


### PR DESCRIPTION
Reduce generator overhead in recursive calls by using simple for loops - improves this `has_instance_in_type` function by 20%, resulting in a 1% speedup globally.

Continuing to chip away 1% by 1%.