### PR TITLE
Experimental feature: opt-in fast build

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -89,6 +89,7 @@ class ConfigWrapper:
     validation_error_cause: bool
     use_attribute_docstrings: bool
     cache_strings: bool | Literal['all', 'keys', 'none']
+    experimental_fast_build: bool
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -272,6 +273,7 @@ config_defaults = ConfigDict(
     validation_error_cause=False,
     use_attribute_docstrings=False,
     cache_strings=True,
+    experimental_fast_build=False,
 )
 
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -191,11 +191,14 @@ class ModelMetaclass(ABCMeta):
             for name, obj in private_attributes.items():
                 obj.__set_name__(cls, name)
 
-            if __pydantic_reset_parent_namespace__:
-                cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
-            parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None)
-            if isinstance(parent_namespace, dict):
-                parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
+            if not config_wrapper.experimental_fast_build:
+                if __pydantic_reset_parent_namespace__:
+                    cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
+                parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None)
+                if isinstance(parent_namespace, dict):
+                    parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
+            else:
+                parent_namespace = {}
 
             types_namespace = get_cls_types_namespace(cls, parent_namespace)
             set_model_fields(cls, bases, config_wrapper, types_namespace)

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -198,6 +198,7 @@ class ModelMetaclass(ABCMeta):
                 if isinstance(parent_namespace, dict):
                     parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
             else:
+                cls.__pydantic_parent_namespace__ = None
                 parent_namespace = {}
 
             types_namespace = get_cls_types_namespace(cls, parent_namespace)

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1017,12 +1017,18 @@ class ConfigDict(TypedDict, total=False):
     experimental_fast_build: bool
     """Build models faster by skipping the logic associated with storing the parent namespace on the model.
 
-    Defaults to `False` to maintain backwards compatibility.
+    Defaults to `False` to maintain backwards compatibility, for now. The ideal case is that this change or it's successor
+    can become the default. Thus, if you experience issues with this setting that have not already been documented,
+    please open an issue on GitHub.
 
     !!! warning
-        If this setting is set to `True`, model schemas for generic typed dicts and named tuples might be incorrect.
+        If this setting is set to `True`, model schemas for models that involve edge case uses of namespaces, such as
+        generic typed dicts and named tuples, might be incorrect. In some cases, type hints may be resolved with
+        incorrect namespaces.
+
         There may also be other edge cases where the model schema is incorrect. That being said, this setting has the potential
-        to speed up schema builds by a factor of 10x in cases with hundreds or thousands of complex models.
+        to speed up schema builds by a factor of 10x in cases with hundreds or thousands of complex models, hence the value.
+        We're working on making this speedup compatible with schema builds across the board.
     """
 
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1026,6 +1026,9 @@ class ConfigDict(TypedDict, total=False):
         generic typed dicts and named tuples, might be incorrect. In some cases, type hints may be resolved with
         incorrect namespaces.
 
+        We've demonstrated some of these cases in https://github.com/pydantic/pydantic/blob/main/tests/test_fast_build.py
+        to help folks better understand the limitations of this setting.
+
         There may also be other edge cases where the model schema is incorrect. That being said, this setting has the potential
         to speed up schema builds by a factor of 10x in cases with hundreds or thousands of complex models, hence the value.
         We're working on making this speedup compatible with schema builds across the board.

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1015,7 +1015,7 @@ class ConfigDict(TypedDict, total=False):
     """
 
     experimental_fast_build: bool
-    """Build models faster by skipping the logic associated with storing the parent namespace on the model.
+    """Build model schemas faster by skipping the logic associated with storing the parent namespace on the model.
 
     Defaults to `False` to maintain backwards compatibility, for now. The ideal case is that this change or it's successor
     can become the default. Thus, if you experience issues with this setting that have not already been documented,

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1014,6 +1014,17 @@ class ConfigDict(TypedDict, total=False):
         as the performance difference is minimal if repeated strings are rare.
     """
 
+    experimental_fast_build: bool
+    """Build models faster by skipping the logic associated with storing the parent namespace on the model.
+
+    Defaults to `False` to maintain backwards compatibility.
+
+    !!! warning
+        If this setting is set to `True`, model schemas for generic typed dicts and named tuples might be incorrect.
+        There may also be other edge cases where the model schema is incorrect. That being said, this setting has the potential
+        to speed up schema builds by a factor of 10x in cases with hundreds or thousands of complex models.
+    """
+
 
 _TypeT = TypeVar('_TypeT', bound=type)
 

--- a/tests/test_fast_build.py
+++ b/tests/test_fast_build.py
@@ -1,0 +1,216 @@
+"""Tests for our experimental."""
+
+import re
+import time
+from typing import Generic, List, Optional, TypeVar
+
+import pytest
+from typing_extensions import TypedDict
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+@pytest.mark.xfail(
+    reason='Models defined in function require namespace operations not yet compatible with `experimental_fast_build`'
+)
+def test_nested_annotation(create_module):
+    module = create_module(
+        # language=Python
+        """
+from __future__ import annotations
+from pydantic import BaseModel as BM, ConfigDict
+
+class BaseModel(BM):
+    model_config = ConfigDict(experimental_fast_build=True)
+
+def nested():
+    class Foo(BaseModel):
+        a: int
+
+    class Bar(BaseModel):
+        b: Foo
+
+    return Bar
+"""
+    )
+
+    bar_model = module.nested()
+    assert bar_model.__pydantic_complete__ is True
+    assert bar_model(b={'a': 1}).model_dump() == {'b': {'a': 1}}
+
+
+@pytest.mark.xfail(
+    reason='Models defined in function require namespace operations not yet compatible with `experimental_fast_build`'
+)
+def test_nested_annotation_priority(create_module):
+    @create_module
+    def module():
+        from annotated_types import Gt
+        from typing_extensions import Annotated
+
+        from pydantic import BaseModel, ConfigDict
+
+        Foobar = Annotated[int, Gt(0)]  # noqa: F841
+
+        def nested():
+            Foobar = Annotated[int, Gt(10)]
+
+            class Bar(BaseModel):
+                b: 'Foobar'
+
+                model_config = ConfigDict(experimental_fast_build=True)
+
+            return Bar
+
+    bar_model = module.nested()
+    assert bar_model.model_fields['b'].metadata[0].gt == 10
+    assert bar_model(b=11).model_dump() == {'b': 11}
+    with pytest.raises(ValidationError, match=r'Input should be greater than 10 \[type=greater_than,'):
+        bar_model(b=1)
+
+
+@pytest.mark.xfail(reason='Invalid parametrization of custom types is not yet supported with `experimental_fast_build`')
+def test_invalid_forward_ref() -> None:
+    class CustomType:
+        """A custom type that isn't subscriptable."""
+
+    msg = "Unable to evaluate type annotation 'CustomType[int]'."
+
+    with pytest.raises(TypeError, match=re.escape(msg)):
+
+        class Model(BaseModel):
+            foo: 'CustomType[int]'
+
+            model_config = ConfigDict(experimental_fast_build=True)
+
+
+@pytest.mark.xfail(reason='This type of forward reference is not yet supported with `experimental_fast_build`')
+def test_extra_validator_named() -> None:
+    class BaseModel_(BaseModel):
+        model_config = ConfigDict(experimental_fast_build=True)
+
+    class Foo(BaseModel_):
+        x: int
+
+    class Model(BaseModel_):
+        model_config = ConfigDict(extra='allow')
+        __pydantic_extra__: 'dict[str, Foo]'
+
+    class Child(Model):
+        y: int
+
+    m = Child(a={'x': '1'}, y=2)
+    assert m.__pydantic_extra__ == {'a': Foo(x=1)}
+
+    # insert_assert(Child.model_json_schema())
+    assert Child.model_json_schema() == {
+        '$defs': {
+            'Foo': {
+                'properties': {'x': {'title': 'X', 'type': 'integer'}},
+                'required': ['x'],
+                'title': 'Foo',
+                'type': 'object',
+            }
+        },
+        'additionalProperties': {'$ref': '#/$defs/Foo'},
+        'properties': {'y': {'title': 'Y', 'type': 'integer'}},
+        'required': ['y'],
+        'title': 'Child',
+        'type': 'object',
+    }
+
+
+@pytest.mark.xfail(reason='Parametrized TypedDicts are not yet supported with `experimental_fast_build`')
+def test_recursive_generic_typeddict_in_function_1():
+    T = TypeVar('T')
+
+    class BaseModel_(BaseModel):
+        model_config = ConfigDict(experimental_fast_build=True)
+
+    # First ordering: typed dict first
+    class RecursiveGenTypedDict(TypedDict, Generic[T]):
+        foo: Optional['RecursiveGenTypedDict[T]']
+        ls: List[T]
+
+    class RecursiveGenTypedDictModel(BaseModel_, Generic[T]):
+        rec: 'RecursiveGenTypedDict[T]'
+
+    # Note: no model_rebuild() necessary here
+    # RecursiveGenTypedDictModel.model_rebuild()
+
+    int_data: RecursiveGenTypedDict[int] = {'foo': {'foo': None, 'ls': [1]}, 'ls': [1]}
+    assert RecursiveGenTypedDictModel[int](rec=int_data).rec == int_data
+
+    str_data: RecursiveGenTypedDict[str] = {'foo': {'foo': None, 'ls': ['a']}, 'ls': ['a']}
+    with pytest.raises(ValidationError) as exc_info:
+        RecursiveGenTypedDictModel[int](rec=str_data)
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'input': 'a',
+            'loc': ('rec', 'foo', 'ls', 0),
+            'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
+            'type': 'int_parsing',
+        },
+        {
+            'input': 'a',
+            'loc': ('rec', 'ls', 0),
+            'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
+            'type': 'int_parsing',
+        },
+    ]
+
+
+@pytest.mark.xfail(reason='Parametrized TypedDicts are not yet supported with `experimental_fast_build`')
+def test_recursive_generic_typeddict_in_function_2():
+    T = TypeVar('T')
+
+    class BaseModel_(BaseModel):
+        model_config = ConfigDict(experimental_fast_build=True)
+
+    # Second ordering: model first
+    class RecursiveGenTypedDictModel(BaseModel_, Generic[T]):
+        rec: 'RecursiveGenTypedDict[T]'
+
+    class RecursiveGenTypedDict(TypedDict, Generic[T]):
+        foo: Optional['RecursiveGenTypedDict[T]']
+        ls: List[T]
+
+    int_data: RecursiveGenTypedDict[int] = {'foo': {'foo': None, 'ls': [1]}, 'ls': [1]}
+    assert RecursiveGenTypedDictModel[int](rec=int_data).rec == int_data
+
+    str_data: RecursiveGenTypedDict[str] = {'foo': {'foo': None, 'ls': ['a']}, 'ls': ['a']}
+    with pytest.raises(ValidationError) as exc_info:
+        RecursiveGenTypedDictModel[int](rec=str_data)
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'input': 'a',
+            'loc': ('rec', 'foo', 'ls', 0),
+            'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
+            'type': 'int_parsing',
+        },
+        {
+            'input': 'a',
+            'loc': ('rec', 'ls', 0),
+            'msg': 'Input should be a valid integer, unable to parse string as an ' 'integer',
+            'type': 'int_parsing',
+        },
+    ]
+
+
+def experimental_fast_build_success() -> None:
+    """If this test ends up being flaky we can disable, though I'd doubt it will, the difference is often on the order of 10-100x."""
+    start = time.time()
+
+    class SlowModel(BaseModel):
+        x: int
+
+    checkpoint = time.time()
+
+    class FastModel(BaseModel):
+        model_config = ConfigDict(experimental_fast_build=True)
+
+        x: int
+
+    end = time.time()
+
+    assert checkpoint - start > end - checkpoint

--- a/tests/test_fast_build.py
+++ b/tests/test_fast_build.py
@@ -120,7 +120,7 @@ def test_extra_validator_named() -> None:
     }
 
 
-@pytest.mark.xfail(reason='Parametrized TypedDicts are not yet supported with `experimental_fast_build`')
+@pytest.mark.xfail(reason='Parametrized TypedDicts are not yet supported with `experimental_fast_build`', strict=False)
 def test_recursive_generic_typeddict_in_function_1():
     T = TypeVar('T')
 
@@ -160,7 +160,7 @@ def test_recursive_generic_typeddict_in_function_1():
     ]
 
 
-@pytest.mark.xfail(reason='Parametrized TypedDicts are not yet supported with `experimental_fast_build`')
+@pytest.mark.xfail(reason='Parametrized TypedDicts are not yet supported with `experimental_fast_build`', strict=False)
 def test_recursive_generic_typeddict_in_function_2():
     T = TypeVar('T')
 

--- a/tests/test_fast_build.py
+++ b/tests/test_fast_build.py
@@ -1,4 +1,4 @@
-"""Tests for our experimental."""
+"""Tests for our experimental fast build flag."""
 
 import re
 import time


### PR DESCRIPTION
This opt in config setting allows for skipping the memory + time heavy parent namespace preparation logic needed for edge cases involving model rebuilds, forward ref simplification, and typevar substitution.

With future refactors, we can hopefully make this speedup the default by eliminating the need for the `__pydantic_parent_namespace__` cache, but that will take significantly more effort.

This is a more practical follow up to https://github.com/pydantic/pydantic/pull/10026.

Closes https://github.com/pydantic/pydantic/issues/8652
Closes https://github.com/pydantic/pydantic/issues/9905

I think for now it's fair to say this closes the following issues, though as mentioned above, there's lots of room for improvement in the default case. I'll open an issue to reflect this.