### PR TITLE
Update tests for changes to core

### DIFF
--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -764,7 +764,9 @@ def test_generic_computed_field():
         def double_x(self) -> T:
             return 'abc'  # this may not match the annotated return type, and will warn if not
 
-    with pytest.warns(UserWarning, match='Expected `int` but got `str` - serialized value may not be as expected'):
+    with pytest.warns(
+        UserWarning, match="Expected `int` but got `str` with value `'abc'` - serialized value may not be as expected"
+    ):
         B[int]().model_dump()
 
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -482,10 +482,14 @@ def test_model_serializer_plain_json_return_type():
 
     m = MyModel(a=666)
     assert m.model_dump() == {'a': 666}
-    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+    with pytest.warns(
+        UserWarning, match='Expected `str` but got `int` with value `666` - serialized value may not be as expected'
+    ):
         assert m.model_dump(mode='json') == 666
 
-    with pytest.warns(UserWarning, match='Expected `str` but got `int` - serialized value may not be as expected'):
+    with pytest.warns(
+        UserWarning, match='Expected `str` but got `int` with value `666` - serialized value may not be as expected'
+    ):
         assert m.model_dump_json() == '666'
 
 


### PR DESCRIPTION
In pydantic/pydantic-core#1377 the warning when providing a wrongly typed value for serialization was changed. This PR updates pydantic's tests to check for the new warning 

cc @sydney-runkle 
