### PR TITLE
Allow validators to customize validation JSON schema

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -733,9 +733,9 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'validator-instance-method'
 ```
 
-## `input_type` is {#validator-input-type}
+## `json_schema_input_type` used with the wrong mode {#validator-input-type}
 
-This error is raised when you explicitly specify a value for the `input_type`
+This error is raised when you explicitly specify a value for the `json_schema_input_type`
 argument and `mode` isn't set to either `'before'`, `'plain'` or `'wrap'`.
 
 ```py
@@ -746,7 +746,7 @@ try:
     class Model(BaseModel):
         a: int = 1
 
-        @field_validator('a', mode='after', input_type=int)
+        @field_validator('a', mode='after', json_schema_input_type=int)
         @classmethod
         def check_a(self, value):
             return value

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -726,11 +726,33 @@ try:
         a: int = 1
 
         @field_validator('a')
-        def check_a(self, values):
-            return values
+        def check_a(self, value):
+            return value
 
 except PydanticUserError as exc_info:
     assert exc_info.code == 'validator-instance-method'
+```
+
+## `input_type` is {#validator-input-type}
+
+This error is raised when you explicitly specify a value for the `input_type`
+argument and `mode` isn't set to either `'before'`, `'plain'` or `'wrap'`.
+
+```py
+from pydantic import BaseModel, PydanticUserError, field_validator
+
+try:
+
+    class Model(BaseModel):
+        a: int = 1
+
+        @field_validator('a', mode='after', input_type=int)
+        @classmethod
+        def check_a(self, value):
+            return value
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'validator-input-type'
 ```
 
 ## Root validator, `pre`, `skip_on_failure` {#root-validator-pre-skip}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -755,6 +755,10 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'validator-input-type'
 ```
 
+Documenting the JSON Schema input type is only possible for validators where the given
+value can be anything. That is why it isn't available for `after` validators, where
+the value is first validated against the type annotation.
+
 ## Root validator, `pre`, `skip_on_failure` {#root-validator-pre-skip}
 
 If you use `@root_validator` with `pre=False` (the default) you MUST specify `skip_on_failure=True`.

--- a/pydantic/_internal/_core_metadata.py
+++ b/pydantic/_internal/_core_metadata.py
@@ -6,10 +6,10 @@ from typing import Any, cast
 import typing_extensions
 
 if typing.TYPE_CHECKING:
+    from pydantic_core import CoreSchema
+
     from ._schema_generation_shared import (
-        CoreSchemaOrField as CoreSchemaOrField,
-    )
-    from ._schema_generation_shared import (
+        CoreSchemaOrField,
         GetJsonSchemaFunction,
     )
 
@@ -29,6 +29,7 @@ class CoreMetadata(typing_extensions.TypedDict, total=False):
     # If `pydantic_js_prefer_positional_arguments` is True, the JSON schema generator will
     # prefer positional over keyword arguments for an 'arguments' schema.
     pydantic_js_prefer_positional_arguments: bool | None
+    pydantic_js_input_core_schema: CoreSchema | None
 
 
 class CoreMetadataHandler:
@@ -71,11 +72,13 @@ def build_metadata_dict(
     js_functions: list[GetJsonSchemaFunction] | None = None,
     js_annotation_functions: list[GetJsonSchemaFunction] | None = None,
     js_prefer_positional_arguments: bool | None = None,
+    js_input_core_schema: CoreSchema | None = None,
 ) -> dict[str, Any]:
     """Builds a dict to use as the metadata field of a CoreSchema object in a manner that is consistent with the `CoreMetadataHandler` class."""
     metadata = CoreMetadata(
         pydantic_js_functions=js_functions or [],
         pydantic_js_annotation_functions=js_annotation_functions or [],
         pydantic_js_prefer_positional_arguments=js_prefer_positional_arguments,
+        pydantic_js_input_core_schema=js_input_core_schema,
     )
     return {k: v for k, v in metadata.items() if v is not None}

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -56,7 +56,7 @@ class FieldValidatorDecoratorInfo:
         fields: A tuple of field names the validator should be called on.
         mode: The proposed validator mode.
         check_fields: Whether to check that the fields actually exist on the model.
-        input_type: The input type of the function. This is only used to generate
+        json_schema_input_type: The input type of the function. This is only used to generate
             the appropriate JSON Schema (in validation mode) and can only specified
             when `mode` is either `'before'`, `'plain'` or `'wrap'`.
     """
@@ -66,7 +66,7 @@ class FieldValidatorDecoratorInfo:
     fields: tuple[str, ...]
     mode: FieldValidatorModes
     check_fields: bool | None
-    input_type: Any
+    json_schema_input_type: Any
 
 
 @dataclass(**slots_true)

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -56,6 +56,9 @@ class FieldValidatorDecoratorInfo:
         fields: A tuple of field names the validator should be called on.
         mode: The proposed validator mode.
         check_fields: Whether to check that the fields actually exist on the model.
+        input_type: The input type of the function. This is only used to generate
+            the appropriate JSON Schema (in validation mode) and can only specified
+            when `mode` is either `'before'`, `'plain'` or `'wrap'`.
     """
 
     decorator_repr: ClassVar[str] = '@field_validator'
@@ -63,6 +66,7 @@ class FieldValidatorDecoratorInfo:
     fields: tuple[str, ...]
     mode: FieldValidatorModes
     check_fields: bool | None
+    input_type: Any
 
 
 @dataclass(**slots_true)

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -58,6 +58,7 @@ from ..aliases import AliasChoices, AliasGenerator, AliasPath
 from ..annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ..config import ConfigDict, JsonDict, JsonEncoder
 from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation, PydanticUserError
+from ..functional_validators import AfterValidator, BeforeValidator, FieldValidatorModes, PlainValidator, WrapValidator
 from ..json_schema import JsonSchemaValue
 from ..version import version_short
 from ..warnings import PydanticDeprecatedSince20
@@ -103,7 +104,6 @@ if TYPE_CHECKING:
     from ..fields import ComputedFieldInfo, FieldInfo
     from ..main import BaseModel
     from ..types import Discriminator
-    from ..validators import FieldValidatorModes
     from ._dataclasses import StandardDataclass
     from ._schema_generation_shared import GetJsonSchemaFunction
 
@@ -148,6 +148,10 @@ MAPPING_TYPES = [
     typing.Counter,
 ]
 DEQUE_TYPES: list[type] = [collections.deque, typing.Deque]
+
+_mode_to_validator: dict[
+    FieldValidatorModes, type[BeforeValidator | AfterValidator | PlainValidator | WrapValidator]
+] = {'before': BeforeValidator, 'after': AfterValidator, 'plain': PlainValidator, 'wrap': WrapValidator}
 
 
 def check_validator_fields_against_field_name(
@@ -1289,13 +1293,20 @@ class GenerateSchema:
             schema = self._apply_discriminator_to_union(schema, field_info.discriminator)
             return schema
 
+        # Convert `@field_validator` decorators to `Before/After/Plain/WrapValidator` instances:
+        validators_from_decorators = []
+        for decorator in filter_field_decorator_info_by_field(decorators.field_validators.values(), name):
+            validators_from_decorators.append(_mode_to_validator[decorator.info.mode]._from_decorator(decorator))
+
         with self.field_name_stack.push(name):
             if field_info.discriminator is not None:
-                schema = self._apply_annotations(source_type, annotations, transform_inner_schema=set_discriminator)
+                schema = self._apply_annotations(
+                    source_type, annotations + validators_from_decorators, transform_inner_schema=set_discriminator
+                )
             else:
                 schema = self._apply_annotations(
                     source_type,
-                    annotations,
+                    annotations + validators_from_decorators,
                 )
 
         # This V1 compatibility shim should eventually be removed
@@ -1309,10 +1320,7 @@ class GenerateSchema:
         this_field_validators = [v for v in this_field_validators if v not in each_item_validators]
         schema = apply_each_item_validators(schema, each_item_validators, name)
 
-        schema = apply_validators(schema, filter_field_decorator_info_by_field(this_field_validators, name), name)
-        schema = apply_validators(
-            schema, filter_field_decorator_info_by_field(decorators.field_validators.values(), name), name
-        )
+        schema = apply_validators(schema, this_field_validators, name)
 
         # the default validator needs to go outside of any other validators
         # so that it is the topmost validator for the field validator
@@ -2305,6 +2313,8 @@ _VALIDATOR_F_MATCH: Mapping[
 }
 
 
+# TODO V3: this function is only used for deprecated decorators. It should
+# be removed once we drop support for those.
 def apply_validators(
     schema: core_schema.CoreSchema,
     validators: Iterable[Decorator[RootValidatorDecoratorInfo]]

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -48,6 +48,7 @@ PydanticErrorCodes = Literal[
     'validator-no-fields',
     'validator-invalid-fields',
     'validator-instance-method',
+    'validator-input-type',
     'root-validator-pre-skip',
     'model-serializer-instance-method',
     'validator-field-config-info',

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -441,7 +441,7 @@ def field_validator(
     if mode not in ('before', 'plain', 'wrap') and input_type is not PydanticUndefined:
         raise PydanticUserError(
             f"`input_type` can't be used when mode is set to {mode!r}",
-            code=None,
+            code='validator-input-type',
         )
 
     fields = field, *fields

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -92,8 +92,8 @@ class BeforeValidator:
 
     Attributes:
         func: The validator function.
-        input_type: The input type of the function. This is only used to generate the appropriate JSON Schema
-            (in validation mode).
+        json_schema_input_type: The input type of the function. This is only used to generate the appropriate
+            JSON Schema (in validation mode).
 
     Example:
         ```py
@@ -118,11 +118,15 @@ class BeforeValidator:
     """
 
     func: core_schema.NoInfoValidatorFunction | core_schema.WithInfoValidatorFunction
-    input_type: Any = PydanticUndefined
+    json_schema_input_type: Any = PydanticUndefined
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         schema = handler(source_type)
-        input_schema = None if self.input_type is PydanticUndefined else handler.generate_schema(self.input_type)
+        input_schema = (
+            None
+            if self.json_schema_input_type is PydanticUndefined
+            else handler.generate_schema(self.json_schema_input_type)
+        )
         metadata = {'input_schema': input_schema}
 
         info_arg = _inspect_validator(self.func, 'before')
@@ -142,7 +146,7 @@ class BeforeValidator:
     def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
         return cls(
             func=decorator.func,
-            input_type=decorator.info.input_type,
+            json_schema_input_type=decorator.info.json_schema_input_type,
         )
 
 
@@ -154,8 +158,8 @@ class PlainValidator:
 
     Attributes:
         func: The validator function.
-        input_type: The input type of the function. This is only used to generate the appropriate JSON Schema
-            (in validation mode).
+        json_schema_input_type: The input type of the function. This is only used to generate the appropriate
+            JSON Schema (in validation mode).
 
     Example:
         ```py
@@ -174,7 +178,7 @@ class PlainValidator:
     """
 
     func: core_schema.NoInfoValidatorFunction | core_schema.WithInfoValidatorFunction
-    input_type: Any = PydanticUndefined
+    json_schema_input_type: Any = PydanticUndefined
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         # Note that for some valid uses of PlainValidator, it is not possible to generate a core schema for the
@@ -194,7 +198,11 @@ class PlainValidator:
         except PydanticSchemaGenerationError:
             serialization = None
 
-        input_schema = None if self.input_type is PydanticUndefined else handler.generate_schema(self.input_type)
+        input_schema = (
+            None
+            if self.json_schema_input_type is PydanticUndefined
+            else handler.generate_schema(self.json_schema_input_type)
+        )
         metadata = {'input_schema': input_schema}
 
         info_arg = _inspect_validator(self.func, 'plain')
@@ -214,7 +222,7 @@ class PlainValidator:
     def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
         return cls(
             func=decorator.func,
-            input_type=decorator.info.input_type,
+            json_schema_input_type=decorator.info.json_schema_input_type,
         )
 
 
@@ -226,8 +234,8 @@ class WrapValidator:
 
     Attributes:
         func: The validator function.
-        input_type: The input type of the function. This is only used to generate the appropriate JSON Schema
-            (in validation mode).
+        json_schema_input_type: The input type of the function. This is only used to generate the appropriate
+            JSON Schema (in validation mode).
 
     ```py
     from datetime import datetime
@@ -259,11 +267,15 @@ class WrapValidator:
     """
 
     func: core_schema.NoInfoWrapValidatorFunction | core_schema.WithInfoWrapValidatorFunction
-    input_type: Any = PydanticUndefined
+    json_schema_input_type: Any = PydanticUndefined
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         schema = handler(source_type)
-        input_schema = None if self.input_type is PydanticUndefined else handler.generate_schema(self.input_type)
+        input_schema = (
+            None
+            if self.json_schema_input_type is PydanticUndefined
+            else handler.generate_schema(self.json_schema_input_type)
+        )
         metadata = {'input_schema': input_schema}
 
         info_arg = _inspect_validator(self.func, 'wrap')
@@ -287,7 +299,7 @@ class WrapValidator:
     def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
         return cls(
             func=decorator.func,
-            input_type=decorator.info.input_type,
+            json_schema_input_type=decorator.info.json_schema_input_type,
         )
 
 
@@ -339,7 +351,7 @@ def field_validator(
     *fields: str,
     mode: Literal['wrap'],
     check_fields: bool | None = ...,
-    input_type: Any = ...,
+    json_schema_input_type: Any = ...,
 ) -> Callable[[_V2WrapValidatorType], _V2WrapValidatorType]: ...
 
 
@@ -350,7 +362,7 @@ def field_validator(
     *fields: str,
     mode: Literal['before', 'plain'],
     check_fields: bool | None = ...,
-    input_type: Any = ...,
+    json_schema_input_type: Any = ...,
 ) -> Callable[[_V2BeforeAfterOrPlainValidatorType], _V2BeforeAfterOrPlainValidatorType]: ...
 
 
@@ -370,7 +382,7 @@ def field_validator(
     *fields: str,
     mode: FieldValidatorModes = 'after',
     check_fields: bool | None = None,
-    input_type: Any = PydanticUndefined,
+    json_schema_input_type: Any = PydanticUndefined,
 ) -> Callable[[Any], Any]:
     """Usage docs: https://docs.pydantic.dev/2.9/concepts/validators/#field-validators
 
@@ -418,7 +430,7 @@ def field_validator(
         *fields: Additional field(s) the `field_validator` should be called on.
         mode: Specifies whether to validate the fields before or after validation.
         check_fields: Whether to check that the fields actually exist on the model.
-        input_type: The input type of the function. This is only used to generate
+        json_schema_input_type: The input type of the function. This is only used to generate
             the appropriate JSON Schema (in validation mode) and can only specified
             when `mode` is either `'before'`, `'plain'` or `'wrap'`.
 
@@ -438,9 +450,9 @@ def field_validator(
             code='validator-no-fields',
         )
 
-    if mode not in ('before', 'plain', 'wrap') and input_type is not PydanticUndefined:
+    if mode not in ('before', 'plain', 'wrap') and json_schema_input_type is not PydanticUndefined:
         raise PydanticUserError(
-            f"`input_type` can't be used when mode is set to {mode!r}",
+            f"`json_schema_input_type` can't be used when mode is set to {mode!r}",
             code='validator-input-type',
         )
 
@@ -464,7 +476,7 @@ def field_validator(
         f = _decorators.ensure_classmethod_based_on_signature(f)
 
         dec_info = _decorators.FieldValidatorDecoratorInfo(
-            fields=fields, mode=mode, check_fields=check_fields, input_type=input_type
+            fields=fields, mode=mode, check_fields=check_fields, json_schema_input_type=json_schema_input_type
         )
         return _decorators.PydanticDescriptorProxy(f, dec_info)
 

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, cast, overload
 
 from pydantic_core import PydanticUndefined, core_schema
 from pydantic_core import core_schema as _core_schema
-from typing_extensions import Annotated, Literal, TypeAlias
+from typing_extensions import Annotated, Literal, Self, TypeAlias
 
 from ._internal import _core_metadata, _decorators, _generics, _internal_dataclass
 from .annotated_handlers import GetCoreSchemaHandler
@@ -79,6 +79,10 @@ class AfterValidator:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
             return core_schema.no_info_after_validator_function(func, schema=schema)
 
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(func=decorator.func)
+
 
 @dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
 class BeforeValidator:
@@ -133,6 +137,13 @@ class BeforeValidator:
         else:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
             return core_schema.no_info_before_validator_function(func, schema=schema, metadata=metadata)
+
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(
+            func=decorator.func,
+            input_type=decorator.info.input_type,
+        )
 
 
 @dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
@@ -199,6 +210,13 @@ class PlainValidator:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
             return core_schema.no_info_plain_validator_function(func, serialization=serialization, metadata=metadata)
 
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(
+            func=decorator.func,
+            input_type=decorator.info.input_type,
+        )
+
 
 @dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
 class WrapValidator:
@@ -264,6 +282,13 @@ class WrapValidator:
                 schema=schema,
                 metadata=metadata,
             )
+
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(
+            func=decorator.func,
+            input_type=decorator.info.input_type,
+        )
 
 
 if TYPE_CHECKING:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -981,7 +981,8 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        if self._mode == 'validation' and (input_schema := schema.get('metadata', {}).get('input_schema')):
+        metadata = _core_metadata.CoreMetadataHandler(schema).metadata
+        if self._mode == 'validation' and (input_schema := metadata.get('pydantic_js_input_core_schema')):
             return self.generate_inner(input_schema)
 
         return self.generate_inner(schema['schema'])
@@ -1006,7 +1007,8 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        if self._mode == 'validation' and (input_schema := schema.get('metadata', {}).get('input_schema')):
+        metadata = _core_metadata.CoreMetadataHandler(schema).metadata
+        if self._mode == 'validation' and (input_schema := metadata.get('pydantic_js_input_core_schema')):
             return self.generate_inner(input_schema)
 
         return self.handle_invalid_for_json_schema(
@@ -1022,7 +1024,8 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        if self._mode == 'validation' and (input_schema := schema.get('metadata', {}).get('input_schema')):
+        metadata = _core_metadata.CoreMetadataHandler(schema).metadata
+        if self._mode == 'validation' and (input_schema := metadata.get('pydantic_js_input_core_schema')):
             return self.generate_inner(input_schema)
 
         return self.generate_inner(schema['schema'])

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -972,20 +972,6 @@ class GenerateJsonSchema:
         self.update_with_validations(json_schema, schema, self.ValidationsMapping.object)
         return json_schema
 
-    def _function_schema(
-        self,
-        schema: _core_utils.AnyFunctionSchema,
-    ) -> JsonSchemaValue:
-        if _core_utils.is_function_with_inner_schema(schema):
-            # This could be wrong if the function's mode is 'before', but in practice will often be right, and when it
-            # isn't, I think it would be hard to automatically infer what the desired schema should be.
-            return self.generate_inner(schema['schema'])
-
-        # function-plain
-        return self.handle_invalid_for_json_schema(
-            schema, f'core_schema.PlainValidatorFunctionSchema ({schema["function"]})'
-        )
-
     def function_before_schema(self, schema: core_schema.BeforeValidatorFunctionSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a function-before schema.
 
@@ -995,7 +981,10 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        return self._function_schema(schema)
+        if self._mode == 'validation' and (input_schema := schema.get('metadata', {}).get('input_schema')):
+            return self.generate_inner(input_schema)
+
+        return self.generate_inner(schema['schema'])
 
     def function_after_schema(self, schema: core_schema.AfterValidatorFunctionSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a function-after schema.
@@ -1006,7 +995,7 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        return self._function_schema(schema)
+        return self.generate_inner(schema['schema'])
 
     def function_plain_schema(self, schema: core_schema.PlainValidatorFunctionSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a function-plain schema.
@@ -1017,7 +1006,12 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        return self._function_schema(schema)
+        if self._mode == 'validation' and (input_schema := schema.get('metadata', {}).get('input_schema')):
+            return self.generate_inner(input_schema)
+
+        return self.handle_invalid_for_json_schema(
+            schema, f'core_schema.PlainValidatorFunctionSchema ({schema["function"]})'
+        )
 
     def function_wrap_schema(self, schema: core_schema.WrapValidatorFunctionSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a function-wrap schema.
@@ -1028,7 +1022,10 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        return self._function_schema(schema)
+        if self._mode == 'validation' and (input_schema := schema.get('metadata', {}).get('input_schema')):
+            return self.generate_inner(input_schema)
+
+        return self.generate_inner(schema['schema'])
 
     def default_schema(self, schema: core_schema.WithDefaultSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a schema with a default value.

--- a/tests/pyright/decorators.py
+++ b/tests/pyright/decorators.py
@@ -108,7 +108,7 @@ class BeforeFieldValidator(BaseModel):
     @classmethod
     def invalid_with_info(cls, value: Any, info: int) -> Any: ...
 
-    @field_validator('foo', mode='before', input_type=int)  # `input_type` allowed here.
+    @field_validator('foo', mode='before', json_schema_input_type=int)  # `input_type` allowed here.
     @classmethod
     def valid_with_info(cls, value: Any, info: ValidationInfo) -> Any: ...
 
@@ -118,7 +118,7 @@ class AfterFieldValidator(BaseModel):
     @classmethod
     def valid_classmethod(cls, value: Any) -> Any: ...
 
-    @field_validator('foo', mode='after', input_type=int)  # pyright: ignore[reportCallIssue, reportArgumentType]
+    @field_validator('foo', mode='after', json_schema_input_type=int)  # pyright: ignore[reportCallIssue, reportArgumentType]
     @classmethod
     def invalid_input_type_not_allowed(cls, value: Any) -> Any: ...
 
@@ -137,7 +137,7 @@ class WrapFieldValidator(BaseModel):
     def valid_no_info(cls, value: Any, handler: ValidatorFunctionWrapHandler) -> Any:
         """TODO this should be valid."""
 
-    @field_validator('foo', mode='wrap', input_type=int)
+    @field_validator('foo', mode='wrap', json_schema_input_type=int)
     @classmethod
     def valid_with_info(cls, value: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any: ...
 

--- a/tests/pyright/decorators.py
+++ b/tests/pyright/decorators.py
@@ -108,7 +108,7 @@ class BeforeFieldValidator(BaseModel):
     @classmethod
     def invalid_with_info(cls, value: Any, info: int) -> Any: ...
 
-    @field_validator('foo', mode='before', json_schema_input_type=int)  # `input_type` allowed here.
+    @field_validator('foo', mode='before', json_schema_input_type=int)  # `json_schema_input_type` allowed here.
     @classmethod
     def valid_with_info(cls, value: Any, info: ValidationInfo) -> Any: ...
 
@@ -137,7 +137,7 @@ class WrapFieldValidator(BaseModel):
     def valid_no_info(cls, value: Any, handler: ValidatorFunctionWrapHandler) -> Any:
         """TODO this should be valid."""
 
-    @field_validator('foo', mode='wrap', json_schema_input_type=int)
+    @field_validator('foo', mode='wrap', json_schema_input_type=int)  # `json_schema_input_type` allowed here.
     @classmethod
     def valid_with_info(cls, value: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any: ...
 

--- a/tests/pyright/decorators.py
+++ b/tests/pyright/decorators.py
@@ -137,7 +137,7 @@ class WrapFieldValidator(BaseModel):
     def valid_no_info(cls, value: Any, handler: ValidatorFunctionWrapHandler) -> Any:
         """TODO this should be valid."""
 
-    @field_validator('foo', mode='wrap')
+    @field_validator('foo', mode='wrap', input_type=int)
     @classmethod
     def valid_with_info(cls, value: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any: ...
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6468,17 +6468,17 @@ def test_plain_field_validator_serialization() -> None:
 
 def test_field_validator_input_type() -> None:
     class Model(BaseModel):
-        a: Annotated[int, BeforeValidator(lambda v: v, input_type=Union[int, str])]
-        b: Annotated[int, WrapValidator(lambda v, h: h(v), input_type=Union[int, str])]
-        c: Annotated[int, PlainValidator(lambda v: v, input_type=Union[int, str])]
+        a: Annotated[int, BeforeValidator(lambda v: v, json_schema_input_type=Union[int, str])]
+        b: Annotated[int, WrapValidator(lambda v, h: h(v), json_schema_input_type=Union[int, str])]
+        c: Annotated[int, PlainValidator(lambda v: v, json_schema_input_type=Union[int, str])]
         d: int
         e: int
 
-        @field_validator('d', mode='before', input_type=Union[int, str])
+        @field_validator('d', mode='before', json_schema_input_type=Union[int, str])
         @classmethod
         def validate_d(cls, value: Any) -> int: ...
 
-        @field_validator('d', mode='wrap', input_type=Union[int, str])
+        @field_validator('e', mode='wrap', json_schema_input_type=Union[int, str])
         @classmethod
         def validate_e(cls, value: Any, handler: ValidatorFunctionWrapHandler) -> int: ...
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6465,20 +6465,27 @@ def test_plain_field_validator_serialization() -> None:
     }
 
 
-def test_validator_input_type() -> None:
+def test_field_validator_input_type() -> None:
     class Model(BaseModel):
         a: Annotated[int, BeforeValidator(lambda v: v, input_type=Union[int, str])]
         b: Annotated[int, WrapValidator(lambda v, h: h(v), input_type=Union[int, str])]
         c: Annotated[int, PlainValidator(lambda v: v, input_type=Union[int, str])]
+        d: int
+
+        @field_validator('d', mode='before', input_type=Union[int, str])
+        @classmethod
+        def validate_d(cls, value: Any) -> int: ...
 
     assert Model.model_json_schema(mode='validation')['properties'] == {
         'a': {'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'title': 'A'},
         'b': {'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'title': 'B'},
         'c': {'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'title': 'C'},
+        'd': {'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'title': 'D'},
     }
 
     assert Model.model_json_schema(mode='serialization')['properties'] == {
         'a': {'title': 'A', 'type': 'integer'},
         'b': {'title': 'B', 'type': 'integer'},
         'c': {'title': 'C', 'type': 'integer'},
+        'd': {'title': 'D', 'type': 'integer'},
     }

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2898,3 +2898,14 @@ def test_validator_with_default_values() -> None:
 
     with pytest.raises(ValidationError):
         Model(x=-1)
+
+
+def test_field_validator_input_type_invalid_mode() -> None:
+    with pytest.raises(PydanticUserError, match=re.escape("`input_type` can't be used when mode is set to 'after'")):
+
+        class Model(BaseModel):
+            a: int
+
+            @field_validator('a', mode='after', input_type=Union[int, str])  # pyright: ignore
+            @classmethod
+            def validate_a(cls, value: Any) -> Any: ...

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2901,11 +2901,13 @@ def test_validator_with_default_values() -> None:
 
 
 def test_field_validator_input_type_invalid_mode() -> None:
-    with pytest.raises(PydanticUserError, match=re.escape("`input_type` can't be used when mode is set to 'after'")):
+    with pytest.raises(
+        PydanticUserError, match=re.escape("`json_schema_input_type` can't be used when mode is set to 'after'")
+    ):
 
         class Model(BaseModel):
             a: int
 
-            @field_validator('a', mode='after', input_type=Union[int, str])  # pyright: ignore
+            @field_validator('a', mode='after', json_schema_input_type=Union[int, str])  # pyright: ignore
             @classmethod
             def validate_a(cls, value: Any) -> Any: ...


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/8208

The annotated validators now have a `input_type` argument. Users can provide a type hint reflecting the allowed type for the validator. Unlike serializers where the type hint can be inferred from the return type annotation of the function, we don't allow this pattern in our case as we want to enforce the validator functions to check for any type (by using `typing.Any`).

TODO:
- [x] Update `field_validator` as well. This is going to be tricky as core schema from validators are created in `apply_validators`. This function has less flexibility as no `GetCoreSchemaHandler` is available, but we require one (or at least maybe an instance of the current `GenerateSchema`) to call `handler.generate_schema(input_type)`.
- [x] Decide if we want to default to `Any` for `input_type` (so that the JSON Schema for a model with a `PlainValidator` works out of the box). 

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
