### PR TITLE
fix model_dump json mode serialization issue

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -359,20 +359,38 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A dictionary representation of the model.
         """
-        return self.__pydantic_serializer__.to_python(
-            self,
-            mode=mode,
-            by_alias=by_alias,
-            include=include,
-            exclude=exclude,
-            context=context,
-            exclude_unset=exclude_unset,
-            exclude_defaults=exclude_defaults,
-            exclude_none=exclude_none,
-            round_trip=round_trip,
-            warnings=warnings,
-            serialize_as_any=serialize_as_any,
-        )
+        import json
+
+        if mode == 'json':
+            json_str = self.__pydantic_serializer__.to_json(
+                self,
+                include=include,
+                exclude=exclude,
+                context=context,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+                round_trip=round_trip,
+                warnings=warnings,
+                serialize_as_any=serialize_as_any,
+            ).decode()
+            return json.loads(json_str)
+        else:
+            return self.__pydantic_serializer__.to_python(
+                self,
+                mode=mode,
+                by_alias=by_alias,
+                include=include,
+                exclude=exclude,
+                context=context,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+                round_trip=round_trip,
+                warnings=warnings,
+                serialize_as_any=serialize_as_any,
+            )
 
     def model_dump_json(
         self,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3368,3 +3368,21 @@ def test_model_construct_with_model_post_init_and_model_copy() -> None:
 
     assert m == copy
     assert id(m) != id(copy)
+
+
+def test_model_dump_float_serialization():
+    """
+    This test checks the following:
+    - The `x` field, which is a float with a value of NaN, should be serialized as `null` in JSON.
+    - The `y` field, which is a Decimal, should be serialized correctly as a string representation of the decimal value.
+
+    """
+    from decimal import Decimal
+
+    class Model(BaseModel):
+        x: float
+        y: Decimal
+
+    result = Model(x=float('nan'), y=Decimal('12345')).model_dump(mode='json')
+
+    assert result == {'x': None, 'y': '12345'}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixed the serialization behavior of the `model_dump` method in cases where a float is `NaN`, ensuring it is correctly serialized as `null` in JSON format. Added corresponding unit tests to validate this behavior.

## Related issue number

fix #10037

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
