### PR TITLE
Do not compute JSON Schema default when plain serializers are used with `when_used` set to `'json-unless-none'` and the default value is `None`

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1043,17 +1043,17 @@ class GenerateJsonSchema:
         #     return json_schema
 
         # we reflect the application of custom plain, no-info serializers to defaults for
-        # json schemas viewed in serialization mode
+        # JSON Schemas viewed in serialization mode:
         # TODO: improvements along with https://github.com/pydantic/pydantic/issues/8208
-        # TODO: improve type safety here
-        if self.mode == 'serialization':
-            if (
-                (ser_schema := schema['schema'].get('serialization', {}))
-                and (ser_func := ser_schema.get('function'))
-                and ser_schema.get('type') == 'function-plain'  # type: ignore
-                and ser_schema.get('info_arg') is False  # type: ignore
-            ):
-                default = ser_func(default)  # type: ignore
+        if (
+            self.mode == 'serialization'
+            and (ser_schema := schema['schema'].get('serialization'))
+            and (ser_func := ser_schema.get('function'))
+            and ser_schema.get('type') == 'function-plain'
+            and not ser_schema.get('info_arg')
+            and not (default is None and ser_schema.get('when_used') == 'json-unless-none')
+        ):
+            default = ser_func(default)  # type: ignore
 
         try:
             encoded_default = self.encode_default(default)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6257,6 +6257,22 @@ def test_plain_serializer_applies_to_default() -> None:
     }
 
 
+def test_plain_serializer_does_not_apply_json_unless_none() -> None:
+    """Test plain serializers aren't used to compute the JSON Schema default if mode is 'json-unless-none'
+    and default value is `None`."""
+
+    class Model(BaseModel):
+        custom_decimal: Annotated[
+            Optional[Decimal], PlainSerializer(lambda x: float(x), when_used='json-unless-none', return_type=float)
+        ] = None
+
+    assert Model.model_json_schema(mode='serialization') == {
+        'properties': {'custom_decimal': {'default': None, 'title': 'Custom Decimal', 'type': 'number'}},
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
 def test_merge_json_schema_extra_from_field_infos() -> None:
     class Model(BaseModel):
         f: Annotated[str, Field(json_schema_extra={'a': 1, 'b': 2})]


### PR DESCRIPTION
Fixes #10118

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
