### PR TITLE
Add warning for double `frozen` config setting on dataclass

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -233,7 +233,7 @@ def dataclass(
             if config_wrapper.frozen:
                 # It's not recommended to define both, as the setting from the dataclass decorator will take priority.
                 warn(
-                    f'`frozen` is set via both the `dataclass` decorator and `config` for dataclass {cls.__name__}.'
+                    f'`frozen` is set via both the `dataclass` decorator and `config` for dataclass {cls.__name__!r}.'
                     'This is not recommended. The `frozen` specification on `dataclass` will take priority.',
                     category=UserWarning,
                     stacklevel=3,

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -233,9 +233,10 @@ def dataclass(
             if config_wrapper.frozen:
                 # It's not recommended to define both, as the setting from the dataclass decorator will take priority.
                 warn(
-                    f"`frozen` is set via both the 'dataclass' decorator and `config` for dataclass {cls.__name__}."
+                    f'`frozen` is set via both the `dataclass` decorator and `config` for dataclass {cls.__name__}.'
                     'This is not recommended. The `frozen` specification on `dataclass` will take priority.',
-                    UserWarning,
+                    category=UserWarning,
+                    stacklevel=3,
                 )
         else:
             frozen_ = config_wrapper.frozen or False

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -236,7 +236,7 @@ def dataclass(
                     f'`frozen` is set via both the `dataclass` decorator and `config` for dataclass {cls.__name__!r}.'
                     'This is not recommended. The `frozen` specification on `dataclass` will take priority.',
                     category=UserWarning,
-                    stacklevel=3,
+                    stacklevel=2,
                 )
         else:
             frozen_ = config_wrapper.frozen or False

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -3029,3 +3029,11 @@ def test_frozen_with_validate_assignment() -> None:
         inst.x = 'other'
     except ValidationError as e:
         assert 'Instance is frozen' in repr(e)
+
+
+def test_warns_on_double_frozen() -> None:
+    with pytest.warns(UserWarning, match='`frozen` is set via both the `dataclass` decorator and `config`'):
+
+        @pydantic.dataclasses.dataclass(frozen=True, config=ConfigDict(frozen=True))
+        class DC:
+            x: int


### PR DESCRIPTION
Adding a test to follow up with warning added via https://github.com/pydantic/pydantic/pull/10082