### PR TITLE
Handle `nullable` schemas with `serialization` schema available during JSON Schema generation

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -490,8 +490,14 @@ class GenerateJsonSchema:
             # Generate the core-schema-type-specific bits of the schema generation:
             json_schema: JsonSchemaValue | None = None
             if self.mode == 'serialization' and 'serialization' in schema_or_field:
+                # In this case, we skip the JSON Schema generation of the schema
+                # and use the `'serialization'` schema instead (canonical example:
+                # `Annotated[int, PlainSerializer(str)]`).
                 ser_schema = schema_or_field['serialization']  # type: ignore
                 json_schema = self.ser_schema(ser_schema)
+
+                # It might be that the 'serialization'` is skipped depending on `when_used`.
+                # This is only relevant for `nullable` schemas though, so we special case here.
                 if (
                     json_schema is not None
                     and ser_schema.get('when_used') in ('unless-none', 'json-unless-none')

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -492,6 +492,12 @@ class GenerateJsonSchema:
             if self.mode == 'serialization' and 'serialization' in schema_or_field:
                 ser_schema = schema_or_field['serialization']  # type: ignore
                 json_schema = self.ser_schema(ser_schema)
+                if (
+                    json_schema is not None
+                    and ser_schema.get('when_used') in ('unless-none', 'json-unless-none')
+                    and schema_or_field['type'] == 'nullable'
+                ):
+                    json_schema = self.get_flattened_anyof([{'type': 'null'}, json_schema])
             if json_schema is None:
                 if _core_utils.is_core_schema(schema_or_field) or _core_utils.is_core_schema_field(schema_or_field):
                     generate_for_schema_type = self._schema_type_to_method[schema_or_field['type']]
@@ -1051,7 +1057,7 @@ class GenerateJsonSchema:
             and (ser_func := ser_schema.get('function'))
             and ser_schema.get('type') == 'function-plain'
             and not ser_schema.get('info_arg')
-            and not (default is None and ser_schema.get('when_used') == 'json-unless-none')
+            and not (default is None and ser_schema.get('when_used') in ('unless-none', 'json-unless-none'))
         ):
             try:
                 default = ser_func(default)  # type: ignore

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6268,17 +6268,31 @@ def test_plain_serializer_applies_to_default() -> None:
     }
 
 
-def test_plain_serializer_does_not_apply_json_unless_none() -> None:
+def test_plain_serializer_does_not_apply_with_unless_none() -> None:
     """Test plain serializers aren't used to compute the JSON Schema default if mode is 'json-unless-none'
     and default value is `None`."""
 
     class Model(BaseModel):
-        custom_decimal: Annotated[
+        custom_decimal_json_unless_none: Annotated[
             Optional[Decimal], PlainSerializer(lambda x: float(x), when_used='json-unless-none', return_type=float)
+        ] = None
+        custom_decimal_unless_none: Annotated[
+            Optional[Decimal], PlainSerializer(lambda x: float(x), when_used='unless-none', return_type=float)
         ] = None
 
     assert Model.model_json_schema(mode='serialization') == {
-        'properties': {'custom_decimal': {'default': None, 'title': 'Custom Decimal', 'type': 'number'}},
+        'properties': {
+            'custom_decimal_json_unless_none': {
+                'anyOf': [{'type': 'null'}, {'type': 'number'}],
+                'default': None,
+                'title': 'Custom Decimal Json Unless None',
+            },
+            'custom_decimal_unless_none': {
+                'anyOf': [{'type': 'null'}, {'type': 'number'}],
+                'default': None,
+                'title': 'Custom Decimal Unless None',
+            },
+        },
         'title': 'Model',
         'type': 'object',
     }


### PR DESCRIPTION
As per https://github.com/pydantic/pydantic/pull/10121/files#r1715043570:

It might be that the `serialization` schema has a specific `when_used` mode set to `unless-none` or `json-unless-none`. In that case, if the base core schema is of type `nullable`, we need to account for this as the `serialization` schema might not be used.

This also fixes an issue where `unless-none` was not taken into account when trying to figure out if the default value should be passed into the plain serializer function to get the JSON Schema default. This was missed in https://github.com/pydantic/pydantic/pull/10121.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
