### PR TITLE
Fix mypy v1 plugin for mypy 1.11 release

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -499,7 +499,7 @@ class PydanticModelTransformer:
             tvd = TypeVarType(
                 self_tvar_name,
                 tvar_fullname,
-                TypeVarId(-1),
+                TypeVarId(-1, namespace=ctx.cls.fullname + '.construct') if MYPY_VERSION_TUPLE >= (1, 11) else TypeVarId(-1),
                 [],
                 obj_type,
                 AnyType(TypeOfAny.from_omitted_generics),  # type: ignore[arg-type]

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -499,7 +499,11 @@ class PydanticModelTransformer:
             tvd = TypeVarType(
                 self_tvar_name,
                 tvar_fullname,
-                TypeVarId(-1, namespace=ctx.cls.fullname + '.construct') if MYPY_VERSION_TUPLE >= (1, 11) else TypeVarId(-1),
+                (
+                    TypeVarId(-1, namespace=ctx.cls.fullname + '.construct')
+                    if MYPY_VERSION_TUPLE >= (1, 11)
+                    else TypeVarId(-1)
+                ),
                 [],
                 obj_type,
                 AnyType(TypeOfAny.from_omitted_generics),  # type: ignore[arg-type]

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -9,4 +9,6 @@ pre-commit==2.20.0
 pycodestyle==2.11.1
 pyflakes==3.1.0
 twine==4.0.1
+# So twine doesn't crash with a keyerror, https://github.com/pypa/twine/issues/1125
+importlib-metadata==7.2.1
 tomli==2.0.1 # to squelch mypy warnings about types

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -8,7 +8,5 @@ mypy==0.971
 pre-commit==2.20.0
 pycodestyle==2.11.1
 pyflakes==3.1.0
-twine==4.0.1
-# So twine doesn't crash with a keyerror, https://github.com/pypa/twine/issues/1125
-importlib-metadata==7.2.1
+twine==5.1.1
 tomli==2.0.1 # to squelch mypy warnings about types


### PR DESCRIPTION
## Change Summary

Repairs the mypy plugin for pydantic v1 by passing a `namespace` when defining a `TypeVarId` for `mypy>=1.11`. This is a continuation on the changes in #9586 which missed the new `namespace` argument from https://github.com/python/mypy/pull/17311

I arrived at these changes by bisecting mypy, via my own project that got stuck at the issue in #10000, and ending up at https://github.com/python/mypy/pull/17311.

https://github.com/python/mypy/pull/17311 includes similar changes to the one found in here for mypy's `attrs` plugin:

https://github.com/python/mypy/blob/8332c6e7992fa9655b79ef55c410a805ad1e6d34/mypy/plugins/attrs.py#L841-L843

I know this is part of `1.10.x` but I found the quite recent https://github.com/pydantic/pydantic/issues/10000#issuecomment-2260358228 that you could consider a PR with a fix. I hope this is still OK. I'm also hoping I'm doing the right thing here by opening a PR towards `1.10.x-fixes` instead of `main`.

## Related issue number

fix #10000 

- Refs https://github.com/python/mypy/pull/17311
- Refs #9586

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

skip change file check


Selected Reviewer: @hramezani