### PR TITLE
fix: discriminator key used when discriminator has alias and schema g…

### DIFF
--- a/pydantic/schema.py
+++ b/pydantic/schema.py
@@ -738,7 +738,7 @@ def field_singleton_sub_fields_schema(
                     discriminator_models_refs[discriminator_value] = discriminator_model_ref['$ref']
 
             s['discriminator'] = {
-                'propertyName': field.discriminator_alias,
+                'propertyName': field.discriminator_alias if by_alias else field.discriminator_key,
                 'mapping': discriminator_models_refs,
             }
 


### PR DESCRIPTION
## Change Summary

Fixes an issue in pydantic v1 whereby a discriminated union model where the discriminated field has an alias does not get the field _name_ propagated to the schema's `discriminator.propertyName` when the model has `.schema(by_alias=False)` called.

## Related issue number

fix #10131 

skip change file check

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

skip file change check

Selected Reviewer: @samuelcolvin