### PR TITLE
Refactor how `field_validator` decorators are applied during core schema generation

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union, cast, overload
 
 from pydantic_core import core_schema
 from pydantic_core import core_schema as _core_schema
-from typing_extensions import Annotated, Literal, TypeAlias
+from typing_extensions import Annotated, Literal, Self, TypeAlias
 
 from . import GetCoreSchemaHandler as _GetCoreSchemaHandler
 from ._internal import _core_metadata, _decorators, _generics, _internal_dataclass
@@ -80,6 +80,10 @@ class AfterValidator:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
             return core_schema.no_info_after_validator_function(func, schema=schema)
 
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(func=decorator.func)
+
 
 @dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
 class BeforeValidator:
@@ -123,6 +127,13 @@ class BeforeValidator:
         else:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
             return core_schema.no_info_before_validator_function(func, schema=schema)
+
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(
+            func=decorator.func,
+            input_type=decorator.info.input_type,
+        )
 
 
 @dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
@@ -176,6 +187,13 @@ class PlainValidator:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
             return core_schema.no_info_plain_validator_function(func, serialization=serialization)
 
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(
+            func=decorator.func,
+            input_type=decorator.info.input_type,
+        )
+
 
 @dataclasses.dataclass(frozen=True, **_internal_dataclass.slots_true)
 class WrapValidator:
@@ -226,6 +244,13 @@ class WrapValidator:
         else:
             func = cast(core_schema.NoInfoWrapValidatorFunction, self.func)
             return core_schema.no_info_wrap_validator_function(func, schema=schema)
+
+    @classmethod
+    def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:
+        return cls(
+            func=decorator.func,
+            input_type=decorator.info.input_type,
+        )
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Required by https://github.com/pydantic/pydantic/pull/10094.

This reduces code duplication, as the only source of truth is now defined in the `__get_pydantic_core_schema__` methods. The `apply_validators` function is kept for deprecated decorators but will be removed at some point.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
