### PR TITLE
Fix core schema simplification when serialization schemas are involved in specific scenarios

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -212,6 +212,7 @@ class _WalkCoreSchema:
     def _handle_ser_schemas(self, ser_schema: core_schema.SerSchema, f: Walk) -> core_schema.SerSchema:
         schema: core_schema.CoreSchema | None = ser_schema.get('schema', None)
         if schema is not None:
+            ser_schema = ser_schema.copy()
             ser_schema['schema'] = self.walk(schema, f)  # type: ignore
         return_schema: core_schema.CoreSchema | None = ser_schema.get('return_schema', None)
         if return_schema is not None:

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -3,11 +3,14 @@ Tests for internal things that are complex enough to warrant their own unit test
 """
 
 from dataclasses import dataclass
+from typing import Sequence
 
 import pytest
 from pydantic_core import CoreSchema, SchemaValidator
 from pydantic_core import core_schema as cs
+from typing_extensions import Annotated
 
+from pydantic import BaseModel, PlainValidator
 from pydantic._internal._core_utils import (
     HAS_INVALID_SCHEMAS_METADATA_KEY,
     Walk,
@@ -207,3 +210,41 @@ def test_schema_is_valid():
         collect_invalid_schemas(cs.nullable_schema(cs.int_schema(metadata={HAS_INVALID_SCHEMAS_METADATA_KEY: True})))
         is True
     )
+
+
+def test_walk_core_schema_copies_ser_schema() -> None:
+    """Regression test for https://github.com/pydantic/pydantic/issues/9319.
+
+    In some specific scenarios during schema references simplification,
+    the inner schema of the `'serialization'` core schemas aren't properly copied,
+    resulting in the mutation of the original `__pydantic_core_schema__` dict of a model.
+    """
+
+    class Model1(BaseModel):
+        pass
+
+    class Model2(BaseModel):
+        model1: Annotated[Model1, PlainValidator(lambda _: Model1())]
+
+    ser_schema_type = Model2.__pydantic_core_schema__['schema']['fields']['model1']['schema']['serialization'][
+        'schema'
+    ]['type']
+
+    # `PlainValidator` creates a ser. core schema (see https://github.com/pydantic/pydantic/pull/8567#discussion_r1459110715
+    # for more context). In our case, the inner core schema of the ser. schema is the core schema of `Model1`.
+    assert ser_schema_type == 'model'
+
+    class Model3(BaseModel):
+        # Using `Sequence` (instead of e.g. `list`) generates a `'json-or-python'` core schema.
+        # It is still unclear why, but this is a necessary condition to reproduce the issue
+        model2: Sequence[Model2]
+
+    # During the simplification of schema references, the previously defined ser. schema of our `PlainValidator`
+    # is changed (by doing `ser_schema['schema'] = self.walk(schema, f)`). However it wasn't copied properly before
+    # doing so. This resulted in the original `Model2.__pydantic_core_schema__` to be modified, by having a leftover
+    # `'definition-ref'` schema in place of a proper `'model'` schema.
+    ser_schema_type = Model2.__pydantic_core_schema__['schema']['fields']['model1']['schema']['serialization'][
+        'schema'
+    ]['type']
+
+    assert ser_schema_type == 'model'  # 'definition-ref' without the dict copy.


### PR DESCRIPTION
Fixes #9319

After a lot of debugging in the core schema generation internals, I managed to find where the issue was coming from. I'm still unsure why using a `Sequence` instead of a `list` leads to the original issue. My best guess is that is it purely a coincidence: `Sequence` creates a different core schema, and probably it led to a really specific scenario where _not_ having the serialization schema copied would result in a crash later on as the `Model1` definition wasn't saved retained (I suspect this issue where the serialization schema isn't copied already happened in other cases, but had no incident). 

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
