### PR TITLE
Improve runtime errors for string constraints like `pattern` for incompatible types

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -240,7 +240,9 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         #  else, apply a function after validator to the schema to enforce the corresponding constraint
         if constraint in chain_schema_constraints:
 
-            def _apply_constraint_with_incompatibility_info(value: Any, handler: cs.ValidatorFunctionWrapHandler):
+            def _apply_constraint_with_incompatibility_info(
+                value: Any, handler: cs.ValidatorFunctionWrapHandler
+            ) -> Any:
                 try:
                     x = handler(value)
                 except ValidationError as ve:

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -246,6 +246,11 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
                 try:
                     x = handler(value)
                 except ValidationError as ve:
+                    # if the error is about the type, it's likely that the constraint is incompatible the type of the field
+                    # for example, the following invalid schema wouldn't be caught during schema build, but rather at this point
+                    # with a cryptic 'string_type' error coming from the string validator,
+                    # that we'd rather express as a constraint incompatibility error (TypeError)
+                    # Annotated[list[int], Field(pattern='abc')]
                     if 'type' in ve.errors()[0]['type']:
                         raise TypeError(
                             f"Unable to apply constraint '{constraint}' to supplied value {value} for schema of type '{schema_type}'"  # noqa: B023

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -240,7 +240,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         #  else, apply a function after validator to the schema to enforce the corresponding constraint
         if constraint in chain_schema_constraints:
 
-            def _apply_constraint_with_incompatibility_info(value, handler):
+            def _apply_constraint_with_incompatibility_info(value: Any, handler: cs.ValidatorFunctionWrapHandler):
                 try:
                     x = handler(value)
                 except ValidationError as ve:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1802,14 +1802,7 @@ def test_enum_with_no_cases() -> None:
 @pytest.mark.parametrize(
     'kwargs,type_,a',
     [
-        pytest.param(
-            {'pattern': '^foo$'},
-            int,
-            1,
-            marks=pytest.mark.xfail(
-                reason='int cannot be used with pattern but we do not currently validate that at schema build time'
-            ),
-        ),
+        ({'pattern': '^foo$'}, int, 1),
         ({'gt': 0}, conlist(int, min_length=4), [1, 2, 3, 4, 5]),
         ({'gt': 0}, conset(int, min_length=4), {1, 2, 3, 4, 5}),
         ({'gt': 0}, confrozenset(int, min_length=4), frozenset({1, 2, 3, 4, 5})),


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/10151

I suppose you could say this is contributing to https://github.com/pydantic/pydantic/issues/10036

Admittedly, this adds another custom wrap validator which is slower, but I think the behavior is better, and this is for a case that's already slow.