### PR TITLE
Added section in Migration Guide: `constr` constraints order changed

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -535,10 +535,12 @@ Therefore, this snippet, while working in Pydantic V1, will result in a `Validat
 ```py
 from pydantic import BaseModel, constr
 
-class Foo(BaseModel):
-    bar: constr(strip_whitespace=True, to_upper=True, pattern=r'^[A-Z]+$')
 
-foo = Foo(bar='  hello  ')
+class Foo(BaseModel):
+    bar: constr(strip_whitespace=True, to_upper=True, pattern=r"^[A-Z]+$")
+
+
+foo = Foo(bar="  hello  ")
 print(foo)
 """
 1 validation error for Foo
@@ -556,16 +558,18 @@ from pydantic import BaseModel, StringConstraints
 from pydantic.functional_validators import AfterValidator
 from typing_extensions import Annotated
 
+
 class Foo(BaseModel):
     bar: Annotated[
         str,
-        AfterValidator(lambda s: s.strip().upper()), 
-        StringConstraints(pattern=r'^[A-Z]+$')
+        AfterValidator(lambda s: s.strip().upper()),
+        StringConstraints(pattern=r"^[A-Z]+$"),
     ]
 
-foo = Foo(bar='  hello  ')
+
+foo = Foo(bar="  hello  ")
 print(foo)
-#> bar='HELLO'
+# > bar='HELLO'
 ```
 
 `After` validators run after Pydantic's internal parsing, so we still benefit from the type validation.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* `constr` constraints order changed between Pydantic V1 and Pydantic V2
* Current Migration Guide does not make mention of this breaking change
* This PR is just an update to the Migration Guide to highlight the change
* It also provides a working snippet to achieve original V1 behavior in V2

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
#8577, especially https://github.com/pydantic/pydantic/issues/8577#issuecomment-2287696991

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
