### PR TITLE
Fix JSON Schema generation of fields with plain validators in serialization mode

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -211,12 +211,13 @@ class _WalkCoreSchema:
 
     def _handle_ser_schemas(self, ser_schema: core_schema.SerSchema, f: Walk) -> core_schema.SerSchema:
         schema: core_schema.CoreSchema | None = ser_schema.get('schema', None)
-        if schema is not None:
-            ser_schema = ser_schema.copy()
-            ser_schema['schema'] = self.walk(schema, f)  # type: ignore
         return_schema: core_schema.CoreSchema | None = ser_schema.get('return_schema', None)
-        if return_schema is not None:
-            ser_schema['return_schema'] = self.walk(return_schema, f)  # type: ignore
+        if schema is not None or return_schema is not None:
+            ser_schema = ser_schema.copy()
+            if schema is not None:
+                ser_schema['schema'] = self.walk(schema, f)  # type: ignore
+            if return_schema is not None:
+                ser_schema['return_schema'] = self.walk(return_schema, f)  # type: ignore
         return ser_schema
 
     def handle_definitions_schema(self, schema: core_schema.DefinitionsSchema, f: Walk) -> core_schema.CoreSchema:

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -162,7 +162,11 @@ class PlainValidator:
 
         try:
             schema = handler(source_type)
-            serialization = core_schema.wrap_serializer_function_ser_schema(function=lambda v, h: h(v), schema=schema)
+            serialization = core_schema.wrap_serializer_function_ser_schema(
+                function=lambda v, h: h(v),
+                schema=schema,
+                return_schema=schema,
+            )
         except PydanticSchemaGenerationError:
             serialization = None
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -48,6 +48,7 @@ from pydantic import (
     ImportString,
     InstanceOf,
     PlainSerializer,
+    PlainValidator,
     PydanticDeprecatedSince20,
     PydanticUserError,
     RootModel,
@@ -6383,3 +6384,19 @@ def test_ta_and_bm_same_json_schema() -> None:
 def test_min_and_max_in_schema() -> None:
     TSeq = TypeAdapter(Annotated[Sequence[int], Field(min_length=2, max_length=5)])
     assert TSeq.json_schema() == {'items': {'type': 'integer'}, 'maxItems': 5, 'minItems': 2, 'type': 'array'}
+
+
+def test_plain_field_validator_serialization() -> None:
+    """`PlainValidator` internally creates a wrap ser. schema. This tests that we can
+    still generate a JSON Schema in `'serialization'` mode.
+    """
+
+    class Foo(BaseModel):
+        a: Annotated[int, PlainValidator(lambda x: x)]
+
+    assert Foo.model_json_schema(mode='serialization') == {
+        'properties': {'a': {'title': 'A', 'type': 'integer'}},
+        'required': ['a'],
+        'title': 'Foo',
+        'type': 'object',
+    }


### PR DESCRIPTION
As per https://github.com/pydantic/pydantic/pull/10094#discussion_r1719994354.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
