### PR TITLE
Fix JSON Schema `number` type for literal and enum schemas

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -748,7 +748,7 @@ class GenerateJsonSchema:
         elif types == {int}:
             result['type'] = 'integer'
         elif types == {float}:
-            result['type'] = 'numeric'
+            result['type'] = 'number'
         elif types == {bool}:
             result['type'] = 'boolean'
         elif types == {list}:
@@ -787,7 +787,7 @@ class GenerateJsonSchema:
         elif isinstance(enum_type, int) or types == {int}:
             result['type'] = 'integer'
         elif isinstance(enum_type, float) or types == {float}:
-            result['type'] = 'numeric'
+            result['type'] = 'number'
         elif types == {bool}:
             result['type'] = 'boolean'
         elif types == {list}:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2311,7 +2311,7 @@ def test_literal_schema():
             'b': {'const': 'a', 'enum': ['a'], 'title': 'B', 'type': 'string'},
             'c': {'enum': ['a', 1], 'title': 'C'},
             'd': {'enum': ['a', 'b', 1, 2], 'title': 'D'},
-            'e': {'const': 1.0, 'enum': [1.0], 'title': 'E', 'type': 'numeric'},
+            'e': {'const': 1.0, 'enum': [1.0], 'title': 'E', 'type': 'number'},
             'f': {'const': ['a', 1], 'enum': [['a', 1]], 'title': 'F', 'type': 'array'},
         },
         'required': ['a', 'b', 'c', 'd', 'e', 'f'],
@@ -2366,7 +2366,7 @@ def test_literal_types() -> None:
     # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         '$defs': {
-            'FloatEnum': {'enum': [123.0, 123.1], 'title': 'FloatEnum', 'type': 'numeric'},
+            'FloatEnum': {'enum': [123.0, 123.1], 'title': 'FloatEnum', 'type': 'number'},
             'ListEnum': {'enum': [[123], [456]], 'title': 'ListEnum', 'type': 'array'},
         },
         'properties': {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/10163

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
