### PR TITLE
Remove `typed_dict_cls` data from `CoreMetadata`

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:4f6c25c6596d9ef5e4af591eb21e8a869bfbf8343ebf78032325c6d7a735a8de"
+content_hash = "sha256:b2b67fad4dd6af7f8f1cd52fba813f474f79d31419b0210f47bce8d60fdd9117"
 
 [[metadata.targets]]
 requires_python = ">=3.8"
@@ -1039,7 +1039,7 @@ files = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.31"
+version = "9.5.32"
 requires_python = ">=3.8"
 summary = "Documentation that simply works"
 dependencies = [
@@ -1056,8 +1056,8 @@ dependencies = [
     "requests~=2.26",
 ]
 files = [
-    {file = "mkdocs_material-9.5.31-py3-none-any.whl", hash = "sha256:1b1f49066fdb3824c1e96d6bacd2d4375de4ac74580b47e79ff44c4d835c5fcb"},
-    {file = "mkdocs_material-9.5.31.tar.gz", hash = "sha256:31833ec664772669f5856f4f276bf3fdf0e642a445e64491eda459249c3a1ca8"},
+    {file = "mkdocs_material-9.5.32-py3-none-any.whl", hash = "sha256:f3704f46b63d31b3cd35c0055a72280bed825786eccaf19c655b44e0cd2c6b3f"},
+    {file = "mkdocs_material-9.5.32.tar.gz", hash = "sha256:38ed66e6d6768dde4edde022554553e48b2db0d26d1320b19e2e2b9da0be1120"},
 ]
 
 [[package]]
@@ -1246,102 +1246,102 @@ files = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.22.0"
+version = "2.23.0"
 requires_python = ">=3.8"
 summary = "Core functionality for Pydantic validation and serialization"
 dependencies = [
     "typing-extensions!=4.7.0,>=4.6.0",
 ]
 files = [
-    {file = "pydantic_core-2.22.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:83fec9cddd471b1aefce3229e94f45d879f332ebd9c2ff138cd5cdf8c72e985d"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1e3d4c224a9846a401fd3e02ca5be246d55e368e468ef373665507bd4772645"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf9737357c03925c1e5597ffe4d60df5749c6d3f4ea7d8cf9827d0d17047f430"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:beedd1b5f071f489aa4876513b2303c150edb53b29d47b2994c940320499b36f"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:81d033f4ab585e4bdd29394f38e2b02dfb743b4633e0855f2f2be142cac9e579"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a7d8e3f7f9835591f99e594d985d26dcca1a40f1e20745f5490e2b6c4f9fec5"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2519bdf41f7bcf0af8a9c4f79de176729ced0bb8b3b37dbbaab4b63b52a6485e"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5295be60b33438dfac79a31a9b9aaf4f7c640032f93d215a00123bdc2c4b0e1f"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b5c10d7fab71d4671c388db710b3e98b30130ab1e6b04cdbf058ac9aae6dbe7b"},
-    {file = "pydantic_core-2.22.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:339acae553816d7b3279833356c44efe996f31f8a3e1b19f4c633fd8998ba86b"},
-    {file = "pydantic_core-2.22.0-cp310-none-win32.whl", hash = "sha256:2a5dac12dd64c88208e11e9ee32469922a9aa47f874d19af68111466d64b33a5"},
-    {file = "pydantic_core-2.22.0-cp310-none-win_amd64.whl", hash = "sha256:8e0671d56313eab29e551117a049aeb552b11c8b2eb39f3a6377ee5bd83ccb94"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:def75e81ff5be2caef8becd1c5c000c80060fe39976e2fd313698350615d6c64"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:eb1f82b4883245f4d04329d6ac8a4e82b131e4f7bbc57020805b2dbdb6ed78c3"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92bc5640af67ca720bb2cdc05f95b4fccf03eb35f8713204fbfb1fe5ac05d34d"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f85416dbd68141e0996603ee0d99b00a383fb47d4668b61595c4987507094db9"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b16e89256b5987c94d3bed37e26f72beba211d1ba604b8c4a17f8466881cadb"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef5704efcb56d3d62e8f75a2a09321488e8af8f167b9658348639a623ce5f598"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:350a72f030b7186ca3a7d501ca7188deb3251ebf0de58fc8ad19bc0d870df2e0"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:726ab817e3bd90a3fa6538e3ff7f37645befdd1761e3a995be40635d3df89ae9"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:646a3c23391b49ba270b98afe712fb4cb43d21ee0a9eda6b708367832086e8cb"},
-    {file = "pydantic_core-2.22.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a3720dec4062432fc171424a2e8ba73d65842454c6ad8b70669e64598d9784b1"},
-    {file = "pydantic_core-2.22.0-cp311-none-win32.whl", hash = "sha256:89f0b7a13d3979c15fa2065b5eac62910fa22735cf5eda3eff1ceecb880afe87"},
-    {file = "pydantic_core-2.22.0-cp311-none-win_amd64.whl", hash = "sha256:fe12e0ad53281dbf4a6ba2d4400e24ae22d706c35b33dd7605b1433e0cc2d1b6"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c5a0d2eebfc15edcf2836e883e9466c61459773204c83fff2f6031f2b1cd44f2"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9e9ecf03b1ed8556f9ba06470aac36c82ed907407132f4aa770c06dba85d4600"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baf9ed0c28e51cd0bfa520dad6cb63699efbd369da276e6e37cb5f48c9d6c1e9"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:27e862e20f01286130119614fc58d0cc82b149fe9ea9981f5743b58fecf30ff6"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a9c6a1572da935ef3666d3f54937d43af9fee4e8712bb50473d06c6d3fc6aec"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5de7b43d01badcd8f1eac2040f971beabb11ce5542cee7c7894f6564e683776"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74d69a99b1f23620d7ceb9b0cd970b9060e8f4ef25e1231bf9feca88c0387dde"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c5c2369b5c443d7224da5454c9375768467fd3072cdc0406176e38b6d28307b"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d01d5be4fb2e97202311488eeb6d93ff39f1ced0bfe5bdb29d678bb1956c3c84"},
-    {file = "pydantic_core-2.22.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b0fbc33b40ef15437a31a907db56a726ee215231037e14a4bf4a723b928fb3d9"},
-    {file = "pydantic_core-2.22.0-cp312-none-win32.whl", hash = "sha256:773f23468d7c5ca2b35f7892ecf6409ded74253d42d539d3ff6c9edd634ce3d8"},
-    {file = "pydantic_core-2.22.0-cp312-none-win_amd64.whl", hash = "sha256:607a38af629f93513a29b7cc7ea6c131b084afa2077852342c1a792083951a9f"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e2fa6b820cbfe1b5af777f3dc1969f91be26266b3fcb761ab632d50d668b3ece"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f796b31ec01aee5f197b334c3e42a5eb0e87405bc62da8dcfad1e428eb79f829"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d084f60d9bb393295f2570b43b8b993b1a117a11c29daf3e81fa4a660ebd2d4"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d71c3ebcae6ceab1223bf0521c2d00ea1dacd0527514147dabe1f29762a15e7"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42d3cc9f2dec462af572931f4cdf09f26e7e3684b737b3986eaf809856df48b9"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bdcfe490aade7134bbe62a59f6d460abcdee8365a76fa7f0e6ecbbe9039b540e"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52a5917806a0e76c53cefbe98341178a96f6373fc318ec4edc7daf11c399111"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0ea740d768bbc039a3b584b5db876bdffce6c6dfd2c759608374aeced6fe3466"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c7688a20a3fc36963cf66464d30154e2f226f2833e497b11b966c6c38107f76f"},
-    {file = "pydantic_core-2.22.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c055adfd8379a82c813dca1554fe62ce9ae886f90b21914cd34e14b806f8499c"},
-    {file = "pydantic_core-2.22.0-cp313-none-win32.whl", hash = "sha256:f94296856b2f84fd560923f122a5b7b5a14cc20386c3d6dcb3d96bd9e3da9ce4"},
-    {file = "pydantic_core-2.22.0-cp313-none-win_amd64.whl", hash = "sha256:ef36683823b2bafbac662247caa259c7e0a8e6019f434ee17ee003aacd06e8a0"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:31ee29b22b9c7381fd76e5c68a7c7288f2acd2aa131313db96c649734557c510"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c170337fecf3e929b11b31585619d281826cd172552fcbffe18e75b021458b64"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a177d1102e98a1fe3daaf77c9eea9299766a3c5bea940185008acffc83c08b22"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43a85873c0f0dae6c1d013d46f33951369f6eccf97e51980c9653feb8d50c021"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6ec75aca91b69968d2dc58c73da337e658741d7d37abb842096e6694e17b8fb"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97094bc16172981e291cdcf51fa9a8450cee6b5cefdf686b09cea9fd9c6508d1"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c91847a23392b0f88963b8bcc9aa11236a67a6b31d041574d2daf978403745f2"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:daee7d862a2c6ba42e83cbe1d4dc2bce53cce0bd10b884f2c820a36d50049f0c"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b3b88e0395ba632b83e17df89823f41196685ccee0d6bffef127a12078489808"},
-    {file = "pydantic_core-2.22.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:103775eccfb3e5d32ba2d570af9a233785157ffba23b915938c3664b2e646cb5"},
-    {file = "pydantic_core-2.22.0-cp38-none-win32.whl", hash = "sha256:acd192bf80dbab6f2bf1a0e394890685fb9bb183c49a509076805ca75044a525"},
-    {file = "pydantic_core-2.22.0-cp38-none-win_amd64.whl", hash = "sha256:d8f777318932e1c372330651f5b34bae5e2594fce5859ce9b08c57f0c5ddac05"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:ce388f4003310e40f1298a2eeee3d14c52730051bce402c1b2cacd32cf11c17f"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:07cd8f316cb266ea8c859036d36ad2d23627b77702e556e0eb57efd5ea0d65bf"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f03bbea8776270115452022c5b7c43da424f13933f3a48157fd20f0ca469e1c9"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c9a7257b11efeaee0d467ba7a0bbec443af69ee4f2787db051220c3054bb8541"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:97a446beec55f26c1b591cdf9ab47f15378c89a01c830463cf3dc7c97a7f137a"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3aa6c09ecafeea2ceb8ce501a3a358a4c7d129a7f7da0f72302ddd03973d3182"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3beee4e9975e3d70ebcceec68f822a29d31ff3f437ba594db02502ee94513bcb"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8819378010cf00d7b555949b7dfa5ea60b859cc85a683c3c551f98bfa3cbf61e"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9e7546bb8bf635407196708502c96525637d0af0774e0df581dabbcd4b58541c"},
-    {file = "pydantic_core-2.22.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:fb6c5acc629e3cbee480a1ac86ec5265ca1d1404172e888dc2ed5816c4db7dc6"},
-    {file = "pydantic_core-2.22.0-cp39-none-win32.whl", hash = "sha256:25bf28cfa929aabffe616205bec8033f8674388b3742db8bd81ddcfbb40e6d64"},
-    {file = "pydantic_core-2.22.0-cp39-none-win_amd64.whl", hash = "sha256:7bba17b329b3f7f686795e03c9f20978065b8020d6c711f349e7781f0a67e306"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5424d9a8c4df366d7d95f14a854e6d9f40a2cebcbc85cc2fe7f255e58ff791fe"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:ae88c67082c518c65e029d22be1051577522dcf56677d00820652964f6295865"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d26f14d9e27dc43a5b2e4458370c567e43ce98ec08bfa7381200ac22faf8983d"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afed4e30ef27800cf0149f37ea2c7910dd4f8386df243c60aea5ea2fafd56331"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:39796a914577b3b751fe15b87c7618e8cbf7543b101ecc756a46767fa32b2526"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:95579d21aee389315fd0c549efc07b3832cf053cff374f3b865423e11385e108"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:396aaa4056adee4117767cb21c3708cde4bd2f80b7cc3b1c4b251abac85f948b"},
-    {file = "pydantic_core-2.22.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e340fe2aff8f4c8954e46d46650bede97b5a1db85d704b6bd1da137bdf1fa54f"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:44f7bd2e859b1168202091c4ca1b030a54cc64f408020f4b90f060868f8339ee"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:50fe2f17751a5facb0090e26ca3281992cf0df09cd4778915a56ab6f116e0bab"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02fd95cc7b1c7b7efe38a050e73f9529d37a12a325dd659728bd77769120d6a8"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b62633b55f67543f61c2b4c0014424ffc271ace83ef871577c20815009948e0"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f107ec7bc92cb3799814322e426a7c154c162bd397c3dd195e4f94dbcd62a671"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a63d1efccfa06fce1a2921cc7c9158889ca60a1be5b5d38f07529d77e663b9f5"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fc06df6aeba6d430ad97fb44106fd9ef88d372b34b9144a3f72609520d8f72bf"},
-    {file = "pydantic_core-2.22.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:520aad1d5316cc6cd31a1b89b753ab2e917d9fdd75215d1baf90f50187f7fa10"},
-    {file = "pydantic_core-2.22.0.tar.gz", hash = "sha256:2a05b1b367888d841da8497fb00bc003a61cf930f38aa01c61f0bf99b3d11db6"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c3ed715355de44fd1ad5e2347ae9d8b48c12423a938174accd98f3c21cd35141"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e1eaba0496f00923f125bea4ce2ec2ad7b32753d037ad456ea8b971888ccebf"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4cd64a16bdd44ea2120e5592818b1391b22adb02632ca4438897b10c07ef62a"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:843c98c21b7cd80b0e6f8a44e84fc6ebe63a823b991c337361d1e9141a7d753d"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:848727b22f9117b826a5cc769a874c8a218ab994a455a739fee1aaab611e10f8"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3afe0158f5ee4ba5a0b468dbd3adc46e1c460a2de10ab6af19cab7ccf2831aaa"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5d6c3a0a5f3a1c0c7d57acbb1cce592525959414b8f0b79e00d123b8f979d8b"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6f4806078005609da8957757ec41632da08ae33d2e12ce9b82a03e0f9bd9296a"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f288373c599466a3977b6305e8ff21ed81465b8c5b5ba2b1a160c89ad6a09285"},
+    {file = "pydantic_core-2.23.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b0749590fa48c99d93670d2b6a452e0b08c0accd39d86e7579ed176fd8ce9687"},
+    {file = "pydantic_core-2.23.0-cp310-none-win32.whl", hash = "sha256:f6f2083e9e2250ea7563a809dc28f4df1c4f78a0f8191fc82755bb9edff438a4"},
+    {file = "pydantic_core-2.23.0-cp310-none-win_amd64.whl", hash = "sha256:30bab73daf1cbd751fb925fbf43c932dc5edfd694af2ee6d207bf9daccf86abd"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c174a6a3885f04da4a94ca15e2ce5ec4db535b8468ee71de246bf709188630e6"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:38ce3939035e86c775427135a59f4d0da6a2fd567851fc921b24993898d2c584"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:433ae51fcd7e32e82a922aa67b2233a94f72e58d1d5674322eeeedc2a2a5de1f"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:be25600552428fb43a4d94da3d9001f2a519bde715515bf8704acbd80495b279"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:15ec667c44d32995b71959edfbb3687508686cd06b16fecd8c1d0b97e4195c06"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b73ee3051e98a096027f529a5169560e22c61de067d44858b680fc21b0bd6c20"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100fc9d3a681864212dc5d0d25bbac545205d4c31e5f93095f9b6b1f799e8be7"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e082678c0bf14e9204175db2d0364410549f6457dcbd297ef642011d369283f2"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ba66866a945f96dd20a34c2205822131e8786c2402ce5620e8d73b3b3da665e1"},
+    {file = "pydantic_core-2.23.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f476419afe9b70d7f25fef7bec7033f69c2e3e1f35de23dad5dc5cc098759ce2"},
+    {file = "pydantic_core-2.23.0-cp311-none-win32.whl", hash = "sha256:c886deed32c95db3d3f46195316aea5b87b754e2b84ab14da0aea491df38a997"},
+    {file = "pydantic_core-2.23.0-cp311-none-win_amd64.whl", hash = "sha256:d3eda2b28ed432709f4eae83316fe8a64e5ab79a9d5d9a45950e89c8d43d17d0"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:638f8bae1d32f1cff46ed7742782b255d8175c4b006f1f41dccfa68ae7bbd2d2"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fe9743b50b86bf75b2f0b48c899665da30ae4e332963a0054d4c74548ba72ab0"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8681973c8648bca5f18aae7a949a90b2177d894a30763b54d35b264c6b3cb02"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e9935b6c89171bab3e4d3f67c4d4d19df60ab2db5676d27894cd39a834b97dde"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3dafe486b2cd19b119d6dce9cd4b2545eb04a679ef4faa6e5b895e0c2838d020"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:21b2d238fd200162e64303fd9e805b27d96ffe24164b31350a97eba75bf712e9"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0abc8460e7f214631bd14af8fde2ad69dcc54ae5facabdeb93150c5d3bd2abf3"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bb6f9b87d5e1a558f0a8ac9a9282f76505b1ac96695d6bac4a036dce88d927ec"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:262d77d4c4fa31f4bdfd838d21f265c35c469e980cc422a47d0b2ae796f38d07"},
+    {file = "pydantic_core-2.23.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:781ba2aa6023a14bf865d7368d674db44c99a8630fc76ba73e850ca7b5a1febb"},
+    {file = "pydantic_core-2.23.0-cp312-none-win32.whl", hash = "sha256:2670f3a68d1a574ae1b0f3da016c010dd08d0a422d14a3b78be47aebbae9a310"},
+    {file = "pydantic_core-2.23.0-cp312-none-win_amd64.whl", hash = "sha256:29904fc5b7c2795b236e1a54680b3cb203c50b1968938a06a4ca7aaee45e71cc"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:be43d9249acf772be100ca1f687680d0e2e2bd5fbaecc3e904f5a65762d45a86"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c9c3b124d0c1f2b6d462aac3cd194457d419e62d62bbd7fc60392e10eb179d10"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2933accfb2e181d67ae37eb2c40abb1a226841392e90edaa62900c0fe7f47e0e"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eac616e3571f9083d972accae44e98ca7020e7c345ac9317fcc8b5638175cadc"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6264eee5c7fced027286ed143c329f531878ec9ae11e7be3c06635045ecbf81f"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:10a6b04f4f86e3816b50dc9785bb662d87e5eda8423f15a80e6f245f6695828a"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d9053f4c9ff5ed98270937938efaadf8a4beb6826ce6cee1e66614b7613c969"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:00eb370a47bd63d6f0e59bae8080c43eb21aca033785ecaeba3fd36f2cfe0877"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6c093a00bce0de23102c3f4a8fab5629f6c0e2dc09eeb7f275c03895fcee8598"},
+    {file = "pydantic_core-2.23.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ee96b28ffefe34ddf5e83e28c0ece5f96f7e3a4caa51b1683b2a71d990f8235e"},
+    {file = "pydantic_core-2.23.0-cp313-none-win32.whl", hash = "sha256:a69297f237984b358275cde98bf81b816a6528f579cf3818954d6266bd64c48d"},
+    {file = "pydantic_core-2.23.0-cp313-none-win_amd64.whl", hash = "sha256:8ff9bd3024412d9766343fe60e1dd6e590d30202dd20d27a881dd790b9b1b72d"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:690a49c803412267758d114dd8f1e2a819436e1ec3df5043b7ea25bcbfabe40a"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:987503763bbdc403821e8b0e618888eae02531f416964aeb1f867ca53f0d1e72"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b7f929d7fffe5017aa0b50414a94a57ac21d96004673856147ea2af90beac7b"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a17d5524f10afd850a0b4365f38931079dc5b00e3417e6b1774d0b8683a5244"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ec9897bde1b4654d513e065a97d7af50de5bfdf3419ba4ef3fed0fbe2d57451e"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f7d0a3607a63c328762b904e8ecb471b2fbe0223bfc01d30e0e962cb71ca508"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:649b1f24ac7a09c430929234d43011e5a4195c1b3d32dd3a80fb6f175dcf301b"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9f186dc1c1e0fe14a453ccc9a90201c03c12fbdda30e1624e405cf67dcf1dc00"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9add1a74e7d8008f4ed9bd4b7cb62de6fd28f81b28f7f6def8c0389a50a98127"},
+    {file = "pydantic_core-2.23.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d129992e977ecf672d4eb7c7ba0e5f13725995d0fac246c673f699b7722c9ae5"},
+    {file = "pydantic_core-2.23.0-cp38-none-win32.whl", hash = "sha256:b75989878eb94f1a63a6a558735cee1c8d6c7d24007b61df41efc8cdbe819f70"},
+    {file = "pydantic_core-2.23.0-cp38-none-win_amd64.whl", hash = "sha256:08dae83791aee669f7160a94e801162e8f17612c4a821c86e17f9a802389a011"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8e18fb1effad8d28ae510d35507eecf79abcba96c09627443c51acdfbfa30f93"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84667cd32f432bb7f1e0bc5f57c4ea2767d9493e9beef8f195657c16ea3a6076"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5202456ff1f71c2146ba63ffe4538be7fa5d0b6697de14f706d4266aa4e7bf47"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ae227d46fd1fa1b5a02c18a5a7c80ccff014b7bf596731af5bb157f33e058c6"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05a0d09b436ab65a35b5ad90fc295c4a0e545c2456e2212f242809c7474e60c6"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:49dea6930ab48b3ca233e7d541d5f6480f6ffa67a1cc2352cd8395c6f3c14745"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e21b2ee6273cf0d637a7b1622a6ece8761f111083822f1e814e7522d5efb1772"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:873e2453ff6451bdf5619c3c1122fa9998a39552d2fd4c2d9c34f61611e026d6"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c0eb1577f5073cfb336e5d08cb91e717197c0727803962850561d529c07e53c"},
+    {file = "pydantic_core-2.23.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c97f1fb88ec947522ec5863630cb17e3b3ec9f6ca09f954107ad3d35ca3abfe8"},
+    {file = "pydantic_core-2.23.0-cp39-none-win32.whl", hash = "sha256:804a81e50dc43508068964a2b7abacaf99850e2cb7cbd0ae3a8e0145cb89ba1f"},
+    {file = "pydantic_core-2.23.0-cp39-none-win_amd64.whl", hash = "sha256:54a4da481e9130eeba5b02fcfe95fcf26e188747b5b9c6a3bc434ee6f7573b04"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7e8e33bf23a61b07456a1666a07ba453c0906ed74c1330a60ba4c10691628310"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b28dadb0c7494e47304e5c0fec95c500ed914e88b53018ccb85d700fbb1d2bdc"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92137a6a2236223ae5aa4f610ca2a4fe5c8770941deeb6b295f477c71257e618"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3482e7e003b2b391ad2441c98ba219cbd71e3de12b3a5f422c5d9151479c827"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e34ae0eed62065a917f527296a0da2dc71056d53e5b7c8849d48ad69cc73a486"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:81b84e88ed517a4911f8ebef141b41f5b1d21f8100209b0fc118079accede06e"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:837cbeec0ad83ebd57ae9f4e8bd18c8ed34acfe3ec809e2ceceac253b0bc3fd7"},
+    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:39d4ac2cf7a25f1ceec7588a5c9b86ccdf330a5941753e1779974c08a9d763c4"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:865f96455c0f5af1b1e73c4f52659899a635af4c1e4db5ae40f848ba456dfd24"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:ff54894bc04f5982db8fa6ff6d336afa2e4b66cccc76952a35772ff7485d5553"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3734dd979f69b322ec7ddff60123264474801ef9620255f120e10d33596c3a6"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca5363fb0f39135cd6cbdbaa542c24a91246cf9d08fb5c3ba23f774ef4e91f66"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d00380dbb87abf553d173e2b0c4863a4e2e8573e36ee865af7237a065adc3519"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:5fc73dd963497080b1961c16e6a01c054acb525fb8108c6aeed208d109d7385e"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:151968f31efca42a9a5ae25cd00a62a67fb368ed4fdf05c861c629138e5cf674"},
+    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:95e912ae3ccbd9c20f44b85fc7f3e1e55db8f8688c8cf519aa517580ae7ba399"},
+    {file = "pydantic_core-2.23.0.tar.gz", hash = "sha256:954509ea58b1adf6614390056da194e86feb83423679984f8453416db7cfa8c9"},
 ]
 
 [[package]]
@@ -1350,7 +1350,7 @@ version = "2.9.0"
 requires_python = ">=3.8"
 git = "https://github.com/pydantic/pydantic-extra-types.git"
 ref = "main"
-revision = "49db83a9dfbdbec887f90ab78b0403720543c049"
+revision = "d409bfa22a72bf4228dab2995a7de1b935c8d9bd"
 summary = "Extra Pydantic types."
 dependencies = [
     "pydantic>=2.5.2",

--- a/pydantic/_internal/_core_metadata.py
+++ b/pydantic/_internal/_core_metadata.py
@@ -30,8 +30,6 @@ class CoreMetadata(typing_extensions.TypedDict, total=False):
     # prefer positional over keyword arguments for an 'arguments' schema.
     pydantic_js_prefer_positional_arguments: bool | None
 
-    pydantic_typed_dict_cls: type[Any] | None  # TODO: Consider moving this into the pydantic-core TypedDictSchema
-
 
 class CoreMetadataHandler:
     """Because the metadata field in pydantic_core is of type `Any`, we can't assume much about its contents.
@@ -69,7 +67,6 @@ def build_metadata_dict(
     js_functions: list[GetJsonSchemaFunction] | None = None,
     js_annotation_functions: list[GetJsonSchemaFunction] | None = None,
     js_prefer_positional_arguments: bool | None = None,
-    typed_dict_cls: type[Any] | None = None,
     initial_metadata: Any | None = None,
 ) -> Any:
     """Builds a dict to use as the metadata field of a CoreSchema object in a manner that is consistent
@@ -82,7 +79,6 @@ def build_metadata_dict(
         pydantic_js_functions=js_functions or [],
         pydantic_js_annotation_functions=js_annotation_functions or [],
         pydantic_js_prefer_positional_arguments=js_prefer_positional_arguments,
-        pydantic_typed_dict_cls=typed_dict_cls,
     )
     metadata = {k: v for k, v in metadata.items() if v is not None}
 

--- a/pydantic/_internal/_core_metadata.py
+++ b/pydantic/_internal/_core_metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
 import typing
-from typing import Any
+from typing import Any, cast
 
 import typing_extensions
 
@@ -45,7 +45,7 @@ class CoreMetadataHandler:
 
         metadata = schema.get('metadata')
         if metadata is None:
-            schema['metadata'] = CoreMetadata()
+            schema['metadata'] = CoreMetadata()  # type: ignore
         elif not isinstance(metadata, dict):
             raise TypeError(f'CoreSchema metadata should be a dict; got {metadata!r}.')
 
@@ -56,10 +56,10 @@ class CoreMetadataHandler:
         """
         metadata = self._schema.get('metadata')
         if metadata is None:
-            self._schema['metadata'] = metadata = CoreMetadata()
+            self._schema['metadata'] = metadata = CoreMetadata()  # type: ignore
         if not isinstance(metadata, dict):
             raise TypeError(f'CoreSchema metadata should be a dict; got {metadata!r}.')
-        return metadata
+        return cast(CoreMetadata, metadata)
 
 
 def build_metadata_dict(

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1507,10 +1507,10 @@ class GenerateSchema:
                 title = self._get_model_title_from_config(typed_dict_cls, ConfigWrapper(config))
                 metadata = build_metadata_dict(
                     js_functions=[partial(modify_model_json_schema, cls=typed_dict_cls, title=title)],
-                    typed_dict_cls=typed_dict_cls,
                 )
                 td_schema = core_schema.typed_dict_schema(
                     fields,
+                    cls=typed_dict_cls,
                     computed_fields=[
                         self._computed_field_schema(d, decorators.field_serializers)
                         for d in decorators.computed_fields.values()

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1280,7 +1280,7 @@ class GenerateJsonSchema:
         ]
         if self.mode == 'serialization':
             named_required_fields.extend(self._name_required_computed_fields(schema.get('computed_fields', [])))
-        cls = _get_typed_dict_cls(schema)
+        cls = schema.get('cls')
         config = _get_typed_dict_config(cls)
         with self._config_wrapper_stack.push(config):
             json_schema = self._named_required_fields_schema(named_required_fields)
@@ -2524,12 +2524,6 @@ else:
 
         def __hash__(self) -> int:
             return hash(type(self))
-
-
-def _get_typed_dict_cls(schema: core_schema.TypedDictSchema) -> type[Any] | None:
-    metadata = _core_metadata.CoreMetadataHandler(schema).metadata
-    cls = metadata.get('pydantic_typed_dict_cls')
-    return cls
 
 
 def _get_typed_dict_config(cls: type[Any] | None) -> ConfigDict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     'typing-extensions>=4.6.1; python_version < "3.13"',
     'typing-extensions>=4.12.2; python_version >= "3.13"',
     'annotated-types>=0.4.0',
-    "pydantic-core==2.22.0",
+    "pydantic-core==2.23.0",
     # See: https://docs.python.org/3/library/zoneinfo.html#data-sources
     'tzdata; python_version >= "3.9"',
 ]


### PR DESCRIPTION
A companion PR to https://github.com/pydantic/pydantic-core/pull/1410 (we'll have to wait on a release with said change)

The idea here: move away from storing information used for JSON schema generation in the catchall `metadata` attribute, and instead explicitly store it on the core schema itself.

Also, we already store `cls` for dataclasses and models, so this makes things more consistent overall.