### PR TITLE
Breaking Change: Fix JSON Schema generation for constrained dates

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -687,9 +687,7 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        json_schema = {'type': 'string', 'format': 'date'}
-        self.update_with_validations(json_schema, schema, self.ValidationsMapping.date)
-        return json_schema
+        return {'type': 'string', 'format': 'date'}
 
     def time_schema(self, schema: core_schema.TimeSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a time value.
@@ -2135,12 +2133,6 @@ class GenerateJsonSchema:
         object = {
             'min_length': 'minProperties',
             'max_length': 'maxProperties',
-        }
-        date = {
-            'le': 'maximum',
-            'ge': 'minimum',
-            'lt': 'exclusiveMaximum',
-            'gt': 'exclusiveMinimum',
         }
 
     def get_flattened_anyof(self, schemas: list[JsonSchemaValue]) -> JsonSchemaValue:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -811,24 +811,23 @@ def test_date_types(field_type, expected_schema):
 
 
 @pytest.mark.parametrize(
-    'field_type,expected_schema',
+    'field_type',
     [
-        (condate(), {}),
-        (
-            condate(gt=date(2010, 1, 1), lt=date(2021, 2, 2)),
-            {'exclusiveMinimum': date(2010, 1, 1), 'exclusiveMaximum': date(2021, 2, 2)},
-        ),
-        (condate(ge=date(2010, 1, 1), le=date(2021, 2, 2)), {'minimum': date(2010, 1, 1), 'maximum': date(2021, 2, 2)}),
+        condate(),
+        condate(gt=date(2010, 1, 1), lt=date(2021, 2, 2)),
+        condate(ge=date(2010, 1, 1), le=date(2021, 2, 2)),
     ],
 )
-def test_date_constrained_types(field_type, expected_schema):
+def test_date_constrained_types_no_constraints(field_type):
+    """No constraints added, see https://github.com/json-schema-org/json-schema-spec/issues/116."""
+
     class Model(BaseModel):
         a: field_type
 
     assert Model.model_json_schema() == {
         'title': 'Model',
         'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': 'string', 'format': 'date', **expected_schema}},
+        'properties': {'a': {'title': 'A', 'type': 'string', 'format': 'date'}},
         'required': ['a'],
     }
 


### PR DESCRIPTION
This is technically a breaking change, but the previously generated JSON Schema was:
- not valid JSON
- not a valid JSON Schema

So I think we should document the breaking change but not do any deprecation process.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
