### PR TITLE
Fix invalid JSON Schemas being generated for functions in certain scenarios

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1706,7 +1706,9 @@ class GenerateJsonSchema:
                 # I believe this is true, but I am not 100% sure
                 min_items += 1
 
-        json_schema: JsonSchemaValue = {'type': 'array', 'prefixItems': prefix_items}
+        json_schema: JsonSchemaValue = {'type': 'array'}
+        if prefix_items:
+            json_schema['prefixItems'] = prefix_items
         if min_items:
             json_schema['minItems'] = min_items
 

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -437,7 +437,19 @@ def test_json_schema():
         return sum(numbers)
 
     assert foo(1, 2, 3) == 6
-    assert TypeAdapter(foo).json_schema() == {'items': {'type': 'integer'}, 'prefixItems': [], 'type': 'array'}
+    assert TypeAdapter(foo).json_schema() == {'items': {'type': 'integer'}, 'type': 'array'}
+
+    @validate_call
+    def foo(a: int, *numbers: int) -> int:
+        return a + sum(numbers)
+
+    assert foo(1, 2, 3) == 6
+    assert TypeAdapter(foo).json_schema() == {
+        'items': {'type': 'integer'},
+        'prefixItems': [{'title': 'A', 'type': 'integer'}],
+        'minItems': 1,
+        'type': 'array',
+    }
 
     @validate_call
     def foo(**scores: int) -> str:


### PR DESCRIPTION
When a function is defined only with variable length positional arguments (`(*args) -> ...`), an empty `prefixItems` is added, which is invalid JSON Schema.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
