### PR TITLE
Use a default of `Any` for the `ImportString` type variable

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -23,7 +23,6 @@ from typing import (
     List,
     Pattern,
     Set,
-    TypeVar,
     Union,
     cast,
     get_args,
@@ -34,7 +33,7 @@ from uuid import UUID
 import annotated_types
 from annotated_types import BaseMetadata, MaxLen, MinLen
 from pydantic_core import CoreSchema, PydanticCustomError, core_schema
-from typing_extensions import Annotated, Literal, Protocol, TypeAlias, TypeAliasType, deprecated
+from typing_extensions import Annotated, Literal, Protocol, TypeAlias, TypeAliasType, TypeVar, deprecated
 
 from ._internal import _core_utils, _fields, _internal_dataclass, _typing_extra, _utils, _validators
 from ._migration import getattr_migration
@@ -898,7 +897,7 @@ def conlist(
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~ IMPORT STRING TYPE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-AnyType = TypeVar('AnyType')
+AnyType = TypeVar('AnyType', default=Any)
 if TYPE_CHECKING:
     ImportString = Annotated[AnyType, ...]
 else:

--- a/tests/pyright/json_schema_examples.py
+++ b/tests/pyright/json_schema_examples.py
@@ -1,4 +1,0 @@
-from pydantic.json_schema import Examples
-
-e_good = Examples([])
-e_deprecated = Examples({})  # pyright: ignore[reportDeprecated]

--- a/tests/pyright/misc.py
+++ b/tests/pyright/misc.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from typing_extensions import assert_type
+
+from pydantic import ImportString
+from pydantic.json_schema import Examples
+
+e_good = Examples([])
+e_deprecated = Examples({})  # pyright: ignore[reportDeprecated]
+
+# `ImportString` is defined as `Annotated[AnyType, ...]` (`AnyType` is a type var).
+# If not parametrized, type checkers will complain provided they are configured
+# to do so on missing type arguments (for pyright, this is controlled
+# by `reportMissingTypeArgument`). This shouldn't error because we use
+# a default value for the type var.
+i_any: ImportString = ...
+
+assert_type(i_any, ImportString[Any])

--- a/tests/pyright/pyproject.toml
+++ b/tests/pyright/pyproject.toml
@@ -4,3 +4,4 @@ reportUnnecessaryTypeIgnoreComment = true
 pythonVersion = '3.10'
 enableExperimentalFeatures = true
 reportDeprecated = true
+reportMissingTypeArgument = true


### PR DESCRIPTION
The runtime behavior is to allow anything if `ImportString` isn't parametrized. We reflect this by providing a default value to the type variable, so that type checkers don't complain on missing parametrization.

Requires:
- https://github.com/pydantic/pydantic/issues/10197

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
