### PR TITLE
Remove `initial_metadata` from internal metadata construct

### DIFF
--- a/pydantic/_internal/_core_metadata.py
+++ b/pydantic/_internal/_core_metadata.py
@@ -32,10 +32,14 @@ class CoreMetadata(typing_extensions.TypedDict, total=False):
 
 
 class CoreMetadataHandler:
-    """Because the metadata field in pydantic_core is of type `Any`, we can't assume much about its contents.
+    """Because the metadata field in pydantic_core is of type `Dict[str, Any]`, we can't assume much about its contents.
 
-    This class is used to interact with the metadata field on a CoreSchema object in a consistent
-    way throughout pydantic.
+    This class is used to interact with the metadata field on a CoreSchema object in a consistent way throughout pydantic.
+
+    TODO: We'd like to refactor the storage of json related metadata to be more explicit, and less functionally oriented.
+    This should make its way into our v2.10 release. It's inevitable that we need to store some json schema related information
+    on core schemas, given that we generate JSON schemas directly from core schemas. That being said, debugging related
+    issues is quite difficult when JSON schema information is disguised via dynamically defined functions.
     """
 
     __slots__ = ('_schema',)
@@ -67,22 +71,11 @@ def build_metadata_dict(
     js_functions: list[GetJsonSchemaFunction] | None = None,
     js_annotation_functions: list[GetJsonSchemaFunction] | None = None,
     js_prefer_positional_arguments: bool | None = None,
-    initial_metadata: Any | None = None,
-) -> Any:
-    """Builds a dict to use as the metadata field of a CoreSchema object in a manner that is consistent
-    with the CoreMetadataHandler class.
-    """
-    if initial_metadata is not None and not isinstance(initial_metadata, dict):
-        raise TypeError(f'CoreSchema metadata should be a dict; got {initial_metadata!r}.')
-
+) -> dict[str, Any]:
+    """Builds a dict to use as the metadata field of a CoreSchema object in a manner that is consistent with the `CoreMetadataHandler` class."""
     metadata = CoreMetadata(
         pydantic_js_functions=js_functions or [],
         pydantic_js_annotation_functions=js_annotation_functions or [],
         pydantic_js_prefer_positional_arguments=js_prefer_positional_arguments,
     )
-    metadata = {k: v for k, v in metadata.items() if v is not None}
-
-    if initial_metadata is not None:
-        metadata = {**initial_metadata, **metadata}
-
-    return metadata
+    return {k: v for k, v in metadata.items() if v is not None}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5148,17 +5148,6 @@ def test_core_metadata_core_schema_metadata():
         core_metadata_handler.metadata
 
 
-def test_build_metadata_dict_initial_metadata():
-    assert build_metadata_dict(initial_metadata={'foo': 'bar'}) == {
-        'foo': 'bar',
-        'pydantic_js_functions': [],
-        'pydantic_js_annotation_functions': [],
-    }
-
-    with pytest.raises(TypeError, match=re.escape("CoreSchema metadata should be a dict; got 'test'.")):
-        build_metadata_dict(initial_metadata='test')
-
-
 def test_type_adapter_json_schemas_title_description():
     class Model(BaseModel):
         a: str


### PR DESCRIPTION
* Remove `initial_metadata` parameter from `build_metadata_dict` that encouraged abuse of the `metadata` construct by magic string injection
* Improve docstring of `CoreMetadataHandler` class with TODO relating to next steps for a refactor (I'm happy to investigate this for v2.10)

I investigated removing the `metadata` property from `CoreMetadataHandler` due to the abundance of shared logic with `__init__` in the same class, but it appears that this is necessary due to the mutation of `metadata` on the schema passed in. I'll note, in terms of best practices, this should certainly be changed with the aforementioned refactor - the less in place mutation we can do for core schemas, the better.