### PR TITLE
Update and clean up several aspects of documentation tooling

### DIFF
--- a/docs/concepts/pydantic_settings.md
+++ b/docs/concepts/pydantic_settings.md
@@ -6,4 +6,4 @@ description: Support for loading a settings or config class from environment var
 
 [Pydantic Settings](https://github.com/pydantic/pydantic-settings) provides optional Pydantic features for loading a settings or config class from environment variables or secrets files.
 
-{{ external_markdown('https://raw.githubusercontent.com/pydantic/pydantic-settings/main/docs/index.md', '') }}
+{{ pydantic_settings }}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1,8 +1,6 @@
 Pydantic attempts to provide useful errors. The following sections provide details on common errors developers may
 encounter when working with Pydantic, along with suggestions for addressing the error condition.
 
-<!-- Note: raw tag is used to avoid rendering of jinja2 template tags in the docs. -->
-{% raw %}
 ## Class not fully defined {#class-not-fully-defined}
 
 This error is raised when a type referenced in an annotation of a pydantic-validated type
@@ -1165,4 +1163,3 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'dataclass-on-model'
 ```
 
-{% endraw %}

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1162,4 +1162,3 @@ try:
 except PydanticUserError as exc_info:
     assert exc_info.code == 'dataclass-on-model'
 ```
-

--- a/docs/plugins/griffe_doclinks.py
+++ b/docs/plugins/griffe_doclinks.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import ast
-import logging
 import re
 from functools import partial
 from pathlib import Path
+from typing import Any
 
-from griffe import Extension, ObjectNode
+from griffe import Extension, Inspector, ObjectNode, Visitor, get_logger
 from griffe import Object as GriffeObject
 from pymdownx.slugs import slugify
 
 DOCS_PATH = Path(__file__).parent.parent
 slugifier = slugify(case='lower')
-logger = logging.getLogger('griffe_docklinks')
+logger = get_logger('griffe_docklinks')
 
 
 def find_heading(content: str, slug: str, file_path: Path) -> tuple[str, int]:
@@ -80,6 +80,8 @@ def update_docstring(obj: GriffeObject) -> str:
 
 
 class UpdateDocstringsExtension(Extension):
-    def on_instance(self, *, node: ast.AST | ObjectNode, obj: GriffeObject) -> None:
+    def on_instance(
+        self, *, node: ast.AST | ObjectNode, obj: GriffeObject, agent: Visitor | Inspector, **kwargs: Any
+    ) -> None:
         if not obj.is_alias and obj.docstring is not None:
-            update_docstring(obj)
+            obj.docstring.value = update_docstring(obj)

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -7,7 +7,6 @@ import re
 import textwrap
 from pathlib import Path
 from textwrap import indent
-from typing import TYPE_CHECKING
 
 import autoflake
 import pyupgrade._main as pyupgrade_main  # type: ignore
@@ -25,9 +24,13 @@ DOCS_DIR = THIS_DIR.parent
 PROJECT_ROOT = DOCS_DIR.parent
 
 
-if TYPE_CHECKING:
+try:
     from .conversion_table import conversion_table
-else:
+except ImportError:
+    # Due to how MkDocs requires this file to be specified (as a path and not a
+    # dot-separated module name), relative imports don't work:
+    # MkDocs is adding the dir. of this file to `sys.path` and uses
+    # `importlib.spec_from_file_location` and `module_from_spec`, which isn't ideal.
     from conversion_table import conversion_table
 
 # Start definition of MkDocs hooks

--- a/docs/why.md
+++ b/docs/why.md
@@ -4,9 +4,7 @@ Today, Pydantic is downloaded <span id="download-count">many</span> times a mont
 
 It's hard to know why so many people have adopted Pydantic since its inception six years ago, but here are a few guesses.
 
-{% raw %}
 ## Type hints powering schema validation {#type-hints}
-{% endraw %}
 
 The schema that Pydantic validates against is generally defined by Python type hints.
 
@@ -213,9 +211,7 @@ Pydantic generates [JSON Schema version 2020-12](https://json-schema.org/draft/2
 !!! tip "Learn more"
     See the [documentation on JSON Schema](concepts/json_schema.md).
 
-{% raw %}
 ## Strict mode and data coercion {#strict-lax}
-{% endraw %}
 
 By default, Pydantic is tolerant to common incorrect types and coerces data to the right type &mdash; e.g. a numeric string passed to an `int` field will be parsed as an `int`.
 
@@ -264,9 +260,7 @@ To solve this, Pydantic can parse and validate JSON in one step. This allows sen
 !!! tip "Learn more"
     See the [documentation on strict mode](concepts/strict_mode.md).
 
-{% raw %}
 ## Dataclasses, TypedDicts, and more {#typeddict}
-{% endraw %}
 
 Pydantic provides four ways to create schemas and perform validation and serialization:
 
@@ -364,7 +358,6 @@ Some notable libraries that depend on Pydantic:
 
 More libraries using Pydantic can be found at [`Kludex/awesome-pydantic`](https://github.com/Kludex/awesome-pydantic).
 
-{% raw %}
 ## Organisations using Pydantic {#using-pydantic}
 
 Some notable companies and organisations using Pydantic together with comments on why/how we know they're using Pydantic.
@@ -378,4 +371,3 @@ The organisations below are included because they match one or more of the follo
 We've included some extra detail where appropriate and already in the public domain.
 
 {{ organisations }}
-{% endraw %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,9 @@ markdown_extensions:
 watch:
 - pydantic
 
+hooks:
+- 'docs/plugins/main.py'
+
 plugins:
 - mike:
     alias_type: symlink
@@ -215,11 +218,6 @@ plugins:
             - docs/plugins/griffe_doclinks.py
         import:
           - https://docs.python.org/3/objects.inv
-- mkdocs-simple-hooks:
-    hooks:
-      on_pre_build: 'docs.plugins.main:on_pre_build'
-      on_files: 'docs.plugins.main:on_files'
-      on_page_markdown: 'docs.plugins.main:on_page_markdown'
 - redirects:
     redirect_maps:
       'usage/mypy.md': 'integrations/mypy.md'
@@ -289,4 +287,3 @@ plugins:
       'blog/pydantic-v2-alpha.md': 'https://blog.pydantic.dev/blog/2023/04/03/pydantic-v2-pre-release/'
       'blog/pydantic-v2-final.md': 'https://blog.pydantic.dev/blog/2023/06/30/pydantic-v2-is-here/'
       'blog/pydantic-v2.md': 'https://blog.pydantic.dev/blog/2022/07/10/pydantic-v2-plan/'
-- external-markdown:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:61fcc293656d68a5c7c263fdaff9733357e0308e154ae9e706709bded249140f"
+content_hash = "sha256:0e81124dab45100ba65495984444d92cca6155098073443dc5b7e2ca94cf72be"
 
 [[metadata.targets]]
 requires_python = ">=3.8"
@@ -101,16 +101,6 @@ dependencies = [
 files = [
     {file = "Babel-2.15.0-py3-none-any.whl", hash = "sha256:08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb"},
     {file = "babel-2.15.0.tar.gz", hash = "sha256:8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413"},
-]
-
-[[package]]
-name = "backports-strenum"
-version = "1.3.1"
-requires_python = ">=3.8.6,<3.11"
-summary = "Base class for creating enumerated constants that are also subclasses of str"
-files = [
-    {file = "backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83"},
-    {file = "backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414"},
 ]
 
 [[package]]
@@ -684,7 +674,7 @@ files = [
 
 [[package]]
 name = "griffe"
-version = "0.49.0"
+version = "1.1.1"
 requires_python = ">=3.8"
 summary = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 dependencies = [
@@ -692,8 +682,8 @@ dependencies = [
     "colorama>=0.4",
 ]
 files = [
-    {file = "griffe-0.49.0-py3-none-any.whl", hash = "sha256:c0d505f2a444ac342b22f4647d6444c8db64964b6a379c14f401fc467c0741a3"},
-    {file = "griffe-0.49.0.tar.gz", hash = "sha256:a7e1235c27d8139e0fd24a5258deef6061bc876a9fda8117a5cf7b53ee940a91"},
+    {file = "griffe-1.1.1-py3-none-any.whl", hash = "sha256:0c469411e8d671a545725f5c0851a746da8bd99d354a79fdc4abd45219252efb"},
+    {file = "griffe-1.1.1.tar.gz", hash = "sha256:faeb78764c0b2bd010719d6e015d07709b0f260258b5d4dd6c88343d9702aa30"},
 ]
 
 [[package]]
@@ -984,10 +974,7 @@ files = [
 
 [[package]]
 name = "mike"
-version = "2.2.0.dev0"
-git = "https://github.com/jimporter/mike.git"
-ref = "master"
-revision = "3b425156dec71bd7cd3440f42f41b99c7013a9ce"
+version = "2.1.3"
 summary = "Manage multiple versions of your MkDocs-powered documentation"
 dependencies = [
     "importlib-metadata",
@@ -998,6 +985,10 @@ dependencies = [
     "pyyaml-env-tag",
     "pyyaml>=5.1",
     "verspec",
+]
+files = [
+    {file = "mike-2.1.3-py3-none-any.whl", hash = "sha256:d90c64077e84f06272437b464735130d380703a76a5738b152932884c60c062a"},
+    {file = "mike-2.1.3.tar.gz", hash = "sha256:abd79b8ea483fb0275b7972825d3082e5ae67a41820f8d8a0dc7a3f49944e810"},
 ]
 
 [[package]]
@@ -1039,20 +1030,6 @@ dependencies = [
 files = [
     {file = "mkdocs_autorefs-1.0.1-py3-none-any.whl", hash = "sha256:aacdfae1ab197780fb7a2dac92ad8a3d8f7ca8049a9cbe56a4218cd52e8da570"},
     {file = "mkdocs_autorefs-1.0.1.tar.gz", hash = "sha256:f684edf847eced40b570b57846b15f0bf57fb93ac2c510450775dcf16accb971"},
-]
-
-[[package]]
-name = "mkdocs-embed-external-markdown"
-version = "2.3.0"
-requires_python = ">=3.6.2,<4.0.0"
-summary = "Mkdocs plugin that allow to inject external markdown or markdown section from given url"
-dependencies = [
-    "Jinja2<4.0.0,>=3.0.3",
-    "requests<3.0.0,>=2.27.1",
-]
-files = [
-    {file = "mkdocs-embed-external-markdown-2.3.0.tar.gz", hash = "sha256:543ecbaf1d1b62bb6b557714d20ac76b7c24b2b76adc5243a406e636964a8d45"},
-    {file = "mkdocs_embed_external_markdown-2.3.0-py3-none-any.whl", hash = "sha256:a14918a2beacf50ba215670e802fee75de3013bb9db8d8e8d23dd6978004b5bc"},
 ]
 
 [[package]]
@@ -1126,18 +1103,6 @@ dependencies = [
 files = [
     {file = "mkdocs-redirects-1.2.1.tar.gz", hash = "sha256:9420066d70e2a6bb357adf86e67023dcdca1857f97f07c7fe450f8f1fb42f861"},
     {file = "mkdocs_redirects-1.2.1-py3-none-any.whl", hash = "sha256:497089f9e0219e7389304cffefccdfa1cac5ff9509f2cb706f4c9b221726dffb"},
-]
-
-[[package]]
-name = "mkdocs-simple-hooks"
-version = "0.1.5"
-summary = "Define your own hooks for mkdocs, without having to create a new package."
-dependencies = [
-    "mkdocs>=1.2",
-]
-files = [
-    {file = "mkdocs-simple-hooks-0.1.5.tar.gz", hash = "sha256:dddbdf151a18723c9302a133e5cf79538be8eb9d274e8e07d2ac3ac34890837c"},
-    {file = "mkdocs_simple_hooks-0.1.5-py3-none-any.whl", hash = "sha256:efeabdbb98b0850a909adee285f3404535117159d5cb3a34f541d6eaa644d50a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,21 +104,17 @@ substitutions = [
 docs = [
     "autoflake",
     "mkdocs",
-    "mkdocs-embed-external-markdown",
     "mkdocs-exclude",
     "mkdocs-material",
     "mkdocs-redirects",
-    "mkdocs-simple-hooks",
     "mkdocstrings-python",
     "tomli",
     "pyupgrade",
-    "mike @ git+https://github.com/jimporter/mike.git@master",
-    "mkdocs-embed-external-markdown>=2.3.0",
+    "mike",
     "pytest-examples>=0.0.13",
     "pydantic-settings>=2.0b1",
     "pydantic-extra-types @ git+https://github.com/pydantic/pydantic-extra-types.git@main",
-    # Not available before v3.8.6, hence the pin here, as it's required by griffe
-    "backports-strenum==1.3.1; python_version >= '3.8.6' and python_version < '3.11'"
+    "requests",
 ]
 linting = [
     "eval-type-backport>=0.1.3",


### PR DESCRIPTION
Work towards https://github.com/pydantic/pydantic/issues/10083.

Remove `mkdocs-simple-hooks` dependency, this is now available in MkDocs
Remove `mkdocs-embed-external-markdown` and apply same logic in a hook instead. The extension was parsing every markdown file as Jinja2 templates, which had limitations with some syntax. There's also a small performance improvement in not doing so.
Update `griffe` to the latest version, fixing breaking changes to extension, and remove dependency to `backports-strenum`.
Do not unnecessarily depend on a git version of `mike`

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
