### PR TITLE
fix: new paths that are too long for the file system are now invalid as `NewPath`

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -4,11 +4,12 @@ from __future__ import annotations as _annotations
 
 import base64
 import dataclasses as _dataclasses
+import os
 import re
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PosixPath
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -1276,7 +1277,9 @@ class PathType:
 
     @staticmethod
     def validate_new(path: Path, _: core_schema.ValidationInfo) -> Path:
-        if path.exists():
+        if isinstance(path, PosixPath) and os.statvfs(path.parent).f_namemax < len(path.name):
+            raise PydanticCustomError('path_too_long', 'Path name is too long')
+        elif path.exists():
             raise PydanticCustomError('path_exists', 'Path already exists')
         elif not path.parent.exists():
             raise PydanticCustomError('parent_does_not_exist', 'Parent directory does not exist')


### PR DESCRIPTION
Contributing #8308 (WIP) file path length checks, which were causing an OSError to raise unexpectedly

## Change Summary

- fix: new paths that are too long for the file system are now invalid as `NewPath`'
  - **edit** ignore original commit title, the readonly check was removed (did not seem to work as expected, out of scope for this PR)

## Related issue number

- #8308

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
