### PR TITLE
Add 'wss' for allowed schemes in NatsDsn

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -339,7 +339,8 @@ KafkaDsn = Annotated[Url, UrlConstraints(allowed_schemes=['kafka'], default_host
 * Host required
 """
 NatsDsn = Annotated[
-    MultiHostUrl, UrlConstraints(allowed_schemes=['nats', 'tls', 'ws'], default_host='localhost', default_port=4222)
+    MultiHostUrl,
+    UrlConstraints(allowed_schemes=['nats', 'tls', 'ws', 'wss'], default_host='localhost', default_port=4222),
 ]
 """A type that will accept any NATS DSN.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Nats also supports the `wss` scheme, and this is failing with: 


```
NATS_SERVER_URL="wss://nats-url" python run.py 
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/pydantic_settings/main.py", line 144, in __init__
    super().__init__(
  File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 193, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
NATS_SERVER_URL
  URL scheme should be 'nats', 'tls' or 'ws' [type=url_scheme, input_value='wss://nats-url', input_type=str]
    For further information visit https://errors.pydantic.dev/2.8/v/url_scheme
```

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist -- unsure
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle