### PR TITLE
Have a distinct type for `EmailStr` during type checking

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -424,7 +424,7 @@ def import_email_validator() -> None:
 
 
 if TYPE_CHECKING:
-    EmailStr = NewType("EmailStr", str)
+    EmailStr = NewType('EmailStr', str)
 else:
 
     class EmailStr:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -6,7 +6,7 @@ import dataclasses as _dataclasses
 import re
 from importlib.metadata import version
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NewType
 
 from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, Self, TypeAlias
@@ -424,7 +424,7 @@ def import_email_validator() -> None:
 
 
 if TYPE_CHECKING:
-    EmailStr = Annotated[str, ...]
+    EmailStr = NewType("EmailStr", str)
 else:
 
     class EmailStr:


### PR DESCRIPTION
## Change Summary

Add a distinct type for `EmailStr` via `NewType` instead of a noop(?) `Annotated[str, ...]` type.

Not sure if this could have any further implications, e.g. mypy plugin or whatnot. But I don't think it's touching `EmailStr`.

## Related issue number

fix #10237 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle