### PR TITLE
Add benchmarks for categories: serialization, validation and schema generation

### DIFF
--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -1,0 +1,52 @@
+from typing import Dict, List, Optional, Union
+
+import pytest
+
+from pydantic import BaseModel
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_simple_model_schema_generation(benchmark):
+    def generate_schema():
+        class SimpleModel(BaseModel):
+            field1: str
+            field2: int
+            field3: float
+
+    benchmark(generate_schema)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_nested_model_schema_generation(benchmark):
+    def generate_schema():
+        class NestedModel(BaseModel):
+            field1: str
+            field2: List[int]
+            field3: Dict[str, float]
+
+        class OuterModel(BaseModel):
+            nested: NestedModel
+            optional_nested: Optional[NestedModel]
+
+    benchmark(generate_schema)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_complex_model_schema_generation(benchmark):
+    def generate_schema():
+        class ComplexModel(BaseModel):
+            field1: Union[str, int, float]
+            field2: List[Dict[str, Union[int, float]]]
+            field3: Optional[List[Union[str, int]]]
+
+    benchmark(generate_schema)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_recursive_model_schema_generation(benchmark):
+    def generate_schema():
+        class RecursiveModel(BaseModel):
+            name: str
+            children: Optional[List['RecursiveModel']] = None
+
+    benchmark(generate_schema)

--- a/tests/benchmarks/test_model_serialization.py
+++ b/tests/benchmarks/test_model_serialization.py
@@ -1,0 +1,63 @@
+from typing import Dict, List, Optional, Union
+
+import pytest
+
+from pydantic import BaseModel
+
+
+class SimpleModel(BaseModel):
+    field1: str
+    field2: int
+    field3: float
+
+
+class NestedModel(BaseModel):
+    field1: str
+    field2: List[int]
+    field3: Dict[str, float]
+
+
+class OuterModel(BaseModel):
+    nested: NestedModel
+    optional_nested: Optional[NestedModel]
+
+
+class ComplexModel(BaseModel):
+    field1: Union[str, int, float]
+    field2: List[Dict[str, Union[int, float]]]
+    field3: Optional[List[Union[str, int]]]
+
+
+@pytest.mark.benchmark(group='model_serialization')
+def test_simple_model_serialization(benchmark):
+    model = SimpleModel(field1='test', field2=42, field3=3.14)
+    benchmark(model.model_dump)
+
+
+@pytest.mark.benchmark(group='model_serialization')
+def test_nested_model_serialization(benchmark):
+    model = OuterModel(
+        nested=NestedModel(field1='test', field2=[1, 2, 3], field3={'a': 1.1, 'b': 2.2}), optional_nested=None
+    )
+    benchmark(model.model_dump)
+
+
+@pytest.mark.benchmark(group='model_serialization')
+def test_complex_model_serialization(benchmark):
+    model = ComplexModel(field1='test', field2=[{'a': 1, 'b': 2.2}, {'c': 3, 'd': 4.4}], field3=['test', 1, 2, 'test2'])
+    benchmark(model.model_dump)
+
+
+@pytest.mark.benchmark(group='model_serialization')
+def test_list_of_models_serialization(benchmark):
+    class SimpleListModel(BaseModel):
+        items: List[SimpleModel]
+
+    model = SimpleListModel(items=[SimpleModel(field1=f'test{i}', field2=i, field3=float(i)) for i in range(10)])
+    benchmark(model.model_dump)
+
+
+@pytest.mark.benchmark(group='model_serialization')
+def test_model_json_serialization(benchmark):
+    model = ComplexModel(field1='test', field2=[{'a': 1, 'b': 2.2}, {'c': 3, 'd': 4.4}], field3=['test', 1, 2, 'test2'])
+    benchmark(model.model_dump_json)

--- a/tests/benchmarks/test_model_validation.py
+++ b/tests/benchmarks/test_model_validation.py
@@ -1,0 +1,55 @@
+from typing import Dict, List, Optional, Union
+
+import pytest
+
+from pydantic import BaseModel
+
+
+class SimpleModel(BaseModel):
+    field1: str
+    field2: int
+    field3: float
+
+
+class NestedModel(BaseModel):
+    field1: str
+    field2: List[int]
+    field3: Dict[str, float]
+
+
+class OuterModel(BaseModel):
+    nested: NestedModel
+    optional_nested: Optional[NestedModel]
+
+
+class ComplexModel(BaseModel):
+    field1: Union[str, int, float]
+    field2: List[Dict[str, Union[int, float]]]
+    field3: Optional[List[Union[str, int]]]
+
+
+@pytest.mark.benchmark(group='model_validation')
+def test_simple_model_validation(benchmark):
+    data = {'field1': 'test', 'field2': 42, 'field3': 3.14}
+    benchmark(SimpleModel.model_validate, data)
+
+
+@pytest.mark.benchmark(group='model_validation')
+def test_nested_model_validation(benchmark):
+    data = {'nested': {'field1': 'test', 'field2': [1, 2, 3], 'field3': {'a': 1.1, 'b': 2.2}}, 'optional_nested': None}
+    benchmark(OuterModel.model_validate, data)
+
+
+@pytest.mark.benchmark(group='model_validation')
+def test_complex_model_validation(benchmark):
+    data = {'field1': 'test', 'field2': [{'a': 1, 'b': 2.2}, {'c': 3, 'd': 4.4}], 'field3': ['test', 1, 2, 'test2']}
+    benchmark(ComplexModel.model_validate, data)
+
+
+@pytest.mark.benchmark(group='model_validation')
+def test_list_of_models_validation(benchmark):
+    class SimpleListModel(BaseModel):
+        items: List[SimpleModel]
+
+    data = {'items': [{'field1': f'test{i}', 'field2': i, 'field3': float(i)} for i in range(10)]}
+    benchmark(SimpleListModel.model_validate, data)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -503,10 +503,10 @@ def test_list_unions():
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, None])
 
-    assert exc_info.value.errors(include_url=False) == [
+    assert set(exc_info.value.errors(include_url=False)) == set([
         {'input': None, 'loc': ('v', 2, 'int'), 'msg': 'Input should be a valid integer', 'type': 'int_type'},
         {'input': None, 'loc': ('v', 2, 'str'), 'msg': 'Input should be a valid string', 'type': 'string_type'},
-    ]
+    ])
 
 
 def test_recursive_lists():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -503,10 +503,12 @@ def test_list_unions():
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, None])
 
-    assert set(exc_info.value.errors(include_url=False)) == set([
-        {'input': None, 'loc': ('v', 2, 'int'), 'msg': 'Input should be a valid integer', 'type': 'int_type'},
-        {'input': None, 'loc': ('v', 2, 'str'), 'msg': 'Input should be a valid string', 'type': 'string_type'},
-    ])
+    assert set(exc_info.value.errors(include_url=False)) == set(
+        [
+            {'input': None, 'loc': ('v', 2, 'int'), 'msg': 'Input should be a valid integer', 'type': 'int_type'},
+            {'input': None, 'loc': ('v', 2, 'str'), 'msg': 'Input should be a valid string', 'type': 'string_type'},
+        ]
+    )
 
 
 def test_recursive_lists():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -503,12 +503,14 @@ def test_list_unions():
     with pytest.raises(ValidationError) as exc_info:
         Model(v=[1, 2, None])
 
-    assert set(exc_info.value.errors(include_url=False)) == set(
-        [
-            {'input': None, 'loc': ('v', 2, 'int'), 'msg': 'Input should be a valid integer', 'type': 'int_type'},
-            {'input': None, 'loc': ('v', 2, 'str'), 'msg': 'Input should be a valid string', 'type': 'string_type'},
-        ]
-    )
+    errors = exc_info.value.errors(include_url=False)
+
+    expected_errors = [
+        {'input': None, 'loc': ('v', 2, 'int'), 'msg': 'Input should be a valid integer', 'type': 'int_type'},
+        {'input': None, 'loc': ('v', 2, 'str'), 'msg': 'Input should be a valid string', 'type': 'string_type'},
+    ]
+
+    assert sorted(errors, key=str) == sorted(expected_errors, key=str)
 
 
 def test_recursive_lists():


### PR DESCRIPTION
## Change Summary

I created three tests to benchmark Pydantic's performance in basic categories:

- Schema generation
- Serialization
- Validation.

The tests handle varying levels of complexity ranging from simple tests to nested scenarios, inspired by the pydantic-core test suite. 

## Related issue number

Contributes to #9711 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
