### PR TITLE
Fix new warnings assertions to use `pytest.warns()`

### DIFF
--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -512,7 +512,7 @@ def test_mixed_discriminated_union(data):
         root: Union[SModel, RModel] = Field(discriminator='kind')
 
     if data['kind'] == 'IModel':
-        with pytest.raises(UserWarning, match='Failed to get discriminator value for tagged union serialization'):
+        with pytest.warns(UserWarning, match='Failed to get discriminator value for tagged union serialization'):
             assert Model(data).model_dump() == data
             assert Model(**data).model_dump() == data
     else:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6942,5 +6942,5 @@ def test_ser_ip_with_union() -> None:
 def test_ser_ip_with_unexpected_value() -> None:
     ta = TypeAdapter(ipaddress.IPv4Address)
 
-    with pytest.raises(UserWarning, match='serialized value may not be as expected.'):
+    with pytest.warns(UserWarning, match='serialized value may not be as expected.'):
         assert ta.dump_python(123)


### PR DESCRIPTION
## Change Summary

Fix new tests to use the correct `pytest.warns()` function to assert for warnings, rather than `pytest.raises()`.  This fixes testing without `-Werror`.

## Related issue number

n/a

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle