### PR TITLE
Fix a crash when cleaning the namespace in `ModelMetaclass`

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -243,7 +243,8 @@ class ModelMetaclass(ABCMeta):
         else:
             # These are instance variables, but have been assigned to `NoInitField` to trick the type checker.
             for instance_slot in '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__':
-                del namespace[instance_slot]
+                if instance_slot in namespace:  # Safe check in case the metaclass is used other than in `BaseModel`:
+                    del namespace[instance_slot]
             namespace.get('__annotations__', {}).clear()
             return super().__new__(mcs, cls_name, bases, namespace, **kwargs)
 


### PR DESCRIPTION
This happens when `MotelMetaclass` is used as a metaclass for a class other than `BaseModel`.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
