### PR TITLE
Pydantic side of reusing validators and serializers

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,6 +26,22 @@ jobs:
           pdm venv create --with-pip --force $PYTHON
           pdm install -G testing -G testing-extra -G email
 
+      # override pydantic-core from git - to report benchmarks
+      # FIXME DO NOT MERGE THIS
+
+      - uses: actions/checkout@v4
+        with:
+          repository: pydantic/pydantic-core
+          ref: boxy/validator_serializer_reuse
+          path: pydantic-core
+
+      - name: install rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - run: pdm run pip install ./pydantic-core
+
+      # END
+
       - name: Run CodSpeed benchmarks
         uses: CodSpeedHQ/action@v3
         with:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -834,6 +834,10 @@ class GenerateJsonSchema:
         """
         return self.handle_invalid_for_json_schema(schema, 'core_schema.CallableSchema')
 
+    def nested_schema(self, schema: core_schema.NestedSchema) -> JsonSchemaValue:
+        # FIXME: See PR description for an explanation of how we should handle nested schemas
+        return None
+
     def list_schema(self, schema: core_schema.ListSchema) -> JsonSchemaValue:
         """Returns a schema that matches a list schema.
 

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -37,7 +37,7 @@ def test_simple_model_schema_generation(benchmark) -> None:
 
 
 @pytest.mark.benchmark(group='model_schema_generation')
-def test_nested_model_schema_generation(benchmark) -> None:
+def test_nested_schema_generation(benchmark) -> None:
     def generate_schema():
         class NestedModel(BaseModel):
             field1: str

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -800,14 +800,10 @@ def test_config_model_defer_build_nested(defer_build: bool, generate_schema_call
     assert m.model_validate({'y': {'x': 1}}).y.x == 1
     assert m.model_json_schema()['type'] == 'object'
 
-    if defer_build:
-        assert isinstance(MyNestedModel.__pydantic_validator__, MockValSer)
-        assert isinstance(MyNestedModel.__pydantic_serializer__, MockValSer)
-    else:
-        assert isinstance(MyNestedModel.__pydantic_validator__, SchemaValidator)
-        assert isinstance(MyNestedModel.__pydantic_serializer__, SchemaSerializer)
-
-    assert generate_schema_calls.count == expected_schema_count, 'Should not build duplicated core schemas'
+    # validating `MyModel` requires building `MyNestedModel` as its validator/serializer is reused.
+    assert isinstance(MyNestedModel.__pydantic_validator__, SchemaValidator)
+    assert isinstance(MyNestedModel.__pydantic_serializer__, SchemaSerializer)
+    assert generate_schema_calls.count == 2, 'Should not build duplicated core schemas'
 
 
 def test_config_model_defer_build_ser_first():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Python side of pydantic/pydantic-core#1414, implements a new core schema variant for reusing schema, validators, and serializers for some sizeable performance wins *right now* and also lots of future possibilities for more wins.

## Future work

We do not use the new `nested-model` schema in all applicable circumstances which leaves performance on the table. Below I've outlined what those cases are and why I did so:

- When generating schema for union choices we fallback to the old schema generation strategy and do not use `nested-model` as the `apply_discriminators` logic requires being able to recurse into the models which is not possible with `nested-model`.
- When generating schema for root models we do not use `nested-model` for the usage of the inner model as if we reused schema for it via `__pydantic_core_schema__` for a union choice, then once again `apply_discriminators` logic would not be able to recurse into the model's fields.
- We also do not use `nested-model` to refer to generic schemas, I do not believe there to be any problem with using `nested-model` here *conceptually*. However, in practice this hits pydantic/pydantic#10279 so we fallback to the old generation strategy when encountering usages of generic schemas.
- The last exception is that when we have a field types as `BaseModel`, e.g:
    ```python
    class MyModel(BaseModel):
        field: BaseModel
    ```
    We do not use a `nested-model` for the field's schema, this caused some issues (that I can't quite remember, though it ought to be simple to disable the exception and see what breaks). 
- The schema is only used for *models* but it should be capable of supporting arbitrary schema/validator/serializer reuse and then we can reuse these things for dataclasses and typed dicts. I avoided implementing this right now since it seemed like a lot of extra work. (Though the name `nested-model` should be changed before anything is landed here)

I would expect that removing these special cases is a good opportunity for performance improvements. My assumption would be that allowing `nested-model` in union choices, using `nested-model` to refer to generic schemas, and reusing schema/validators/serializers on dataclasses/typed dicts, would be the most important wins. 

I have opened an issue #10394 to track this future work

## Before merging

- Most of the test failures at this point are due to incorrect handling of json schema generation. The current implementation when encountering a `nested-model` schema recurses into the model as if the core schema was inlined. This is incorrect when encountering cycles as it has cycle check and also does not create any `$def`s in the json schema.

  The solution here would be to search for any `nested-model` in the core schema and create a `$def` in the json schema for the referenced model. This would allow us to correctly handle mutually recursive model definitions.
- Remove the commit that changes CI to build against `pydantic_core/boxy/validator_serializer_reuse

---

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
