### PR TITLE
Add schema generation benchmarks for models with custom field and model validators

### DIFF
--- a/.hyperlint/.vale.ini
+++ b/.hyperlint/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = styles
+MinAlertLevel = suggestion
+Vocab = hyperlint
+SkippedScopes = script, style, pre, figure, code, code-block
+
+[*]
+BasedOnStyles = Vale, hyperlint

--- a/.hyperlint/style_guide_test.md
+++ b/.hyperlint/style_guide_test.md
@@ -1,0 +1,11 @@
+
+
+# This ia a test file
+
+it will flag errors like on pydantic.
+
+It won't flag on validators.
+
+but it won't flag errors on SDK or SDKs or APIs anymore.
+
+This is is an issue.

--- a/.hyperlint/styles/config/vocabularies/hyperlint/accept.txt
+++ b/.hyperlint/styles/config/vocabularies/hyperlint/accept.txt
@@ -1,0 +1,12 @@
+validator
+Pydantic
+validators
+namespace
+Hyperlint
+preprocess
+tokenization
+tokenizer
+API
+APIs
+SDKs
+SDK

--- a/.hyperlint/styles/hyperlint/repeatedWords.yml
+++ b/.hyperlint/styles/hyperlint/repeatedWords.yml
@@ -1,0 +1,6 @@
+extends: repetition
+message: "'%s' is repeated, did you mean to repeat this word?"
+level: error
+alpha: true
+tokens:
+  - '[^\s]+'

--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -564,7 +564,7 @@ print(Model.model_validate({'pet': {'pet_type': 'cat', 'age': 12}}))  # (1)!
 #> pet=Cat(pet_type='cat', age=12)
 ```
 
-1. See more about [Helper Functions] in the [Models] page.
+1. See more about [Validating data] in the [Models] page.
 
 The following example shows how to use the `discriminator` keyword argument with a `Discriminator` instance:
 
@@ -863,7 +863,7 @@ class Box(BaseModel):
 
 [JSON Schema Draft 2020-12]: https://json-schema.org/understanding-json-schema/reference/numeric.html#numeric-types
 [Discriminated Unions]: ../concepts/unions.md#discriminated-unions
-[Helper Functions]: models.md#helper-functions
+[Validating data]: models.md#validating-data
 [Models]: models.md
 [init-only field]: https://docs.python.org/3/library/dataclasses.html#init-only-variables
 [frozen dataclass documentation]: https://docs.python.org/3/library/dataclasses.html#frozen-instances

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -2,12 +2,12 @@
     [`pydantic.main.BaseModel`][pydantic.main.BaseModel]<br>
 
 One of the primary ways of defining schema in Pydantic is via models. Models are simply classes which inherit from
-[`pydantic.BaseModel`][pydantic.main.BaseModel] and define fields as annotated attributes.
+[`BaseModel`][pydantic.main.BaseModel] and define fields as annotated attributes.
 
 You can think of models as similar to structs in languages like C, or as the requirements of a single endpoint
 in an API.
 
-Models share many similarities with Python's dataclasses, but have been designed with some subtle-yet-important
+Models share many similarities with Python's [dataclasses][dataclasses], but have been designed with some subtle-yet-important
 differences that streamline certain workflows related to validation, serialization, and JSON schema generation.
 You can find more discussion of this in the [Dataclasses](dataclasses.md) section of the docs.
 
@@ -52,6 +52,14 @@ of the resultant model instance will conform to the field types defined on the m
 
 ## Basic model usage
 
+!!! note
+
+    Pydantic relies heavily on the existing Python typing constructs to define models. If you are not familiar with those, the following resources
+    can be useful:
+
+    - The [Type System Guides](https://typing.readthedocs.io/en/latest/guides/index.html)
+    - The [mypy documentation](https://mypy.readthedocs.io/en/latest/)
+
 ```py group="basic-model"
 from pydantic import BaseModel
 
@@ -66,77 +74,95 @@ In this example, `User` is a model with two fields:
 * `id`, which is an integer and is required
 * `name`, which is a string and is not required (it has a default value).
 
+The model can then be instantiated:
+
 ```py group="basic-model"
 user = User(id='123')
 ```
 
-In this example, `user` is an instance of `User`.
-Initialization of the object will perform all parsing and validation.
-If no `ValidationError` is raised, you know the resulting model instance is valid.
+`user` is an instance of `User`. Initialization of the object will perform all parsing and validation.
+If no [`ValidationError`][pydantic_core.ValidationError] exception is raised,
+you know the resulting model instance is valid.
+
+Fields of a model can be accessed as normal attributes of the `user` object:
 
 ```py group="basic-model"
-assert user.id == 123
+assert user.name == 'Jane Doe'  # (1)!
+assert user.id == 123  # (2)!
 assert isinstance(user.id, int)
-# Note that '123' was coerced to an int and its value is 123
 ```
 
-More details on pydantic's coercion logic can be found in [Data Conversion](#data-conversion).
-Fields of a model can be accessed as normal attributes of the `user` object.
-The string `'123'` has been converted into an int as per the field type.
+1. `name` wasn't set when `user` was initialized, so the default value was used.
+   The [`model_fields_set`][pydantic.BaseModel.model_fields_set] attribute can be
+   inspected to check the field names explicitly set during instantiation.
+2. Note that the string `'123'` was coerced to an integer and its value is `123`.
+   More details on Pydantic's coercion logic can be found in the [Data Conversion](#data-conversion) section.
 
-```py group="basic-model"
-assert user.name == 'Jane Doe'
-```
-
-`name` wasn't set when `user` was initialized, so it has the default value.
-
-```py group="basic-model"
-assert user.model_fields_set == {'id'}
-```
-
-The fields which were supplied when user was initialized.
+The model instance can be serialized using the [`model_dump`][pydantic.BaseModel.model_dump] method:
 
 ```py group="basic-model"
 assert user.model_dump() == {'id': 123, 'name': 'Jane Doe'}
 ```
 
-Either `.model_dump()` or `dict(user)` will provide a dict of fields, but `.model_dump()` can take numerous other
-arguments. (Note that `dict(user)` will not recursively convert nested models into dicts, but `.model_dump()` will.)
+Calling [dict][] on the instance will also provide a dictionary, but nested fields will not be
+recursively converted into dictionaries. [`model_dump`][pydantic.BaseModel.model_dump] also
+provides numerous arguments to customize the serialization result.
+
+By default, models are mutable and field values can be changed through attribute assignment:
 
 ```py group="basic-model"
 user.id = 321
 assert user.id == 321
 ```
 
-By default, models are mutable and field values can be changed through attribute assignment.
+!!! warning
+    When defining your models, watch out for naming collisions between your field name and its type annotation.
+
+    For example, the following will not behave as expected and would yield a validation error:
+
+    ```py test="skip"
+    from typing import Optional
+
+    from pydantic import BaseModel
+
+
+    class Boo(BaseModel):
+        int: Optional[int] = None
+
+
+    m = Boo(int=123)  # Will fail to validate.
+    ```
+
+    Because of how Python evaluates [annotated assignment statements][annassign], the statement is equivalent to `int: None = None`, thus
+    leading to a validation error.
 
 ### Model methods and properties
 
 The example above only shows the tip of the iceberg of what models can do.
 Models possess the following methods and attributes:
 
-* [`model_computed_fields`][pydantic.main.BaseModel.model_computed_fields]: a dictionary of the computed fields of this model instance.
-* [`model_construct()`][pydantic.main.BaseModel.model_construct]: a class method for creating models without running validation. See
+* [`model_validate()`][pydantic.main.BaseModel.model_validate]: Validates the given object against the Pydantic model. See [Validating data](#validating-data).
+* [`model_validate_json()`][pydantic.main.BaseModel.model_validate_json]: Validates the given JSON data against the Pydantic model. See
+    [Validating data](#validating-data).
+* [`model_construct()`][pydantic.main.BaseModel.model_construct]: Creates models without running validation. See
     [Creating models without validation](#creating-models-without-validation).
-* [`model_copy()`][pydantic.main.BaseModel.model_copy]: returns a copy (by default, shallow copy) of the model. See
-    [Serialization](serialization.md#model_copy).
-* [`model_dump()`][pydantic.main.BaseModel.model_dump]: returns a dictionary of the model's fields and values. See
+* [`model_dump()`][pydantic.main.BaseModel.model_dump]: Returns a dictionary of the model's fields and values. See
     [Serialization](serialization.md#model_dump).
-* [`model_dump_json()`][pydantic.main.BaseModel.model_dump_json]: returns a JSON string representation of [`model_dump()`][pydantic.main.BaseModel.model_dump]. See
-    [Serialization](serialization.md#model_dump_json).
-* [`model_extra`][pydantic.main.BaseModel.model_extra]: get extra fields set during validation.
-* [`model_fields_set`][pydantic.main.BaseModel.model_fields_set]: set of fields which were set when the model instance was initialized.
-* [`model_json_schema()`][pydantic.main.BaseModel.model_json_schema]: returns a jsonable dictionary representing the model as JSON Schema. See [JSON Schema](json_schema.md).
-* [`model_parametrized_name()`][pydantic.main.BaseModel.model_parametrized_name]: compute the class name for parametrizations of generic classes.
-* [`model_post_init()`][pydantic.main.BaseModel.model_post_init]: perform additional initialization after the model is initialized.
-* [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild]: rebuild the model schema, which also supports building recursive generic models.
-    See [Rebuild model schema](#rebuild-model-schema).
-* [`model_validate()`][pydantic.main.BaseModel.model_validate]: a utility for loading any object into a model. See [Helper functions](#helper-functions).
-* [`model_validate_json()`][pydantic.main.BaseModel.model_validate_json]: a utility for validating the given JSON data against the Pydantic model. See
-    [Helper functions](#helper-functions).
+* [`model_dump_json()`][pydantic.main.BaseModel.model_dump_json]: Returns a JSON string representation of [`model_dump()`][pydantic.main.BaseModel.model_dump]. See [Serialization](serialization.md#model_dump_json).
+* [`model_copy()`][pydantic.main.BaseModel.model_copy]: Returns a copy (by default, shallow copy) of the model. See
+    [Serialization](serialization.md#model_copy).
+* [`model_json_schema()`][pydantic.main.BaseModel.model_json_schema]: Returns a jsonable dictionary representing the model's JSON Schema. See [JSON Schema](json_schema.md).
+* [`model_fields`][pydantic.main.BaseModel.model_fields]: A mapping between field names and their definitions ([`FieldInfo`][pydantic.fields.FieldInfo] instances).
+* [`model_computed_fields`][pydantic.main.BaseModel.model_computed_fields]: A mapping between computed field names and their definitions ([`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] instances).
+* [`model_extra`][pydantic.main.BaseModel.model_extra]: The extra fields set during validation.
+* [`model_fields_set`][pydantic.main.BaseModel.model_fields_set]: The set of fields which were explicitly provided when the model was initialized.
+* [`model_parametrized_name()`][pydantic.main.BaseModel.model_parametrized_name]: Computes the class name for parametrizations of generic classes.
+* [`model_post_init()`][pydantic.main.BaseModel.model_post_init]: Performs additional actions after the model is initialized.
+* [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild]: Rebuilds the model schema, which also supports building recursive generic models.
+    See [Rebuilding model schema](#rebuilding-model-schema).
 
 !!! note
-    See [`BaseModel`][pydantic.main.BaseModel] for the class definition including a full list of methods and attributes.
+    See the API documentation of [`BaseModel`][pydantic.main.BaseModel] for the class definition including a full list of methods and attributes.
 
 !!! tip
     See [Changes to `pydantic.BaseModel`](../migration.md#changes-to-pydanticbasemodel) in the
@@ -181,36 +207,22 @@ print(m.model_dump())
 """
 ```
 
-For self-referencing models, see [postponed annotations](postponed_annotations.md#self-referencing-or-recursive-models).
+Self-referencing models are supported. For more details, see [postponed annotations](postponed_annotations.md#self-referencing-or-recursive-models).
 
-!!! note
-    When defining your models, watch out for naming collisions between your field name and its type, a previously defined model, or an imported library.
+## Rebuilding model schema
 
-    For example, the following would yield a validation error:
-    ```py test="skip"
-    from typing import Optional
-
-    from pydantic import BaseModel
-
-
-    class Boo(BaseModel):
-        int: Optional[int] = None
-
-
-    m = Boo(int=123)  # errors
-    ```
-    An error occurs since the field  `int` is set to a default value of `None` and has the exact same name as its type, so both are interpreted to be `None`.
-
-## Rebuild model schema
-
-The model schema can be rebuilt using [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild]. This is useful for building recursive generic models.
+When you define a model class in your code, Pydantic will analyze the body of the class to collect a variety of information
+required to perform validation and serialization, gathered in a core schema. Notably, the model's type annotations are evaluated to
+understand the valid types for each field (more information can be found in the [Architecture](../architecture.md) documentation).
+However, it might be the case that annotations refer to symbols not defined when the model class is being created.
+To circumvent this issue, the [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild] method can be used:
 
 ```py
 from pydantic import BaseModel, PydanticUserError
 
 
 class Foo(BaseModel):
-    x: 'Bar'
+    x: 'Bar'  # (1)!
 
 
 try:
@@ -241,6 +253,11 @@ print(Foo.model_json_schema())
 """
 ```
 
+1. `Bar` is not yet defined when the `Foo` class is being created. For this reason,
+   a [string annotation](https://typing.readthedocs.io/en/latest/spec/annotations.html#string-annotations)
+   is being used. Alternatively, postponed annotations can be used with the `from __future__ import annotations` import
+   (see [PEP 563](https://peps.python.org/pep-0563/)).
+
 Pydantic tries to determine when this is necessary automatically and error if it wasn't done, but you may want to
 call [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild] proactively when dealing with recursive models or generics.
 
@@ -250,37 +267,39 @@ whole model (nested models and all), so all types at all levels need to be ready
 
 ## Arbitrary class instances
 
-(Formerly known as "ORM Mode"/`from_orm`.)
+(Formerly known as "ORM Mode"/`from_orm`).
 
 Pydantic models can also be created from arbitrary class instances by reading the instance attributes corresponding
 to the model field names. One common application of this functionality is integration with object-relational mappings
 (ORMs).
 
-To do this, set the config attribute `model_config['from_attributes'] = True`. See
-[Model Config][pydantic.config.ConfigDict.from_attributes] and [ConfigDict][pydantic.config.ConfigDict] for more information.
+To do this, set the [`from_attributes`][pydantic.config.ConfigDict.from_attributes] config value to `True`
+(see the documentation on [Configuration](./config.md) for more details).
 
 The example here uses [SQLAlchemy](https://www.sqlalchemy.org/), but the same approach should work for any ORM.
 
 ```py
 from typing import List
 
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.dialects.postgresql import ARRAY
-from sqlalchemy.orm import declarative_base
+from sqlalchemy import ARRAY, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, ConfigDict, StringConstraints
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    pass
 
 
 class CompanyOrm(Base):
     __tablename__ = 'companies'
 
-    id = Column(Integer, primary_key=True, nullable=False)
-    public_key = Column(String(20), index=True, nullable=False, unique=True)
-    name = Column(String(63), unique=True)
-    domains = Column(ARRAY(String(255)))
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    public_key: Mapped[str] = mapped_column(
+        String(20), index=True, nullable=False, unique=True
+    )
+    domains: Mapped[List[str]] = mapped_column(ARRAY(String(255)))
 
 
 class CompanyModel(BaseModel):
@@ -288,68 +307,20 @@ class CompanyModel(BaseModel):
 
     id: int
     public_key: Annotated[str, StringConstraints(max_length=20)]
-    name: Annotated[str, StringConstraints(max_length=63)]
     domains: List[Annotated[str, StringConstraints(max_length=255)]]
 
 
 co_orm = CompanyOrm(
     id=123,
     public_key='foobar',
-    name='Testing',
     domains=['example.com', 'foobar.com'],
 )
 print(co_orm)
 #> <__main__.CompanyOrm object at 0x0123456789ab>
 co_model = CompanyModel.model_validate(co_orm)
 print(co_model)
-"""
-id=123 public_key='foobar' name='Testing' domains=['example.com', 'foobar.com']
-"""
+#> id=123 public_key='foobar' domains=['example.com', 'foobar.com']
 ```
-
-### Reserved names
-
-You may want to name a `Column` after a reserved SQLAlchemy field. In that case, `Field` aliases will be
-convenient:
-
-```py
-import typing
-
-import sqlalchemy as sa
-from sqlalchemy.orm import declarative_base
-
-from pydantic import BaseModel, ConfigDict, Field
-
-
-class MyModel(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    metadata: typing.Dict[str, str] = Field(alias='metadata_')
-
-
-Base = declarative_base()
-
-
-class SQLModel(Base):
-    __tablename__ = 'my_table'
-    id = sa.Column('id', sa.Integer, primary_key=True)
-    # 'metadata' is reserved by SQLAlchemy, hence the '_'
-    metadata_ = sa.Column('metadata', sa.JSON)
-
-
-sql_model = SQLModel(metadata_={'key': 'val'}, id=1)
-
-pydantic_model = MyModel.model_validate(sql_model)
-
-print(pydantic_model.model_dump())
-#> {'metadata': {'key': 'val'}}
-print(pydantic_model.model_dump(by_alias=True))
-#> {'metadata_': {'key': 'val'}}
-```
-
-!!! note
-    The example above works because aliases have priority over field names for
-    field population. Accessing `SQLModel`'s `metadata` attribute would lead to a `ValidationError`.
 
 ### Nested attributes
 
@@ -404,10 +375,10 @@ name='Anna' age=20.0 pets=[Pet(name='Bones', species='dog'), Pet(name='Orion', s
 
 ## Error handling
 
-Pydantic will raise `ValidationError` whenever it finds an error in the data it's validating.
+Pydantic will raise a [`ValidationError`][pydantic_core.ValidationError] exception whenever it finds an error in the data it's validating.
 
-A single exception of type `ValidationError` will be raised regardless of the number of errors found,
-and that `ValidationError` will contain information about all of the errors and how they happened.
+A single exception will be raised regardless of the number of errors found, and that validation error
+will contain information about all of the errors and how they happened.
 
 See [Error Handling](../errors/errors.md) for details on standard and custom errors.
 
@@ -442,15 +413,17 @@ except ValidationError as e:
     """
 ```
 
-## Helper functions
+## Validating data
 
-*Pydantic* provides three `classmethod` helper functions on models for parsing data:
+Pydantic provides three methods on models classes for parsing data:
 
-* [`model_validate()`][pydantic.main.BaseModel.model_validate]: this is very similar to the `__init__` method of the model, except it takes a dict or an object
-  rather than keyword arguments. If the object passed cannot be validated, or if it's not a dictionary
-  or instance of the model in question, a `ValidationError` will be raised.
-* [`model_validate_json()`][pydantic.main.BaseModel.model_validate_json]: this takes a *str* or *bytes* and parses it as *json*, then passes the result to [`model_validate()`][pydantic.main.BaseModel.model_validate].
-* [`model_validate_strings()`][pydantic.main.BaseModel.model_validate_strings]: this takes a dict (can be nested) with string keys and values and validates the data in *json* mode so that said strings can be coerced into the correct types.
+* [`model_validate()`][pydantic.main.BaseModel.model_validate]: this is very similar to the `__init__` method of the model,
+  except it takes a dictionary or an object rather than keyword arguments. If the object passed cannot be validated,
+  or if it's not a dictionary or instance of the model in question, a [`ValidationError`][pydantic_core.ValidationError] will be raised.
+* [`model_validate_json()`][pydantic.main.BaseModel.model_validate_json]: this validates the provided data as a JSON string or `bytes` object.
+  If your incoming data is a JSON payload, this is generally considered faster (instead of manually parsing the data as a dictionary).
+  Learn more about JSON parsing in the [JSON](../concepts/json.md) section of the docs.
+* [`model_validate_strings()`][pydantic.main.BaseModel.model_validate_strings]: this takes a dictionary (can be nested) with string keys and values and validates the data in JSON mode so that said strings can be coerced into the correct types.
 
 ```py
 from datetime import datetime
@@ -524,7 +497,7 @@ except ValidationError as e:
     """
 ```
 
-If you want to validate serialized data in a format other than JSON, you should load the data into a dict yourself and
+If you want to validate serialized data in a format other than JSON, you should load the data into a dictionary yourself and
 then pass it to [`model_validate`][pydantic.main.BaseModel.model_validate].
 
 !!! note
@@ -532,165 +505,118 @@ then pass it to [`model_validate`][pydantic.main.BaseModel.model_validate].
     and [`model_validate_json`][pydantic.main.BaseModel.model_validate_json] may have different validation behavior.
     If you have data coming from a non-JSON source, but want the same validation
     behavior and errors you'd get from [`model_validate_json`][pydantic.main.BaseModel.model_validate_json],
-    our recommendation for now is to use either use `model_validate_json(json.dumps(data))`, or use [`model_validate_strings`][pydantic.main.BaseModel.model_validate_strings] if the data takes the form of a (potentially nested) dict with string keys and values.
-
-!!! note
-    Learn more about JSON parsing in the [JSON](../concepts/json.md) section of the docs.
+    our recommendation for now is to use either use `model_validate_json(json.dumps(data))`, or use [`model_validate_strings`][pydantic.main.BaseModel.model_validate_strings] if the data takes the form of a (potentially nested) dictionary with string keys and values.
 
 !!! note
     If you're passing in an instance of a model to [`model_validate`][pydantic.main.BaseModel.model_validate], you will want to consider setting
-    [`revalidate_instances`](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.revalidate_instances)
-    in the model's config. If you don't set this value, then validation will be skipped on model instances. See the below example:
+    [`revalidate_instances`][pydantic.ConfigDict.revalidate_instances] in the model's config.
+    If you don't set this value, then validation will be skipped on model instances. See the below example:
+
+    === ":x: `revalidate_instances='never'`"
+        ```py
+        from pydantic import BaseModel
 
 
-=== ":x: `revalidate_instances='never'`"
-    ```py
-    from pydantic import BaseModel
+        class Model(BaseModel):
+            a: int
 
 
-    class Model(BaseModel):
-        a: int
+        m = Model(a=0)
+        # note: setting `validate_assignment` to `True` in the config can prevent this kind of misbehavior.
+        m.a = 'not an int'
 
-
-    m = Model(a=0)
-    # note: the `model_config` setting validate_assignment=True` can prevent this kind of misbehavior
-    m.a = 'not an int'
-
-    # doesn't raise a validation error even though m is invalid
-    m2 = Model.model_validate(m)
-    ```
-
-=== ":white_check_mark: `revalidate_instances='always'`"
-    ```py
-    from pydantic import BaseModel, ConfigDict, ValidationError
-
-
-    class Model(BaseModel):
-        a: int
-
-        model_config = ConfigDict(revalidate_instances='always')
-
-
-    m = Model(a=0)
-    # note: the `model_config` setting validate_assignment=True` can prevent this kind of misbehavior
-    m.a = 'not an int'
-
-    try:
+        # doesn't raise a validation error even though m is invalid
         m2 = Model.model_validate(m)
-    except ValidationError as e:
-        print(e)
-        """
-        1 validation error for Model
-        a
-          Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='not an int', input_type=str]
-        """
-    ```
+        ```
+
+    === ":white_check_mark: `revalidate_instances='always'`"
+        ```py
+        from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+        class Model(BaseModel):
+            a: int
+
+            model_config = ConfigDict(revalidate_instances='always')
+
+
+        m = Model(a=0)
+        # note: setting `validate_assignment` to `True` in the config can prevent this kind of misbehavior.
+        m.a = 'not an int'
+
+        try:
+            m2 = Model.model_validate(m)
+        except ValidationError as e:
+            print(e)
+            """
+            1 validation error for Model
+            a
+              Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='not an int', input_type=str]
+            """
+        ```
 
 ### Creating models without validation
 
-Pydantic also provides the [`model_construct()`][pydantic.main.BaseModel.model_construct] method, which allows models to be created **without validation**. This
-can be useful in at least a few cases:
+Pydantic also provides the [`model_construct()`][pydantic.main.BaseModel.model_construct] method, which allows models to be created **without validation**.
+This can be useful in at least a few cases:
 
 * when working with complex data that is already known to be valid (for performance reasons)
-* when one or more of the validator functions are non-idempotent, or
+* when one or more of the validator functions are non-idempotent
 * when one or more of the validator functions have side effects that you don't want to be triggered.
 
-!!! note
-    In Pydantic V2, the performance gap between `BaseModel.__init__` and `BaseModel.model_construct` has been narrowed
-    considerably. For simple models, calling `BaseModel.__init__` may even be faster. If you are using [`model_construct()`][pydantic.main.BaseModel.model_construct]
-    for performance reasons, you may want to profile your use case before assuming that [`model_construct()`][pydantic.main.BaseModel.model_construct] is faster.
-
 !!! warning
-    [`model_construct()`][pydantic.main.BaseModel.model_construct] does not do any validation, meaning it can create models which are invalid. **You should only
-    ever use the [`model_construct()`][pydantic.main.BaseModel.model_construct] method with data which has already been validated, or that you definitely trust.**
+    [`model_construct()`][pydantic.main.BaseModel.model_construct] does not do any validation, meaning it can create
+    models which are invalid. **You should only ever use the [`model_construct()`][pydantic.main.BaseModel.model_construct]
+    method with data which has already been validated, or that you definitely trust.**
 
-```py
-from pydantic import BaseModel
+!!! note
+    In Pydantic V2, the performance gap between validation (either with direct instantiation or the `model_validate*` methods)
+    and [`model_construct()`][pydantic.main.BaseModel.model_construct] has been narrowed
+    considerably. For simple models, going with validation may even be faster. If you are using [`model_construct()`][pydantic.main.BaseModel.model_construct]
+    for performance reasons, you may want to profile your use case before assuming it is actually faster.
 
-
-class User(BaseModel):
-    id: int
-    age: int
-    name: str = 'John Doe'
-
-
-original_user = User(id=123, age=32)
-
-user_data = original_user.model_dump()
-print(user_data)
-#> {'id': 123, 'age': 32, 'name': 'John Doe'}
-fields_set = original_user.model_fields_set
-print(fields_set)
-#> {'age', 'id'}
-
-# ...
-# pass user_data and fields_set to RPC or save to the database etc.
-# ...
-
-# you can then create a new instance of User without
-# re-running validation which would be unnecessary at this point:
-new_user = User.model_construct(_fields_set=fields_set, **user_data)
-print(repr(new_user))
-#> User(id=123, age=32, name='John Doe')
-print(new_user.model_fields_set)
-#> {'age', 'id'}
-
-# construct can be dangerous, only use it with validated data!:
-bad_user = User.model_construct(id='dog')
-print(repr(bad_user))
-#> User(id='dog', name='John Doe')
-```
-
-The `_fields_set` keyword argument to [`model_construct()`][pydantic.main.BaseModel.model_construct] is optional, but allows you to be more precise about
-which fields were originally set and which weren't. If it's omitted [`model_fields_set`][pydantic.main.BaseModel.model_fields_set] will just be the keys
-of the data provided.
-
-For example, in the example above, if `_fields_set` was not provided,
-`new_user.model_fields_set` would be `{'id', 'age', 'name'}`.
-
-Note that for subclasses of [`RootModel`](#rootmodel-and-custom-root-types), the root value can be passed to [`model_construct()`][pydantic.main.BaseModel.model_construct]
-positionally, instead of using a keyword argument.
+Note that for [root models](#rootmodel-and-custom-root-types), the root value can be passed to
+[`model_construct()`][pydantic.main.BaseModel.model_construct] positionally, instead of using a keyword argument.
 
 Here are some additional notes on the behavior of [`model_construct()`][pydantic.main.BaseModel.model_construct]:
 
-* When we say "no validation is performed" — this includes converting dicts to model instances. So if you have a field
-  with a `Model` type, you will need to convert the inner dict to a model yourself before passing it to
-  [`model_construct()`][pydantic.main.BaseModel.model_construct].
-  * In particular, the [`model_construct()`][pydantic.main.BaseModel.model_construct] method does not support recursively constructing models from dicts.
+* When we say "no validation is performed" — this includes converting dictionaries to model instances. So if you have a field
+  referring to a model type, you will need to convert the inner dictionary to a model yourself.
 * If you do not pass keyword arguments for fields with defaults, the default values will still be used.
-* For models with private attributes, the `__pydantic_private__` dict will be initialized the same as it would be when
-  calling `__init__`.
-* When constructing an instance using [`model_construct()`][pydantic.main.BaseModel.model_construct], no `__init__` method from the model or any of its parent
-  classes will be called, even when a custom `__init__` method is defined.
+* For models with private attributes, the `__pydantic_private__` dictionary will be populated the same as it would be when
+  creating the model with validation.
+* No `__init__` method from the model or any of its parent classes will be called, even when a custom `__init__` method is defined.
 
-!!! note "On `extra` behavior with `model_construct`"
-    * For models with `model_config['extra'] == 'allow'`, data not corresponding to fields will be correctly stored in
-    the `__pydantic_extra__` dict and saved to the model's `__dict__`.
-    * For models with `model_config['extra'] == 'ignore'`, data not corresponding to fields will be ignored - that is,
+!!! note "On [extra fields](#extra-fields) behavior with [`model_construct()`][pydantic.main.BaseModel.model_construct]"
+    * For models with [`extra`][pydantic.ConfigDict.extra] set to `'allow'`, data not corresponding to fields will be correctly stored in
+    the `__pydantic_extra__` dictionary and saved to the model's `__dict__` attribute.
+    * For models with [`extra`][pydantic.ConfigDict.extra] set to `'ignore'`, data not corresponding to fields will be ignored — that is,
     not stored in `__pydantic_extra__` or `__dict__` on the instance.
-    * Unlike a call to `__init__`, a call to `model_construct` with `model_config['extra'] == 'forbid'` doesn't raise an
-    error in the presence of data not corresponding to fields. Rather, said input data is simply ignored.
+    * Unlike when instiating the model with validation, a call to [`model_construct()`][pydantic.main.BaseModel.model_construct] with [`extra`][pydantic.ConfigDict.extra] set to `'forbid'` doesn't raise an error in the presence of data not corresponding to fields. Rather, said input data is simply ignored.
 
 ## Generic models
 
 Pydantic supports the creation of generic models to make it easier to reuse a common model structure.
 
-In order to declare a generic model, you perform the following steps:
+In order to declare a generic model, you should follow the following steps:
 
-1. Declare one or more `typing.TypeVar` instances to use to parameterize your model.
-2. Declare a pydantic model that inherits from `pydantic.BaseModel` and `typing.Generic`,
-  where you pass the `TypeVar` instances as parameters to `typing.Generic`.
-3. Use the `TypeVar` instances as annotations where you will want to replace them with other types or
-  pydantic models.
+1. Declare one or more [type variables][typing.TypeVar] to use to parameterize your model.
+2. Declare a pydantic model that inherits from [`BaseModel`][pydantic.BaseModel] and [`typing.Generic`][] (in this specific order),
+  and add the list of type variables you declared previously as parameters to the [`Generic`][typing.Generic] parent.
+3. Use the type variables as annotations where you will want to replace them with other types.
 
-Here is an example using a generic `BaseModel` subclass to create an easily-reused HTTP response payload wrapper:
+!!! warning "PEP 695 support"
+    Pydantic does not support the new syntax for generic classes (introduced by [PEP 695](https://peps.python.org/pep-0695/)),
+    available since Python 3.12. Progress can be tracked in [this issue](https://github.com/pydantic/pydantic/issues/9782).
+
+Here is an example using a generic Pydantic model to create an easily-reused HTTP response payload wrapper:
 
 ```py
 from typing import Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
-DataT = TypeVar('DataT')
+DataT = TypeVar('DataT')  # (1)!
 
 
 class DataModel(BaseModel):
@@ -698,8 +624,8 @@ class DataModel(BaseModel):
     people: List[str]
 
 
-class Response(BaseModel, Generic[DataT]):
-    data: Optional[DataT] = None
+class Response(BaseModel, Generic[DataT]):  # (2)!
+    data: Optional[DataT] = None  # (3)!
 
 
 print(Response[int](data=1))
@@ -723,19 +649,23 @@ except ValidationError as e:
     """
 ```
 
-If you set the `model_config` or make use of `@field_validator` or other Pydantic decorators in your generic model
-definition, they will be applied to parametrized subclasses in the same way as when inheriting from a `BaseModel`
-subclass. Any methods defined on your generic class will also be inherited.
+1. Refers to step 1 described above.
+2. Refers to step 2 described above.
+3. Refers to step 3 described above.
 
-Pydantic's generics also integrate properly with type checkers, so you get all the type checking
+Any [configuration](./config.md), [validation](./validators.md) or [serialization](./serialization.md) logic
+set on the generic model will also be applied to the parametrized classes, in the same way as when inheriting from
+a model class. Any custom methods or attributes will also be inherited.
+
+Generic models also integrate properly with type checkers, so you get all the type checking
 you would expect if you were to declare a distinct type for each parametrization.
 
 !!! note
-    Internally, Pydantic creates subclasses of `BaseModel` at runtime when generic models are parametrized.
+    Internally, Pydantic creates subclasses of the generic model at runtime when the generic model class is parametrized.
     These classes are cached, so there should be minimal overhead introduced by the use of generics models.
 
 To inherit from a generic model and preserve the fact that it is generic, the subclass must also inherit from
-`typing.Generic`:
+[`Generic`][typing.Generic]:
 
 ```py
 from typing import Generic, TypeVar
@@ -750,16 +680,15 @@ class BaseClass(BaseModel, Generic[TypeX]):
 
 
 class ChildClass(BaseClass[TypeX], Generic[TypeX]):
-    # Inherit from Generic[TypeX]
     pass
 
 
-# Replace TypeX by int
+# Parametrize `TypeX` with `int`:
 print(ChildClass[int](X=1))
 #> X=1
 ```
 
-You can also create a generic subclass of a `BaseModel` that partially or fully replaces the type parameters in the
+You can also create a generic subclass of a model that partially or fully replaces the type variables in the
 superclass:
 
 ```py
@@ -781,12 +710,13 @@ class ChildClass(BaseClass[int, TypeY], Generic[TypeY, TypeZ]):
     z: TypeZ
 
 
-# Replace TypeY by str
+# Parametrize `TypeY` with `str`:
 print(ChildClass[str, int](x='1', y='y', z='3'))
 #> x=1 y='y' z=3
 ```
 
-If the name of the concrete subclasses is important, you can also override the default name generation:
+If the name of the concrete subclasses is important, you can also override the default name generation
+by overriding the [`model_parametrized_name()`][pydantic.main.BaseModel.model_parametrized_name] method:
 
 ```py
 from typing import Any, Generic, Tuple, Type, TypeVar
@@ -846,10 +776,10 @@ Order(id=1, product=ResponseModel[Product](content=Product(name='Apple', price=0
 !!! tip
     When using a parametrized generic model as a type in another model (like `product: ResponseModel[Product]`),
     make sure to parametrize said generic model when you initialize the model instance
-    (like `response = ResponseModel[Product](content=product)`). If you don't, a `ValidationError` will be raised, as
-    Pydantic doesn't infer the type of the generic model based on the data passed to it.
+    (like `response = ResponseModel[Product](content=product)`). If you don't, a [`ValidationError`][pydantic_core.ValidationError]
+    will be raised, as Pydantic doesn't infer the type of the generic model based on the data passed to it.
 
-Using the same `TypeVar` in nested models allows you to enforce typing relationships at different points in your model:
+Using the same type variable in nested models allows you to enforce typing relationships at different points in your model:
 
 ```py
 from typing import Generic, TypeVar
@@ -885,63 +815,109 @@ except ValidationError as e:
     """
 ```
 
-When using bound type parameters, and when leaving type parameters unspecified, Pydantic treats generic models
-similarly to how it treats built-in generic types like `List` and `Dict`:
+!!! warning
+    While it may not raise an error, we strongly advise against using parametrized generics in [`isinstance()`](https://docs.python.org/3/library/functions.html#isinstance) checks.
 
-* If you don't specify parameters before instantiating the generic model, they are validated as the bound of the `TypeVar`.
-* If the `TypeVar`s involved have no bounds, they are treated as `Any`.
+    For example, you should not do `isinstance(my_model, MyGenericModel[int])`. However, it is fine to do `isinstance(my_model, MyGenericModel)` (note that, for standard generics, it would raise an error to do a subclass check with a parameterized generic class).
 
-Also, like `List` and `Dict`, any parameters specified using a `TypeVar` can later be substituted with concrete types:
+    If you need to perform [`isinstance()`](https://docs.python.org/3/library/functions.html#isinstance) checks against parametrized generics, you can do this by subclassing the parametrized generic class:
 
-```py requires="3.12"
-from typing import Generic, TypeVar
+    ```py test="skip" lint="skip"
+    class MyIntModel(MyGenericModel[int]): ...
+
+    isinstance(my_model, MyIntModel)
+    ```
+
+### Validation of unparametrized type variables
+
+When leaving type variables unparametrized, Pydantic treats generic models similarly to how it treats built-in generic
+types like [`list`][] and [`dict`][]:
+
+* If the type variable is [bound](https://typing.readthedocs.io/en/latest/reference/generics.html#type-variables-with-upper-bounds)
+  or [constrained](https://typing.readthedocs.io/en/latest/reference/generics.html#type-variables-with-constraints) to a specific type,
+  it will be used.
+* If the type variable has a default type (as specified by [PEP 696](https://peps.python.org/pep-0696/)), it will be used.
+* For unbound or unconstrained type variables, Pydantic will fallback to [`Any`][typing.Any].
+
+```py
+from typing import Generic
+
+from typing_extensions import TypeVar
 
 from pydantic import BaseModel, ValidationError
 
-AT = TypeVar('AT')
-BT = TypeVar('BT')
+T = TypeVar('T')
+U = TypeVar('U', bound=int)
+V = TypeVar('V', default=str)
 
 
-class Model(BaseModel, Generic[AT, BT]):
-    a: AT
-    b: BT
+class Model(BaseModel, Generic[T, U, V]):
+    t: T
+    u: U
+    v: V
 
 
-print(Model(a='a', b='a'))
-#> a='a' b='a'
+print(Model(t='t', u=1, v='v'))
+#> t='t' u=1 v='v'
 
-IntT = TypeVar('IntT', bound=int)
-typevar_model = Model[int, IntT]
-print(typevar_model(a=1, b=1))
-#> a=1 b=1
 try:
-    typevar_model(a='a', b='a')
+    Model(t='t', u='u', v=1)
 except ValidationError as exc:
     print(exc)
     """
-    2 validation errors for Model[int, TypeVar]
-    a
-      Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='a', input_type=str]
-    b
-      Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='a', input_type=str]
+    2 validation errors for Model
+    u
+      Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='u', input_type=str]
+    v
+      Input should be a valid string [type=string_type, input_value=1, input_type=int]
     """
-
-concrete_model = typevar_model[int]
-print(concrete_model(a=1, b=1))
-#> a=1 b=1
 ```
 
 !!! warning
-    While it may not raise an error, we strongly advise against using parametrized generics in isinstance checks.
 
-    For example, you should not do `isinstance(my_model, MyGenericModel[int])`. However, it is fine to do `isinstance(my_model, MyGenericModel)`. (Note that, for standard generics, it would raise an error to do a subclass check with a parameterized generic.)
+    In some cases, validation against an unparametrized generic model can lead to data loss. Specifically, if a subtype of the type variable upper bound, constraints, or default is being used and the model isn't explicitly parametrized, the resulting type **will not be** the one being provided:
 
-    If you need to perform isinstance checks against parametrized generics, you can do this by subclassing the parametrized generic class. This looks like `class MyIntModel(MyGenericModel[int]): ...` and `isinstance(my_model, MyIntModel)`.
+    ```py
+    from typing import Generic, TypeVar
 
-If a Pydantic model is used in a `TypeVar` bound and the generic type is never parametrized then Pydantic will use the bound for validation but treat the value as `Any` in terms of serialization:
+    from pydantic import BaseModel
+
+    ItemT = TypeVar('ItemT', bound='ItemBase')
+
+
+    class ItemBase(BaseModel): ...
+
+
+    class IntItem(ItemBase):
+        value: int
+
+
+    class ItemHolder(BaseModel, Generic[ItemT]):
+        item: ItemT
+
+
+    loaded_data = {'item': {'value': 1}}
+
+
+    print(ItemHolder(**loaded_data))  # (1)!
+    #> item=ItemBase()
+
+    print(ItemHolder[IntItem](**loaded_data))  # (2)!
+    #> item=IntItem(value=1)
+    ```
+
+    1. When the generic isn't parametrized, the input data is validated against the `ItemT` upper bound.
+       Given that `ItemBase` has no fields, the `item` field information is lost.
+    2. In this case, the type variable is explicitly parametrized, so the input data is validated against the `IntItem` class.
+
+### Serialization of unparametrized type variables
+
+The behavior of serialization differs when using type variables with [upper bounds](https://typing.readthedocs.io/en/latest/reference/generics.html#type-variables-with-upper-bounds), [constraints](https://typing.readthedocs.io/en/latest/reference/generics.html#type-variables-with-constraints), or a default value:
+
+If a Pydantic model is used in a type variable upper bound and the type variable is never parametrized, then Pydantic will use the upper bound for validation but treat the value as [`Any`][typing.Any] in terms of serialization:
 
 ```py
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -955,7 +931,7 @@ ErrorDataT = TypeVar('ErrorDataT', bound=ErrorDetails)
 
 class Error(BaseModel, Generic[ErrorDataT]):
     message: str
-    details: Optional[ErrorDataT]
+    details: ErrorDataT
 
 
 class MyErrorDetails(ErrorDetails):
@@ -990,10 +966,9 @@ assert error.model_dump() == {
 ```
 
 Here's another example of the above behavior, enumerating all permutations regarding bound specification and generic type parametrization:
-```py
-from typing import Generic
 
-from typing_extensions import TypeVar
+```py
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -1022,13 +997,14 @@ item_no_bound_explicit = ItemNoBound[IntValue](item=IntValue(value=3))
 #> {'item': {'value': 3}}
 ```
 
-If you use a `default=...` (available in Python >= 3.13 or via `typing-extensions`) or constraints (`TypeVar('T', str, int)`;
-note that you rarely want to use this form of a `TypeVar`) then the default value or constraints will be used for both
-validation and serialization if the type variable is not parametrized.
-You can override this behavior using `pydantic.SerializeAsAny`:
+However, if [constraints](https://typing.readthedocs.io/en/latest/reference/generics.html#type-variables-with-constraints)
+or a default value (as per [PEP 696](https://peps.python.org/pep-0696/)) is being used, then the default type or constraints
+will be used for both validation and serialization if the type variable is not parametrized. You can override this behavior
+using [`SerializeAsAny`](./serialization.md#serializeasany-annotation):
+
 
 ```py
-from typing import Generic, Optional
+from typing import Generic
 
 from typing_extensions import TypeVar
 
@@ -1044,7 +1020,7 @@ ErrorDataT = TypeVar('ErrorDataT', default=ErrorDetails)
 
 class Error(BaseModel, Generic[ErrorDataT]):
     message: str
-    details: Optional[ErrorDataT]
+    details: ErrorDataT
 
 
 class MyErrorDetails(ErrorDetails):
@@ -1062,11 +1038,12 @@ assert error.model_dump() == {
         'foo': 'var',
     },
 }
+# If `ErrorDataT` was using an upper bound, `bar` would be present in `details`.
 
 
 class SerializeAsAnyError(BaseModel, Generic[ErrorDataT]):
     message: str
-    details: Optional[SerializeAsAny[ErrorDataT]]
+    details: SerializeAsAny[ErrorDataT]
 
 
 # serialized as Any
@@ -1082,46 +1059,6 @@ assert error.model_dump() == {
     },
 }
 ```
-
-!!! note
-    Note, you may run into a bit of trouble if you don't parametrize a generic when the case of validating against the generic's bound
-    could cause data loss. See the example below:
-
-```py
-from typing import Generic
-
-from typing_extensions import TypeVar
-
-from pydantic import BaseModel
-
-TItem = TypeVar('TItem', bound='ItemBase')
-
-
-class ItemBase(BaseModel): ...
-
-
-class IntItem(ItemBase):
-    value: int
-
-
-class ItemHolder(BaseModel, Generic[TItem]):
-    item: TItem
-
-
-loaded_data = {'item': {'value': 1}}
-
-
-print(ItemHolder(**loaded_data).model_dump())  # (1)!
-#> {'item': {}}
-
-print(ItemHolder[IntItem](**loaded_data).model_dump())  # (2)!
-#> {'item': {'value': 1}}
-```
-
-1. When the generic isn't parametrized, the input data is validated against the generic bound.
-   Given that `ItemBase` has no fields, the `item` field information is lost.
-2. In this case, the runtime type information is provided explicitly via the generic parametrization,
-   so the input data is validated against the `IntItem` class and the serialization output matches what's expected.
 
 ## Dynamic model creation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,7 +217,8 @@ plugins:
           extensions:
             - docs/plugins/griffe_doclinks.py
         import:
-          - https://docs.python.org/3/objects.inv
+          - url: https://docs.python.org/3/objects.inv
+            domains: [py, std]
 - redirects:
     redirect_maps:
       'usage/mypy.md': 'integrations/mypy.md'

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:0e81124dab45100ba65495984444d92cca6155098073443dc5b7e2ca94cf72be"
+content_hash = "sha256:64d51ce12cf3ad98d0c763b7a2a764fff1c611004a8a4a5d2d2331988598b356"
 
 [[metadata.targets]]
 requires_python = ">=3.8"
@@ -583,15 +583,15 @@ files = [
 
 [[package]]
 name = "faker"
-version = "27.0.0"
+version = "28.0.0"
 requires_python = ">=3.8"
 summary = "Faker is a Python package that generates fake data for you."
 dependencies = [
     "python-dateutil>=2.4",
 ]
 files = [
-    {file = "Faker-27.0.0-py3-none-any.whl", hash = "sha256:55ed0c4ed7bf16800c64823805f6fbbe6d4823db4b7c0903f6f890b8e4d6c34b"},
-    {file = "faker-27.0.0.tar.gz", hash = "sha256:32c78b68d2ba97aaad78422e4035785de2b4bb46b81e428190fc11978da9036c"},
+    {file = "Faker-28.0.0-py3-none-any.whl", hash = "sha256:6a3a08be54c37e05f7943d7ba5211d252c1de737687a46ad6f29209d8d5db11f"},
+    {file = "faker-28.0.0.tar.gz", hash = "sha256:0d3c0399204aaf8205cc1750db443474ca0436f177126b2c27b798e8336cc74f"},
 ]
 
 [[package]]
@@ -1061,7 +1061,7 @@ files = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.32"
+version = "9.5.33"
 requires_python = ">=3.8"
 summary = "Documentation that simply works"
 dependencies = [
@@ -1078,8 +1078,8 @@ dependencies = [
     "requests~=2.26",
 ]
 files = [
-    {file = "mkdocs_material-9.5.32-py3-none-any.whl", hash = "sha256:f3704f46b63d31b3cd35c0055a72280bed825786eccaf19c655b44e0cd2c6b3f"},
-    {file = "mkdocs_material-9.5.32.tar.gz", hash = "sha256:38ed66e6d6768dde4edde022554553e48b2db0d26d1320b19e2e2b9da0be1120"},
+    {file = "mkdocs_material-9.5.33-py3-none-any.whl", hash = "sha256:dbc79cf0fdc6e2c366aa987de8b0c9d4e2bb9f156e7466786ba2fd0f9bf7ffca"},
+    {file = "mkdocs_material-9.5.33.tar.gz", hash = "sha256:d23a8b5e3243c9b2f29cdfe83051104a8024b767312dc8fde05ebe91ad55d89d"},
 ]
 
 [[package]]
@@ -1266,102 +1266,102 @@ files = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.23.0"
+version = "2.23.1"
 requires_python = ">=3.8"
 summary = "Core functionality for Pydantic validation and serialization"
 dependencies = [
     "typing-extensions!=4.7.0,>=4.6.0",
 ]
 files = [
-    {file = "pydantic_core-2.23.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c3ed715355de44fd1ad5e2347ae9d8b48c12423a938174accd98f3c21cd35141"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e1eaba0496f00923f125bea4ce2ec2ad7b32753d037ad456ea8b971888ccebf"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4cd64a16bdd44ea2120e5592818b1391b22adb02632ca4438897b10c07ef62a"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:843c98c21b7cd80b0e6f8a44e84fc6ebe63a823b991c337361d1e9141a7d753d"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:848727b22f9117b826a5cc769a874c8a218ab994a455a739fee1aaab611e10f8"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3afe0158f5ee4ba5a0b468dbd3adc46e1c460a2de10ab6af19cab7ccf2831aaa"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5d6c3a0a5f3a1c0c7d57acbb1cce592525959414b8f0b79e00d123b8f979d8b"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6f4806078005609da8957757ec41632da08ae33d2e12ce9b82a03e0f9bd9296a"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f288373c599466a3977b6305e8ff21ed81465b8c5b5ba2b1a160c89ad6a09285"},
-    {file = "pydantic_core-2.23.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b0749590fa48c99d93670d2b6a452e0b08c0accd39d86e7579ed176fd8ce9687"},
-    {file = "pydantic_core-2.23.0-cp310-none-win32.whl", hash = "sha256:f6f2083e9e2250ea7563a809dc28f4df1c4f78a0f8191fc82755bb9edff438a4"},
-    {file = "pydantic_core-2.23.0-cp310-none-win_amd64.whl", hash = "sha256:30bab73daf1cbd751fb925fbf43c932dc5edfd694af2ee6d207bf9daccf86abd"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c174a6a3885f04da4a94ca15e2ce5ec4db535b8468ee71de246bf709188630e6"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:38ce3939035e86c775427135a59f4d0da6a2fd567851fc921b24993898d2c584"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:433ae51fcd7e32e82a922aa67b2233a94f72e58d1d5674322eeeedc2a2a5de1f"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:be25600552428fb43a4d94da3d9001f2a519bde715515bf8704acbd80495b279"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:15ec667c44d32995b71959edfbb3687508686cd06b16fecd8c1d0b97e4195c06"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b73ee3051e98a096027f529a5169560e22c61de067d44858b680fc21b0bd6c20"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100fc9d3a681864212dc5d0d25bbac545205d4c31e5f93095f9b6b1f799e8be7"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e082678c0bf14e9204175db2d0364410549f6457dcbd297ef642011d369283f2"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ba66866a945f96dd20a34c2205822131e8786c2402ce5620e8d73b3b3da665e1"},
-    {file = "pydantic_core-2.23.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f476419afe9b70d7f25fef7bec7033f69c2e3e1f35de23dad5dc5cc098759ce2"},
-    {file = "pydantic_core-2.23.0-cp311-none-win32.whl", hash = "sha256:c886deed32c95db3d3f46195316aea5b87b754e2b84ab14da0aea491df38a997"},
-    {file = "pydantic_core-2.23.0-cp311-none-win_amd64.whl", hash = "sha256:d3eda2b28ed432709f4eae83316fe8a64e5ab79a9d5d9a45950e89c8d43d17d0"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:638f8bae1d32f1cff46ed7742782b255d8175c4b006f1f41dccfa68ae7bbd2d2"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fe9743b50b86bf75b2f0b48c899665da30ae4e332963a0054d4c74548ba72ab0"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8681973c8648bca5f18aae7a949a90b2177d894a30763b54d35b264c6b3cb02"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e9935b6c89171bab3e4d3f67c4d4d19df60ab2db5676d27894cd39a834b97dde"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3dafe486b2cd19b119d6dce9cd4b2545eb04a679ef4faa6e5b895e0c2838d020"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:21b2d238fd200162e64303fd9e805b27d96ffe24164b31350a97eba75bf712e9"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0abc8460e7f214631bd14af8fde2ad69dcc54ae5facabdeb93150c5d3bd2abf3"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bb6f9b87d5e1a558f0a8ac9a9282f76505b1ac96695d6bac4a036dce88d927ec"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:262d77d4c4fa31f4bdfd838d21f265c35c469e980cc422a47d0b2ae796f38d07"},
-    {file = "pydantic_core-2.23.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:781ba2aa6023a14bf865d7368d674db44c99a8630fc76ba73e850ca7b5a1febb"},
-    {file = "pydantic_core-2.23.0-cp312-none-win32.whl", hash = "sha256:2670f3a68d1a574ae1b0f3da016c010dd08d0a422d14a3b78be47aebbae9a310"},
-    {file = "pydantic_core-2.23.0-cp312-none-win_amd64.whl", hash = "sha256:29904fc5b7c2795b236e1a54680b3cb203c50b1968938a06a4ca7aaee45e71cc"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:be43d9249acf772be100ca1f687680d0e2e2bd5fbaecc3e904f5a65762d45a86"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c9c3b124d0c1f2b6d462aac3cd194457d419e62d62bbd7fc60392e10eb179d10"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2933accfb2e181d67ae37eb2c40abb1a226841392e90edaa62900c0fe7f47e0e"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eac616e3571f9083d972accae44e98ca7020e7c345ac9317fcc8b5638175cadc"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6264eee5c7fced027286ed143c329f531878ec9ae11e7be3c06635045ecbf81f"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:10a6b04f4f86e3816b50dc9785bb662d87e5eda8423f15a80e6f245f6695828a"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d9053f4c9ff5ed98270937938efaadf8a4beb6826ce6cee1e66614b7613c969"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:00eb370a47bd63d6f0e59bae8080c43eb21aca033785ecaeba3fd36f2cfe0877"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6c093a00bce0de23102c3f4a8fab5629f6c0e2dc09eeb7f275c03895fcee8598"},
-    {file = "pydantic_core-2.23.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ee96b28ffefe34ddf5e83e28c0ece5f96f7e3a4caa51b1683b2a71d990f8235e"},
-    {file = "pydantic_core-2.23.0-cp313-none-win32.whl", hash = "sha256:a69297f237984b358275cde98bf81b816a6528f579cf3818954d6266bd64c48d"},
-    {file = "pydantic_core-2.23.0-cp313-none-win_amd64.whl", hash = "sha256:8ff9bd3024412d9766343fe60e1dd6e590d30202dd20d27a881dd790b9b1b72d"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:690a49c803412267758d114dd8f1e2a819436e1ec3df5043b7ea25bcbfabe40a"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:987503763bbdc403821e8b0e618888eae02531f416964aeb1f867ca53f0d1e72"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b7f929d7fffe5017aa0b50414a94a57ac21d96004673856147ea2af90beac7b"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a17d5524f10afd850a0b4365f38931079dc5b00e3417e6b1774d0b8683a5244"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ec9897bde1b4654d513e065a97d7af50de5bfdf3419ba4ef3fed0fbe2d57451e"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f7d0a3607a63c328762b904e8ecb471b2fbe0223bfc01d30e0e962cb71ca508"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:649b1f24ac7a09c430929234d43011e5a4195c1b3d32dd3a80fb6f175dcf301b"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9f186dc1c1e0fe14a453ccc9a90201c03c12fbdda30e1624e405cf67dcf1dc00"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9add1a74e7d8008f4ed9bd4b7cb62de6fd28f81b28f7f6def8c0389a50a98127"},
-    {file = "pydantic_core-2.23.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d129992e977ecf672d4eb7c7ba0e5f13725995d0fac246c673f699b7722c9ae5"},
-    {file = "pydantic_core-2.23.0-cp38-none-win32.whl", hash = "sha256:b75989878eb94f1a63a6a558735cee1c8d6c7d24007b61df41efc8cdbe819f70"},
-    {file = "pydantic_core-2.23.0-cp38-none-win_amd64.whl", hash = "sha256:08dae83791aee669f7160a94e801162e8f17612c4a821c86e17f9a802389a011"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8e18fb1effad8d28ae510d35507eecf79abcba96c09627443c51acdfbfa30f93"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84667cd32f432bb7f1e0bc5f57c4ea2767d9493e9beef8f195657c16ea3a6076"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5202456ff1f71c2146ba63ffe4538be7fa5d0b6697de14f706d4266aa4e7bf47"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ae227d46fd1fa1b5a02c18a5a7c80ccff014b7bf596731af5bb157f33e058c6"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05a0d09b436ab65a35b5ad90fc295c4a0e545c2456e2212f242809c7474e60c6"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:49dea6930ab48b3ca233e7d541d5f6480f6ffa67a1cc2352cd8395c6f3c14745"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e21b2ee6273cf0d637a7b1622a6ece8761f111083822f1e814e7522d5efb1772"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:873e2453ff6451bdf5619c3c1122fa9998a39552d2fd4c2d9c34f61611e026d6"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c0eb1577f5073cfb336e5d08cb91e717197c0727803962850561d529c07e53c"},
-    {file = "pydantic_core-2.23.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c97f1fb88ec947522ec5863630cb17e3b3ec9f6ca09f954107ad3d35ca3abfe8"},
-    {file = "pydantic_core-2.23.0-cp39-none-win32.whl", hash = "sha256:804a81e50dc43508068964a2b7abacaf99850e2cb7cbd0ae3a8e0145cb89ba1f"},
-    {file = "pydantic_core-2.23.0-cp39-none-win_amd64.whl", hash = "sha256:54a4da481e9130eeba5b02fcfe95fcf26e188747b5b9c6a3bc434ee6f7573b04"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7e8e33bf23a61b07456a1666a07ba453c0906ed74c1330a60ba4c10691628310"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b28dadb0c7494e47304e5c0fec95c500ed914e88b53018ccb85d700fbb1d2bdc"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92137a6a2236223ae5aa4f610ca2a4fe5c8770941deeb6b295f477c71257e618"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3482e7e003b2b391ad2441c98ba219cbd71e3de12b3a5f422c5d9151479c827"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e34ae0eed62065a917f527296a0da2dc71056d53e5b7c8849d48ad69cc73a486"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:81b84e88ed517a4911f8ebef141b41f5b1d21f8100209b0fc118079accede06e"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:837cbeec0ad83ebd57ae9f4e8bd18c8ed34acfe3ec809e2ceceac253b0bc3fd7"},
-    {file = "pydantic_core-2.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:39d4ac2cf7a25f1ceec7588a5c9b86ccdf330a5941753e1779974c08a9d763c4"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:865f96455c0f5af1b1e73c4f52659899a635af4c1e4db5ae40f848ba456dfd24"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:ff54894bc04f5982db8fa6ff6d336afa2e4b66cccc76952a35772ff7485d5553"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3734dd979f69b322ec7ddff60123264474801ef9620255f120e10d33596c3a6"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca5363fb0f39135cd6cbdbaa542c24a91246cf9d08fb5c3ba23f774ef4e91f66"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d00380dbb87abf553d173e2b0c4863a4e2e8573e36ee865af7237a065adc3519"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:5fc73dd963497080b1961c16e6a01c054acb525fb8108c6aeed208d109d7385e"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:151968f31efca42a9a5ae25cd00a62a67fb368ed4fdf05c861c629138e5cf674"},
-    {file = "pydantic_core-2.23.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:95e912ae3ccbd9c20f44b85fc7f3e1e55db8f8688c8cf519aa517580ae7ba399"},
-    {file = "pydantic_core-2.23.0.tar.gz", hash = "sha256:954509ea58b1adf6614390056da194e86feb83423679984f8453416db7cfa8c9"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:78b02f84640a019e6047c92b4fb2c11c30c9c6ccd8d2966875d29d7650924bd8"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9fb8e75b67c05c2c7f0c0850b6fc7fc4e8ac101b1dd8d756a5f86cce42719ba1"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56cbb7ee53d2759b0c962595f33de36f63d31c45f88a94ef238e9e86a03bd42c"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:88a17eefe87873329086ec6c89295a3eb3eef7e54ebd307417a89d9b1fc5c02f"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:189008f80d1de57b659b37287cac704deecaca152e9f435281b505b101febc23"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9a67a959919b4e28969c240a68f1000bfa11cf6f892eb31a236e4d1a696edef3"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7742c1874b15d89f44dc287f9562b6447cd9cbfc858fdce00cfdb7d97cd53ec"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a89295e3a7b66267d4eefcaba054bee732821c4c5ef8d7a70e9cffd81fc6e31"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbaa71734f9324903127c0409ba7947d0594bb0d4598fc25f05e4fb747350f7e"},
+    {file = "pydantic_core-2.23.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9c71ccf9d306047452f803b65f229c02bccaab0c2cbd477f99774eb121df1c5f"},
+    {file = "pydantic_core-2.23.1-cp310-none-win32.whl", hash = "sha256:a303360a0840c11582abd940018890c78496fa04dd2667322a1416c87265c3d4"},
+    {file = "pydantic_core-2.23.1-cp310-none-win_amd64.whl", hash = "sha256:648707577e921b77d00252801fa07a65db076da25195e642fc11683d5ba4c6f6"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0bed69450e904ef4e71a4f6b7d7efd8186b33863d685eaf6110a8015f0c9c027"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6a1bfa416b6abed69db08d3ef7c51074c893feb870ffdb8f5b1f207fe53731b8"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6da375565d5ea446dc59e7360926daca18fd6dc2fcdb8eb3f7e3cc084b43b1cf"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5709b0c54340c6982120f9839654db6b0b0009a84e9c1fec4d8f82d5929ca264"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:83cd436d0cde245a6b91c5e184e5838bff98ed2ad6c79e55a04a749f3ac2cfe6"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3fcbafb95bf28133c165569c5f8b532ab39e04a9056f5faed19a529138ceef33"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e459f22aabc08630a77e578bea4114a057a49c6e080585ce4639378690b888d9"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c977c8ff0d1a675c264b69c9dee30fea10476b84957c47687aeaceefbaf9eba0"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d4100639ef7c7f137521edba8bd0ede2c5abe0ddc202348dd020b8dee971ee41"},
+    {file = "pydantic_core-2.23.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bf1f38bf5a9bd32b6a3bf92a3a29e2a64984db326c83eea17e2423076e1b2cbb"},
+    {file = "pydantic_core-2.23.1-cp311-none-win32.whl", hash = "sha256:a6b253b770fa1b3a616c1f2ead901bb80f502ea635a1e7c53984664330c2ec12"},
+    {file = "pydantic_core-2.23.1-cp311-none-win_amd64.whl", hash = "sha256:d123373421f2e810659d0d08da08bf2039282e7bdf16459d0a2bba105b0fd2fe"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ab49d80a018e34d5e79478185c38924ff2339d3104a3cb3226c2557ec277f8a2"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b032223071564a10551a97fa4196b50b6c2c1564335f71b2a950b82e02ccf951"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c10cc5b42d5df0d3e5ca1b6f8ed477405a1f3992c42f0e937fed0b94b6d51470"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3e2444fd5599457671a569e4ccc0158beeba8222a5f38a4468e15f3c7d0d66fc"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3a3683ffeee0116e57846fab3621b4d5c5b35f9407a88d57287dc1d04db0765"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cfacd9ae0f361c343a94267a0fabf31b4f02dd38bf9ffdd37a44f913f4804662"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2435fe50a40a016627188a690e297e11a10285d72a3051a02de13efe6f3792fb"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8966c9acfb8d0604d8f0cfba48f56a5d307502c9d5287cb2d473b71ae7da11cb"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:cd5435d5bd43505f9801de0ff42a29e2bf540b3b73c528ceb56c176f5c56a2e2"},
+    {file = "pydantic_core-2.23.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4dd5c1a6078841a80ef04e337983c6df830a8434aace1f61c9d44554fd619502"},
+    {file = "pydantic_core-2.23.1-cp312-none-win32.whl", hash = "sha256:4718b13ae5cf243b1df1f818e5c908338706be7bf1bd6c54c508643ac4596933"},
+    {file = "pydantic_core-2.23.1-cp312-none-win_amd64.whl", hash = "sha256:5523edfe13aeeaf507fb809794572bb62247be264ad9197281b0bccb7eb5a0ae"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8219764ec8df466ec5f541cdfa1857fca0bfe373281a35fa96ec37a1684a612b"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:178b1e6ad1290cba831d2b3c846e302928ba6da9a87ae0d6614d8a56ef1f2285"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a544f13fbcf3a7eb8398a2d0db13b4d640ddb8e511b2fc890c6c4c4968b7ccb"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3273aa949243f1a4bfb09ade15eec133806a8e73dabf8ecdaae6eb46301fbca8"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:94efbb3e3026bace137e289a2ed7ebd0b1fd483a891c3bbcf6f7e4f8b8862a7b"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35e2a6c66c6528576ac9563c6db509fd0a3c4364f3aefc5834fd43ab74091dad"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ef5ba921e4b680291a2d72b5233769d2e507452e10a9ff6e83dbb2315c8f01c"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:19200fb17d5e44b7ccda36ee848643cb65d23973b889e24269084377988dee25"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:19f3ac00336113ef10bd4ed6c3d5d2d2c309d5f8f195273b246fa9af00e81cb3"},
+    {file = "pydantic_core-2.23.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c275847f4afb48e84db2b486caa03ac6859fd1a434750e426ca7a3386d36a215"},
+    {file = "pydantic_core-2.23.1-cp313-none-win32.whl", hash = "sha256:401a184c7c8e8d90b3077d25ce99f012b9d093f1f57b9390f52737c42f8ed3d4"},
+    {file = "pydantic_core-2.23.1-cp313-none-win_amd64.whl", hash = "sha256:3c647805e383bc9eca36b96de935a6f3b9368b90ab773faccdb8438ef598fa41"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:73fee718bc43963fd87f820f987bfbd9b45517e77e9c30e2c9ed5c6dee13dfe3"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2538d5496cbbb34afef558b2bdaf74e1e5348b0f9f29472a24f923d6e4e0eda1"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:508bc9533fc3c3a7f6bcb542ce291c7641acd7e9c6c7eca8a2c5097fad1abf03"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b716a29a18da9e87f92d674688e200ef96fe5cab2c2283d2425eeb7d38cd6e8b"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b76a492eee676871702d883f0b09c6aef3e045bd4350d565bdf13b7aebcb29a"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82f6f20cd78d61008b32e38328041a5f63dc693a4be3be70239e877adb63b991"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3604a23b8050d18389967626b2f5597e6e5f5b1da07c9105465b61c5c3b43907"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fd401a7e1e38590fe0427328efca287b85ab528955f8d3636c886ad24d0681cd"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1e3113b02fd26b665d096cbbd9d3e903fe61889ec15eaebdbd903816143073a0"},
+    {file = "pydantic_core-2.23.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c777bf800b6b5387e3ca10b4500245bb129c2c9703b1c81f64c4b303d30d2db5"},
+    {file = "pydantic_core-2.23.1-cp38-none-win32.whl", hash = "sha256:20d459252542e1300694902b960e49503dd092a79a008ca50624c0b3d1bc94f7"},
+    {file = "pydantic_core-2.23.1-cp38-none-win_amd64.whl", hash = "sha256:3cb4cf38f41a7b80635debc23dcc5854bbc16cb41f64e2afb8e5cfe493fe9e46"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:1e3216ab36b4e41d40aecd13f0ee7724d8e7239b2c9de9c1ec36a83466f4ad55"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a04ec6de11e186e223de1e53a40b9c666aea2ef0108da22f899c2c45eaa9080d"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:214e2128e0e4a19d390d83054c347f9d15f6dab4ab8ba377abec00d95138052d"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:073bf07ce7626e4472df9428cebb0f692ed15b3128f83eb559ed9df81b8223c7"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4de2710e8acd4ce38265f62a71b47fdd132a324145ab3d41cb0ca5f52b7401f"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0b869f48d46ee9e77a25ea4ee479c2d463322e799aec41c284f6e9c9e0c1d2a7"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddc182839d40f2f3bd63b606da9f135c9a03dd09bb3b42a3cfaff47f2145547a"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ebc1067e85c3785c4b170da816629ea5247bbdbd403b94d795c572828441a8ef"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1c115d0d965a0dc36ab7afb2e48af493d3a72ae40e12c2de6aaf7295a919f0d9"},
+    {file = "pydantic_core-2.23.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ed6f1f62d8e209a8d78bc1c8cee1e73642bb5985a6bc4a18fc0d9e59fd926f1"},
+    {file = "pydantic_core-2.23.1-cp39-none-win32.whl", hash = "sha256:dd3eeee9e81c4bef82460d86a01e67249c715a41797e14cca286eb2006260c41"},
+    {file = "pydantic_core-2.23.1-cp39-none-win_amd64.whl", hash = "sha256:6c8a21cfaacb38ff5478f72e634a2a4ad178662ca57f32279ad743708b1aa36b"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9c9581fb2dee020c7fbfef4ec5e5ddbed47f42a7f29f3e99f628caf815498502"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b078d67accfe0b8b00dfea6c86826f95568ed0fa363881701145bd04b64c13ab"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9ed8f911c595b731c80c3744f393ed0ac8625d3c5bce83859513d509ada60ec"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aa1e807f455cbcfea6cff6d567dd9483924691e9b24e68f52fefd04b56486b4"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f21cfb7a8b102ec641d6de8636850fc62971e11f85569448de7ebfe27dd6b129"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2c85a302402b0400dcc1dfab6bf21b4ad6bacb5dfda273b227d7e90ee56f6490"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:265e50d461022b5f1c23fd6cf3d4e899ab5ecb36450488e3f9c464f07ff3834e"},
+    {file = "pydantic_core-2.23.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:29363ba693c0ca24f6094b21e174d2353dfe5747c0b8f55dcd4b1ae5b392332c"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8be3009cd73964ae56a23f7e09248ff0cb2d153a7ad11ecd5e1fff5b03935b47"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:3571a95cd4ebca483752c32aadc422e3b81e5998ae0505a2af3e563f93a67a2b"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:373d9b63b22436d53b383bf96239d4ac14c8469ccfa8b5b75d698140a87d2f2f"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a3fb2116337bcb4a75c4d4ead1944ee433e9bd3265c1505416d939005f4a5fc"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce5528e81bdae0b8ba707121a3bd59325686c377aaa65db7f7d99333c2f98b4e"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:4fd499a82ee3dabb5e5f346de7c73144e0486e8bc9bc62318cd8561695e6244c"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:16fe8b72776c3f99c0f61c76312c2aedf270bf2edd9893e074bb39e477cd7fa5"},
+    {file = "pydantic_core-2.23.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:29232456ca7fba105740a3eea460e2d7c96cd907727ea54f515f978f6064967d"},
+    {file = "pydantic_core-2.23.1.tar.gz", hash = "sha256:12543919dbf3021e17b9e2cd5cd1b570c6585794fa487339b5b95564b9689452"},
 ]
 
 [[package]]

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,7 +336,9 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
-        types_namespace = {**_typing_extra.get_cls_types_namespace(for_type), **(self.tail or {})}
+        # we already copy the namespace in get_cls_types_namespace, so we don't need to create a new dict here
+        types_namespace = _typing_extra.get_cls_types_namespace(for_type)
+        types_namespace.update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)
         try:
             yield

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -209,7 +209,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
         __tracebackhide__ = True
         validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
-        if self != validated_self:
+        if self is not validated_self:
             warnings.warn(
                 'A custom validator is returning a value other than `self`.\n'
                 "Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.\n"

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -254,7 +254,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             an error if extra values are passed, but they will be ignored.
 
         Args:
-            _fields_set: The set of field names accepted for the Model instance.
+            _fields_set: A set of field names that were originally explicitly set during instantiation. If provided,
+                this is directly used for the [`model_fields_set`][pydantic.BaseModel.model_fields_set] attribute.
+                Otherwise, the field names from the `values` argument will be used.
             values: Trusted or pre-validated data dictionary.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     'typing-extensions>=4.6.1; python_version < "3.13"',
     'typing-extensions>=4.12.2; python_version >= "3.13"',
     'annotated-types>=0.4.0',
-    "pydantic-core==2.23.0",
+    "pydantic-core==2.23.1",
     # See: https://docs.python.org/3/library/zoneinfo.html#data-sources
     'tzdata; python_version >= "3.9"',
 ]

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -1,11 +1,20 @@
-from typing import Dict, Generic, List, Literal, Optional, TypeVar, Union, get_origin
+from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar, Union, get_origin
 
 import pytest
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, Discriminator, Field, create_model, field_validator, model_validator, ValidationInfo, ValidatorFunctionWrapHandler
-from pydantic.functional_validators import WrapValidator
+from pydantic import (
+    BaseModel,
+    Discriminator,
+    Field,
+    ValidationInfo,
+    ValidatorFunctionWrapHandler,
+    create_model,
+    field_validator,
+    model_validator,
+)
 from pydantic.dataclasses import dataclass
+from pydantic.functional_validators import WrapValidator
 
 
 @pytest.mark.benchmark(group='model_schema_generation')

--- a/tests/benchmarks/test_model_validation.py
+++ b/tests/benchmarks/test_model_validation.py
@@ -6,29 +6,42 @@ from pydantic import BaseModel
 
 from .shared import ComplexModel, OuterModel, SimpleModel
 
+pytestmark = [
+    pytest.mark.benchmark(group='model_validation'),
+    pytest.mark.parametrize('method', ['model_validate', '__init__']),
+]
 
-@pytest.mark.benchmark(group='model_validation')
-def test_simple_model_validation(benchmark):
+
+def test_simple_model_validation(method: str, benchmark):
     data = {'field1': 'test', 'field2': 42, 'field3': 3.14}
-    benchmark(SimpleModel.model_validate, data)
+    if method == '__init__':
+        benchmark(lambda data: SimpleModel(**data), data)
+    else:
+        benchmark(SimpleModel.model_validate, data)
 
 
-@pytest.mark.benchmark(group='model_validation')
-def test_nested_model_validation(benchmark):
+def test_nested_model_validation(method: str, benchmark):
     data = {'nested': {'field1': 'test', 'field2': [1, 2, 3], 'field3': {'a': 1.1, 'b': 2.2}}, 'optional_nested': None}
-    benchmark(OuterModel.model_validate, data)
+    if method == '__init__':
+        benchmark(lambda data: OuterModel(**data), data)
+    else:
+        benchmark(OuterModel.model_validate, data)
 
 
-@pytest.mark.benchmark(group='model_validation')
-def test_complex_model_validation(benchmark):
+def test_complex_model_validation(method: str, benchmark):
     data = {'field1': 'test', 'field2': [{'a': 1, 'b': 2.2}, {'c': 3, 'd': 4.4}], 'field3': ['test', 1, 2, 'test2']}
-    benchmark(ComplexModel.model_validate, data)
+    if method == '__init__':
+        benchmark(lambda data: ComplexModel(**data), data)
+    else:
+        benchmark(ComplexModel.model_validate, data)
 
 
-@pytest.mark.benchmark(group='model_validation')
-def test_list_of_models_validation(benchmark):
+def test_list_of_models_validation(method: str, benchmark):
     class SimpleListModel(BaseModel):
         items: List[SimpleModel]
 
     data = {'items': [{'field1': f'test{i}', 'field2': i, 'field3': float(i)} for i in range(10)]}
-    benchmark(SimpleListModel.model_validate, data)
+    if method == '__init__':
+        benchmark(lambda data: SimpleListModel(**data), data)
+    else:
+        benchmark(SimpleListModel.model_validate, data)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -111,6 +111,7 @@ def test_parent_frame_namespace(mocker):
     @dataclass
     class MockedFrame:
         f_back = None
+        f_locals = {}
 
     mocker.patch('sys._getframe', return_value=MockedFrame())
     assert parent_frame_namespace() is None

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2918,7 +2918,9 @@ def test_non_self_return_val_warns() -> None:
 
         @model_validator(mode='after')  # type: ignore
         def validate_model(self) -> 'Child':
-            return Child.model_construct(name='different!')
+            return Child.model_construct(name='different')
 
     with pytest.warns(UserWarning, match='A custom validator is returning a value other than `self`'):
-        Child(name='foo')
+        c = Child(name='name')
+        # confirmation of behavior: non-self return value is ignored
+        assert c.name == 'name'


### PR DESCRIPTION
## Change Summary

This PR expands the benchmark suite by adding "schema generation" benchmarks in the following cases:
- Models with custom field validators (before, wrap, after, and plain modes)
- Models with custom model validators (before, wrap and after modes)

I am open to suggestions. A benchmark mixing both model and field custom validators might be valuable.

## Related issue number

Contributes to #9711 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
