### PR TITLE
Raise helpful warning when `self` isn't returned from model validator

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -461,7 +461,7 @@ except ValidationError as e:
     return type of the decorated method.
     In the context of the above example, you could also use `def check_passwords_match(self: 'UserModel') -> 'UserModel'` to indicate that the method returns an instance of the model.
 
-!!! warning "On not returning `self`
+!!! warning "On not returning `self`"
     If you fail to return `self` at the end of a `@model_validator` method (either, returning `None` or returning something other than `self`),
     you may encounter unexpected behavior.
 

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -459,8 +459,44 @@ except ValidationError as e:
     Methods decorated with `@model_validator` should return the self instance at the end of the method.
     For type checking purposes, you can use `Self` from either `typing` or the `typing_extensions` backport as the
     return type of the decorated method.
-    In the context of the above example, you could also use `def check_passwords_match(self: 'UserModel') -> 'UserModel'` to indicate that
-    the method returns an instance of the model.
+    In the context of the above example, you could also use `def check_passwords_match(self: 'UserModel') -> 'UserModel'` to indicate that the method returns an instance of the model.
+
+!!! warning "On not returning `self`
+    If you fail to return `self` at the end of a `@model_validator` method (either, returning `None` or returning something other than `self`),
+    you may encounter unexpected behavior.
+
+    Specifically, for nested models, if you return `None` (or equivalently, don't include a `return` statement),
+    despite a potentially successful validation, the nested model will be `None` in the parent model.
+
+    Returning a value other than `self` causes unexpected behavior at the top level of validation when validating via `__init__`.
+    In order to avoid this, we recommend one of:
+    1. Simply mutate and return `self` at the end of the method.
+    2. If you must return a value other than `self`, use a method like `model_validate` where you can directly fetch the return value.
+
+    Here's an example of the unexpected behavior, and the warning you'll receive:
+
+    ```python test="skip"
+    from pydantic import BaseModel
+    from pydantic.functional_validators import model_validator
+
+
+    class Child(BaseModel):
+        name: str
+
+        @model_validator(mode='after')  # type: ignore
+        def validate_model(self) -> 'Child':
+            return Child.model_construct(name='different!')
+
+
+    print(repr(Child(name='foo')))
+    """
+    UserWarning: A custom validator is returning a value other than `self`.
+    Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.
+    See the `model_validator` docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.
+
+    Child(name='foo')
+    """
+    ```
 
 !!! note "On Inheritance"
     A `@model_validator` defined in a base class will be called during the validation of a subclass instance.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -208,7 +208,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
         # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
         __tracebackhide__ = True
-        self.__pydantic_validator__.validate_python(data, self_instance=self)
+        validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
+        if self != validated_self:
+            warnings.warn(
+                'A custom validator is returning a value other than `self`.\n'
+                "Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.\n"
+                'See the `model_validator` docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.',
+                category=None,
+            )
 
     # The following line sets a flag that we use to determine when `__init__` gets overridden by the user
     __init__.__pydantic_base_init__ = True  # pyright: ignore[reportFunctionMemberAccess]
@@ -1499,7 +1506,7 @@ def create_model(  # noqa: C901
             if `None`, the value is taken from `sys._getframe(1)`
         __validators__: A dictionary of methods that validate fields. The keys are the names of the validation methods to
             be added to the model, and the values are the validation methods themselves. You can read more about functional
-            validators [here](https://docs.pydantic.dev/2.8/concepts/validators/#field-validators).
+            validators [here](https://docs.pydantic.dev/2.9/concepts/validators/#field-validators).
         __cls_kwargs__: A dictionary of keyword arguments for class creation, such as `metaclass`.
         __slots__: Deprecated. Should not be passed to `create_model`.
         **field_definitions: Attributes of the new model. They should be passed in the format:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1542,8 +1542,6 @@ def test_root_validator_returns_none_exception():
 
 
 def test_model_validator_returns_ignore():
-    # This is weird, and I don't understand entirely why it's happening, but it kind of makes sense
-
     class Model(BaseModel):
         a: int = 1
 
@@ -1551,7 +1549,8 @@ def test_model_validator_returns_ignore():
         def model_validator_return_none(self) -> None:
             return None
 
-    m = Model(a=2)
+    with pytest.warns(UserWarning, match='A custom validator is returning a value other than `self`'):
+        m = Model(a=2)
     assert m.model_dump() == {'a': 2}
 
 
@@ -2911,3 +2910,15 @@ def test_field_validator_input_type_invalid_mode() -> None:
             @field_validator('a', mode='after', json_schema_input_type=Union[int, str])  # pyright: ignore
             @classmethod
             def validate_a(cls, value: Any) -> Any: ...
+
+
+def test_non_self_return_val_warns() -> None:
+    class Child(BaseModel):
+        name: str
+
+        @model_validator(mode='after')  # type: ignore
+        def validate_model(self) -> 'Child':
+            return Child.model_construct(name='different!')
+
+    with pytest.warns(UserWarning, match='A custom validator is returning a value other than `self`'):
+        Child(name='foo')


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/7252