### PR TITLE
Update ns stack with already copied ns

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,6 +336,7 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
+        # we already copy the namespace in get_cls_types_namespace, so we don't need to create a new dict here
         types_namespace = _typing_extra.get_cls_types_namespace(for_type)
         types_namespace.update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,7 +336,8 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
-        types_namespace = _typing_extra.get_cls_types_namespace(for_type).update(self.tail or {})
+        types_namespace = _typing_extra.get_cls_types_namespace(for_type)
+        types_namespace.update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)
         try:
             yield

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,7 +336,7 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
-        types_namespace = {**_typing_extra.get_cls_types_namespace(for_type), **(self.tail or {})}
+        types_namespace = _typing_extra.get_cls_types_namespace(for_type).update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)
         try:
             yield


### PR DESCRIPTION
Reducing a significant amount of temporary allocations in cases with large namespaces:

`this branch`

```
📏 Total allocations:
        2973786

📦 Total memory allocated:
        4.018GB

🥇 Top 5 largest allocating locations (by size):
        - add_module_globals:/Users/programming/pydantic_work/pydantic/pydantic/_internal/_typing_extra.py:215 -> 2.028GB
        - validate_core_schema:/Users/programming/pydantic_work/pydantic/pydantic/_internal/_core_utils.py:570 -> 902.446MB
        - __init__:/Users/programming/anaconda3/envs/pydantic_env/lib/python3.10/typing.py:668 -> 349.622MB
        - create_schema_validator:/Users/programming/pydantic_work/pydantic/pydantic/plugin/_schema_validator.py:50 -> 162.853MB
        - complete_model_class:/Users/programming/pydantic_work/pydantic/pydantic/_internal/_model_construction.py:595 -> 116.021MB
```


`main`
```
📏 Total allocations:
        2981103

📦 Total memory allocated:
        5.032GB

🥇 Top 5 largest allocating locations (by size):
        - add_module_globals:/Users/programming/pydantic_work/pydantic/pydantic/_internal/_typing_extra.py:215 -> 2.028GB
        - push:/Users/programming/pydantic_work/pydantic/pydantic/_internal/_generate_schema.py:339 -> 1.014GB
        - validate_core_schema:/Users/programming/pydantic_work/pydantic/pydantic/_internal/_core_utils.py:570 -> 901.436MB
        - __init__:/Users/programming/anaconda3/envs/pydantic_env/lib/python3.10/typing.py:668 -> 347.622MB
        - create_schema_validator:/Users/programming/pydantic_work/pydantic/pydantic/plugin/_schema_validator.py:50 -> 164.853MB
```

