### PR TITLE
Reorganize types ns functions

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -115,7 +115,7 @@ def complete_dataclass(
         )
 
     if types_namespace is None:
-        types_namespace = _typing_extra.get_cls_types_namespace(cls)
+        types_namespace = _typing_extra.merge_cls_and_parent_ns(cls)
 
     set_dataclass_fields(cls, types_namespace, config_wrapper=config_wrapper)
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,8 +336,8 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
-        # we already copy the namespace in get_cls_types_namespace, so we don't need to create a new dict here
-        types_namespace = _typing_extra.get_cls_types_namespace(for_type)
+        # we already copy the namespace in merge_cls_and_parent_ns, so we don't need to create a new dict here
+        types_namespace = _typing_extra.merge_cls_and_parent_ns(for_type)
         types_namespace.update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)
         try:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,8 +336,7 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
-        # we already copy the namespace in merge_cls_and_parent_ns, so we don't need to create a new dict here
-        types_namespace = _typing_extra.merge_cls_and_parent_ns(for_type)
+        types_namespace = _typing_extra.get_module_ns_of(for_type).copy()
         types_namespace.update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)
         try:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,6 +336,7 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
+        # we already copy the namespace in get_cls_types_namespace, so we don't need to create a new dict here
         types_namespace = _typing_extra.get_cls_types_namespace(for_type)
         types_namespace.update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,7 +336,8 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
-        types_namespace = _typing_extra.get_cls_types_namespace(for_type).update(self.tail or {})
+        types_namespace = _typing_extra.get_cls_types_namespace(for_type)
+        types_namespace.update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)
         try:
             yield

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -336,7 +336,7 @@ class TypesNamespaceStack:
 
     @contextmanager
     def push(self, for_type: type[Any]):
-        types_namespace = {**_typing_extra.get_cls_types_namespace(for_type), **(self.tail or {})}
+        types_namespace = _typing_extra.get_cls_types_namespace(for_type).update(self.tail or {})
         self._types_namespace_stack.append(types_namespace)
         try:
             yield

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -31,9 +31,9 @@ from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
 from ._typing_extra import (
     eval_type_backport,
-    get_cls_types_namespace,
     is_annotated,
     is_classvar,
+    merge_cls_and_parent_ns,
     parent_frame_namespace,
 )
 from ._utils import ClassAttribute, SafeGetItemProxy
@@ -214,7 +214,7 @@ class ModelMetaclass(ABCMeta):
             if isinstance(parent_namespace, dict):
                 parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
 
-            types_namespace = get_cls_types_namespace(cls, parent_namespace)
+            types_namespace = merge_cls_and_parent_ns(cls, parent_namespace)
             set_model_fields(cls, bases, config_wrapper, types_namespace)
 
             if config_wrapper.frozen and '__hash__' not in namespace:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -221,7 +221,8 @@ def get_module_ns_of(obj: Any) -> dict[str, Any]:
 
 def merge_cls_and_parent_ns(cls: type[Any], parent_namespace: dict[str, Any] | None = None) -> dict[str, Any]:
     ns = get_module_ns_of(cls).copy()
-    ns.update(parent_namespace or {})
+    if parent_namespace is not None:
+        ns.update(parent_namespace)
     ns[cls.__name__] = cls
     return ns
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -185,7 +185,7 @@ def parent_frame_namespace(*, parent_depth: int = 2, force: bool = False) -> dic
 
     In other cases, like during initial schema build, if a class is defined at the top module level, we don't need to
     fetch that module's namespace, because the class' __module__ attribute can be used to access the parent namespace.
-    This is done in `_typing_extra.add_module_globals`. Thus, there's no need to cache the parent frame namespace in this case.
+    This is done in `_typing_extra.get_module_ns_of`. Thus, there's no need to cache the parent frame namespace in this case.
     """
     frame = sys._getframe(parent_depth)
 
@@ -203,24 +203,25 @@ def parent_frame_namespace(*, parent_depth: int = 2, force: bool = False) -> dic
     return frame.f_locals
 
 
-def add_module_globals(obj: Any, globalns: dict[str, Any] | None = None) -> dict[str, Any]:
+def get_module_ns_of(obj: Any) -> dict[str, Any]:
+    """Get the namespace of the module where the object is defined.
+
+    Caution: this function does not return a copy of the module namespace, so it should not be mutated.
+    The burden of enforcing this is on the caller.
+    """
     module_name = getattr(obj, '__module__', None)
     if module_name:
         try:
-            module_globalns = sys.modules[module_name].__dict__
+            return sys.modules[module_name].__dict__
         except KeyError:
             # happens occasionally, see https://github.com/pydantic/pydantic/issues/2363
-            ns = {}
-        else:
-            ns = {**module_globalns, **globalns} if globalns else module_globalns.copy()
-    else:
-        ns = globalns or {}
-
-    return ns
+            return {}
+    return {}
 
 
-def get_cls_types_namespace(cls: type[Any], parent_namespace: dict[str, Any] | None = None) -> dict[str, Any]:
-    ns = add_module_globals(cls, parent_namespace)
+def merge_cls_and_parent_ns(cls: type[Any], parent_namespace: dict[str, Any] | None = None) -> dict[str, Any]:
+    ns = get_module_ns_of(cls).copy()
+    ns.update(parent_namespace or {})
     ns[cls.__name__] = cls
     return ns
 
@@ -363,7 +364,7 @@ def get_function_type_hints(
             type_hints.setdefault('return', function)
         return type_hints
 
-    globalns = add_module_globals(function)
+    globalns = get_module_ns_of(function)
     type_hints = {}
     type_params: tuple[Any] = getattr(function, '__type_params__', ())  # type: ignore
     for name, value in annotations.items():

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -42,7 +42,7 @@ class ValidateCallWrapper:
             self.__qualname__ = function.__qualname__
             self.__module__ = function.__module__
 
-        global_ns = _typing_extra.add_module_globals(function, None)
+        global_ns = _typing_extra.get_module_ns_of(function)
         # TODO: this is a bit of a hack, we should probably have a better way to handle this
         # specifically, we shouldn't be pumping the namespace full of type_params
         # when we take namespace and type_params arguments in eval_type_backport

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -322,7 +322,7 @@ def rebuild_dataclass(
             else:
                 types_namespace = {}
 
-            types_namespace = _typing_extra.get_cls_types_namespace(cls, types_namespace)
+            types_namespace = _typing_extra.merge_cls_and_parent_ns(cls, types_namespace)
         return _pydantic_dataclasses.complete_dataclass(
             cls,
             _config.ConfigWrapper(cls.__pydantic_config__, check=False),

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -555,7 +555,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                         cls.__pydantic_parent_namespace__
                     )
 
-                types_namespace = _typing_extra.get_cls_types_namespace(cls, types_namespace)
+                types_namespace = _typing_extra.merge_cls_and_parent_ns(cls, types_namespace)
 
             # manually override defer_build so complete_model_class doesn't skip building the model again
             config = {**cls.model_config, 'defer_build': False}

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -111,6 +111,7 @@ def test_parent_frame_namespace(mocker):
     @dataclass
     class MockedFrame:
         f_back = None
+        f_locals = {}
 
     mocker.patch('sys._getframe', return_value=MockedFrame())
     assert parent_frame_namespace() is None


### PR DESCRIPTION
Refactor types namespace modification functions to highlight 2 different use cases.

I'm in no rush to merge this - would love some other ideas about how we could restructure this to make the most sense internally.

One idea - we could break out another function that adds `cls.__name__` to the namespace.