### PR TITLE
Add benchmarks for schema generation with custom validators

### DIFF
--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -1,9 +1,19 @@
-from typing import Dict, Generic, List, Literal, Optional, TypeVar, Union, get_origin
+from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar, Union, get_origin
 
 import pytest
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, Discriminator, Field, create_model
+from pydantic import (
+    BaseModel,
+    Discriminator,
+    Field,
+    ValidationInfo,
+    ValidatorFunctionWrapHandler,
+    WrapValidator,
+    create_model,
+    field_validator,
+    model_validator,
+)
 from pydantic.dataclasses import dataclass
 
 
@@ -154,3 +164,115 @@ def test_lots_of_models_with_lots_of_fields():
         model_name = f'Model_{i}'
         model = create_model(model_name, **model_fields)
         globals()[model_name] = model
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_custom_field_validator_before(benchmark):
+    def schema_gen():
+        class ModelWithBeforeValidator(BaseModel):
+            field1: int
+
+            @field_validator('field1', mode='before')
+            def validate_before(cls, v):
+                return v
+
+    benchmark(schema_gen)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_custom_field_validator_after(benchmark):
+    def schema_gen():
+        class ModelWithAfterValidator(BaseModel):
+            field2: int
+
+            @field_validator('field2', mode='after')
+            def validate_after(cls, v):
+                return v
+
+    benchmark(schema_gen)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_custom_field_validator_plain(benchmark):
+    def schema_gen():
+        class ModelWithPlainValidator(BaseModel):
+            field3: str
+
+            @field_validator('field3', mode='plain')
+            def validate_plain(cls, v):
+                if ' ' in v:
+                    raise ValueError('field3 must not contain spaces')
+                return v
+
+    benchmark(schema_gen)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_custom_field_validator_wrap(benchmark):
+    def schema_gen():
+        def wrap_validator_field4(v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> str:
+            if ' ' in v:
+                raise ValueError('field4 must not contain spaces')
+            return v
+
+        class ModelWithWrapValidator(BaseModel):
+            field4: Annotated[str, WrapValidator(wrap_validator_field4)]
+
+    benchmark(schema_gen)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_custom_model_validator_before(benchmark):
+    def schema_gen():
+        class ModelWithBeforeValidator(BaseModel):
+            field1: int
+
+            @model_validator(mode='before')
+            @classmethod
+            def validate_model_before(cls, data):
+                if isinstance(data, dict):
+                    data['field1'] = data.get('field1', 0) + 1
+                return data
+
+    benchmark(schema_gen)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_custom_model_validator_after(benchmark):
+    def schema_gen():
+        class ModelWithAfterValidator(BaseModel):
+            field2: str
+
+            @model_validator(mode='after')
+            def validate_model_after(self):
+                self.field2 = self.field2.upper()
+                return self
+
+    benchmark(schema_gen)
+
+
+@pytest.mark.benchmark(group='model_schema_generation')
+def test_custom_model_validator_wrap(benchmark):
+    def schema_gen():
+        class ModelWithWrapValidator(BaseModel):
+            field1: int
+            field2: str
+            field3: float
+            field4: bool
+
+            @model_validator(mode='wrap')
+            def validate_model_wrap(cls, values, handler):
+                # Perform some validation before the default validation
+                if values.get('field4') is True and values.get('field3', 0) < 0:
+                    raise ValueError('field3 must be non-negative when field4 is True')
+
+                # Call the default validation
+                instance = handler(values)
+
+                # Perform some validation after the default validation
+                if instance.field1 > 100:
+                    instance.field2 += '!'
+
+                return instance
+
+    benchmark(schema_gen)


### PR DESCRIPTION
## Change Summary

This PR expands the benchmark suite by adding "schema generation" benchmarks in the following cases:

1. Models with custom field validators (before, wrap, after, and plain modes).  Every mode has it's own benchmark
2. Models with custom model validators (before, wrap and after modes). Every mode has it's own benchmark

I am open to suggestions. A benchmark mixing both model and field custom validators might be valuable.

## Related issue number

fix #9711 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
