### PR TITLE
Support signature for wrap validators without `info`

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -307,6 +307,9 @@ if TYPE_CHECKING:
     class _V2ValidatorClsMethod(Protocol):
         def __call__(self, cls: Any, value: Any, info: _core_schema.ValidationInfo, /) -> Any: ...
 
+    class _OnlyValueWrapValidatorClsMethod(Protocol):
+        def __call__(self, cls: Any, value: Any, handler: _core_schema.ValidatorFunctionWrapHandler, /) -> Any: ...
+
     class _V2WrapValidatorClsMethod(Protocol):
         def __call__(
             self,
@@ -327,6 +330,8 @@ if TYPE_CHECKING:
     _V2WrapValidator = Union[
         _V2WrapValidatorClsMethod,
         _core_schema.WithInfoWrapValidatorFunction,
+        _OnlyValueWrapValidatorClsMethod,
+        _core_schema.NoInfoWrapValidatorFunction,
     ]
 
     _PartialClsOrStaticMethod: TypeAlias = Union[classmethod[Any, Any, Any], staticmethod[Any, Any], partialmethod[Any]]

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -331,7 +331,14 @@ if TYPE_CHECKING:
         _V2WrapValidatorClsMethod,
         _core_schema.WithInfoWrapValidatorFunction,
         _OnlyValueWrapValidatorClsMethod,
-        _core_schema.NoInfoWrapValidatorFunction,
+        # TODO: figure out why we can't add this
+        # For some reason, it makes it such that this case is allowed:
+        #
+        # @field_validator('foo', mode='wrap')  # pyright: ignore[reportArgumentType]
+        # @classmethod
+        # def invalid_missing_handler(cls, value: Any) -> Any: ...
+        #
+        # _core_schema.NoInfoWrapValidatorFunction,
     ]
 
     _PartialClsOrStaticMethod: TypeAlias = Union[classmethod[Any, Any, Any], staticmethod[Any, Any], partialmethod[Any]]

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -331,14 +331,7 @@ if TYPE_CHECKING:
         _V2WrapValidatorClsMethod,
         _core_schema.WithInfoWrapValidatorFunction,
         _OnlyValueWrapValidatorClsMethod,
-        # TODO: figure out why we can't add this
-        # For some reason, it makes it such that this case is allowed:
-        #
-        # @field_validator('foo', mode='wrap')  # pyright: ignore[reportArgumentType]
-        # @classmethod
-        # def invalid_missing_handler(cls, value: Any) -> Any: ...
-        #
-        # _core_schema.NoInfoWrapValidatorFunction,
+        _core_schema.NoInfoWrapValidatorFunction,
     ]
 
     _PartialClsOrStaticMethod: TypeAlias = Union[classmethod[Any, Any, Any], staticmethod[Any, Any], partialmethod[Any]]

--- a/tests/pyright/decorators.py
+++ b/tests/pyright/decorators.py
@@ -132,10 +132,9 @@ class WrapFieldValidator(BaseModel):
     @classmethod
     def invalid_handler(cls, value: Any, handler: int) -> Any: ...
 
-    @field_validator('foo', mode='wrap')  # pyright: ignore[reportArgumentType]
+    @field_validator('foo', mode='wrap')
     @classmethod
-    def valid_no_info(cls, value: Any, handler: ValidatorFunctionWrapHandler) -> Any:
-        """TODO this should be valid."""
+    def valid_no_info(cls, value: Any, handler: ValidatorFunctionWrapHandler) -> Any: ...
 
     @field_validator('foo', mode='wrap', json_schema_input_type=int)  # `json_schema_input_type` allowed here.
     @classmethod

--- a/tests/pyright/decorators.py
+++ b/tests/pyright/decorators.py
@@ -124,9 +124,15 @@ class AfterFieldValidator(BaseModel):
 
 
 class WrapFieldValidator(BaseModel):
-    @field_validator('foo', mode='wrap')  # pyright: ignore[reportArgumentType]
+    @field_validator('foo', mode='wrap')
     @classmethod
-    def invalid_missing_handler(cls, value: Any) -> Any: ...
+    def invalid_missing_handler(cls, value: Any) -> Any:
+        """TODO This shouldn't be valid.
+
+        At runtime, `check_decorator_fields_exist` raises an error, as the `handler` argument is missing.
+        However, there's no type checking error as the provided signature matches
+        `pydantic_core.core_schema.NoInfoWrapValidatorFunction`.
+        """
 
     @field_validator('foo', mode='wrap')  # pyright: ignore[reportArgumentType]
     @classmethod


### PR DESCRIPTION
Typing support for a signature like the following:

```py
from pydantic import BaseModel, field_validator, ValidatorFunctionWrapHandler
from typing import Any


class A(BaseModel):
    a: int

    @field_validator('a', mode='wrap')
    @classmethod
    def validate_a(cls, value: Any, handler: ValidatorFunctionWrapHandler) -> Any:
        validated = handler(value)
        return validated + 1
```