### PR TITLE
Ensure `__pydantic_complete__` is set when rebuilding dataclasses

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -191,6 +191,7 @@ def complete_dataclass(
 
         cls.__setattr__ = validated_setattr.__get__(None, cls)  # type: ignore
 
+    cls.__pydantic_complete__ = True
     return True
 
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -257,10 +257,8 @@ def dataclass(
         cls.__doc__ = original_doc
         cls.__module__ = original_cls.__module__
         cls.__qualname__ = original_cls.__qualname__
-        pydantic_complete = _pydantic_dataclasses.complete_dataclass(
-            cls, config_wrapper, raise_errors=False, types_namespace=None
-        )
-        cls.__pydantic_complete__ = pydantic_complete  # type: ignore
+        cls.__pydantic_complete__ = False  # `complete_dataclass` will set it to `True` if successful.
+        _pydantic_dataclasses.complete_dataclass(cls, config_wrapper, raise_errors=False, types_namespace=None)
         return cls
 
     return create_dataclass if _cls is None else create_dataclass(_cls)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2453,12 +2453,20 @@ def test_rebuild_dataclass():
 
     assert rebuild_dataclass(MyDataClass) is None
 
-    @pydantic.dataclasses.dataclass()
+    @pydantic.dataclasses.dataclass
     class MyDataClass1:
         d2: Optional['Foo'] = None  # noqa F821
 
     with pytest.raises(PydanticUndefinedAnnotation, match="name 'Foo' is not defined"):
         rebuild_dataclass(MyDataClass1, _parent_namespace_depth=0)
+
+    @pydantic.dataclasses.dataclass
+    class MyDataClass2:
+        x: 'Foo'  # noqa F821
+
+    assert not MyDataClass2.__pydantic_complete__
+    assert rebuild_dataclass(MyDataClass2, _types_namespace={'Foo': int})
+    assert MyDataClass2.__pydantic_complete__
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/10284.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
