### PR TITLE
Ensure coverage data artifact is correctly uploaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,7 @@ jobs:
         with:
           name: coverage-data
           path: .coverage
+          include-hidden-files: true
 
       - name: Store coverage html
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Github released a new version of the `actions/upload-artifact@v4` action (without a major bump), now discarding hidden files (starting with a `.`).

See https://github.com/actions/upload-artifact/issues/602.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
