### PR TITLE
Schema building: add a global type cache

### DIFF
--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -120,8 +120,7 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
                     ' Maybe you tried to call resolve_ref_schema from within a recursive model?'
                 )
             definition = self._generate_schema.defs.definitions[ref]
-            if self._generate_schema.defs.recording:
-                self._generate_schema.defs.recorded[ref] = definition
+            self._generate_schema.defs.recording_stack[ref] = definition
             return definition
         elif maybe_ref_schema['type'] == 'definitions':
             return self.resolve_ref_schema(maybe_ref_schema['schema'])

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -119,7 +119,10 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
                     f'Could not find a ref for {ref}.'
                     ' Maybe you tried to call resolve_ref_schema from within a recursive model?'
                 )
-            return self._generate_schema.defs.definitions[ref]
+            definition = self._generate_schema.defs.definitions[ref]
+            if self._generate_schema.defs.recording:
+                self._generate_schema.defs.recorded[ref] = definition
+            return definition
         elif maybe_ref_schema['type'] == 'definitions':
             return self.resolve_ref_schema(maybe_ref_schema['schema'])
         return maybe_ref_schema

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1172,7 +1172,7 @@ class UuidVersion:
             return schema
 
     def __hash__(self) -> int:
-        return hash(type(self.uuid_version))
+        return hash(self.uuid_version)
 
 
 UUID1 = Annotated[UUID, UuidVersion(1)]


### PR DESCRIPTION
This is an attempt to construct a global cache, as per https://github.com/pydantic/pydantic/issues/10297.

There's quite some added complexity. When we generate the schema for the first time in `_apply_annotations`, we keep track of definitions being added in the `self.defs.definitions` dict. For each annotation + metadata, a two-tuple is then cached: the generated schema and a mapping of refs to definitions that were collected when this annotations + metadata was processed the first time.

To collect the definitions, a custom `RecordingDict` class is used, overriding `__setitem__`. However, this isn't sufficient as we also need to track definitions being accessed, e.g. in `get_schema_or_ref`. Things get even more complicated when nested instances of the `GenerateSchema` class are created to generate schema for other models. For example with:

```python
class Sub(BaseModel):
    f: 'Forward'

class Forward(BaseModel):
    a: int

class Model(BaseModel):
    sub: Sub
```

When the `sub` field is processed, the schema for `Sub` is generated again because it couldn't be when defined in the first place. To do so, a new instance of `GenerateSchema` is created, and the same instance of `Definitions` is passed (L398):

https://github.com/pydantic/pydantic/blob/8a01cc8f96ea3ca4f46b4ae3cbf36084081383ac/pydantic/_internal/_generate_schema.py#L384-L398

