### PR TITLE
Don't allow customization of `SchemaGenerator` until interface is more stable

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -534,7 +534,6 @@ Specifically, the following config options are relevant:
 
 * [`title`][pydantic.config.ConfigDict.title]
 * [`json_schema_extra`][pydantic.config.ConfigDict.json_schema_extra]
-* [`schema_generator`][pydantic.config.ConfigDict.schema_generator]
 * [`json_schema_mode_override`][pydantic.config.ConfigDict.json_schema_mode_override]
 * [`field_title_generator`][pydantic.config.ConfigDict.field_title_generator]
 * [`model_title_generator`][pydantic.config.ConfigDict.model_title_generator]

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,5 +1,6 @@
 import typing
 from importlib import import_module
+from warnings import warn
 
 from ._migration import getattr_migration
 from .version import VERSION
@@ -384,14 +385,19 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'parse_obj_as': (__spec__.parent, '.deprecated.tools'),
     'schema_of': (__spec__.parent, '.deprecated.tools'),
     'schema_json_of': (__spec__.parent, '.deprecated.tools'),
+    # deprecated dynamic imports
     'FieldValidationInfo': ('pydantic_core', '.core_schema'),
+    'GenerateSchema': (__spec__.parent, '._internal._generate_schema'),
 }
-_deprecated_dynamic_imports = {'FieldValidationInfo'}
+_deprecated_dynamic_imports = {'FieldValidationInfo', 'GenerateSchema'}
 
 _getattr_migration = getattr_migration(__name__)
 
 
 def __getattr__(attr_name: str) -> object:
+    if attr_name in _deprecated_dynamic_imports:
+        warn('Importing {module_name} from `pydantic` is deprecated.', DeprecationWarning, stacklevel=2)
+
     dynamic_attr = _dynamic_imports.get(attr_name)
     if dynamic_attr is None:
         return _getattr_migration(attr_name)

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -396,7 +396,11 @@ _getattr_migration = getattr_migration(__name__)
 
 def __getattr__(attr_name: str) -> object:
     if attr_name in _deprecated_dynamic_imports:
-        warn(f'Importing {attr_name} from `pydantic` is deprecated.', DeprecationWarning, stacklevel=2)
+        warn(
+            f'Importing {attr_name} from `pydantic` is deprecated. This feature is either no longer supported, or is not public.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     dynamic_attr = _dynamic_imports.get(attr_name)
     if dynamic_attr is None:

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -396,7 +396,7 @@ _getattr_migration = getattr_migration(__name__)
 
 def __getattr__(attr_name: str) -> object:
     if attr_name in _deprecated_dynamic_imports:
-        warn('Importing {module_name} from `pydantic` is deprecated.', DeprecationWarning, stacklevel=2)
+        warn(f'Importing {attr_name} from `pydantic` is deprecated.', DeprecationWarning, stacklevel=2)
 
     dynamic_attr = _dynamic_imports.get(attr_name)
     if dynamic_attr is None:

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -17,7 +17,6 @@ if typing.TYPE_CHECKING:
     )
 
     from . import dataclasses
-    from ._internal._generate_schema import GenerateSchema as GenerateSchema
     from .aliases import AliasChoices, AliasGenerator, AliasPath
     from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
     from .config import ConfigDict, with_config
@@ -217,8 +216,6 @@ __all__ = (
     # annotated handlers
     'GetCoreSchemaHandler',
     'GetJsonSchemaHandler',
-    # generate schema from ._internal
-    'GenerateSchema',
     # pydantic_core
     'ValidationError',
     'ValidationInfo',
@@ -372,8 +369,6 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     # annotated handlers
     'GetCoreSchemaHandler': (__spec__.parent, '.annotated_handlers'),
     'GetJsonSchemaHandler': (__spec__.parent, '.annotated_handlers'),
-    # generate schema from ._internal
-    'GenerateSchema': (__spec__.parent, '._internal._generate_schema'),
     # pydantic_core stuff
     'ValidationError': ('pydantic_core', '.'),
     'ValidationInfo': ('pydantic_core', '.core_schema'),

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -26,7 +26,6 @@ if not TYPE_CHECKING:
     DeprecationWarning = PydanticDeprecatedSince20
 
 if TYPE_CHECKING:
-    from .._internal._schema_generation_shared import GenerateSchema
     from ..fields import ComputedFieldInfo, FieldInfo
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
@@ -81,7 +80,6 @@ class ConfigWrapper:
     defer_build: bool
     experimental_defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
     plugin_settings: dict[str, object] | None
-    schema_generator: type[GenerateSchema] | None
     json_schema_serialization_defaults_required: bool
     json_schema_mode_override: Literal['validation', 'serialization', None]
     coerce_numbers_to_str: bool
@@ -264,7 +262,6 @@ config_defaults = ConfigDict(
     defer_build=False,
     experimental_defer_build_mode=('model',),
     plugin_settings=None,
-    schema_generator=None,
     json_schema_serialization_defaults_required=False,
     json_schema_mode_override=None,
     coerce_numbers_to_str=False,

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -381,11 +381,10 @@ class GenerateSchema:
         self.defs = _Definitions()
 
     def __init_subclass__(cls) -> None:
-        super().__init_subclass__(**kwargs)
+        super().__init_subclass__()
         warnings.warn(
             'Subclassing `GenerateSchema` is not supported. The API is highly subject to change in minor versions.',
             UserWarning,
-            stack_level=2,
         )
 
     @property

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -385,6 +385,7 @@ class GenerateSchema:
         warnings.warn(
             'Subclassing `GenerateSchema` is not supported. The API is highly subject to change in minor versions.',
             UserWarning,
+            stacklevel=2,
         )
 
     @property

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -380,6 +380,13 @@ class GenerateSchema:
         self.model_type_stack = _ModelTypeStack()
         self.defs = _Definitions()
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        warnings.warn(
+            f'Subclassing {cls.__name__} is not supported. The API is highly subject to change in minor versions.',
+            UserWarning,
+        )
+
     @property
     def _config_wrapper(self) -> ConfigWrapper:
         return self._config_wrapper_stack.tail

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -372,7 +372,7 @@ class GenerateSchema:
         types_namespace: dict[str, Any] | None,
         typevars_map: dict[Any, Any] | None = None,
     ) -> None:
-        # we need a stack for recursing into child models
+        # we need a stack for recursing into nested models
         self._config_wrapper_stack = ConfigWrapperStack(config_wrapper)
         self._types_namespace_stack = TypesNamespaceStack(types_namespace)
         self._typevars_map = typevars_map
@@ -408,7 +408,7 @@ class GenerateSchema:
 
     @property
     def _current_generate_schema(self) -> GenerateSchema:
-        cls = self._config_wrapper.schema_generator or GenerateSchema
+        cls = GenerateSchema
         return cls.__from_parent(
             self._config_wrapper_stack,
             self._types_namespace_stack,
@@ -420,10 +420,6 @@ class GenerateSchema:
     @property
     def _arbitrary_types(self) -> bool:
         return self._config_wrapper.arbitrary_types_allowed
-
-    def str_schema(self) -> CoreSchema:
-        """Generate a CoreSchema for `str`"""
-        return core_schema.str_schema()
 
     # the following methods can be overridden but should be considered
     # unstable / private APIs
@@ -942,7 +938,7 @@ class GenerateSchema:
         as they get requested and we figure out what the right API for them is.
         """
         if obj is str:
-            return self.str_schema()
+            return core_schema.str_schema()
         elif obj is bytes:
             return core_schema.bytes_schema()
         elif obj is int:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -383,7 +383,7 @@ class GenerateSchema:
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         warnings.warn(
-            f'Subclassing {cls.__name__} is not supported. The API is highly subject to change in minor versions.',
+            'Subclassing `GenerateSchema` is not supported. The API is highly subject to change in minor versions.',
             UserWarning,
         )
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -11,7 +11,6 @@ from .aliases import AliasGenerator
 from .errors import PydanticUserError
 
 if TYPE_CHECKING:
-    from ._internal._generate_schema import GenerateSchema as _GenerateSchema
     from .fields import ComputedFieldInfo, FieldInfo
 
 __all__ = ('ConfigDict', 'with_config')
@@ -762,18 +761,7 @@ class ConfigDict(TypedDict, total=False):
     """
 
     plugin_settings: dict[str, object] | None
-    """A `dict` of settings for plugins. Defaults to `None`.
-    """
-
-    schema_generator: type[_GenerateSchema] | None
-    """
-    A custom core schema generator class to use when generating JSON schemas.
-    Useful if you want to change the way types are validated across an entire model/schema. Defaults to `None`.
-
-    The `GenerateSchema` interface is subject to change, currently only the `string_schema` method is public.
-
-    See [#6737](https://github.com/pydantic/pydantic/pull/6737) for details.
-    """
+    """A `dict` of settings for plugins. Defaults to `None`."""
 
     json_schema_serialization_defaults_required: bool
     """

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -98,9 +98,7 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
     local_ns = _typing_extra.parent_frame_namespace(parent_depth=parent_depth)
     global_ns = sys._getframe(max(parent_depth - 1, 1)).f_globals.copy()
     global_ns.update(local_ns or {})
-    gen = (config_wrapper.schema_generator or _generate_schema.GenerateSchema)(
-        config_wrapper, types_namespace=global_ns, typevars_map={}
-    )
+    gen = _generate_schema.GenerateSchema(config_wrapper, types_namespace=global_ns, typevars_map={})
     schema = gen.generate_schema(type_)
     schema = gen.clean_schema(schema)
     return schema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import pytest
 from _pytest.assertion.rewrite import AssertionRewritingHook
 from jsonschema import Draft202012Validator, SchemaError
 
-from pydantic import GenerateSchema
+from pydantic._internal._generate_schema import GenerateSchema
 from pydantic.json_schema import GenerateJsonSchema
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,6 @@ from pydantic import (
     BaseConfig,
     BaseModel,
     Field,
-    GenerateSchema,
     PrivateAttr,
     PydanticDeprecatedSince20,
     PydanticSchemaGenerationError,
@@ -519,8 +518,6 @@ def test_multiple_inheritance_config():
 
 def test_config_wrapper_match():
     localns = {
-        '_GenerateSchema': GenerateSchema,
-        'GenerateSchema': GenerateSchema,
         'JsonValue': JsonValue,
         'FieldInfo': FieldInfo,
         'ComputedFieldInfo': ComputedFieldInfo,
@@ -568,8 +565,6 @@ def test_config_validation_error_cause():
 
 def test_config_defaults_match():
     localns = {
-        '_GenerateSchema': GenerateSchema,
-        'GenerateSchema': GenerateSchema,
         'FieldInfo': FieldInfo,
         'ComputedFieldInfo': ComputedFieldInfo,
     }

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, ClassVar, Dict, FrozenSet, Generic, List, Opti
 
 import pytest
 from dirty_equals import HasRepr
-from pydantic_core import ArgsKwargs, CoreSchema, SchemaValidator, core_schema
+from pydantic_core import ArgsKwargs, SchemaValidator
 from typing_extensions import Annotated, Literal
 
 import pydantic
@@ -20,7 +20,6 @@ from pydantic import (
     BaseModel,
     BeforeValidator,
     ConfigDict,
-    GenerateSchema,
     PydanticDeprecatedSince20,
     PydanticUndefinedAnnotation,
     PydanticUserError,
@@ -2652,19 +2651,6 @@ def test_dataclasses_with_slots_and_default():
         b: int = Field(1)
 
     assert B().b == 1
-
-
-def test_schema_generator() -> None:
-    class LaxStrGenerator(GenerateSchema):
-        def str_schema(self) -> CoreSchema:
-            return core_schema.no_info_plain_validator_function(str)
-
-    @pydantic.dataclasses.dataclass
-    class Model:
-        x: str
-        __pydantic_config__ = ConfigDict(schema_generator=LaxStrGenerator)
-
-    assert Model(x=1).x == '1'
 
 
 @pytest.mark.parametrize('decorator1', **dataclass_decorators())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,6 +47,7 @@ from pydantic import (
     constr,
     field_validator,
 )
+from pydantic._internal._generate_schema import GenerateSchema
 from pydantic._internal._mock_val_ser import MockCoreSchema
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
@@ -3312,3 +3313,9 @@ def test_model_construct_with_model_post_init_and_model_copy() -> None:
 
     assert m == copy
     assert id(m) != id(copy)
+
+
+def test_subclassing_gen_schema_warns() -> None:
+    with pytest.warns(UserWarning, match='Subclassing `GenerateSchema` is not supported.'):
+
+        class MyGenSchema(GenerateSchema): ...

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -5,11 +5,10 @@ from datetime import date, datetime
 from typing import Any, Dict, ForwardRef, Generic, List, NamedTuple, Optional, Tuple, TypeVar, Union
 
 import pytest
-from pydantic_core import ValidationError, core_schema
+from pydantic_core import ValidationError
 from typing_extensions import Annotated, TypeAlias, TypedDict
 
 from pydantic import BaseModel, Field, TypeAdapter, ValidationInfo, create_model, field_validator
-from pydantic._internal._generate_schema import GenerateSchema
 from pydantic._internal._typing_extra import annotated_type
 from pydantic.config import ConfigDict
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -568,11 +567,3 @@ def test_core_schema_respects_defer_build(model: Any, config: ConfigDict, method
     assert type_adapter._core_schema is not None, 'Should be initialized after the usage'
     assert type_adapter._validator is not None, 'Should be initialized after the usage'
     assert type_adapter._serializer is not None, 'Should be initialized after the usage'
-
-
-def test_custom_schema_gen_respected() -> None:
-    class LaxStrGenerator(GenerateSchema):
-        def str_schema(self) -> core_schema.CoreSchema:
-            return core_schema.no_info_plain_validator_function(str)
-
-    assert TypeAdapter(str, config=ConfigDict(schema_generator=LaxStrGenerator)).validate_python(1) == '1'

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -9,14 +9,13 @@ from typing import Any, Dict, Generic, List, Optional, TypeVar
 import pytest
 import typing_extensions
 from annotated_types import Lt
-from pydantic_core import CoreSchema, core_schema
+from pydantic_core import core_schema
 from typing_extensions import Annotated, TypedDict
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    GenerateSchema,
     GetCoreSchemaHandler,
     PositiveInt,
     PydanticUserError,
@@ -879,20 +878,6 @@ def test_model_config_inherited() -> None:
     ta = TypeAdapter(Model)
 
     assert ta.validate_python({'x': 'ABC'}) == {'x': 'abc'}
-
-
-def test_schema_generator() -> None:
-    class LaxStrGenerator(GenerateSchema):
-        def str_schema(self) -> CoreSchema:
-            return core_schema.no_info_plain_validator_function(str)
-
-    class Model(TypedDict):
-        x: str
-        __pydantic_config__ = ConfigDict(schema_generator=LaxStrGenerator)  # type: ignore
-
-    ta = TypeAdapter(Model)
-
-    assert ta.validate_python(dict(x=1))['x'] == '1'
 
 
 def test_grandparent_config():


### PR DESCRIPTION
Marked as experimental in the docs: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.schema_generator

There are lots of things that can simply be done by overriding `__get_pydantic_core_schema__` on a model class or using a custom type with a custom core schema.

There are a few things that were advantageous about this approach, like being able to customize how unknown type schemas were handled. That being said, I think we should:

1. In the short term, add explicit support for these use cases
2. In the long term, solidify the API for core schema generation such that we can support and document stable ways to customize schema at the model level.