### PR TITLE
Do not check for `str` when using `has_instance_in_type`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1264,7 +1264,7 @@ class GenerateSchema:
         # Update FieldInfo annotation if appropriate:
         FieldInfo = import_cached_field_info()
 
-        if has_instance_in_type(field_info.annotation, (ForwardRef, str)):
+        if has_instance_in_type(field_info.annotation, ForwardRef):
             types_namespace = self._types_namespace
             if self._typevars_map:
                 types_namespace = (types_namespace or {}).copy()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

`has_instance_in_type(Literal["test"], str)` wrongfully returns `True`.

`str` was removed entirely as `field_info.annotation` is either a `ForwardRef` instance or a typing construct, where stringified annotations are guaranteed to be wrapped around `ForwardRef` instances by the `typing` module

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
