### PR TITLE
Fixing `annotated-types` bound

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:45f8c82d3cadfc9650934637c003cd47f88b5cf9487a09801e06c847690abc01"
+content_hash = "sha256:a35cfb3d1aa9400acb86d7b2a4727c0d4dd0998e3a00cd7cccd5d26893211f31"
 
 [[metadata.targets]]
 requires_python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ requires-python = '>=3.8'
 dependencies = [
     'typing-extensions>=4.6.1; python_version < "3.13"',
     'typing-extensions>=4.12.2; python_version >= "3.13"',
-    'annotated-types>=0.4.0',
+    'annotated-types>=0.6.0',
     "pydantic-core==2.23.2",
     # See: https://docs.python.org/3/library/zoneinfo.html#data-sources
     'tzdata; python_version >= "3.9"',


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/10323

Min version needs to be bumped because we support `annotated_types.Not` which was introduced in `v0.6.0`