### PR TITLE
Cleanly `defer_build` on `TypeAdapters`, removing experimental flag

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -78,7 +78,6 @@ class ConfigWrapper:
     protected_namespaces: tuple[str, ...]
     hide_input_in_errors: bool
     defer_build: bool
-    experimental_defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
     plugin_settings: dict[str, object] | None
     json_schema_serialization_defaults_required: bool
     json_schema_mode_override: Literal['validation', 'serialization', None]
@@ -260,7 +259,6 @@ config_defaults = ConfigDict(
     hide_input_in_errors=False,
     json_encoders=None,
     defer_build=False,
-    experimental_defer_build_mode=('model',),
     plugin_settings=None,
     json_schema_serialization_defaults_required=False,
     json_schema_mode_override=None,

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -560,7 +560,7 @@ def complete_model_class(
         ref_mode='unpack',
     )
 
-    if config_wrapper.defer_build and 'model' in config_wrapper.experimental_defer_build_mode:
+    if config_wrapper.defer_build:
         set_model_mocks(cls, cls_name)
         return False
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -734,30 +734,6 @@ class ConfigDict(TypedDict, total=False):
     This can be useful to avoid the overhead of building models which are only
     used nested within other models, or when you want to manually define type namespace via
     [`Model.model_rebuild(_types_namespace=...)`][pydantic.BaseModel.model_rebuild].
-
-    See also [`experimental_defer_build_mode`][pydantic.config.ConfigDict.experimental_defer_build_mode].
-
-    !!! note
-        `defer_build` does not work by default with FastAPI Pydantic models. By default, the validator and serializer
-        for said models is constructed immediately for FastAPI routes. You also need to define
-        [`experimental_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict.experimental_defer_build_mode] with FastAPI
-        models in order for `defer_build=True` to take effect. This additional (experimental) parameter is required for
-        the deferred building due to FastAPI relying on `TypeAdapter`s.
-    """
-
-    experimental_defer_build_mode: tuple[Literal['model', 'type_adapter'], ...]
-    """
-    Controls when [`defer_build`][pydantic.config.ConfigDict.defer_build] is applicable. Defaults to `('model',)`.
-
-    Due to backwards compatibility reasons [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] does not by default
-    respect `defer_build`. Meaning when `defer_build` is `True` and `experimental_defer_build_mode` is the default `('model',)`
-    then `TypeAdapter` immediately constructs its validator and serializer instead of postponing said construction until
-    the first model validation. Set this to `('model', 'type_adapter')` to make `TypeAdapter` respect the `defer_build`
-    so it postpones validator and serializer construction until the first validation or serialization.
-
-    !!! note
-        The `experimental_defer_build_mode` parameter is named with an underscore to suggest this is an experimental feature. It may
-        be removed or changed in the future in a minor release.
     """
 
     plugin_settings: dict[str, object] | None

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -157,13 +157,6 @@ class TypeAdapter(Generic[T]):
 
     **Note:** `TypeAdapter` instances are not types, and cannot be used as type annotations for fields.
 
-    **Note:** By default, `TypeAdapter` does not respect the
-    [`defer_build=True`][pydantic.config.ConfigDict.defer_build] setting in the
-    [`model_config`][pydantic.BaseModel.model_config] or in the `TypeAdapter` constructor `config`. You need to also
-    explicitly set [`experimental_defer_build_mode=('model', 'type_adapter')`][pydantic.config.ConfigDict.experimental_defer_build_mode] of the
-    config to defer the model validator and serializer construction. Thus, this feature is opt-in to ensure backwards
-    compatibility.
-
     Attributes:
         core_schema: The core schema for the type.
         validator (SchemaValidator): The schema validator for the type.
@@ -329,21 +322,13 @@ class TypeAdapter(Generic[T]):
 
     def _defer_build(self) -> bool:
         config = self._config if self._config is not None else self._model_config()
-        return self._is_defer_build_config(config) if config is not None else False
+        return config.get('defer_build') is True if config else False
 
     def _model_config(self) -> ConfigDict | None:
         type_: Any = _typing_extra.annotated_type(self._type) or self._type  # Eg FastAPI heavily uses Annotated
         if _utils.lenient_issubclass(type_, BaseModel):
             return type_.model_config
         return getattr(type_, '__pydantic_config__', None)
-
-    @staticmethod
-    def _is_defer_build_config(config: ConfigDict) -> bool:
-        # TODO reevaluate this logic when we have a better understanding of how defer_build should work with TypeAdapter
-        # Should we drop the special experimental_defer_build_mode check?
-        return config.get('defer_build', False) is True and 'type_adapter' in config.get(
-            'experimental_defer_build_mode', ()
-        )
 
     @_frame_depth(1)
     def validate_python(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import sys
 from contextlib import nullcontext as does_not_raise
 from decimal import Decimal
 from inspect import signature
-from typing import Any, ContextManager, Dict, Iterable, NamedTuple, Optional, Tuple, Type, Union
+from typing import Any, ContextManager, Dict, Iterable, NamedTuple, Optional, Type, Union
 
 from dirty_equals import HasRepr, IsPartialDict
 from pydantic_core import SchemaError, SchemaSerializer, SchemaValidator
@@ -35,9 +35,9 @@ from pydantic.warnings import PydanticDeprecationWarning
 from .conftest import CallCounter
 
 if sys.version_info < (3, 9):
-    from typing_extensions import Annotated, Literal
+    from typing_extensions import Annotated
 else:
-    from typing import Annotated, Literal
+    from typing import Annotated
 
 import pytest
 
@@ -700,26 +700,22 @@ def test_json_encoders_type_adapter() -> None:
     assert json.loads(ta.dump_json(1)) == '2'
 
 
-@pytest.mark.parametrize('defer_build_mode', [None, tuple(), ('model',), ('type_adapter',), ('model', 'type_adapter')])
-def test_config_model_defer_build(
-    defer_build_mode: Optional[Tuple[Literal['model', 'type_adapter'], ...]], generate_schema_calls: CallCounter
-):
-    config = ConfigDict(defer_build=True)
-    if defer_build_mode is not None:
-        config['experimental_defer_build_mode'] = defer_build_mode
+@pytest.mark.parametrize('defer_build', [True, False])
+def test_config_model_defer_build(defer_build: bool, generate_schema_calls: CallCounter):
+    config = ConfigDict(defer_build=defer_build)
 
     class MyModel(BaseModel):
         model_config = config
         x: int
 
-    if defer_build_mode is None or 'model' in defer_build_mode:
+    if defer_build is True:
         assert isinstance(MyModel.__pydantic_validator__, MockValSer)
         assert isinstance(MyModel.__pydantic_serializer__, MockValSer)
-        assert generate_schema_calls.count == 0, 'Should respect experimental_defer_build_mode'
+        assert generate_schema_calls.count == 0, 'Should respect defer_build'
     else:
         assert isinstance(MyModel.__pydantic_validator__, SchemaValidator)
         assert isinstance(MyModel.__pydantic_serializer__, SchemaSerializer)
-        assert generate_schema_calls.count == 1, 'Should respect experimental_defer_build_mode'
+        assert generate_schema_calls.count == 1, 'Should respect defer_build'
 
     m = MyModel(x=1)
     assert m.x == 1
@@ -732,20 +728,15 @@ def test_config_model_defer_build(
     assert generate_schema_calls.count == 1, 'Should not build duplicated core schemas'
 
 
-@pytest.mark.parametrize('defer_build_mode', [None, tuple(), ('model',), ('type_adapter',), ('model', 'type_adapter')])
-def test_config_model_type_adapter_defer_build(
-    defer_build_mode: Optional[Tuple[Literal['model', 'type_adapter'], ...]], generate_schema_calls: CallCounter
-):
+@pytest.mark.parametrize('defer_build', [True, False])
+def test_config_model_type_adapter_defer_build(defer_build: bool, generate_schema_calls: CallCounter):
     config = ConfigDict(defer_build=True)
-    if defer_build_mode is not None:
-        config['experimental_defer_build_mode'] = defer_build_mode
 
     class MyModel(BaseModel):
         model_config = config
         x: int
 
-    is_deferred = defer_build_mode is None or 'model' in defer_build_mode
-    assert generate_schema_calls.count == (0 if is_deferred else 1)
+    assert generate_schema_calls.count == (0 if defer_build is True else 1)
     generate_schema_calls.reset()
 
     ta = TypeAdapter(MyModel)
@@ -757,21 +748,16 @@ def test_config_model_type_adapter_defer_build(
     assert ta.dump_python(MyModel.model_construct(x=1))['x'] == 1
     assert ta.json_schema()['type'] == 'object'
 
-    assert generate_schema_calls.count == (1 if is_deferred else 0), 'Should not build duplicate core schemas'
+    assert generate_schema_calls.count == (1 if defer_build is True else 0), 'Should not build duplicate core schemas'
 
 
-@pytest.mark.parametrize('defer_build_mode', [None, tuple(), ('model',), ('type_adapter',), ('model', 'type_adapter')])
-def test_config_plain_type_adapter_defer_build(
-    defer_build_mode: Optional[Tuple[Literal['model', 'type_adapter'], ...]], generate_schema_calls: CallCounter
-):
-    config = ConfigDict(defer_build=True)
-    if defer_build_mode is not None:
-        config['experimental_defer_build_mode'] = defer_build_mode
-    is_deferred = defer_build_mode is not None and 'type_adapter' in defer_build_mode
+@pytest.mark.parametrize('defer_build', [True, False])
+def test_config_plain_type_adapter_defer_build(defer_build: bool, generate_schema_calls: CallCounter):
+    config = ConfigDict(defer_build=defer_build)
 
     ta = TypeAdapter(Dict[str, int], config=config)
 
-    assert generate_schema_calls.count == (0 if is_deferred else 1)
+    assert generate_schema_calls.count == (0 if defer_build else 1)
     generate_schema_calls.reset()
 
     assert ta.validate_python({}) == {}
@@ -779,16 +765,12 @@ def test_config_plain_type_adapter_defer_build(
     assert ta.dump_python({'x': 2}) == {'x': 2}
     assert ta.json_schema()['type'] == 'object'
 
-    assert generate_schema_calls.count == (1 if is_deferred else 0), 'Should not build duplicate core schemas'
+    assert generate_schema_calls.count == (1 if defer_build else 0), 'Should not build duplicate core schemas'
 
 
-@pytest.mark.parametrize('defer_build_mode', [None, ('model',), ('type_adapter',), ('model', 'type_adapter')])
-def test_config_model_defer_build_nested(
-    defer_build_mode: Optional[Tuple[Literal['model', 'type_adapter'], ...]], generate_schema_calls: CallCounter
-):
-    config = ConfigDict(defer_build=True)
-    if defer_build_mode:
-        config['experimental_defer_build_mode'] = defer_build_mode
+@pytest.mark.parametrize('defer_build', [True, False])
+def test_config_model_defer_build_nested(defer_build: bool, generate_schema_calls: CallCounter):
+    config = ConfigDict(defer_build=defer_build)
 
     assert generate_schema_calls.count == 0
 
@@ -802,10 +784,10 @@ def test_config_model_defer_build_nested(
     assert isinstance(MyModel.__pydantic_validator__, SchemaValidator)
     assert isinstance(MyModel.__pydantic_serializer__, SchemaSerializer)
 
-    expected_schema_count = 1 if defer_build_mode is None or 'model' in defer_build_mode else 2
+    expected_schema_count = 1 if defer_build is True else 2
     assert generate_schema_calls.count == expected_schema_count, 'Should respect experimental_defer_build_mode'
 
-    if defer_build_mode is None or 'model' in defer_build_mode:
+    if defer_build is True:
         assert isinstance(MyNestedModel.__pydantic_validator__, MockValSer)
         assert isinstance(MyNestedModel.__pydantic_serializer__, MockValSer)
     else:
@@ -818,7 +800,7 @@ def test_config_model_defer_build_nested(
     assert m.model_validate({'y': {'x': 1}}).y.x == 1
     assert m.model_json_schema()['type'] == 'object'
 
-    if defer_build_mode is None or 'model' in defer_build_mode:
+    if defer_build is True:
         assert isinstance(MyNestedModel.__pydantic_validator__, MockValSer)
         assert isinstance(MyNestedModel.__pydantic_serializer__, MockValSer)
     else:

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -19,8 +19,6 @@ ItemType = TypeVar('ItemType')
 
 NestedList = List[List[ItemType]]
 
-DEFER_ENABLE_MODE = ('model', 'type_adapter')
-
 
 class PydanticModel(BaseModel):
     x: int
@@ -73,7 +71,7 @@ OuterDict = Dict[str, 'IntList']
 @pytest.mark.parametrize('defer_build', [False, True])
 @pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
 def test_global_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
-    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True) if defer_build else None
     ta = TypeAdapter(OuterDict, config=config)
 
     assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
@@ -94,9 +92,7 @@ def test_global_namespace_variables(defer_build: bool, method: str, generate_sch
 @pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
 def test_model_global_namespace_variables(defer_build: bool, method: str, generate_schema_calls):
     class MyModel(BaseModel):
-        model_config = (
-            ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
-        )
+        model_config = ConfigDict(defer_build=defer_build)
         x: OuterDict
 
     ta = TypeAdapter(MyModel)
@@ -121,7 +117,7 @@ def test_local_namespace_variables(defer_build: bool, method: str, generate_sche
     IntList = List[int]  # noqa: F841
     OuterDict = Dict[str, 'IntList']
 
-    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True) if defer_build else None
     ta = TypeAdapter(OuterDict, config=config)
 
     assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
@@ -144,9 +140,7 @@ def test_model_local_namespace_variables(defer_build: bool, method: str, generat
     IntList = List[int]  # noqa: F841
 
     class MyModel(BaseModel):
-        model_config = (
-            ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
-        )
+        model_config = ConfigDict(defer_build=defer_build)
         x: Dict[str, 'IntList']
 
     ta = TypeAdapter(MyModel)
@@ -169,7 +163,7 @@ def test_model_local_namespace_variables(defer_build: bool, method: str, generat
 @pytest.mark.parametrize('method', ['validate', 'serialize', 'json_schema', 'json_schemas'])
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="ForwardRef doesn't accept module as a parameter in Python < 3.9")
 def test_top_level_fwd_ref(defer_build: bool, method: str, generate_schema_calls):
-    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True) if defer_build else None
 
     FwdRef = ForwardRef('OuterDict', module=__name__)
     ta = TypeAdapter(FwdRef, config=config)
@@ -397,7 +391,7 @@ def test_validate_python_from_attributes() -> None:
 def test_validate_strings(
     field_type, input_value, expected, raises_match, strict, defer_build: bool, generate_schema_calls
 ):
-    config = ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE) if defer_build else None
+    config = ConfigDict(defer_build=True) if defer_build else None
     ta = TypeAdapter(field_type, config=config)
 
     assert generate_schema_calls.count == (0 if defer_build else 1), 'Should be built deferred'
@@ -518,10 +512,8 @@ def defer_build_test_models(config: ConfigDict) -> List[Any]:
 
 
 CONFIGS = [
-    ConfigDict(defer_build=False, experimental_defer_build_mode=('model',)),
-    ConfigDict(defer_build=False, experimental_defer_build_mode=DEFER_ENABLE_MODE),
-    ConfigDict(defer_build=True, experimental_defer_build_mode=('model',)),
-    ConfigDict(defer_build=True, experimental_defer_build_mode=DEFER_ENABLE_MODE),
+    ConfigDict(defer_build=False),
+    ConfigDict(defer_build=True),
 ]
 MODELS_CONFIGS: List[Tuple[Any, ConfigDict]] = [
     (model, config) for config in CONFIGS for model in defer_build_test_models(config)
@@ -537,7 +529,7 @@ def test_core_schema_respects_defer_build(model: Any, config: ConfigDict, method
 
     type_adapter = TypeAdapter(model) if _type_has_config(model) else TypeAdapter(model, config=config)
 
-    if config['defer_build'] and 'type_adapter' in config['experimental_defer_build_mode']:
+    if config.get('defer_build'):
         assert generate_schema_calls.count == 0, 'Should be built deferred'
         assert type_adapter._core_schema is None, 'Should be initialized deferred'
         assert type_adapter._validator is None, 'Should be initialized deferred'


### PR DESCRIPTION
cc @MarkusSintonen, this will be included in v2.10 🚀.
cc @Viicos, I can merge this after your PR (github.com/pydantic/pydantic/pull/10313) so that the onus of resolving merge conflicts falls on me :).