### PR TITLE
Turn `tzdata` install requirement into optional `timezone` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     - name: install deps
       run: |
         pdm venv create --with-pip --force $PYTHON
-        pdm install -G testing -G email
+        pdm install -G testing -G email -G timezone
 
     - run: pdm info && pdm list
 
@@ -156,7 +156,7 @@ jobs:
         CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}-without-deps
 
     - name: install extra deps
-      run: pdm install -G testing-extra -G email
+      run: pdm install -G testing-extra -G email -G timezone
 
     - name: test with deps
       run: make test

--- a/.hyperlint/styles/config/vocabularies/hyperlint/accept.txt
+++ b/.hyperlint/styles/config/vocabularies/hyperlint/accept.txt
@@ -6,6 +6,7 @@ Hyperlint
 preprocess
 tokenization
 tokenizer
+tzdata
 API
 APIs
 SDKs

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,15 +23,19 @@ conda install pydantic -c conda-forge
 
 Pydantic has the following optional dependencies:
 
-* Email validation provided by the [email-validator](https://pypi.org/project/email-validator/) package.
+* `email`: Email validation provided by the [email-validator](https://pypi.org/project/email-validator/) package.
+* `timezone`: Fallback IANA time zone database provided by the [tzdata](https://pypi.org/project/tzdata/) package.
 
 To install optional dependencies along with Pydantic:
 
 ```bash
+# with the `email` extra:
 pip install pydantic[email]
+# or with `email` and `timezone` extras:
+pip install pydantic[email,timezone]
 ```
 
-Of course, you can also install requirements manually with `pip install email-validator`.
+Of course, you can also install requirements manually with `pip install email-validator tzdata`.
 
 ## Install from repository
 
@@ -39,6 +43,6 @@ And if you prefer to install Pydantic directly from the repository:
 
 ```bash
 pip install git+https://github.com/pydantic/pydantic@main#egg=pydantic
-# or with the `email` extra:
-pip install git+https://github.com/pydantic/pydantic@main#egg=pydantic[email]
+# or with `email` and `timezone` extras:
+pip install git+https://github.com/pydantic/pydantic@main#egg=pydantic[email,timezone]
 ```

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra"]
+groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra", "timezone"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:a35cfb3d1aa9400acb86d7b2a4727c0d4dd0998e3a00cd7cccd5d26893211f31"
+content_hash = "sha256:3a584a7e92099980d8871eb23c5549630f86f8e2284884ab3042dd043ddf50f8"
 
 [[metadata.targets]]
 requires_python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,15 @@ dependencies = [
     'typing-extensions>=4.12.2; python_version >= "3.13"',
     'annotated-types>=0.6.0',
     "pydantic-core==2.23.2",
-    # See: https://docs.python.org/3/library/zoneinfo.html#data-sources
-    'tzdata; python_version >= "3.9"',
 ]
 dynamic = ['version', 'readme']
 
 [project.optional-dependencies]
 email = ['email-validator>=2.0.0']
+timezone = [
+    # See: https://docs.python.org/3/library/zoneinfo.html#data-sources
+    'tzdata; python_version >= "3.9" and sys_platform == "win32"',
+]
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

#9896 adds an install requirement for `tzdata`, which states:

> `tzdata` is intended to be a fallback for systems that do not have system time zone data installed.

Non-Windows system typically have time zone data installed and do not need `tzdata`. This PR turns the `tzdata` dependency into an optional dependency group `timezone`. Documentation is updated accordingly.

## Related issue number

fix #10328

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
