### PR TITLE
Simplify unions involving `Any` or `Never` when replacing type variables

### DIFF
--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -36,6 +36,7 @@ from pydantic_core import CoreSchema, core_schema
 from typing_extensions import (
     Annotated,
     Literal,
+    Never,
     NotRequired,
     ParamSpec,
     TypedDict,
@@ -2875,3 +2876,16 @@ def test_generic_with_allow_extra():
     # This used to raise an error related to accessing the __annotations__ attribute of the Generic class
     class AllowExtraGeneric(BaseModel, Generic[T], extra='allow'):
         data: T
+
+
+def test_generic_any_or_never() -> None:
+    T = TypeVar('T')
+
+    class GenericModel(BaseModel, Generic[T]):
+        f: Union[T, int]
+
+    any_json_schema = GenericModel[Any].model_json_schema()
+    assert any_json_schema['properties']['f'] == {'title': 'F'}  # any type
+
+    never_json_schema = GenericModel[Never].model_json_schema()
+    assert never_json_schema['properties']['f'] == {'type': 'integer', 'title': 'F'}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I could have implemented this simplification for all cases (perhaps in `GenerateSchema._apply_single_annotation` or similar) but I don't want to break any unusual scenarios, plus this kind of situation is pretty uncommon in the general case (you're not really going to annotate a field as `Any | <other>`), it only makes sense when parameterizing `T | <other>` with `Any`/`Never`.

This has the added benefit of creating simplified JSON Schemas, as shown in the test. 

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
