### PR TITLE
benchmark tagged/untagged unions and stdlib types in schema generation

### DIFF
--- a/tests/benchmarks/shared.py
+++ b/tests/benchmarks/shared.py
@@ -20,17 +20,17 @@ from typing import (
     FrozenSet,
     Iterable,
     List,
-    Literal,
     NamedTuple,
     Optional,
     Sequence,
     Set,
     Tuple,
     Type,
-    TypedDict,
     Union,
 )
 from uuid import UUID, uuid4, uuid5
+
+from typing_extensions import Literal, TypedDict
 
 from pydantic import BaseModel
 

--- a/tests/benchmarks/shared.py
+++ b/tests/benchmarks/shared.py
@@ -1,4 +1,36 @@
-from typing import Dict, List, Optional, Union
+from collections import deque
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum, IntEnum
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+)
+from pathlib import Path
+from re import Pattern
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypedDict,
+    Union,
+)
+from uuid import UUID, uuid4, uuid5
 
 from pydantic import BaseModel
 
@@ -24,3 +56,100 @@ class ComplexModel(BaseModel):
     field1: Union[str, int, float]
     field2: List[Dict[str, Union[int, float]]]
     field3: Optional[List[Union[str, int]]]
+
+
+class Color(Enum):
+    RED = 'red'
+    GREEN = 'green'
+    BLUE = 'blue'
+
+
+class ToolEnum(IntEnum):
+    spanner = 1
+    wrench = 2
+    screwdriver = 3
+
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+
+class User(TypedDict):
+    name: str
+    id: int
+
+
+class Foo:
+    pass
+
+
+StdLibTypes = [
+    deque,  # collections.deque
+    Deque[str],  # typing.Deque
+    Deque[int],  # typing.Deque
+    Deque[float],  # typing.Deque
+    Deque[bytes],  # typing.Deque
+    str,  # str
+    int,  # int
+    float,  # float
+    complex,  # complex
+    bool,  # bool
+    bytes,  # bytes
+    date,  # datetime.date
+    datetime,  # datetime.datetime
+    time,  # datetime.time
+    timedelta,  # datetime.timedelta
+    Decimal,  # decimal.Decimal
+    Color,  # enum
+    ToolEnum,  # int enum
+    IPv4Address,  # ipaddress.IPv4Address
+    IPv6Address,  # ipaddress.IPv6Address
+    IPv4Interface,  # ipaddress.IPv4Interface
+    IPv6Interface,  # ipaddress.IPv6Interface
+    IPv4Network,  # ipaddress.IPv4Network
+    IPv6Network,  # ipaddress.IPv6Network
+    Path,  # pathlib.Path
+    Pattern,  # typing.Pattern
+    UUID,  # uuid.UUID
+    uuid4,  # uuid.uuid4
+    uuid5,  # uuid.uuid5
+    Point,  # named tuple
+    list,  # built-in list
+    List[int],  # typing.List
+    List[str],  # typing.List
+    List[bytes],  # typing.List
+    List[float],  # typing.List
+    dict,  # built-in dict
+    Dict[str, float],  # typing.Dict
+    Dict[str, bytes],  # typing.Dict
+    Dict[str, int],  # typing.Dict
+    Dict[str, str],  # typing.Dict
+    User,  # TypedDict
+    tuple,  # tuple
+    Tuple[int, str, float],  # typing.Tuple
+    set,  # built-in set
+    Set[int],  # typing.Set
+    Set[str],  # typing.Set
+    frozenset,  # built-in frozenset
+    FrozenSet[int],  # typing.FrozenSet
+    FrozenSet[str],  # typing.FrozenSet
+    Optional[int],  # typing.Optional
+    Optional[str],  # typing.Optional
+    Optional[float],  # typing.Optional
+    Optional[bytes],  # typing.Optional
+    Optional[bool],  # typing.Optional
+    Sequence[int],  # typing.Sequence
+    Sequence[str],  # typing.Sequence
+    Sequence[bytes],  # typing.Sequence
+    Sequence[float],  # typing.Sequence
+    Iterable[int],  # typing.Iterable
+    Iterable[str],  # typing.Iterable
+    Iterable[bytes],  # typing.Iterable
+    Iterable[float],  # typing.Iterable
+    Callable[[int], int],  # typing.Callable
+    Callable[[str], str],  # typing.Callable
+    Literal['apple', 'pumpkin'],  #
+    Type[Foo],  # typing.Type
+    Any,  # typing.Any
+]

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -291,6 +291,7 @@ def test_tagged_union_with_callable_discriminator_schema_generation(benchmark):
 
 @pytest.mark.parametrize('field_type', StdLibTypes)
 @pytest.mark.benchmark(group='stdlib_schema_generation')
+@pytest.mark.skip('Clutters codspeed CI, but should be enabled on branches where we modify schema building.')
 def test_stdlib_type_schema_generation(benchmark, field_type):
     class StdlibTypeModel(DeferredModel):
         field: field_type

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -23,6 +23,7 @@ from pydantic import (
     Field,
     PlainSerializer,
     PlainValidator,
+    Tag,
     WrapSerializer,
     WrapValidator,
     create_model,
@@ -35,14 +36,14 @@ from .shared import StdLibTypes
 
 
 class DeferredModel(BaseModel):
-    model_config = {"defer_build": True}
+    model_config = {'defer_build': True}
 
 
 def rebuild_model(model: Type[BaseModel]) -> None:
     model.model_rebuild(force=True, _types_namespace={})
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_simple_model_schema_generation(benchmark) -> None:
     class SimpleModel(DeferredModel):
         field1: str
@@ -52,20 +53,20 @@ def test_simple_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, SimpleModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_simple_model_schema_lots_of_fields_generation(benchmark) -> None:
     IntStr = Union[int, str]
 
     Model = create_model(
-        "Model",
-        __config__={"defer_build": True},
-        **{f"f{i}": (IntStr, ...) for i in range(100)},
+        'Model',
+        __config__={'defer_build': True},
+        **{f'f{i}': (IntStr, ...) for i in range(100)},
     )
 
     benchmark(rebuild_model, Model)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_nested_model_schema_generation(benchmark) -> None:
     class NestedModel(BaseModel):
         field1: str
@@ -79,7 +80,7 @@ def test_nested_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, OuterModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_complex_model_schema_generation(benchmark) -> None:
     class ComplexModel(DeferredModel):
         field1: Union[str, int, float]
@@ -89,33 +90,33 @@ def test_complex_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, ComplexModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_recursive_model_schema_generation(benchmark) -> None:
     class RecursiveModel(DeferredModel):
         name: str
-        children: Optional[List["RecursiveModel"]] = None
+        children: Optional[List['RecursiveModel']] = None
 
     benchmark(rebuild_model, RecursiveModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_construct_dataclass_schema(benchmark):
     @dataclass(frozen=True, kw_only=True)
     class Cat:
-        type: Literal["cat"] = "cat"
+        type: Literal['cat'] = 'cat'
 
     @dataclass(frozen=True, kw_only=True)
     class Dog:
-        type: Literal["dog"] = "dog"
+        type: Literal['dog'] = 'dog'
 
     @dataclass(frozen=True, kw_only=True)
     class NestedDataClass:
-        animal: Annotated[Union[Cat, Dog], Discriminator("type")]
+        animal: Annotated[Union[Cat, Dog], Discriminator('type')]
 
     class NestedModel(BaseModel):
-        animal: Annotated[Union[Cat, Dog], Discriminator("type")]
+        animal: Annotated[Union[Cat, Dog], Discriminator('type')]
 
-    @dataclass(frozen=True, kw_only=True, config={"defer_build": True})
+    @dataclass(frozen=True, kw_only=True, config={'defer_build': True})
     class Root:
         data_class: NestedDataClass
         model: NestedModel
@@ -123,21 +124,21 @@ def test_construct_dataclass_schema(benchmark):
     benchmark(lambda: rebuild_dataclass(Root, force=True, _types_namespace={}))
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_lots_of_models_with_lots_of_fields(benchmark):
-    T = TypeVar("T")
+    T = TypeVar('T')
 
     class GenericModel(BaseModel, Generic[T]):
         value: T
 
     class RecursiveModel(BaseModel):
         name: str
-        children: Optional[List["RecursiveModel"]] = None
+        children: Optional[List['RecursiveModel']] = None
 
     class Address(BaseModel):
         street: Annotated[str, Field(max_length=100)]
         city: Annotated[str, Field(min_length=2)]
-        zipcode: Annotated[str, Field(pattern=r"^\d{5}$")]
+        zipcode: Annotated[str, Field(pattern=r'^\d{5}$')]
 
     class Person(BaseModel):
         name: Annotated[str, Field(min_length=1)]
@@ -191,14 +192,12 @@ def test_lots_of_models_with_lots_of_fields(benchmark):
         for j in range(100):
             field_type = field_types[j % len(field_types)]
             if get_origin(field_type) is Annotated:
-                model_fields[f"field_{j}"] = field_type
+                model_fields[f'field_{j}'] = field_type
             else:
-                model_fields[f"field_{j}"] = (field_type, ...)
+                model_fields[f'field_{j}'] = (field_type, ...)
 
-        model_name = f"Model_{i}"
-        models.append(
-            create_model(model_name, __config__={"defer_build": True}, **model_fields)
-        )
+        model_name = f'Model_{i}'
+        models.append(create_model(model_name, __config__={'defer_build': True}, **model_fields))
 
     def rebuild_models(models: List[Type[BaseModel]]) -> None:
         for model in models:
@@ -207,7 +206,7 @@ def test_lots_of_models_with_lots_of_fields(benchmark):
     benchmark(rebuild_models, models)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_field_validators_serializers(benchmark) -> None:
     class ModelWithFieldValidatorsSerializers(DeferredModel):
         field1: Annotated[Any, BeforeValidator(lambda v: v)]
@@ -215,22 +214,22 @@ def test_field_validators_serializers(benchmark) -> None:
         field3: Annotated[Any, PlainValidator(lambda v: v)]
         field4: Annotated[Any, WrapValidator(lambda v, h: h(v))]
         field5: Annotated[Any, PlainSerializer(lambda x: x, return_type=Any)]
-        field6: Annotated[Any, WrapSerializer(lambda x, nxt: nxt(x), when_used="json")]
+        field6: Annotated[Any, WrapSerializer(lambda x, nxt: nxt(x), when_used='json')]
 
     benchmark(rebuild_model, ModelWithFieldValidatorsSerializers)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_model_validators_serializers(benchmark):
     class ModelWithValidator(DeferredModel):
         field: Any
 
-        @model_validator(mode="before")
+        @model_validator(mode='before')
         @classmethod
         def validate_model_before(cls, data: Any) -> Any:
             return data
 
-        @model_validator(mode="after")
+        @model_validator(mode='after')
         def validate_model_after(self) -> Self:
             return self
 
@@ -241,108 +240,102 @@ def test_model_validators_serializers(benchmark):
     benchmark(rebuild_model, ModelWithValidator)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_tagged_union_with_str_discriminator_schema_generation(benchmark):
-    def generate_schema():
-        class Cat(BaseModel):
-            pet_type: Literal["cat"]
-            meows: int
+    class Cat(BaseModel):
+        pet_type: Literal['cat']
+        meows: int
 
-        class Dog(BaseModel):
-            pet_type: Literal["dog"]
-            barks: float
+    class Dog(BaseModel):
+        pet_type: Literal['dog']
+        barks: float
 
-        class Lizard(BaseModel):
-            pet_type: Literal["reptile", "lizard"]
-            scales: bool
+    class Lizard(BaseModel):
+        pet_type: Literal['reptile', 'lizard']
+        scales: bool
 
-        class Model(BaseModel):
-            pet: Union[Cat, Dog, Lizard] = Field(..., discriminator="pet_type")
-            n: int
+    class Model(BaseModel):
+        pet: Union[Cat, Dog, Lizard] = Field(..., discriminator='pet_type')
+        n: int
 
-    benchmark(generate_schema)
+    benchmark(rebuild_model, Model)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_tagged_union_with_callable_discriminator_schema_generation(benchmark):
-    def generate_schema():
-        class Pie(BaseModel):
-            time_to_cook: int
-            num_ingredients: int
+    class Pie(BaseModel):
+        time_to_cook: int
+        num_ingredients: int
 
-        class ApplePie(Pie):
-            fruit: Literal["apple"] = "apple"
+    class ApplePie(Pie):
+        fruit: Literal['apple'] = 'apple'
 
-        class PumpkinPie(Pie):
-            filling: Literal["pumpkin"] = "pumpkin"
+    class PumpkinPie(Pie):
+        filling: Literal['pumpkin'] = 'pumpkin'
 
-        def get_discriminator_value(v: Any) -> str:
-            if isinstance(v, dict):
-                return v.get("fruit", v.get("filling"))
-            return getattr(v, "fruit", getattr(v, "filling", None))
+    def get_discriminator_value(v: Any) -> str:
+        if isinstance(v, dict):
+            return v.get('fruit', v.get('filling'))
+        return getattr(v, 'fruit', getattr(v, 'filling', None))
 
-        class ThanksgivingDinner(BaseModel):
-            dessert: Annotated[
-                Union[
-                    Annotated[ApplePie, Tag("apple")],
-                    Annotated[PumpkinPie, Tag("pumpkin")],
-                ],
-                Discriminator(get_discriminator_value),
-            ]
+    class ThanksgivingDinner(BaseModel):
+        dessert: Annotated[
+            Union[
+                Annotated[ApplePie, Tag('apple')],
+                Annotated[PumpkinPie, Tag('pumpkin')],
+            ],
+            Discriminator(get_discriminator_value),
+        ]
 
-    benchmark(generate_schema)
+    benchmark(rebuild_model, ThanksgivingDinner)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_tagged_union_with_callable_discriminator_nested_schema_generation(benchmark):
-    def generate_schema():
-        class BlackCat(BaseModel):
-            pet_type: Literal["cat"]
-            color: Literal["black"]
-            black_name: str
+    class BlackCat(BaseModel):
+        pet_type: Literal['cat']
+        color: Literal['black']
+        black_name: str
 
-        class WhiteCat(BaseModel):
-            pet_type: Literal["cat"]
-            color: Literal["white"]
-            white_name: str
+    class WhiteCat(BaseModel):
+        pet_type: Literal['cat']
+        color: Literal['white']
+        white_name: str
 
-        Cat = Annotated[Union[BlackCat, WhiteCat], Field(discriminator="color")]
+    Cat = Annotated[Union[BlackCat, WhiteCat], Field(discriminator='color')]
 
-        class Dog(BaseModel):
-            pet_type: Literal["dog"]
-            name: str
+    class Dog(BaseModel):
+        pet_type: Literal['dog']
+        name: str
 
-        class Model(BaseModel):
-            pet: Annotated[Union[Cat, Dog], Field(discriminator="pet_type")]
-            n: int
+    class Model(DeferredModel):
+        pet: Annotated[Union[Cat, Dog], Field(discriminator='pet_type')]
+        n: int
 
-    benchmark(generate_schema)
+    benchmark(rebuild_model, Model)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_untagged_union_left_to_right_mode_schema_generation(benchmark):
-    def generate_schema():
-        class User(BaseModel):
-            id: Union[str, int] = Field(union_mode="left_to_right")
+    class User(DeferredModel):
+        id: Union[str, int] = Field(union_mode='left_to_right')
 
-    benchmark(generate_schema)
+    benchmark(rebuild_model, User)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_untagged_union_smart_mode_schema_generation(benchmark):
-    def generate_schema():
-        class User(BaseModel):
-            id: Union[int, str, UUID]
-            name: str
+    class User(DeferredModel):
+        id: Union[int, str, UUID]
+        name: str
 
-    benchmark(generate_schema)
+    benchmark(rebuild_model, User)
 
 
 @pytest.mark.parametrize('field_type', StdLibTypes)
 @pytest.mark.benchmark(group='stdlib_schema_generation')
 def test_stdlib_type_schema_generation(benchmark, field_type):
-    def generate_schema():
-        class StdlibTypeModel(BaseModel):
-            field: field_type
+    class StdlibTypeModel(DeferredModel):
+        field: field_type
 
-    benchmark(generate_schema)
+    benchmark(rebuild_model, StdlibTypeModel)

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -289,31 +289,6 @@ def test_tagged_union_with_callable_discriminator_schema_generation(benchmark):
     benchmark(rebuild_model, ThanksgivingDinner)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
-def test_tagged_union_with_callable_discriminator_nested_schema_generation(benchmark):
-    class BlackCat(BaseModel):
-        pet_type: Literal['cat']
-        color: Literal['black']
-        black_name: str
-
-    class WhiteCat(BaseModel):
-        pet_type: Literal['cat']
-        color: Literal['white']
-        white_name: str
-
-    Cat = Annotated[Union[BlackCat, WhiteCat], Field(discriminator='color')]
-
-    class Dog(BaseModel):
-        pet_type: Literal['dog']
-        name: str
-
-    class Model(DeferredModel):
-        pet: Annotated[Union[Cat, Dog], Field(discriminator='pet_type')]
-        n: int
-
-    benchmark(rebuild_model, Model)
-
-
 @pytest.mark.parametrize('field_type', StdLibTypes)
 @pytest.mark.benchmark(group='stdlib_schema_generation')
 def test_stdlib_type_schema_generation(benchmark, field_type):

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -10,7 +10,6 @@ from typing import (
     Union,
     get_origin,
 )
-from uuid import UUID
 
 import pytest
 from typing_extensions import Annotated, Self
@@ -254,7 +253,7 @@ def test_tagged_union_with_str_discriminator_schema_generation(benchmark):
         pet_type: Literal['reptile', 'lizard']
         scales: bool
 
-    class Model(BaseModel):
+    class Model(DeferredModel):
         pet: Union[Cat, Dog, Lizard] = Field(..., discriminator='pet_type')
         n: int
 
@@ -278,7 +277,7 @@ def test_tagged_union_with_callable_discriminator_schema_generation(benchmark):
             return v.get('fruit', v.get('filling'))
         return getattr(v, 'fruit', getattr(v, 'filling', None))
 
-    class ThanksgivingDinner(BaseModel):
+    class ThanksgivingDinner(DeferredModel):
         dessert: Annotated[
             Union[
                 Annotated[ApplePie, Tag('apple')],
@@ -313,23 +312,6 @@ def test_tagged_union_with_callable_discriminator_nested_schema_generation(bench
         n: int
 
     benchmark(rebuild_model, Model)
-
-
-@pytest.mark.benchmark(group='model_schema_generation')
-def test_untagged_union_left_to_right_mode_schema_generation(benchmark):
-    class User(DeferredModel):
-        id: Union[str, int] = Field(union_mode='left_to_right')
-
-    benchmark(rebuild_model, User)
-
-
-@pytest.mark.benchmark(group='model_schema_generation')
-def test_untagged_union_smart_mode_schema_generation(benchmark):
-    class User(DeferredModel):
-        id: Union[int, str, UUID]
-        name: str
-
-    benchmark(rebuild_model, User)
 
 
 @pytest.mark.parametrize('field_type', StdLibTypes)

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -1,4 +1,15 @@
-from typing import Any, Dict, Generic, List, Literal, Optional, Type, TypeVar, Union, get_origin
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    get_origin,
+)
 
 import pytest
 from typing_extensions import Annotated, Self
@@ -21,14 +32,14 @@ from pydantic.dataclasses import dataclass, rebuild_dataclass
 
 
 class DeferredModel(BaseModel):
-    model_config = {'defer_build': True}
+    model_config = {"defer_build": True}
 
 
 def rebuild_model(model: Type[BaseModel]) -> None:
     model.model_rebuild(force=True, _types_namespace={})
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_simple_model_schema_generation(benchmark) -> None:
     class SimpleModel(DeferredModel):
         field1: str
@@ -38,16 +49,20 @@ def test_simple_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, SimpleModel)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_simple_model_schema_lots_of_fields_generation(benchmark) -> None:
     IntStr = Union[int, str]
 
-    Model = create_model('Model', __config__={'defer_build': True}, **{f'f{i}': (IntStr, ...) for i in range(100)})
+    Model = create_model(
+        "Model",
+        __config__={"defer_build": True},
+        **{f"f{i}": (IntStr, ...) for i in range(100)},
+    )
 
     benchmark(rebuild_model, Model)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_nested_model_schema_generation(benchmark) -> None:
     class NestedModel(BaseModel):
         field1: str
@@ -61,7 +76,7 @@ def test_nested_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, OuterModel)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_complex_model_schema_generation(benchmark) -> None:
     class ComplexModel(DeferredModel):
         field1: Union[str, int, float]
@@ -71,33 +86,33 @@ def test_complex_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, ComplexModel)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_recursive_model_schema_generation(benchmark) -> None:
     class RecursiveModel(DeferredModel):
         name: str
-        children: Optional[List['RecursiveModel']] = None
+        children: Optional[List["RecursiveModel"]] = None
 
     benchmark(rebuild_model, RecursiveModel)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_construct_dataclass_schema(benchmark):
     @dataclass(frozen=True, kw_only=True)
     class Cat:
-        type: Literal['cat'] = 'cat'
+        type: Literal["cat"] = "cat"
 
     @dataclass(frozen=True, kw_only=True)
     class Dog:
-        type: Literal['dog'] = 'dog'
+        type: Literal["dog"] = "dog"
 
     @dataclass(frozen=True, kw_only=True)
     class NestedDataClass:
-        animal: Annotated[Union[Cat, Dog], Discriminator('type')]
+        animal: Annotated[Union[Cat, Dog], Discriminator("type")]
 
     class NestedModel(BaseModel):
-        animal: Annotated[Union[Cat, Dog], Discriminator('type')]
+        animal: Annotated[Union[Cat, Dog], Discriminator("type")]
 
-    @dataclass(frozen=True, kw_only=True, config={'defer_build': True})
+    @dataclass(frozen=True, kw_only=True, config={"defer_build": True})
     class Root:
         data_class: NestedDataClass
         model: NestedModel
@@ -105,21 +120,21 @@ def test_construct_dataclass_schema(benchmark):
     benchmark(lambda: rebuild_dataclass(Root, force=True, _types_namespace={}))
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_lots_of_models_with_lots_of_fields(benchmark):
-    T = TypeVar('T')
+    T = TypeVar("T")
 
     class GenericModel(BaseModel, Generic[T]):
         value: T
 
     class RecursiveModel(BaseModel):
         name: str
-        children: Optional[List['RecursiveModel']] = None
+        children: Optional[List["RecursiveModel"]] = None
 
     class Address(BaseModel):
         street: Annotated[str, Field(max_length=100)]
         city: Annotated[str, Field(min_length=2)]
-        zipcode: Annotated[str, Field(pattern=r'^\d{5}$')]
+        zipcode: Annotated[str, Field(pattern=r"^\d{5}$")]
 
     class Person(BaseModel):
         name: Annotated[str, Field(min_length=1)]
@@ -173,12 +188,14 @@ def test_lots_of_models_with_lots_of_fields(benchmark):
         for j in range(100):
             field_type = field_types[j % len(field_types)]
             if get_origin(field_type) is Annotated:
-                model_fields[f'field_{j}'] = field_type
+                model_fields[f"field_{j}"] = field_type
             else:
-                model_fields[f'field_{j}'] = (field_type, ...)
+                model_fields[f"field_{j}"] = (field_type, ...)
 
-        model_name = f'Model_{i}'
-        models.append(create_model(model_name, __config__={'defer_build': True}, **model_fields))
+        model_name = f"Model_{i}"
+        models.append(
+            create_model(model_name, __config__={"defer_build": True}, **model_fields)
+        )
 
     def rebuild_models(models: List[Type[BaseModel]]) -> None:
         for model in models:
@@ -187,7 +204,7 @@ def test_lots_of_models_with_lots_of_fields(benchmark):
     benchmark(rebuild_models, models)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_field_validators_serializers(benchmark) -> None:
     class ModelWithFieldValidatorsSerializers(DeferredModel):
         field1: Annotated[Any, BeforeValidator(lambda v: v)]
@@ -195,22 +212,22 @@ def test_field_validators_serializers(benchmark) -> None:
         field3: Annotated[Any, PlainValidator(lambda v: v)]
         field4: Annotated[Any, WrapValidator(lambda v, h: h(v))]
         field5: Annotated[Any, PlainSerializer(lambda x: x, return_type=Any)]
-        field6: Annotated[Any, WrapSerializer(lambda x, nxt: nxt(x), when_used='json')]
+        field6: Annotated[Any, WrapSerializer(lambda x, nxt: nxt(x), when_used="json")]
 
     benchmark(rebuild_model, ModelWithFieldValidatorsSerializers)
 
 
-@pytest.mark.benchmark(group='model_schema_generation')
+@pytest.mark.benchmark(group="model_schema_generation")
 def test_model_validators_serializers(benchmark):
     class ModelWithValidator(DeferredModel):
         field: Any
 
-        @model_validator(mode='before')
+        @model_validator(mode="before")
         @classmethod
         def validate_model_before(cls, data: Any) -> Any:
             return data
 
-        @model_validator(mode='after')
+        @model_validator(mode="after")
         def validate_model_after(self) -> Self:
             return self
 

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -32,14 +32,14 @@ from pydantic.dataclasses import dataclass, rebuild_dataclass
 
 
 class DeferredModel(BaseModel):
-    model_config = {"defer_build": True}
+    model_config = {'defer_build': True}
 
 
 def rebuild_model(model: Type[BaseModel]) -> None:
     model.model_rebuild(force=True, _types_namespace={})
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_simple_model_schema_generation(benchmark) -> None:
     class SimpleModel(DeferredModel):
         field1: str
@@ -49,20 +49,20 @@ def test_simple_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, SimpleModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_simple_model_schema_lots_of_fields_generation(benchmark) -> None:
     IntStr = Union[int, str]
 
     Model = create_model(
-        "Model",
-        __config__={"defer_build": True},
-        **{f"f{i}": (IntStr, ...) for i in range(100)},
+        'Model',
+        __config__={'defer_build': True},
+        **{f'f{i}': (IntStr, ...) for i in range(100)},
     )
 
     benchmark(rebuild_model, Model)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_nested_model_schema_generation(benchmark) -> None:
     class NestedModel(BaseModel):
         field1: str
@@ -76,7 +76,7 @@ def test_nested_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, OuterModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_complex_model_schema_generation(benchmark) -> None:
     class ComplexModel(DeferredModel):
         field1: Union[str, int, float]
@@ -86,33 +86,33 @@ def test_complex_model_schema_generation(benchmark) -> None:
     benchmark(rebuild_model, ComplexModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_recursive_model_schema_generation(benchmark) -> None:
     class RecursiveModel(DeferredModel):
         name: str
-        children: Optional[List["RecursiveModel"]] = None
+        children: Optional[List['RecursiveModel']] = None
 
     benchmark(rebuild_model, RecursiveModel)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_construct_dataclass_schema(benchmark):
     @dataclass(frozen=True, kw_only=True)
     class Cat:
-        type: Literal["cat"] = "cat"
+        type: Literal['cat'] = 'cat'
 
     @dataclass(frozen=True, kw_only=True)
     class Dog:
-        type: Literal["dog"] = "dog"
+        type: Literal['dog'] = 'dog'
 
     @dataclass(frozen=True, kw_only=True)
     class NestedDataClass:
-        animal: Annotated[Union[Cat, Dog], Discriminator("type")]
+        animal: Annotated[Union[Cat, Dog], Discriminator('type')]
 
     class NestedModel(BaseModel):
-        animal: Annotated[Union[Cat, Dog], Discriminator("type")]
+        animal: Annotated[Union[Cat, Dog], Discriminator('type')]
 
-    @dataclass(frozen=True, kw_only=True, config={"defer_build": True})
+    @dataclass(frozen=True, kw_only=True, config={'defer_build': True})
     class Root:
         data_class: NestedDataClass
         model: NestedModel
@@ -120,21 +120,21 @@ def test_construct_dataclass_schema(benchmark):
     benchmark(lambda: rebuild_dataclass(Root, force=True, _types_namespace={}))
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_lots_of_models_with_lots_of_fields(benchmark):
-    T = TypeVar("T")
+    T = TypeVar('T')
 
     class GenericModel(BaseModel, Generic[T]):
         value: T
 
     class RecursiveModel(BaseModel):
         name: str
-        children: Optional[List["RecursiveModel"]] = None
+        children: Optional[List['RecursiveModel']] = None
 
     class Address(BaseModel):
         street: Annotated[str, Field(max_length=100)]
         city: Annotated[str, Field(min_length=2)]
-        zipcode: Annotated[str, Field(pattern=r"^\d{5}$")]
+        zipcode: Annotated[str, Field(pattern=r'^\d{5}$')]
 
     class Person(BaseModel):
         name: Annotated[str, Field(min_length=1)]
@@ -188,14 +188,12 @@ def test_lots_of_models_with_lots_of_fields(benchmark):
         for j in range(100):
             field_type = field_types[j % len(field_types)]
             if get_origin(field_type) is Annotated:
-                model_fields[f"field_{j}"] = field_type
+                model_fields[f'field_{j}'] = field_type
             else:
-                model_fields[f"field_{j}"] = (field_type, ...)
+                model_fields[f'field_{j}'] = (field_type, ...)
 
-        model_name = f"Model_{i}"
-        models.append(
-            create_model(model_name, __config__={"defer_build": True}, **model_fields)
-        )
+        model_name = f'Model_{i}'
+        models.append(create_model(model_name, __config__={'defer_build': True}, **model_fields))
 
     def rebuild_models(models: List[Type[BaseModel]]) -> None:
         for model in models:
@@ -204,7 +202,7 @@ def test_lots_of_models_with_lots_of_fields(benchmark):
     benchmark(rebuild_models, models)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_field_validators_serializers(benchmark) -> None:
     class ModelWithFieldValidatorsSerializers(DeferredModel):
         field1: Annotated[Any, BeforeValidator(lambda v: v)]
@@ -212,22 +210,22 @@ def test_field_validators_serializers(benchmark) -> None:
         field3: Annotated[Any, PlainValidator(lambda v: v)]
         field4: Annotated[Any, WrapValidator(lambda v, h: h(v))]
         field5: Annotated[Any, PlainSerializer(lambda x: x, return_type=Any)]
-        field6: Annotated[Any, WrapSerializer(lambda x, nxt: nxt(x), when_used="json")]
+        field6: Annotated[Any, WrapSerializer(lambda x, nxt: nxt(x), when_used='json')]
 
     benchmark(rebuild_model, ModelWithFieldValidatorsSerializers)
 
 
-@pytest.mark.benchmark(group="model_schema_generation")
+@pytest.mark.benchmark(group='model_schema_generation')
 def test_model_validators_serializers(benchmark):
     class ModelWithValidator(DeferredModel):
         field: Any
 
-        @model_validator(mode="before")
+        @model_validator(mode='before')
         @classmethod
         def validate_model_before(cls, data: Any) -> Any:
             return data
 
-        @model_validator(mode="after")
+        @model_validator(mode='after')
         def validate_model_after(self) -> Self:
             return self
 

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -31,6 +31,8 @@ from pydantic import (
 )
 from pydantic.dataclasses import dataclass, rebuild_dataclass
 
+from .shared import StdLibTypes
+
 
 class DeferredModel(BaseModel):
     model_config = {"defer_build": True}
@@ -332,5 +334,15 @@ def test_untagged_union_smart_mode_schema_generation(benchmark):
         class User(BaseModel):
             id: Union[int, str, UUID]
             name: str
+
+    benchmark(generate_schema)
+
+
+@pytest.mark.parametrize('field_type', StdLibTypes)
+@pytest.mark.benchmark(group='stdlib_schema_generation')
+def test_stdlib_type_schema_generation(benchmark, field_type):
+    def generate_schema():
+        class StdlibTypeModel(BaseModel):
+            field: field_type
 
     benchmark(generate_schema)


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->

This PR expands the benchmark suite by adding "schema generation" benchmarks in the following cases:

1. Models with Tagged and Untagged unions. In the tagged case, we benchmark string and callable discriminators
2. Models with types belonging to the standard library. I took inspiration from See https://docs.pydantic.dev/latest/api/standard_library_types. 

Since we are dealing with two items from Issue #9711, I tackled the benchmarks in two separate commits. 

I am open to suggestions. Let me know if I missed something :)

## Related issue number

Contributes to #9711 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
