### PR TITLE
Fix nested type statement

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -741,7 +741,7 @@ def unpack_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | N
 def default_ignored_types() -> tuple[type[Any], ...]:
     from ..fields import ComputedFieldInfo
 
-    return (
+    ignored_types = [
         FunctionType,
         property,
         classmethod,
@@ -749,4 +749,11 @@ def default_ignored_types() -> tuple[type[Any], ...]:
         PydanticDescriptorProxy,
         ComputedFieldInfo,
         ValidateCallWrapper,
-    )
+    ]
+
+    if sys.version_info >= (3, 12):
+        from typing import TypeAliasType
+
+        ignored_types.append(TypeAliasType)
+
+    return tuple(ignored_types)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2808,3 +2808,21 @@ def test_model_metaclass_on_other_class() -> None:
 
     class OtherClass(metaclass=ModelMetaclass):
         pass
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason='requires Python 3.12+')
+def test_nested_type_statement():
+    # https://docs.python.org/3/reference/simple_stmts.html#type
+
+    globs = {}
+    exec(
+        """
+from pydantic import BaseModel
+class A(BaseModel):
+    type Int = int
+    a: Int
+""",
+        globs,
+    )
+    A = globs['A']
+    assert A(a=1).a == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fix the following:
```py
from pydantic import BaseModel
class A(BaseModel):
    type Int = int  # currently will throws an error because `TypeAliasType` is not in `default_ignored_types()`
    a: Int
```
See: https://docs.python.org/3/reference/simple_stmts.html#type

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
