### PR TITLE
Make sure `inspect.iscoroutinefunction` works on coroutines decorated with `@validate_call`

### DIFF
--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -56,20 +56,23 @@ def validate_call(
 
         validate_call_wrapper = _validate_call.ValidateCallWrapper(function, config, validate_return, local_ns)
 
-        @functools.wraps(function)
-        def wrapper_function(*args, **kwargs):
-            return validate_call_wrapper(*args, **kwargs)
-
-        @functools.wraps(function)
-        async def async_wrapper_function(*args, **kwargs):
-            return await validate_call_wrapper(*args, **kwargs)
-
-        wrapper_function.raw_function = function  # type: ignore
-        async_wrapper_function.raw_function = function  # type: ignore
-
         if inspect.iscoroutinefunction(function):
+
+            @functools.wraps(function)
+            async def async_wrapper_function(*args, **kwargs):
+                return await validate_call_wrapper(*args, **kwargs)
+
+            async_wrapper_function.raw_function = function  # type: ignore
+
             return async_wrapper_function  # type: ignore
         else:
+
+            @functools.wraps(function)
+            def wrapper_function(*args, **kwargs):
+                return validate_call_wrapper(*args, **kwargs)
+
+            wrapper_function.raw_function = function  # type: ignore
+
             return wrapper_function  # type: ignore
 
     if func:

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations as _annotations
 
 import functools
+import inspect
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
 
 from ._internal import _typing_extra, _validate_call
@@ -59,9 +60,17 @@ def validate_call(
         def wrapper_function(*args, **kwargs):
             return validate_call_wrapper(*args, **kwargs)
 
-        wrapper_function.raw_function = function  # type: ignore
+        @functools.wraps(function)
+        async def async_wrapper_function(*args, **kwargs):
+            return await validate_call_wrapper(*args, **kwargs)
 
-        return wrapper_function  # type: ignore
+        wrapper_function.raw_function = function  # type: ignore
+        async_wrapper_function.raw_function = function  # type: ignore
+
+        if inspect.iscoroutinefunction(function):
+            return async_wrapper_function  # type: ignore
+        else:
+            return wrapper_function  # type: ignore
 
     if func:
         return validate(func)

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -59,21 +59,16 @@ def validate_call(
         if inspect.iscoroutinefunction(function):
 
             @functools.wraps(function)
-            async def async_wrapper_function(*args, **kwargs):
+            async def wrapper_function(*args, **kwargs):  # type: ignore
                 return await validate_call_wrapper(*args, **kwargs)
-
-            async_wrapper_function.raw_function = function  # type: ignore
-
-            return async_wrapper_function  # type: ignore
         else:
 
             @functools.wraps(function)
             def wrapper_function(*args, **kwargs):
                 return validate_call_wrapper(*args, **kwargs)
 
-            wrapper_function.raw_function = function  # type: ignore
-
-            return wrapper_function  # type: ignore
+        wrapper_function.raw_function = function  # type: ignore
+        return wrapper_function  # type: ignore
 
     if func:
         return validate(func)

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -10,13 +10,7 @@ import pytest
 from pydantic_core import ArgsKwargs
 from typing_extensions import Annotated, TypedDict
 
-from pydantic import (
-    Field,
-    PydanticInvalidForJsonSchema,
-    TypeAdapter,
-    ValidationError,
-    validate_call,
-)
+from pydantic import Field, PydanticInvalidForJsonSchema, TypeAdapter, ValidationError, validate_call
 from pydantic.main import BaseModel
 
 
@@ -37,18 +31,8 @@ def test_args():
         foo()
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'missing_argument',
-            'loc': ('a',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs(()),
-        },
-        {
-            'type': 'missing_argument',
-            'loc': ('b',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs(()),
-        },
+        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
     ]
 
     with pytest.raises(ValidationError) as exc_info:
@@ -76,18 +60,8 @@ def test_args():
         foo(1, 2, a=3, b=4)
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'multiple_argument_values',
-            'loc': ('a',),
-            'msg': 'Got multiple values for argument',
-            'input': 3,
-        },
-        {
-            'type': 'multiple_argument_values',
-            'loc': ('b',),
-            'msg': 'Got multiple values for argument',
-            'input': 4,
-        },
+        {'type': 'multiple_argument_values', 'loc': ('a',), 'msg': 'Got multiple values for argument', 'input': 3},
+        {'type': 'multiple_argument_values', 'loc': ('b',), 'msg': 'Got multiple values for argument', 'input': 4},
     ]
 
 
@@ -103,12 +77,7 @@ def test_optional():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'int_type',
-            'loc': (0,),
-            'msg': 'Input should be a valid integer',
-            'input': None,
-        }
+        {'type': 'int_type', 'loc': (0,), 'msg': 'Input should be a valid integer', 'input': None}
     ]
 
 
@@ -161,18 +130,8 @@ def test_kwargs():
             'msg': 'Missing required keyword only argument',
             'input': ArgsKwargs((1, 'x')),
         },
-        {
-            'type': 'unexpected_positional_argument',
-            'loc': (0,),
-            'msg': 'Unexpected positional argument',
-            'input': 1,
-        },
-        {
-            'type': 'unexpected_positional_argument',
-            'loc': (1,),
-            'msg': 'Unexpected positional argument',
-            'input': 'x',
-        },
+        {'type': 'unexpected_positional_argument', 'loc': (0,), 'msg': 'Unexpected positional argument', 'input': 1},
+        {'type': 'unexpected_positional_argument', 'loc': (1,), 'msg': 'Unexpected positional argument', 'input': 'x'},
     ]
 
 
@@ -246,12 +205,7 @@ def foo(a, b, /, c=None):
             'msg': 'Missing required positional only argument',
             'input': ArgsKwargs((1,), {'b': 2}),
         },
-        {
-            'type': 'unexpected_keyword_argument',
-            'loc': ('b',),
-            'msg': 'Unexpected keyword argument',
-            'input': 2,
-        },
+        {'type': 'unexpected_keyword_argument', 'loc': ('b',), 'msg': 'Unexpected keyword argument', 'input': 2},
     ]
 
     with pytest.raises(ValidationError) as exc_info:
@@ -270,18 +224,8 @@ def foo(a, b, /, c=None):
             'msg': 'Missing required positional only argument',
             'input': ArgsKwargs((), {'a': 1, 'b': 2}),
         },
-        {
-            'type': 'unexpected_keyword_argument',
-            'loc': ('a',),
-            'msg': 'Unexpected keyword argument',
-            'input': 1,
-        },
-        {
-            'type': 'unexpected_keyword_argument',
-            'loc': ('b',),
-            'msg': 'Unexpected keyword argument',
-            'input': 2,
-        },
+        {'type': 'unexpected_keyword_argument', 'loc': ('a',), 'msg': 'Unexpected keyword argument', 'input': 1},
+        {'type': 'unexpected_keyword_argument', 'loc': ('b',), 'msg': 'Unexpected keyword argument', 'input': 2},
     ]
 
 
@@ -300,18 +244,8 @@ def test_args_name():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'unexpected_keyword_argument',
-            'loc': ('apple',),
-            'msg': 'Unexpected keyword argument',
-            'input': 4,
-        },
-        {
-            'type': 'unexpected_keyword_argument',
-            'loc': ('banana',),
-            'msg': 'Unexpected keyword argument',
-            'input': 5,
-        },
+        {'type': 'unexpected_keyword_argument', 'loc': ('apple',), 'msg': 'Unexpected keyword argument', 'input': 4},
+        {'type': 'unexpected_keyword_argument', 'loc': ('banana',), 'msg': 'Unexpected keyword argument', 'input': 5},
     ]
 
     with pytest.raises(ValidationError) as exc_info:
@@ -319,12 +253,7 @@ def test_args_name():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'unexpected_positional_argument',
-            'loc': (2,),
-            'msg': 'Unexpected positional argument',
-            'input': 3,
-        }
+        {'type': 'unexpected_positional_argument', 'loc': (2,), 'msg': 'Unexpected positional argument', 'input': 3}
     ]
 
 
@@ -371,12 +300,7 @@ def test_async():
         asyncio.run(foo('x'))
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'missing_argument',
-            'loc': ('b',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs(('x',)),
-        }
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(('x',))}
     ]
 
 
@@ -398,12 +322,7 @@ def test_string_annotation():
             'msg': 'Input should be a valid integer, unable to parse string as an integer',
             'input': 'x',
         },
-        {
-            'type': 'missing_argument',
-            'loc': ('b',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs((['x'],)),
-        },
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((['x'],))},
     ]
 
 
@@ -449,18 +368,8 @@ def test_item_method():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'missing_argument',
-            'loc': ('a',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs((x,)),
-        },
-        {
-            'type': 'missing_argument',
-            'loc': ('b',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs((x,)),
-        },
+        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
     ]
 
 
@@ -481,18 +390,8 @@ def test_class_method():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'missing_argument',
-            'loc': ('a',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs((X,)),
-        },
-        {
-            'type': 'missing_argument',
-            'loc': ('b',),
-            'msg': 'Missing required argument',
-            'input': ArgsKwargs((X,)),
-        },
+        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
     ]
 
 
@@ -674,18 +573,8 @@ def test_annotated_use_of_alias():
             'msg': 'Missing required argument',
             'input': ArgsKwargs((), {'a': 10, 'c': 12, 'd': 1}),
         },
-        {
-            'type': 'unexpected_keyword_argument',
-            'loc': ('a',),
-            'msg': 'Unexpected keyword argument',
-            'input': 10,
-        },
-        {
-            'type': 'unexpected_keyword_argument',
-            'loc': ('d',),
-            'msg': 'Unexpected keyword argument',
-            'input': 1,
-        },
+        {'type': 'unexpected_keyword_argument', 'loc': ('a',), 'msg': 'Unexpected keyword argument', 'input': 10},
+        {'type': 'unexpected_keyword_argument', 'loc': ('d',), 'msg': 'Unexpected keyword argument', 'input': 1},
     ]
 
 
@@ -932,12 +821,7 @@ def test_eval_type_backport():
         foo('not a list')  # type: ignore
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'list_type',
-            'loc': (0,),
-            'msg': 'Input should be a valid list',
-            'input': 'not a list',
-        }
+        {'type': 'list_type', 'loc': (0,), 'msg': 'Input should be a valid list', 'input': 'not a list'}
     ]
     with pytest.raises(ValidationError) as exc_info:
         foo([{'not a str or int'}])  # type: ignore

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -10,7 +10,13 @@ import pytest
 from pydantic_core import ArgsKwargs
 from typing_extensions import Annotated, TypedDict
 
-from pydantic import Field, PydanticInvalidForJsonSchema, TypeAdapter, ValidationError, validate_call
+from pydantic import (
+    Field,
+    PydanticInvalidForJsonSchema,
+    TypeAdapter,
+    ValidationError,
+    validate_call,
+)
 from pydantic.main import BaseModel
 
 
@@ -31,8 +37,18 @@ def test_args():
         foo()
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
+        {
+            'type': 'missing_argument',
+            'loc': ('a',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs(()),
+        },
+        {
+            'type': 'missing_argument',
+            'loc': ('b',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs(()),
+        },
     ]
 
     with pytest.raises(ValidationError) as exc_info:
@@ -60,8 +76,18 @@ def test_args():
         foo(1, 2, a=3, b=4)
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'multiple_argument_values', 'loc': ('a',), 'msg': 'Got multiple values for argument', 'input': 3},
-        {'type': 'multiple_argument_values', 'loc': ('b',), 'msg': 'Got multiple values for argument', 'input': 4},
+        {
+            'type': 'multiple_argument_values',
+            'loc': ('a',),
+            'msg': 'Got multiple values for argument',
+            'input': 3,
+        },
+        {
+            'type': 'multiple_argument_values',
+            'loc': ('b',),
+            'msg': 'Got multiple values for argument',
+            'input': 4,
+        },
     ]
 
 
@@ -77,7 +103,12 @@ def test_optional():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'int_type', 'loc': (0,), 'msg': 'Input should be a valid integer', 'input': None}
+        {
+            'type': 'int_type',
+            'loc': (0,),
+            'msg': 'Input should be a valid integer',
+            'input': None,
+        }
     ]
 
 
@@ -130,8 +161,18 @@ def test_kwargs():
             'msg': 'Missing required keyword only argument',
             'input': ArgsKwargs((1, 'x')),
         },
-        {'type': 'unexpected_positional_argument', 'loc': (0,), 'msg': 'Unexpected positional argument', 'input': 1},
-        {'type': 'unexpected_positional_argument', 'loc': (1,), 'msg': 'Unexpected positional argument', 'input': 'x'},
+        {
+            'type': 'unexpected_positional_argument',
+            'loc': (0,),
+            'msg': 'Unexpected positional argument',
+            'input': 1,
+        },
+        {
+            'type': 'unexpected_positional_argument',
+            'loc': (1,),
+            'msg': 'Unexpected positional argument',
+            'input': 'x',
+        },
     ]
 
 
@@ -205,7 +246,12 @@ def foo(a, b, /, c=None):
             'msg': 'Missing required positional only argument',
             'input': ArgsKwargs((1,), {'b': 2}),
         },
-        {'type': 'unexpected_keyword_argument', 'loc': ('b',), 'msg': 'Unexpected keyword argument', 'input': 2},
+        {
+            'type': 'unexpected_keyword_argument',
+            'loc': ('b',),
+            'msg': 'Unexpected keyword argument',
+            'input': 2,
+        },
     ]
 
     with pytest.raises(ValidationError) as exc_info:
@@ -224,8 +270,18 @@ def foo(a, b, /, c=None):
             'msg': 'Missing required positional only argument',
             'input': ArgsKwargs((), {'a': 1, 'b': 2}),
         },
-        {'type': 'unexpected_keyword_argument', 'loc': ('a',), 'msg': 'Unexpected keyword argument', 'input': 1},
-        {'type': 'unexpected_keyword_argument', 'loc': ('b',), 'msg': 'Unexpected keyword argument', 'input': 2},
+        {
+            'type': 'unexpected_keyword_argument',
+            'loc': ('a',),
+            'msg': 'Unexpected keyword argument',
+            'input': 1,
+        },
+        {
+            'type': 'unexpected_keyword_argument',
+            'loc': ('b',),
+            'msg': 'Unexpected keyword argument',
+            'input': 2,
+        },
     ]
 
 
@@ -244,8 +300,18 @@ def test_args_name():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'unexpected_keyword_argument', 'loc': ('apple',), 'msg': 'Unexpected keyword argument', 'input': 4},
-        {'type': 'unexpected_keyword_argument', 'loc': ('banana',), 'msg': 'Unexpected keyword argument', 'input': 5},
+        {
+            'type': 'unexpected_keyword_argument',
+            'loc': ('apple',),
+            'msg': 'Unexpected keyword argument',
+            'input': 4,
+        },
+        {
+            'type': 'unexpected_keyword_argument',
+            'loc': ('banana',),
+            'msg': 'Unexpected keyword argument',
+            'input': 5,
+        },
     ]
 
     with pytest.raises(ValidationError) as exc_info:
@@ -253,7 +319,12 @@ def test_args_name():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'unexpected_positional_argument', 'loc': (2,), 'msg': 'Unexpected positional argument', 'input': 3}
+        {
+            'type': 'unexpected_positional_argument',
+            'loc': (2,),
+            'msg': 'Unexpected positional argument',
+            'input': 3,
+        }
     ]
 
 
@@ -292,12 +363,20 @@ def test_async():
         v = await foo(1, 2)
         assert v == 'a=1 b=2'
 
+    # insert_assert(inspect.iscoroutinefunction(foo)==True)
+    assert inspect.iscoroutinefunction(foo)
+
     asyncio.run(run())
     with pytest.raises(ValidationError) as exc_info:
         asyncio.run(foo('x'))
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(('x',))}
+        {
+            'type': 'missing_argument',
+            'loc': ('b',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs(('x',)),
+        }
     ]
 
 
@@ -319,7 +398,12 @@ def test_string_annotation():
             'msg': 'Input should be a valid integer, unable to parse string as an integer',
             'input': 'x',
         },
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((['x'],))},
+        {
+            'type': 'missing_argument',
+            'loc': ('b',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs((['x'],)),
+        },
     ]
 
 
@@ -365,8 +449,18 @@ def test_item_method():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
+        {
+            'type': 'missing_argument',
+            'loc': ('a',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs((x,)),
+        },
+        {
+            'type': 'missing_argument',
+            'loc': ('b',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs((x,)),
+        },
     ]
 
 
@@ -387,8 +481,18 @@ def test_class_method():
 
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
+        {
+            'type': 'missing_argument',
+            'loc': ('a',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs((X,)),
+        },
+        {
+            'type': 'missing_argument',
+            'loc': ('b',),
+            'msg': 'Missing required argument',
+            'input': ArgsKwargs((X,)),
+        },
     ]
 
 
@@ -402,7 +506,10 @@ def test_json_schema():
     assert foo(1) == '1, None'
     assert TypeAdapter(foo).json_schema() == {
         'type': 'object',
-        'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'default': None, 'title': 'B', 'type': 'integer'}},
+        'properties': {
+            'a': {'title': 'A', 'type': 'integer'},
+            'b': {'default': None, 'title': 'B', 'type': 'integer'},
+        },
         'required': ['a'],
         'additionalProperties': False,
     }
@@ -415,7 +522,10 @@ def test_json_schema():
     assert TypeAdapter(foo).json_schema() == {
         'maxItems': 2,
         'minItems': 2,
-        'prefixItems': [{'title': 'A', 'type': 'integer'}, {'title': 'B', 'type': 'integer'}],
+        'prefixItems': [
+            {'title': 'A', 'type': 'integer'},
+            {'title': 'B', 'type': 'integer'},
+        ],
         'type': 'array',
     }
 
@@ -437,7 +547,10 @@ def test_json_schema():
         return sum(numbers)
 
     assert foo(1, 2, 3) == 6
-    assert TypeAdapter(foo).json_schema() == {'items': {'type': 'integer'}, 'type': 'array'}
+    assert TypeAdapter(foo).json_schema() == {
+        'items': {'type': 'integer'},
+        'type': 'array',
+    }
 
     @validate_call
     def foo(a: int, *numbers: int) -> int:
@@ -518,14 +631,28 @@ def test_config_strict():
     with pytest.raises(ValidationError) as exc_info:
         foo('foo', ('bar', 'foobar'))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'int_type', 'loc': (0,), 'msg': 'Input should be a valid integer', 'input': 'foo'},
-        {'type': 'list_type', 'loc': (1,), 'msg': 'Input should be a valid list', 'input': ('bar', 'foobar')},
+        {
+            'type': 'int_type',
+            'loc': (0,),
+            'msg': 'Input should be a valid integer',
+            'input': 'foo',
+        },
+        {
+            'type': 'list_type',
+            'loc': (1,),
+            'msg': 'Input should be a valid list',
+            'input': ('bar', 'foobar'),
+        },
     ]
 
 
 def test_annotated_use_of_alias():
     @validate_call
-    def foo(a: Annotated[int, Field(alias='b')], c: Annotated[int, Field()], d: Annotated[int, Field(alias='')]):
+    def foo(
+        a: Annotated[int, Field(alias='b')],
+        c: Annotated[int, Field()],
+        d: Annotated[int, Field(alias='')],
+    ):
         return a + c + d
 
     assert foo(**{'b': 10, 'c': 12, '': 1}) == 23
@@ -547,14 +674,27 @@ def test_annotated_use_of_alias():
             'msg': 'Missing required argument',
             'input': ArgsKwargs((), {'a': 10, 'c': 12, 'd': 1}),
         },
-        {'type': 'unexpected_keyword_argument', 'loc': ('a',), 'msg': 'Unexpected keyword argument', 'input': 10},
-        {'type': 'unexpected_keyword_argument', 'loc': ('d',), 'msg': 'Unexpected keyword argument', 'input': 1},
+        {
+            'type': 'unexpected_keyword_argument',
+            'loc': ('a',),
+            'msg': 'Unexpected keyword argument',
+            'input': 10,
+        },
+        {
+            'type': 'unexpected_keyword_argument',
+            'loc': ('d',),
+            'msg': 'Unexpected keyword argument',
+            'input': 1,
+        },
     ]
 
 
 def test_use_of_alias():
     @validate_call
-    def foo(c: int = Field(default_factory=lambda: 20), a: int = Field(default_factory=lambda: 10, alias='b')):
+    def foo(
+        c: int = Field(default_factory=lambda: 20),
+        a: int = Field(default_factory=lambda: 10, alias='b'),
+    ):
         return a + c
 
     assert foo(b=10) == 30
@@ -818,7 +958,10 @@ def test_eval_type_backport():
     ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12), reason='requires Python 3.12+ for PEP 695 syntax with generics')
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason='requires Python 3.12+ for PEP 695 syntax with generics',
+)
 def test_validate_call_with_pep_695_syntax() -> None:
     """Note: validate_call still doesn't work properly with generics, see https://github.com/pydantic/pydantic/issues/7796.
 
@@ -839,7 +982,10 @@ def find_max_validate_return[T](args: Iterable[T]) -> T:
         """,
         globs,
     )
-    functions = [globs['find_max_no_validate_return'], globs['find_max_validate_return']]
+    functions = [
+        globs['find_max_no_validate_return'],
+        globs['find_max_validate_return'],
+    ]
     for find_max in functions:
         assert len(find_max.__type_params__) == 1
         assert find_max([1, 2, 10, 5]) == 10

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -292,8 +292,8 @@ def test_async():
         v = await foo(1, 2)
         assert v == 'a=1 b=2'
 
-    # insert_assert(inspect.iscoroutinefunction(foo)==True)
-    assert inspect.iscoroutinefunction(foo)
+    # insert_assert(inspect.iscoroutinefunction(foo) is True)
+    assert inspect.iscoroutinefunction(foo) is True
 
     asyncio.run(run())
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -405,10 +405,7 @@ def test_json_schema():
     assert foo(1) == '1, None'
     assert TypeAdapter(foo).json_schema() == {
         'type': 'object',
-        'properties': {
-            'a': {'title': 'A', 'type': 'integer'},
-            'b': {'default': None, 'title': 'B', 'type': 'integer'},
-        },
+        'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'default': None, 'title': 'B', 'type': 'integer'}},
         'required': ['a'],
         'additionalProperties': False,
     }
@@ -421,10 +418,7 @@ def test_json_schema():
     assert TypeAdapter(foo).json_schema() == {
         'maxItems': 2,
         'minItems': 2,
-        'prefixItems': [
-            {'title': 'A', 'type': 'integer'},
-            {'title': 'B', 'type': 'integer'},
-        ],
+        'prefixItems': [{'title': 'A', 'type': 'integer'}, {'title': 'B', 'type': 'integer'}],
         'type': 'array',
     }
 
@@ -446,10 +440,7 @@ def test_json_schema():
         return sum(numbers)
 
     assert foo(1, 2, 3) == 6
-    assert TypeAdapter(foo).json_schema() == {
-        'items': {'type': 'integer'},
-        'type': 'array',
-    }
+    assert TypeAdapter(foo).json_schema() == {'items': {'type': 'integer'}, 'type': 'array'}
 
     @validate_call
     def foo(a: int, *numbers: int) -> int:
@@ -530,28 +521,14 @@ def test_config_strict():
     with pytest.raises(ValidationError) as exc_info:
         foo('foo', ('bar', 'foobar'))
     assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'int_type',
-            'loc': (0,),
-            'msg': 'Input should be a valid integer',
-            'input': 'foo',
-        },
-        {
-            'type': 'list_type',
-            'loc': (1,),
-            'msg': 'Input should be a valid list',
-            'input': ('bar', 'foobar'),
-        },
+        {'type': 'int_type', 'loc': (0,), 'msg': 'Input should be a valid integer', 'input': 'foo'},
+        {'type': 'list_type', 'loc': (1,), 'msg': 'Input should be a valid list', 'input': ('bar', 'foobar')},
     ]
 
 
 def test_annotated_use_of_alias():
     @validate_call
-    def foo(
-        a: Annotated[int, Field(alias='b')],
-        c: Annotated[int, Field()],
-        d: Annotated[int, Field(alias='')],
-    ):
+    def foo(a: Annotated[int, Field(alias='b')], c: Annotated[int, Field()], d: Annotated[int, Field(alias='')]):
         return a + c + d
 
     assert foo(**{'b': 10, 'c': 12, '': 1}) == 23
@@ -580,10 +557,7 @@ def test_annotated_use_of_alias():
 
 def test_use_of_alias():
     @validate_call
-    def foo(
-        c: int = Field(default_factory=lambda: 20),
-        a: int = Field(default_factory=lambda: 10, alias='b'),
-    ):
+    def foo(c: int = Field(default_factory=lambda: 20), a: int = Field(default_factory=lambda: 10, alias='b')):
         return a + c
 
     assert foo(b=10) == 30
@@ -821,7 +795,12 @@ def test_eval_type_backport():
         foo('not a list')  # type: ignore
     # insert_assert(exc_info.value.errors(include_url=False))
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'list_type', 'loc': (0,), 'msg': 'Input should be a valid list', 'input': 'not a list'}
+        {
+            'type': 'list_type',
+            'loc': (0,),
+            'msg': 'Input should be a valid list',
+            'input': 'not a list',
+        }
     ]
     with pytest.raises(ValidationError) as exc_info:
         foo([{'not a str or int'}])  # type: ignore
@@ -842,10 +821,7 @@ def test_eval_type_backport():
     ]
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 12),
-    reason='requires Python 3.12+ for PEP 695 syntax with generics',
-)
+@pytest.mark.skipif(sys.version_info < (3, 12), reason='requires Python 3.12+ for PEP 695 syntax with generics')
 def test_validate_call_with_pep_695_syntax() -> None:
     """Note: validate_call still doesn't work properly with generics, see https://github.com/pydantic/pydantic/issues/7796.
 
@@ -866,10 +842,7 @@ def find_max_validate_return[T](args: Iterable[T]) -> T:
         """,
         globs,
     )
-    functions = [
-        globs['find_max_no_validate_return'],
-        globs['find_max_validate_return'],
-    ]
+    functions = [globs['find_max_no_validate_return'], globs['find_max_validate_return']]
     for find_max in functions:
         assert len(find_max.__type_params__) == 1
         assert find_max([1, 2, 10, 5]) == 10


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add judgement for validate_call decorator. Now we can get `True` return from `inpect.iscoroutinefunction()`.

## Related issue number

fix #10370 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle