### PR TITLE
Fix validation with mix of plain validators and serializers

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -193,7 +193,7 @@ class PlainValidator:
             serialization = core_schema.wrap_serializer_function_ser_schema(
                 function=lambda v, h: h(v),
                 schema=schema,
-                return_schema=schema,
+                return_schema=handler.generate_schema(source_type),
             )
         except PydanticSchemaGenerationError:
             serialization = None


### PR DESCRIPTION
Currently breaking core and json schema gen for the case where a validator is listed after a serializer.

Might just have to revert https://github.com/pydantic/pydantic/pull/10167 to fix this issue.

Theoretically, fixes https://github.com/pydantic/pydantic/issues/10385