### PR TITLE
Fix indentation of first note on mypy documentation page

### DIFF
--- a/docs/integrations/mypy.md
+++ b/docs/integrations/mypy.md
@@ -127,7 +127,7 @@ plugins = pydantic.mypy
 ```
 
 !!! note
-  If you're using `pydantic.v1` models, you'll need to add `pydantic.v1.mypy` to your list of plugins.
+    If you're using `pydantic.v1` models, you'll need to add `pydantic.v1.mypy` to your list of plugins.
 
 The plugin is compatible with mypy versions `>=0.930`.
 


### PR DESCRIPTION
Hi! 👋 

## Changes summary

|Before|After|
|-|-|
|<img width="1582" alt="Screenshot 2024-09-13 at 13 42 44" src="https://github.com/user-attachments/assets/3f79d128-79c1-4ff8-b96b-e87a1e7db24d">|<img width="1582" alt="Screenshot 2024-09-13 at 15 14 40" src="https://github.com/user-attachments/assets/b39ae459-e7e0-4644-83e9-947c61e7a9cf">|

## Related issue number

Fix #10403

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review

Selected Reviewer: @sydney-runkle