### PR TITLE
Fix `PydanticUserError` on empty `model_config` with annotations

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -120,7 +120,7 @@ class ConfigWrapper:
         config_dict_from_namespace = namespace.get('model_config')
 
         raw_annotations = namespace.get('__annotations__', {})
-        if raw_annotations.get('model_config') and not config_dict_from_namespace:
+        if raw_annotations.get('model_config') and config_dict_from_namespace is None:
             raise PydanticUserError(
                 '`model_config` cannot be used as a model field name. Use `model_config` for model configuration.',
                 code='model-config-invalid-field-name',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -888,3 +888,10 @@ def test_with_config_disallowed_with_model():
         @with_config({'coerce_numbers_to_str': True})
         class Model(BaseModel):
             pass
+
+
+def test_empty_config_with_annotations():
+    class Model(BaseModel):
+        model_config: ConfigDict = {}
+
+    assert Model.model_config == {}


### PR DESCRIPTION
## Change Summary

Prevents a `PydanticUserError` from being raised when `model_config` has type annotations (`model_config: ConfigDict`), but is also empty.

For example, this previously raised a `PydanticUserError`:

```python
class Model(BaseModel):
    model_config: ConfigDict = {}
```

## Related issue number

Fixes #10411

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
