### PR TITLE
Add support for unpacked `TypedDict` to type hint variadic keyword arguments with `@validate_call`

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1197,13 +1197,14 @@ For reference, see the [related specification section] and [PEP 692].
 ```py
 from typing_extensions import Unpack
 
-from pydantic import validate_call
+from pydantic import PydanticUserError, validate_call
 
 try:
 
     @validate_call
     def func(**kwargs: Unpack[int]):
         pass
+
 except PydanticUserError as exc_info:
     assert exc_info.code == 'unpack-typed-dict'
 ```
@@ -1218,7 +1219,7 @@ For reference, see the [related specification section] and [PEP 692].
 ```py
 from typing_extensions import TypedDict, Unpack
 
-from pydantic import validate_call
+from pydantic import PydanticUserError, validate_call
 
 
 class TD(TypedDict):
@@ -1230,6 +1231,7 @@ try:
     @validate_call
     def func(a: int, **kwargs: Unpack[TD]):
         pass
+
 except PydanticUserError as exc_info:
     assert exc_info.code == 'overlapping-unpack-typed-dict'
 ```

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1208,5 +1208,31 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'unpack-typed-dict'
 ```
 
+## Overlapping unpacked [`TypedDict`][typing.TypedDict] fields and arguments {#overlapping-unpack-typed-dict}
+
+This error is raised when the typed dictionary used to type hint variadic keywords arguments
+has fields names overlapping with arguments (unless [positional only][positional-only_parameter]).
+
+For reference, see the [related specification section] and [PEP 692].
+
+```py
+from typing_extensions import TypedDict, Unpack
+
+from pydantic import validate_call
+
+
+class TD(TypedDict):
+    a: int
+
+
+try:
+
+    @validate_call
+    def func(a: int, **kwargs: Unpack[TD]):
+        pass
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'overlapping-unpack-typed-dict'
+```
+
 [related specification section]: https://typing.readthedocs.io/en/latest/spec/callables.html#unpack-for-keyword-arguments
 [PEP 692]: https://peps.python.org/pep-0692/

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1189,7 +1189,7 @@ except PydanticUserError as exc_info:
 
 ## [`Unpack`][typing.Unpack] used without a [`TypedDict`][typing.TypedDict] {#unpack-typed-dict}
 
-This error is raised when [`Unpack`][typing.Unpack] is used with something else than
+This error is raised when [`Unpack`][typing.Unpack] is used with something other than
 a [`TypedDict`][typing.TypedDict] class object to type hint variadic keyword arguments.
 
 For reference, see the [related specification section] and [PEP 692].

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1151,7 +1151,6 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'model-config-invalid-field-name'
 ```
 
-
 ## [`with_config`][pydantic.config.with_config] is used on a `BaseModel` subclass {#with-config-on-model}
 
 This error is raised when the [`with_config`][pydantic.config.with_config]  decorator is used on a class which is already a Pydantic model (use the `model_config` attribute instead).
@@ -1168,7 +1167,6 @@ try:
 except PydanticUserError as exc_info:
     assert exc_info.code == 'with-config-on-model'
 ```
-
 
 ## `dataclass` is used on a `BaseModel` subclass {#dataclass-on-model}
 
@@ -1188,3 +1186,27 @@ try:
 except PydanticUserError as exc_info:
     assert exc_info.code == 'dataclass-on-model'
 ```
+
+## [`Unpack`][typing.Unpack] used without a [`TypedDict`][typing.TypedDict] {#unpack-typed-dict}
+
+This error is raised when [`Unpack`][typing.Unpack] is used with something else than
+a [`TypedDict`][typing.TypedDict] class object to type hint variadic keyword arguments.
+
+For reference, see the [related specification section] and [PEP 692].
+
+```py
+from typing_extensions import Unpack
+
+from pydantic import validate_call
+
+try:
+
+    @validate_call
+    def func(**kwargs: Unpack[int]):
+        pass
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'unpack-typed-dict'
+```
+
+[related specification section]: https://typing.readthedocs.io/en/latest/spec/callables.html#unpack-for-keyword-arguments
+[PEP 692]: https://peps.python.org/pep-0692/

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1211,7 +1211,7 @@ except PydanticUserError as exc_info:
 ## Overlapping unpacked [`TypedDict`][typing.TypedDict] fields and arguments {#overlapping-unpack-typed-dict}
 
 This error is raised when the typed dictionary used to type hint variadic keywords arguments
-has fields names overlapping with arguments (unless [positional only][positional-only_parameter]).
+has field names overlapping with arguments (unless [positional only][positional-only_parameter]).
 
 For reference, see the [related specification section] and [PEP 692].
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1903,7 +1903,18 @@ class GenerateSchema:
                 if unpack_type is not None:
                     if not is_typeddict(unpack_type):
                         raise PydanticUserError(
-                            f'Expected a `TypedDict` class, got {unpack_type}', code='unpack-typed-dict'
+                            f'Expected a `TypedDict` class, got {unpack_type.__name__!r}', code='unpack-typed-dict'
+                        )
+                    non_pos_only_param_names = {
+                        name for name, p in sig.parameters.items() if p.kind != Parameter.POSITIONAL_ONLY
+                    }
+                    overlapping_params = non_pos_only_param_names.intersection(unpack_type.__annotations__)
+                    if overlapping_params:
+                        raise PydanticUserError(
+                            f'Typed dictionary {unpack_type.__name__!r} overlaps with parameter'
+                            f"{'s' if len(overlapping_params) >= 2 else ''} "
+                            f"{', '.join(repr(p) for p in sorted(overlapping_params))}",
+                            code='overlapping-unpack-typed-dict',
                         )
 
                     var_kwargs_mode = 'unpacked-typed-dict'

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1907,12 +1907,9 @@ class GenerateSchema:
                         )
 
                     var_kwargs_mode = 'unpacked-typed-dict'
-                    # TODO: does it work without resolving?
-                    var_kwargs_schema = resolve_original_schema(
-                        self._typed_dict_schema(unpack_type, None), self.defs.definitions
-                    )
+                    var_kwargs_schema = self._typed_dict_schema(unpack_type, None)
                 else:
-                    var_kwargs_mode = 'single'
+                    var_kwargs_mode = 'uniform'
                     var_kwargs_schema = self.generate_schema(annotation)
 
         return_schema: core_schema.CoreSchema | None = None

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -13,7 +13,7 @@ from functools import partial
 from types import GetSetDescriptorType
 from typing import TYPE_CHECKING, Any, Final, Iterable
 
-from typing_extensions import Annotated, Literal, TypeAliasType, TypeGuard, deprecated, get_args, get_origin
+from typing_extensions import Annotated, Literal, TypeAliasType, TypeGuard, Unpack, deprecated, get_args, get_origin
 
 if TYPE_CHECKING:
     from ._dataclasses import StandardDataclass
@@ -63,7 +63,11 @@ else:
 
 LITERAL_TYPES: set[Any] = {Literal}
 if hasattr(typing, 'Literal'):
-    LITERAL_TYPES.add(typing.Literal)  # type: ignore
+    LITERAL_TYPES.add(typing.Literal)
+
+UNPACK_TYPES: set[Any] = {Unpack}
+if hasattr(typing, 'Unpack'):
+    UNPACK_TYPES.add(typing.Unpack)
 
 # Check if `deprecated` is a type to prevent errors when using typing_extensions < 4.9.0
 DEPRECATED_TYPES: tuple[Any, ...] = (deprecated,) if isinstance(deprecated, type) else ()
@@ -114,6 +118,14 @@ def is_annotated(ann_type: Any) -> bool:
 
 def annotated_type(type_: Any) -> Any | None:
     return get_args(type_)[0] if is_annotated(type_) else None
+
+
+def is_unpack(type_: Any) -> bool:
+    return get_origin(type_) in UNPACK_TYPES
+
+
+def unpack_type(type_: Any) -> Any | None:
+    return get_args(type_)[0] if is_unpack(type_) else None
 
 
 def is_namedtuple(type_: type[Any]) -> bool:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -67,7 +67,7 @@ if hasattr(typing, 'Literal'):
 
 UNPACK_TYPES: set[Any] = {Unpack}
 if hasattr(typing, 'Unpack'):
-    UNPACK_TYPES.add(typing.Unpack)
+    UNPACK_TYPES.add(typing.Unpack)  # pyright: ignore[reportAttributeAccessIssue]
 
 # Check if `deprecated` is a type to prevent errors when using typing_extensions < 4.9.0
 DEPRECATED_TYPES: tuple[Any, ...] = (deprecated,) if isinstance(deprecated, type) else ()

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -66,6 +66,7 @@ PydanticErrorCodes = Literal[
     'model-config-invalid-field-name',
     'with-config-on-model',
     'dataclass-on-model',
+    'unpack-typed-dict',
 ]
 
 

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -67,6 +67,7 @@ PydanticErrorCodes = Literal[
     'with-config-on-model',
     'dataclass-on-model',
     'unpack-typed-dict',
+    'overlapping-unpack-typed-dict',
 ]
 
 

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -201,6 +201,14 @@ def test_unpacked_typed_dict_kwargs() -> None:
     assert exc.value.errors()[1]['type'] == 'missing'
     assert exc.value.errors()[1]['loc'] == ('b',)
 
+    # Make sure that when called without any arguments,
+    # empty kwargs are still validated against the typed dict:
+    with pytest.raises(ValidationError) as exc:
+        foo()
+
+    assert exc.value.errors()[1]['type'] == 'missing'
+    assert exc.value.errors()[1]['loc'] == ('b',)
+
 
 def test_field_can_provide_factory() -> None:
     @validate_call

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -8,14 +8,14 @@ from typing import Any, List, Tuple
 
 import pytest
 from pydantic_core import ArgsKwargs
-from typing_extensions import Annotated, TypedDict, Unpack, Required
+from typing_extensions import Annotated, Required, TypedDict, Unpack
 
 from pydantic import (
     BaseModel,
     Field,
     PydanticInvalidForJsonSchema,
-    TypeAdapter,
     PydanticUserError,
+    TypeAdapter,
     ValidationError,
     validate_call,
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/9619
Requires https://github.com/pydantic/pydantic-core/pull/1451

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
