### PR TITLE
Allow arbitrary refs in JSON schema `examples`

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2172,7 +2172,9 @@ class GenerateJsonSchema:
                         if not json_ref.startswith(('http://', 'https://')):
                             raise
 
-                for v in schema.values():
+                for k, v in schema.items():
+                    if k == 'examples':
+                        continue  # skip refs processing for examples, allow arbitrary values / refs
                     _add_json_refs(v)
             elif isinstance(schema, list):
                 for v in schema:
@@ -2484,6 +2486,8 @@ def _get_all_json_refs(item: Any) -> set[JsonRef]:
         current = stack.pop()
         if isinstance(current, dict):
             for key, value in current.items():
+                if key == 'examples':
+                    continue  # skip examples, allow arbitrary values / refs
                 if key == '$ref' and isinstance(value, str):
                     refs.add(JsonRef(value))
                 elif isinstance(value, dict):

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6554,3 +6554,19 @@ def test_title_strip() -> None:
         some_field: str = Field(alias='_some_field')
 
     assert Model.model_json_schema()['properties']['_some_field']['title'] == 'Some Field'
+
+
+def test_arbitrary_ref_in_json_schema() -> None:
+    """See https://github.com/pydantic/pydantic/issues/9981."""
+
+    class Test(BaseModel):
+        x: dict = Field(examples={'$ref': '#/components/schemas/Pet'})
+
+    assert Test.model_json_schema() == {
+        'properties': {'x': {'examples': {'$ref': '#/components/schemas/Pet'}, 'title': 'X', 'type': 'object'}},
+        'required': ['x'],
+        'title': 'Test',
+        'type': 'object',
+    }
+
+    # raises KeyError: '#/components/schemas/Pet'

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6556,12 +6556,11 @@ def test_title_strip() -> None:
     assert Model.model_json_schema()['properties']['_some_field']['title'] == 'Some Field'
 
 
-@pytest.mark.skip_json_schema_validation(reason='Custom ref used.')
 def test_arbitrary_ref_in_json_schema() -> None:
     """See https://github.com/pydantic/pydantic/issues/9981."""
 
     class Test(BaseModel):
-        x: dict = Field(examples={'$ref': '#/components/schemas/Pet'})
+        x: dict = Field(examples=[{'$ref': '#/components/schemas/Pet'}])
 
     assert Test.model_json_schema() == {
         'properties': {'x': {'examples': {'$ref': '#/components/schemas/Pet'}, 'title': 'X', 'type': 'object'}},

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6556,6 +6556,7 @@ def test_title_strip() -> None:
     assert Model.model_json_schema()['properties']['_some_field']['title'] == 'Some Field'
 
 
+@pytest.mark.skip_json_schema_validation(reason='Custom ref used.')
 def test_arbitrary_ref_in_json_schema() -> None:
     """See https://github.com/pydantic/pydantic/issues/9981."""
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6563,7 +6563,7 @@ def test_arbitrary_ref_in_json_schema() -> None:
         x: dict = Field(examples=[{'$ref': '#/components/schemas/Pet'}])
 
     assert Test.model_json_schema() == {
-        'properties': {'x': {'examples': {'$ref': '#/components/schemas/Pet'}, 'title': 'X', 'type': 'object'}},
+        'properties': {'x': {'examples': [{'$ref': '#/components/schemas/Pet'}], 'title': 'X', 'type': 'object'}},
         'required': ['x'],
         'title': 'Test',
         'type': 'object',


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/9981

Skip ref counting and processing for the custom `examples` block in JSON schema.