### PR TITLE
Fix rendering of `StringContraints` example

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -709,6 +709,7 @@ class StringConstraints(annotated_types.GroupedMetadata):
         from pydantic.types import StringConstraints
 
         ConstrainedStr = Annotated[str, StringConstraints(min_length=1, max_length=10)]
+        ```
     """
 
     strip_whitespace: bool | None = None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fix rendering of `StringContraints` example (https://docs.pydantic.dev/latest/api/types/#pydantic.types.StringConstraints)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle