### PR TITLE
Fix closing of code bloc in StringConstraints docstring

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -709,6 +709,7 @@ class StringConstraints(annotated_types.GroupedMetadata):
         from pydantic.types import StringConstraints
 
         ConstrainedStr = Annotated[str, StringConstraints(min_length=1, max_length=10)]
+        ```
     """
 
     strip_whitespace: bool | None = None


### PR DESCRIPTION
## Change Summary

This helps fix a rendering issue in a example insert in the [documentation](https://docs.pydantic.dev/latest/api/types/#pydantic.types.StringConstraints).

Please review.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
