### PR TITLE
Fix serialization schema generation when using `PlainValidator`

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -197,7 +197,7 @@ class PlainValidator:
                 core_schema.wrap_serializer_function_ser_schema(
                     function=lambda v, h: h(v),
                     schema=schema,
-                    return_schema=schema,
+                    return_schema=handler.generate_schema(source_type),
                 ),
             )
         except PydanticSchemaGenerationError:

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -190,10 +190,15 @@ class PlainValidator:
 
         try:
             schema = handler(source_type)
-            serialization = core_schema.wrap_serializer_function_ser_schema(
-                function=lambda v, h: h(v),
-                schema=schema,
-                return_schema=schema,
+            # TODO if `schema['serialization']` is one of `'include-exclude-dict/sequence',
+            # schema validation will fail. That's why we use 'type ignore' comments below.
+            serialization = schema.get(
+                'serialization',
+                core_schema.wrap_serializer_function_ser_schema(
+                    function=lambda v, h: h(v),
+                    schema=schema,
+                    return_schema=schema,
+                ),
             )
         except PydanticSchemaGenerationError:
             serialization = None
@@ -207,12 +212,16 @@ class PlainValidator:
             return core_schema.with_info_plain_validator_function(
                 func,
                 field_name=handler.field_name,
-                serialization=serialization,
+                serialization=serialization,  # pyright: ignore[reportArgumentType]
                 metadata=metadata,
             )
         else:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
-            return core_schema.no_info_plain_validator_function(func, serialization=serialization, metadata=metadata)
+            return core_schema.no_info_plain_validator_function(
+                func,
+                serialization=serialization,  # pyright: ignore[reportArgumentType]
+                metadata=metadata,
+            )
 
     @classmethod
     def _from_decorator(cls, decorator: _decorators.Decorator[_decorators.FieldValidatorDecoratorInfo]) -> Self:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2869,6 +2869,26 @@ def test_plain_validator_plain_serializer() -> None:
     assert isinstance(data['bar'], ser_type)
 
 
+def test_plain_validator_plain_serializer_single_ser_call() -> None:
+    """https://github.com/pydantic/pydantic/issues/10385"""
+
+    ser_count = 0
+
+    def ser(v):
+        nonlocal ser_count
+        ser_count += 1
+        return v
+
+    class Model(BaseModel):
+        foo: Annotated[bool, PlainSerializer(ser), PlainValidator(lambda v: v)]
+
+    model = Model(foo=True)
+    data = model.model_dump()
+
+    assert data == {'foo': True}
+    assert ser_count == 1
+
+
 def test_plain_validator_with_unsupported_type() -> None:
     class UnsupportedClass:
         pass


### PR DESCRIPTION
Do not hardcode a new wrap serializer schema if a serialization schema was already generated before.

Note that the following can be used as a failing MRE, related to the TODO comment:

```python
from typing import Annotated

from pydantic import BaseModel, PlainValidator
from pydantic_core import core_schema

class MyDict:
    @classmethod
    def __get_pydantic_core_schema__(cls, source, handler):
        return core_schema.dict_schema(
            keys_schema=handler.generate_schema(str),
            values_schema=handler.generate_schema(int),
            serialization=core_schema.filter_dict_schema(
                include={'a'},
            ),
        )


class Model(BaseModel):
    f: Annotated[MyDict, PlainValidator(val)]

# If core schema validation is disabled:
Model(f={'a': 1, 'b': 1}).model_dump()
#> {'f': {'a': 1, 'b': 1}}
# Should be: {'f': {'a': 1}}
```

Maybe we should create a new issue, and add a `xfail` test linking to this issue?

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/10385
Fixes https://github.com/pydantic/pydantic/issues/8586

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
