### PR TITLE
Adding v1 / v2 incompatibility warning for nested v1 model

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -825,7 +825,7 @@ class GenerateSchema:
 
             if issubclass(obj, BaseModelV1):
                 warn(
-                    f'Nesting V1 models inside V2 models is not supported. Please upgrade `{obj.__name__}` to V2.',
+                    f'Mixing V1 models and V2 models (or constructs, like `TypeAdapter`) is not supported. Please upgrade `{obj.__name__}` to V2.',
                     UserWarning,
                 )
             else:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -825,7 +825,7 @@ class GenerateSchema:
 
             if issubclass(obj, BaseModelV1):
                 warn(
-                    f'Nesting V1 models inside V2 models is not supported. Please upgrade {obj.__name__} to V2.',
+                    f'Nesting V1 models inside V2 models is not supported. Please upgrade `{obj.__name__}` to V2.',
                     UserWarning,
                 )
             else:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -821,10 +821,18 @@ class GenerateSchema:
         ):
             schema = existing_schema
         elif (validators := getattr(obj, '__get_validators__', None)) is not None:
-            warn(
-                '`__get_validators__` is deprecated and will be removed, use `__get_pydantic_core_schema__` instead.',
-                PydanticDeprecatedSince20,
-            )
+            from pydantic.v1 import BaseModel as BaseModelV1
+
+            if issubclass(obj, BaseModelV1):
+                warn(
+                    f'Nesting V1 models inside V2 models is not supported. Please upgrade {obj.__name__} to V2.',
+                    UserWarning,
+                )
+            else:
+                warn(
+                    '`__get_validators__` is deprecated and will be removed, use `__get_pydantic_core_schema__` instead.',
+                    PydanticDeprecatedSince20,
+                )
             schema = core_schema.chain_schema([core_schema.with_info_plain_validator_function(v) for v in validators()])
         else:
             # we have no existing schema information on the property, exit early so that we can go generate a schema

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3323,7 +3323,9 @@ def test_subclassing_gen_schema_warns() -> None:
 
 
 def test_nested_v1_model_warns() -> None:
-    with pytest.warns(UserWarning, match='Nesting V1 models inside V2 models is not supported.'):
+    with pytest.warns(
+        UserWarning, match='Mixing V1 models and V2 models (or constructs, like `TypeAdapter`) is not supported.'
+    ):
 
         class V1Model(BaseModelV1):
             a: int

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3324,7 +3324,8 @@ def test_subclassing_gen_schema_warns() -> None:
 
 def test_nested_v1_model_warns() -> None:
     with pytest.warns(
-        UserWarning, match='Mixing V1 models and V2 models (or constructs, like `TypeAdapter`) is not supported.'
+        UserWarning,
+        match=r'Mixing V1 models and V2 models \(or constructs, like `TypeAdapter`\) is not supported. Please upgrade `V1Model` to V2.',
     ):
 
         class V1Model(BaseModelV1):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,6 +50,7 @@ from pydantic import (
 from pydantic._internal._generate_schema import GenerateSchema
 from pydantic._internal._mock_val_ser import MockCoreSchema
 from pydantic.dataclasses import dataclass as pydantic_dataclass
+from pydantic.v1 import BaseModel as BaseModelV1
 
 
 def test_success():
@@ -3319,3 +3320,13 @@ def test_subclassing_gen_schema_warns() -> None:
     with pytest.warns(UserWarning, match='Subclassing `GenerateSchema` is not supported.'):
 
         class MyGenSchema(GenerateSchema): ...
+
+
+def test_nested_v1_model_warns() -> None:
+    with pytest.warns(UserWarning, match='Nesting V1 models inside V2 models is not supported.'):
+
+        class V1Model(BaseModelV1):
+            a: int
+
+        class V2Model(BaseModel):
+            inner: V1Model


### PR DESCRIPTION
Contributing to https://github.com/pydantic/pydantic/issues/10314

```py
from pydantic import BaseModel
from pydantic.v1 import BaseModel as BaseModelV1

class V1Model(BaseModelV1):
    ...

class V2Model(BaseModel):
    inner: V1Model

"""
UserWarning: Nesting V1 models inside V2 models is not supported. Please upgrade V1Model to V2.
"""
```