### PR TITLE
Inline references if possible when generating schema for `json_schema_input_type`

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -127,6 +127,13 @@ class BeforeValidator:
             if self.json_schema_input_type is PydanticUndefined
             else handler.generate_schema(self.json_schema_input_type)
         )
+        # Try to resolve the original schema if required, because schema cleaning
+        # won't inline references in metadata:
+        if input_schema is not None:
+            try:
+                input_schema = handler.resolve_ref_schema(input_schema)
+            except LookupError:
+                pass
         metadata = _core_metadata.build_metadata_dict(js_input_core_schema=input_schema)
 
         info_arg = _inspect_validator(self.func, 'before')
@@ -204,6 +211,13 @@ class PlainValidator:
             serialization = None
 
         input_schema = handler.generate_schema(self.json_schema_input_type)
+        # Try to resolve the original schema if required, because schema cleaning
+        # won't inline references in metadata:
+        try:
+            input_schema = handler.resolve_ref_schema(input_schema)
+        except LookupError:
+            pass
+
         metadata = _core_metadata.build_metadata_dict(js_input_core_schema=input_schema)
 
         info_arg = _inspect_validator(self.func, 'plain')
@@ -281,6 +295,13 @@ class WrapValidator:
             if self.json_schema_input_type is PydanticUndefined
             else handler.generate_schema(self.json_schema_input_type)
         )
+        # Try to resolve the original schema if required, because schema cleaning
+        # won't inline references in metadata:
+        if input_schema is not None:
+            try:
+                input_schema = handler.resolve_ref_schema(input_schema)
+            except LookupError:
+                pass
         metadata = _core_metadata.build_metadata_dict(js_input_core_schema=input_schema)
 
         info_arg = _inspect_validator(self.func, 'wrap')

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6549,6 +6549,44 @@ def test_decorator_field_validator_input_type() -> None:
     }
 
 
+def test_json_schema_input_type_with_refs() -> None:
+    """Test that `'definition-ref` schemas for `json_schema_input_type` are inlined.
+
+    See: https://github.com/pydantic/pydantic/issues/10434.
+    """
+
+    class Sub(BaseModel):
+        pass
+
+    class Model(BaseModel):
+        sub: Annotated[
+            Sub,
+            PlainSerializer(lambda v: v, return_type=Sub),
+            PlainValidator(lambda v: v, json_schema_input_type=Sub),
+        ]
+
+    json_schema = Model.model_json_schema()
+
+    assert 'Sub' in json_schema['$defs']
+    assert json_schema['properties']['sub']['$ref'] == '#/$defs/Sub'
+
+
+def test_json_schema_input_type_with_refs() -> None:
+    """Test that recursive `'definition-ref` schemas for `json_schema_input_type` are not inlined."""
+
+    class Model(BaseModel):
+        model: Annotated[
+            'Model',
+            PlainSerializer(lambda v: v, return_type='Model'),
+            PlainValidator(lambda v: v, json_schema_input_type='Model'),
+        ]
+
+    json_schema = Model.model_json_schema()
+
+    assert 'Model' in json_schema['$defs']
+    assert json_schema['$ref'] == '#/$defs/Model'
+
+
 def test_title_strip() -> None:
     class Model(BaseModel):
         some_field: str = Field(alias='_some_field')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

Fixes https://github.com/pydantic/pydantic/issues/10434.
Requires https://github.com/pydantic/pydantic/pull/10444.

Previously, the core schema for:

```python
{
│   'type': 'model',
│   'cls': <class '__main__.Model'>,
│   'schema': {
│   │   'type': 'model-fields',
│   │   'fields': {
│   │   │   'sub': {
│   │   │   │   'type': 'model-field',
│   │   │   │   'schema': {
│   │   │   │   │   'type': 'function-plain',
│   │   │   │   │   'function': {'type': 'no-info', 'function': <function Model.<lambda> at 0x7bd0081e94e0>},
│   │   │   │   │   'metadata': {
│   │   │   │   │   │   'pydantic_js_functions': [],
│   │   │   │   │   │   'pydantic_js_annotation_functions': [],
│   │   │   │   │   │   'pydantic_js_input_core_schema': {'type': 'definition-ref', 'schema_ref': '__main__.Sub:97821927158416'}
│   │   │   │   │   },
│   │   │   │   │   'serialization': {...}
│   │   │   │   },
│   │   │   │   'metadata': {...}
│   │   │   }
│   │   },
│   │   'model_name': 'Model',
│   │   'computed_fields': []
│   },
│   'custom_init': False,
│   'root_model': False,
│   'config': {'title': 'Model'},
│   'ref': '__main__.Model:97821929019248',
│   'metadata': {...}
}
```

With `pydantic_js_input_core_schema` holding a reference to `__main__.Sub:97821927158416` that would not be present in the core schema (because for a plain validator, the source type is not relevant), JSON Schema generation naturally fails (and thankfully only for JSON Schema generation, as this `pydantic_js_input_core_schema` metadata field is only relevant for JSON Schemas).

---

My first idea was to add extra logic in the `_WalkCoreSchema` class to handle this metadata field and include it in schema walking, but this is truly not ideal as we are leaking JSON Schema related logic inside this class (kind of a consequence of our metadata handling which wasn't ideal in the first place, as discussed already :/).

So I decided we should inline refs in the validator class directly, in a safe way for recursive references.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
