### PR TITLE
Improve error handling for in-evaluable refs for discriminator application

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1201,9 +1201,7 @@ class GenerateJsonSchema:
                     continue  # this means that the "alias" does not represent a field
                 alias_is_present_on_all_choices = True
                 for choice in one_of_choices:
-                    while '$ref' in choice:
-                        assert isinstance(choice['$ref'], str)
-                        choice = self.get_schema_from_definitions(JsonRef(choice['$ref'])) or {}
+                    choice = self.resolve_schema_to_update(choice)
                     properties = choice.get('properties', {})
                     if not isinstance(properties, dict) or alias not in properties:
                         alias_is_present_on_all_choices = False

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -466,7 +466,7 @@ class GenerateJsonSchema:
                 core_ref = CoreRef(core_schema['ref'])  # type: ignore[typeddict-item]
                 defs_ref, ref_json_schema = self.get_cache_defs_ref_schema(core_ref)
                 json_ref = JsonRef(ref_json_schema['$ref'])
-                self.json_to_defs_refs[json_ref] = defs_ref
+                # self.json_to_defs_refs[json_ref] = defs_ref
                 # Replace the schema if it's not a reference to itself
                 # What we want to avoid is having the def be just a ref to itself
                 # which is what would happen if we blindly assigned any

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -466,7 +466,6 @@ class GenerateJsonSchema:
                 core_ref = CoreRef(core_schema['ref'])  # type: ignore[typeddict-item]
                 defs_ref, ref_json_schema = self.get_cache_defs_ref_schema(core_ref)
                 json_ref = JsonRef(ref_json_schema['$ref'])
-                # self.json_to_defs_refs[json_ref] = defs_ref
                 # Replace the schema if it's not a reference to itself
                 # What we want to avoid is having the def be just a ref to itself
                 # which is what would happen if we blindly assigned any

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -1803,7 +1803,9 @@ def test_callable_discriminated_union_with_missing_tag() -> None:
         assert exc_info.code == 'callable-discriminator-no-tag'
 
 
-@pytest.mark.xfail(reason='Issue not yet fixed, see: https://github.com/pydantic/pydantic/issues/8271.')
+@pytest.mark.xfail(
+    reason='Issue not yet fixed, see: https://github.com/pydantic/pydantic/issues/8271. At the moment, JSON schema gen warns with a PydanticJsonSchemaWarning.'
+)
 def test_presence_of_discriminator_when_generating_type_adaptor_json_schema_definitions() -> None:
     class ItemType(str, Enum):
         ITEM1 = 'item1'
@@ -1829,11 +1831,11 @@ def test_presence_of_discriminator_when_generating_type_adaptor_json_schema_defi
             ]
         ]
 
-    adaptor = TypeAdapter(
+    adapter = TypeAdapter(
         Annotated[CreateObjectDto, FieldInfo(examples=[{'id': 1, 'items': [{'id': 3, 'type': 'ITEM1'}]}])]
     )
 
-    schema_map, definitions = GenerateJsonSchema().generate_definitions([(adaptor, 'validation', adaptor.core_schema)])
+    schema_map, definitions = GenerateJsonSchema().generate_definitions([(adapter, 'validation', adapter.core_schema)])
     assert definitions == {
         'CreateItem1': {
             'properties': {'id': {'title': 'Id', 'type': 'integer'}, 'type': {'const': 'item1', 'title': 'Type'}},


### PR DESCRIPTION
This was supposed to close https://github.com/pydantic/pydantic/issues/8271, but right now it just improves the associated error.

My current hunch is that we need to do an apply discriminators step at the end of json schema building, like we do for core schemas, if we want this to work 😭. Not sure how worth the investment that is, at the moment.

I'd also be open to more creative solutions for evaluating refs for which we have not yet generated the schemas. Probably a good conversation to have with @Viicos and @adriangb.

MRE, at the moment:

```py
from enum import Enum
from typing import Annotated, Union, Literal, List

from pydantic import BaseModel as BaseModel, Field, TypeAdapter
from pydantic.fields import FieldInfo
import json
from pydantic._internal._core_utils import pretty_print_core_schema

class ItemType(str, Enum):
    ITEM1 = 'item1'
    ITEM2 = 'item2'

class CreateItem1(BaseModel):
    item_type: Annotated[Literal[ItemType.ITEM1], Field(alias='type')]
    id: int

class CreateItem2(BaseModel):
    item_type: Annotated[Literal[ItemType.ITEM2], Field(alias='type')]
    id: int

class CreateObjectDto(BaseModel):
    id: int
    items: List[
        Annotated[
            Union[
                CreateItem1,
                CreateItem2,
            ],
            Field(discriminator='item_type'),
        ]
    ]

ta = TypeAdapter(
    Annotated[CreateObjectDto, FieldInfo(examples=[{'id': 1, 'items': [{'id': 3, 'type': 'ITEM1'}]}])]
)

print(json.dumps(ta.json_schema(), indent=2))
print(pretty_print_core_schema(ta.core_schema))
```