### PR TITLE
Fix schema generation error when serialization schema holds references

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -458,6 +458,10 @@ def simplify_schema_references(schema: core_schema.CoreSchema) -> core_schema.Co
             return s
 
         current_recursion_ref_count[ref] += 1
+        if 'serialization' in s:
+            # Even though this is a `'definition-ref'` schema, there might
+            # be more references inside the serialization schema:
+            recurse(s, count_refs)
         recurse(definitions[ref], count_refs)
         current_recursion_ref_count[ref] -= 1
         return s

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -892,6 +892,21 @@ def test_clear_return_schema():
     assert return_serializer == 'return_serializer: Any'
 
 
+def test_serializer_return_type_model() -> None:
+    """https://github.com/pydantic/pydantic/issues/10443"""
+
+    class Sub(BaseModel):
+        pass
+
+    class Model(BaseModel):
+        sub: Annotated[
+            Sub,
+            PlainSerializer(lambda v: v, return_type=Sub),
+        ]
+
+    assert Model(sub=Sub()).model_dump() == {'sub': {}}
+
+
 def test_type_adapter_dump_json():
     class Model(TypedDict):
         x: int


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/10443.
I'm not too happy with the solution, feels a bit weird to have to worry about this inside `count_refs`, but couldn't find a better fix.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
