### PR TITLE
docs: More specific `model_post_init` explanation

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -157,7 +157,7 @@ Models possess the following methods and attributes:
 * [`model_extra`][pydantic.main.BaseModel.model_extra]: The extra fields set during validation.
 * [`model_fields_set`][pydantic.main.BaseModel.model_fields_set]: The set of fields which were explicitly provided when the model was initialized.
 * [`model_parametrized_name()`][pydantic.main.BaseModel.model_parametrized_name]: Computes the class name for parametrizations of generic classes.
-* [`model_post_init()`][pydantic.main.BaseModel.model_post_init]: Performs additional actions after the model is initialized.
+* [`model_post_init()`][pydantic.main.BaseModel.model_post_init]: Performs additional actions after the model is initialized and all field validators are applied.
 * [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild]: Rebuilds the model schema, which also supports building recursive generic models.
     See [Rebuilding model schema](#rebuilding-model-schema).
 


### PR DESCRIPTION
I want to make a small but specific change to the documentation. I find the library great, but I feel a little confused when I use field validators, model validators, and `model_post_init` all at once. To illustrate this, I created [this gist](https://gist.github.com/santibreo/8f4c817f88d24f409e72623acdbe6886).

Because there are so many ways to hook into model instantiation, I would like to clarify their order of precedence.