### PR TITLE
Add support for `propertyNames` in JSON schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -958,7 +958,8 @@ class GenerateJsonSchema:
         """
         json_schema: JsonSchemaValue = {'type': 'object'}
 
-        keys_schema = self.generate_inner(schema['keys_schema']).copy() if 'keys_schema' in schema else {}
+        ks = schema['keys_schema'] if 'keys_schema' in schema else None
+        keys_schema = self.generate_inner(ks).copy() if ks is not None else {}
         keys_pattern = keys_schema.pop('pattern', None)
 
         values_schema = self.generate_inner(schema['values_schema']).copy() if 'values_schema' in schema else {}
@@ -969,6 +970,11 @@ class GenerateJsonSchema:
             else:
                 json_schema['patternProperties'] = {keys_pattern: values_schema}
 
+        if ks is not None:
+            keys_type = ks.get('type', None)
+            if keys_type == 'enum':
+                keys_members = ks.get('members', [])
+                json_schema['propertyNames'] = {'enum': keys_members}
         self.update_with_validations(json_schema, schema, self.ValidationsMapping.object)
         return json_schema
 

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -958,8 +958,7 @@ class GenerateJsonSchema:
         """
         json_schema: JsonSchemaValue = {'type': 'object'}
 
-        keys_core_schema = schema.get('keys_schema')
-        self.generate_inner(keys_core_schema).copy() if keys_core_schema is not None else {}
+        keys_schema = self.generate_inner(schema['keys_schema']).copy() if 'keys_schema' in schema else {}
         keys_pattern = keys_schema.pop('pattern', None)
 
         values_schema = self.generate_inner(schema['values_schema']).copy() if 'values_schema' in schema else {}

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -959,9 +959,7 @@ class GenerateJsonSchema:
         json_schema: JsonSchemaValue = {'type': 'object'}
 
         keys_core_schema = schema.get('keys_schema')
-        keys_schema = self.resolve_schema_to_update(
-            self.generate_inner(keys_core_schema).copy() if keys_core_schema is not None else {}
-        )
+        self.generate_inner(keys_core_schema).copy() if keys_core_schema is not None else {}
         keys_pattern = keys_schema.pop('pattern', None)
 
         values_schema = self.generate_inner(schema['values_schema']).copy() if 'values_schema' in schema else {}

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -958,7 +958,9 @@ class GenerateJsonSchema:
         """
         json_schema: JsonSchemaValue = {'type': 'object'}
 
-        keys_schema = self.generate_inner(schema['keys_schema']).copy() if 'keys_schema' in schema else {}
+        keys_schema = self.resolve_schema_to_update(
+            self.generate_inner(schema['keys_schema']).copy() if 'keys_schema' in schema else {}
+        )
         keys_pattern = keys_schema.pop('pattern', None)
 
         values_schema = self.generate_inner(schema['values_schema']).copy() if 'values_schema' in schema else {}

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -974,6 +974,7 @@ class GenerateJsonSchema:
             else:
                 json_schema['patternProperties'] = {keys_pattern: values_schema}
 
+        # The len check indicates that constraints are probably present:
         if keys_schema.get('type') == 'string' and len(keys_schema) > 1:
             keys_schema.pop('type')
             json_schema['propertyNames'] = keys_schema

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -965,7 +965,7 @@ class GenerateJsonSchema:
         keys_pattern = keys_schema.pop('pattern', None)
 
         values_schema = self.generate_inner(schema['values_schema']).copy() if 'values_schema' in schema else {}
-        # don't give a title to additionalProperties and patternProperties
+        # don't give a title to additionalProperties, patternProperties and propertyNames
         values_schema.pop('title', None)
         keys_schema.pop('title', None)
         if values_schema or keys_pattern is not None:  # don't add additionalProperties if it's empty

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7,7 +7,7 @@ import sys
 import typing
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum, IntEnum, StrEnum
+from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
 from typing import (

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1758,21 +1758,15 @@ def test_property_names_constraint():
     assert MyModel.model_json_schema() == {
         'properties': {
             'my_dict': {
-                'additionalProperties': {
-                    'type': 'string'
-                },
-                'propertyNames': {
-                    'maxLength': 1
-                },
+                'additionalProperties': {'type': 'string'},
+                'propertyNames': {'maxLength': 1},
                 'title': 'My Dict',
-                'type': 'object'
+                'type': 'object',
             }
         },
-        'required': [
-            'my_dict'
-        ],
+        'required': ['my_dict'],
         'title': 'MyModel',
-        'type': 'object'
+        'type': 'object',
     }
 
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1728,7 +1728,7 @@ def test_enum_int_default():
 
 
 def test_enum_dict():
-    class MyEnum(StrEnum):
+    class MyEnum(str, Enum):
         FOO = 'foo'
         BAR = 'bar'
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -101,6 +101,7 @@ from pydantic.types import (
     SecretStr,
     StrictBool,
     StrictStr,
+    StringConstraints,
     conbytes,
     condate,
     condecimal,
@@ -1747,6 +1748,31 @@ def test_enum_dict():
             }
         },
         'required': ['enum_dict'],
+    }
+
+
+def test_property_names_constraint():
+    class MyModel(BaseModel):
+        my_dict: Dict[Annotated[str, StringConstraints(max_length=1)], str]
+
+    assert MyModel.model_json_schema() == {
+        'properties': {
+            'my_dict': {
+                'additionalProperties': {
+                    'type': 'string'
+                },
+                'propertyNames': {
+                    'maxLength': 1
+                },
+                'title': 'My Dict',
+                'type': 'object'
+            }
+        },
+        'required': [
+            'my_dict'
+        ],
+        'title': 'MyModel',
+        'type': 'object'
     }
 
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1733,7 +1733,7 @@ def test_enum_dict():
         BAR = 'bar'
 
     class MyModel(BaseModel):
-        enum_dict: dict[MyEnum, str]
+        enum_dict: Dict[MyEnum, str]
 
     assert MyModel.model_json_schema() == {
         'title': 'MyModel',

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7,7 +7,7 @@ import sys
 import typing
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum, IntEnum
+from enum import Enum, IntEnum, StrEnum
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path
 from typing import (
@@ -1725,6 +1725,29 @@ def test_enum_int_default():
     default_value = UserModel.model_json_schema()['properties']['friends']['default']
     assert type(default_value) is int
     assert default_value == MyEnum.FOO.value
+
+
+def test_enum_dict():
+    class MyEnum(StrEnum):
+        FOO = 'foo'
+        BAR = 'bar'
+
+    class MyModel(BaseModel):
+        enum_dict: dict[MyEnum, str]
+
+    assert MyModel.model_json_schema() == {
+        'title': 'MyModel',
+        'type': 'object',
+        'properties': {
+            'enum_dict': {
+                'title': 'Enum Dict',
+                'type': 'object',
+                'additionalProperties': {'type': 'string'},
+                'propertyNames': {'enum': ['foo', 'bar']},
+            }
+        },
+        'required': ['enum_dict'],
+    }
 
 
 def test_dict_default():

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1784,6 +1784,7 @@ def test_model_default():
                     'a': {
                         'additionalProperties': {'type': 'string'},
                         'default': {'.': ''},
+                        'propertyNames': {'format': 'path'},
                         'title': 'A',
                         'type': 'object',
                     }


### PR DESCRIPTION
## Change Summary

JSON schema draft 2020-12 defines a propertyNames key for dict/object schemas which can contain any valid JSON schema that defines to what any property name of the object instance needs to validate to.

This can be mapped to a pydantic/python typing like dict[AnyEnum, str] where AnyEnum is an Enum type with defined values.

propertyNames supports other validation schemas as well, e.g. a pattern. However, this is not covered with this PR.

## Related issue number

Fixes #4393

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle