### PR TITLE
Add warning re deprecation of `schema_generator`

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -26,6 +26,7 @@ if not TYPE_CHECKING:
     DeprecationWarning = PydanticDeprecatedSince20
 
 if TYPE_CHECKING:
+    from .._internal._schema_generation_shared import GenerateSchema
     from ..fields import ComputedFieldInfo, FieldInfo
 
 DEPRECATION_MESSAGE = 'Support for class-based `config` is deprecated, use ConfigDict instead.'
@@ -79,6 +80,7 @@ class ConfigWrapper:
     hide_input_in_errors: bool
     defer_build: bool
     plugin_settings: dict[str, object] | None
+    schema_generator: type[GenerateSchema] | None
     json_schema_serialization_defaults_required: bool
     json_schema_mode_override: Literal['validation', 'serialization', None]
     coerce_numbers_to_str: bool
@@ -165,6 +167,13 @@ class ConfigWrapper:
             A `CoreConfig` object created from config.
         """
         config = self.config_dict
+
+        if config.get('schema_generator') is not None:
+            warnings.warn(
+                'The `schema_generator` setting has been deprecated in v2.10. This setting no longer has any effect.',
+                PydanticDeprecatedSince210,
+                stacklevel=2,
+            )
 
         if config.get('ser_json_timedelta') == 'float':
             warnings.warn(
@@ -267,6 +276,7 @@ config_defaults = ConfigDict(
     hide_input_in_errors=False,
     json_encoders=None,
     defer_build=False,
+    schema_generator=None,
     plugin_settings=None,
     json_schema_serialization_defaults_required=False,
     json_schema_mode_override=None,

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -170,7 +170,7 @@ class ConfigWrapper:
 
         if config.get('schema_generator') is not None:
             warnings.warn(
-                'The `schema_generator` setting has been deprecated in v2.10. This setting no longer has any effect.',
+                'The `schema_generator` setting has been deprecated since v2.10. This setting no longer has any effect.',
                 PydanticDeprecatedSince210,
                 stacklevel=2,
             )

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -11,6 +11,7 @@ from .aliases import AliasGenerator
 from .errors import PydanticUserError
 
 if TYPE_CHECKING:
+    from ._internal._generate_schema import GenerateSchema as _GenerateSchema
     from .fields import ComputedFieldInfo, FieldInfo
 
 __all__ = ('ConfigDict', 'with_config')
@@ -570,7 +571,9 @@ class ConfigDict(TypedDict, total=False):
     - `'iso8601'` will serialize timedeltas to ISO 8601 durations.
     - `'seconds_float'` will serialize timedeltas to the total number of seconds.
     - `'milliseconds_float'` will serialize timedeltas to the total number of milliseconds.
-        NOTE: `'float' is deprecated in v2.10 in favour of `'milliseconds_float'`
+
+    !!! warning
+        `'float' is deprecated in v2.10 in favour of `'milliseconds_float'`
     """
 
     ser_json_bytes: Literal['utf8', 'base64', 'hex']
@@ -740,6 +743,16 @@ class ConfigDict(TypedDict, total=False):
 
     plugin_settings: dict[str, object] | None
     """A `dict` of settings for plugins. Defaults to `None`."""
+
+    schema_generator: type[_GenerateSchema] | None
+    """
+    !!! warning
+        `schema_generator` is deprecated in v2.10.
+
+        Prior to v2.10, this setting was advertised as highly subject to change.
+        It's possible that this interface may once again become public once the internal core schema generation
+        API is more stable, but that will likely come after significant performance improvements have been made.
+    """
 
     json_schema_serialization_defaults_required: bool
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ from pydantic import (
     with_config,
 )
 from pydantic._internal._config import ConfigWrapper, config_defaults
+from pydantic._internal._generate_schema import GenerateSchema
 from pydantic._internal._mock_val_ser import MockValSer
 from pydantic._internal._typing_extra import get_type_hints
 from pydantic.config import ConfigDict, JsonValue
@@ -31,7 +32,7 @@ from pydantic.dataclasses import rebuild_dataclass
 from pydantic.errors import PydanticUserError
 from pydantic.fields import ComputedFieldInfo, FieldInfo
 from pydantic.type_adapter import TypeAdapter
-from pydantic.warnings import PydanticDeprecationWarning
+from pydantic.warnings import PydanticDeprecatedSince210, PydanticDeprecationWarning
 
 from .conftest import CallCounter
 
@@ -519,6 +520,7 @@ def test_multiple_inheritance_config():
 
 def test_config_wrapper_match():
     localns = {
+        '_GenerateSchema': GenerateSchema,
         'JsonValue': JsonValue,
         'FieldInfo': FieldInfo,
         'ComputedFieldInfo': ComputedFieldInfo,
@@ -938,3 +940,12 @@ def test_empty_config_with_annotations():
         model_config: ConfigDict = {}
 
     assert Model.model_config == {}
+
+
+def test_generate_schema_deprecation_warning() -> None:
+    with pytest.warns(
+        PydanticDeprecatedSince210, match='The `schema_generator` setting has been deprecated since v2.10.'
+    ):
+
+        class Model(BaseModel):
+            model_config = ConfigDict(schema_generator=GenerateSchema)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -521,6 +521,7 @@ def test_multiple_inheritance_config():
 def test_config_wrapper_match():
     localns = {
         '_GenerateSchema': GenerateSchema,
+        'GenerateSchema': GenerateSchema,
         'JsonValue': JsonValue,
         'FieldInfo': FieldInfo,
         'ComputedFieldInfo': ComputedFieldInfo,
@@ -568,6 +569,8 @@ def test_config_validation_error_cause():
 
 def test_config_defaults_match():
     localns = {
+        '_GenerateSchema': GenerateSchema,
+        'GenerateSchema': GenerateSchema,
         'FieldInfo': FieldInfo,
         'ComputedFieldInfo': ComputedFieldInfo,
     }


### PR DESCRIPTION
A while back I implemented the deprecation / removal of support for `schema_generator` via https://github.com/pydantic/pydantic/pull/10303.

I thought it best to add a more explicit deprecation warning. We can remove this in a few minor versions.