### PR TITLE
Using `__pydantic_fields__` and `__pydantic_computed_fields__` under the hood

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -104,7 +104,7 @@ def collect_model_fields(  # noqa: C901
 
     parent_fields_lookup: dict[str, FieldInfo] = {}
     for base in reversed(bases):
-        if model_fields := getattr(base, 'model_fields', None):
+        if model_fields := getattr(base, '__pydantic_fields__', None):
             parent_fields_lookup.update(model_fields)
 
     type_hints = get_cls_type_hints_lenient(cls, types_namespace)
@@ -125,7 +125,7 @@ def collect_model_fields(  # noqa: C901
             if ann_name.startswith(protected_namespace):
                 for b in bases:
                     if hasattr(b, ann_name):
-                        if not (issubclass(b, BaseModel) and ann_name in b.model_fields):
+                        if not (issubclass(b, BaseModel) and ann_name in b.__pydantic_fields__):
                             raise NameError(
                                 f'Field "{ann_name}" conflicts with member {getattr(b, ann_name)}'
                                 f' of protected namespace "{protected_namespace}".'

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -125,7 +125,7 @@ def collect_model_fields(  # noqa: C901
             if ann_name.startswith(protected_namespace):
                 for b in bases:
                     if hasattr(b, ann_name):
-                        if not (issubclass(b, BaseModel) and ann_name in b.__pydantic_fields__):
+                        if not (issubclass(b, BaseModel) and ann_name in getattr(b, '__pydantic_fields__', {})):
                             raise NameError(
                                 f'Field "{ann_name}" conflicts with member {getattr(b, ann_name)}'
                                 f' of protected namespace "{protected_namespace}".'

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -665,7 +665,7 @@ class GenerateSchema:
             if maybe_schema is not None:
                 return maybe_schema
 
-            fields = cls.__pydantic_fields__
+            fields = getattr(cls, '__pydantic_fields__', {})
             decorators = cls.__pydantic_decorators__
             computed_fields = decorators.computed_fields
             check_decorator_fields_exist(

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -280,8 +280,8 @@ def modify_model_json_schema(
     docstring = None if cls is BaseModel or is_builtin_dataclass(cls) or is_pydantic_dataclass(cls) else cls.__doc__
     if docstring and 'description' not in original_schema:
         original_schema['description'] = inspect.cleandoc(docstring)
-    elif issubclass(cls, RootModel) and cls.model_fields['root'].description:
-        original_schema['description'] = cls.model_fields['root'].description
+    elif issubclass(cls, RootModel) and cls.__pydantic_fields__['root'].description:
+        original_schema['description'] = cls.__pydantic_fields__['root'].description
     return json_schema
 
 
@@ -665,7 +665,7 @@ class GenerateSchema:
             if maybe_schema is not None:
                 return maybe_schema
 
-            fields = cls.model_fields
+            fields = cls.__pydantic_fields__
             decorators = cls.__pydantic_decorators__
             computed_fields = decorators.computed_fields
             check_decorator_fields_exist(

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -11,7 +11,7 @@ import weakref
 from abc import ABCMeta
 from functools import lru_cache, partial
 from types import FunctionType
-from typing import Any, Callable, ClassVar, Dict, Generic, Literal, NoReturn
+from typing import Any, Callable, Generic, Literal, NoReturn
 
 import typing_extensions
 from pydantic_core import PydanticUndefined, SchemaSerializer
@@ -80,15 +80,6 @@ def NoInitField(
 
 @dataclass_transform(kw_only_default=True, field_specifiers=(PydanticModelField, PydanticModelPrivateAttr, NoInitField))
 class ModelMetaclass(ABCMeta):
-    # Because `dict` is in the local namespace of the `BaseModel` class, we use `Dict` for annotations.
-    # TODO v3 fallback to `dict` when the deprecated `dict` method gets removed.
-
-    __pydantic_fields__: ClassVar[Dict[str, FieldInfo]]  # noqa: UP006
-    """A dictionary of field names and their corresponding [`FieldInfo`][pydantic.fields.FieldInfo] objects. This replaces `Model.__fields__` from Pydantic V1."""
-
-    __pydantic_computed_fields__: ClassVar[Dict[str, ComputedFieldInfo]]  # noqa: UP006
-    """A dictionary of computed field names and their corresponding [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects."""
-
     def __new__(
         mcs,
         cls_name: str,
@@ -371,16 +362,16 @@ class ModelMetaclass(ABCMeta):
         Returns:
             A mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
         """
-        return self.__pydantic_fields__
+        return getattr(self, '__pydantic_fields__', {})
 
     @property
-    def computed_fields(self) -> dict[str, ComputedFieldInfo]:
+    def model_computed_fields(self) -> dict[str, ComputedFieldInfo]:
         """Get metadata about the computed fields defined on the model.
 
         Returns:
             A mapping of computed field names to [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects.
         """
-        return self.__pydantic_computed_fields__
+        return getattr(self, '__pydantic_computed_fields__', {})
 
     def __dir__(self) -> list[str]:
         attributes = list(super().__dir__())

--- a/pydantic/deprecated/copy_internals.py
+++ b/pydantic/deprecated/copy_internals.py
@@ -40,11 +40,11 @@ def _iter(
     # The extra "is not None" guards are not logically necessary but optimizes performance for the simple case.
     if exclude is not None:
         exclude = _utils.ValueItems.merge(
-            {k: v.exclude for k, v in self.model_fields.items() if v.exclude is not None}, exclude
+            {k: v.exclude for k, v in self.__pydantic_fields__.items() if v.exclude is not None}, exclude
         )
 
     if include is not None:
-        include = _utils.ValueItems.merge({k: True for k in self.model_fields}, include, intersect=True)
+        include = _utils.ValueItems.merge({k: True for k in self.__pydantic_fields__}, include, intersect=True)
 
     allowed_keys = _calculate_keys(self, include=include, exclude=exclude, exclude_unset=exclude_unset)  # type: ignore
     if allowed_keys is None and not (to_dict or by_alias or exclude_unset or exclude_defaults or exclude_none):
@@ -68,15 +68,15 @@ def _iter(
 
         if exclude_defaults:
             try:
-                field = self.model_fields[field_key]
+                field = self.__pydantic_fields__[field_key]
             except KeyError:
                 pass
             else:
                 if not field.is_required() and field.default == v:
                     continue
 
-        if by_alias and field_key in self.model_fields:
-            dict_key = self.model_fields[field_key].alias or field_key
+        if by_alias and field_key in self.__pydantic_fields__:
+            dict_key = self.__pydantic_fields__[field_key].alias or field_key
         else:
             dict_key = field_key
 

--- a/pydantic/deprecated/decorator.py
+++ b/pydantic/deprecated/decorator.py
@@ -170,10 +170,10 @@ class ValidatedFunction:
         duplicate_kwargs = []
         fields_alias = [
             field.alias
-            for name, field in self.model.model_fields.items()
+            for name, field in self.model.__pydantic_fields__.items()
             if name not in (self.v_args_name, self.v_kwargs_name)
         ]
-        non_var_fields = set(self.model.model_fields) - {self.v_args_name, self.v_kwargs_name}
+        non_var_fields = set(self.model.__pydantic_fields__) - {self.v_args_name, self.v_kwargs_name}
         for k, v in kwargs.items():
             if k in non_var_fields or k in fields_alias:
                 if k in self.positional_only_args:
@@ -193,7 +193,11 @@ class ValidatedFunction:
         return values
 
     def execute(self, m: BaseModel) -> Any:
-        d = {k: v for k, v in m.__dict__.items() if k in m.__pydantic_fields_set__ or m.model_fields[k].default_factory}
+        d = {
+            k: v
+            for k, v in m.__dict__.items()
+            if k in m.__pydantic_fields_set__ or m.__pydantic_fields__[k].default_factory
+        }
         var_kwargs = d.pop(self.v_kwargs_name, {})
 
         if self.v_args_name in d:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -119,19 +119,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     # Because `dict` is in the local namespace of the `BaseModel` class, we use `Dict` for annotations.
     # TODO v3 fallback to `dict` when the deprecated `dict` method gets removed.
-
-    # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation.
-    model_fields: ClassVar[Dict[str, FieldInfo]] = {}  # noqa: UP006
-    """
-    Metadata about the fields defined on the model,
-    mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
-    This replaces `Model.__fields__` from Pydantic V1.
-    """
-
-    # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation.
-    model_computed_fields: ClassVar[Dict[str, ComputedFieldInfo]] = {}  # noqa: UP006
-    """A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects."""
-
     __class_vars__: ClassVar[set[str]]
     """The names of the class variables defined on the model."""
 
@@ -232,6 +219,27 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
     # The following line sets a flag that we use to determine when `__init__` gets overridden by the user
     __init__.__pydantic_base_init__ = True  # pyright: ignore[reportFunctionMemberAccess]
+
+    # TODO: V3 - remove `model_fields` and `model_computed_fields` properties from the `BaseModel` class - they should only
+    # be accessible on the model class, not on instances. We have these purely for backwards compatibility with Pydantic <v2.10.
+    # This is similar to the fact that we have __fields__ defined here (on `BaseModel`) and on `ModelMetaClass`.
+    @property
+    def model_fields(self) -> dict[str, FieldInfo]:
+        """Get metadata about the fields defined on the model.
+
+        Returns:
+            A mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
+        """
+        return type(self).model_fields
+
+    @property
+    def model_computed_fields(self) -> dict[str, ComputedFieldInfo]:
+        """Get metadata about the computed fields defined on the model.
+
+        Returns:
+            A mapping of computed field names to [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects.
+        """
+        return type(self).model_computed_fields
 
     @property
     def model_extra(self) -> dict[str, Any] | None:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -122,6 +122,17 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     # Because `dict` is in the local namespace of the `BaseModel` class, we use `Dict` for annotations.
     # TODO v3 fallback to `dict` when the deprecated `dict` method gets removed.
 
+    # Note: Many of the below class vars are defined in the metaclass, but we define them here for type checking purposes.
+    model_fields: ClassVar[Dict[str, FieldInfo]] = {}  # noqa: UP006
+    """
+    Metadata about the fields defined on the model,
+    mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
+    This replaces `Model.__fields__` from Pydantic V1.
+    """
+
+    model_computed_fields: ClassVar[Dict[str, ComputedFieldInfo]] = {}  # noqa: UP006
+    """A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects."""
+
     __class_vars__: ClassVar[set[str]]
     """The names of the class variables defined on the model."""
 
@@ -240,24 +251,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 i.e. that were not filled from defaults.
         """
         return self.__pydantic_fields_set__
-
-    @property
-    def model_fields(self) -> dict[str, FieldInfo]:
-        """Get metadata about the fields defined on the model.
-
-        Returns:
-            A mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
-        """
-        return self.__pydantic_fields__
-
-    @property
-    def computed_fields(self) -> dict[str, ComputedFieldInfo]:
-        """Get metadata about the computed fields defined on the model.
-
-        Returns:
-            A mapping of computed field names to [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects.
-        """
-        return self.__pydantic_computed_fields__
 
     @classmethod
     def model_construct(cls, _fields_set: set[str] | None = None, **values: Any) -> Self:  # noqa: C901

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -110,9 +110,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         __pydantic_private__: Values of private attributes set on the model instance.
     """
 
-    # Class attributes:
-    # `__pydantic_fields__` and `__pydantic_decorators__` must be set for
-    # `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation.
+    # Note: Many of the below class vars are defined in the metaclass, but we define them here for type checking purposes.
 
     model_config: ClassVar[ConfigDict] = ConfigDict()
     """
@@ -122,7 +120,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     # Because `dict` is in the local namespace of the `BaseModel` class, we use `Dict` for annotations.
     # TODO v3 fallback to `dict` when the deprecated `dict` method gets removed.
 
-    # Note: Many of the below class vars are defined in the metaclass, but we define them here for type checking purposes.
+    # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation.
     model_fields: ClassVar[Dict[str, FieldInfo]] = {}  # noqa: UP006
     """
     Metadata about the fields defined on the model,
@@ -130,6 +128,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     This replaces `Model.__fields__` from Pydantic V1.
     """
 
+    # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation.
     model_computed_fields: ClassVar[Dict[str, ComputedFieldInfo]] = {}  # noqa: UP006
     """A dictionary of computed field names and their corresponding `ComputedFieldInfo` objects."""
 
@@ -151,6 +150,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     __pydantic_custom_init__: ClassVar[bool]
     """Whether the model has a custom `__init__` method."""
 
+    # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation.
     __pydantic_decorators__: ClassVar[_decorators.DecoratorInfos] = _decorators.DecoratorInfos()
     """Metadata containing the decorators defined on the model.
     This replaces `Model.__validators__` and `Model.__root_validators__` from Pydantic V1."""

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -227,19 +227,27 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     def model_fields(self) -> dict[str, FieldInfo]:
         """Get metadata about the fields defined on the model.
 
+        Deprecation warning: you should be getting this information from the model class, not from an instance.
+        In V3, this property will be removed from the `BaseModel` class.
+
         Returns:
             A mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
         """
-        return type(self).model_fields
+        # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation, hence the default here.
+        return getattr(self, '__pydantic_fields__', {})
 
     @property
     def model_computed_fields(self) -> dict[str, ComputedFieldInfo]:
         """Get metadata about the computed fields defined on the model.
 
+        Deprecation warning: you should be getting this information from the model class, not from an instance.
+        In V3, this property will be removed from the `BaseModel` class.
+
         Returns:
             A mapping of computed field names to [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects.
         """
-        return type(self).model_computed_fields
+        # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation, hence the default here.
+        return getattr(self, '__pydantic_computed_fields__', {})
 
     @property
     def model_extra(self) -> dict[str, Any] | None:

--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -148,7 +148,9 @@ class RootModel(BaseModel, typing.Generic[RootModelRootType], metaclass=_RootMod
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, RootModel):
             return NotImplemented
-        return self.model_fields['root'].annotation == other.model_fields['root'].annotation and super().__eq__(other)
+        return self.__pydantic_fields__['root'].annotation == other.__pydantic_fields__[
+            'root'
+        ].annotation and super().__eq__(other)
 
     def __repr_args__(self) -> _repr.ReprArgs:
         yield 'root', self.root

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -817,7 +817,7 @@ def test_computed_field_with_field_serializer():
     assert MyModel().model_dump() == {'my_field': 'my_field = foo', 'other_field': 'other_field = 42'}
 
 
-def test__fields_on_instance_and_cls() -> None:
+def test_fields_on_instance_and_cls() -> None:
     """For now, we support `model_fields` and `model_computed_fields` access on both instances and classes.
 
     In V3, we should only support class access, though we need to preserve the current behavior for V2 compatibility."""

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -815,3 +815,26 @@ def test_computed_field_with_field_serializer():
             return f'{info.field_name} = {value}'
 
     assert MyModel().model_dump() == {'my_field': 'my_field = foo', 'other_field': 'other_field = 42'}
+
+
+def test__fields_on_instance_and_cls() -> None:
+    """For now, we support `model_fields` and `model_computed_fields` access on both instances and classes.
+
+    In V3, we should only support class access, though we need to preserve the current behavior for V2 compatibility."""
+
+    class Rectangle(BaseModel):
+        x: int
+        y: int
+
+        @computed_field
+        @property
+        def area(self) -> int:
+            return self.x * self.y
+
+    r = Rectangle(x=10, y=5)
+
+    for attr in {'model_fields', 'model_computed_fields'}:
+        assert getattr(r, attr) == getattr(Rectangle, attr)
+
+    assert set(r.model_fields) == {'x', 'y'}
+    assert set(r.model_computed_fields) == {'area'}


### PR DESCRIPTION
Unblocking our namespace PR, this introduces `__pydantic_fields__` and `__pydantic_computed_fields__` under the hood to return from the `model_fields` and `model_computed_fields` properties.

We sort of make these "class" properties (which is generally disallowed) by adding them onto the meta class. For typing purposes (I think, I was mimicking what we had for `__fields__` re duplication across `BaseModel` and `ModelMetaClass`).