### PR TITLE
Add python validators for decimal constraints (`max_digits` and `decimal_places`)

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -335,8 +335,8 @@ def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[in
     """Compute the total number of digits and decimal places for a given [`Decimal`][decimal.Decimal] instance.
 
     This function handles both normalized and non-normalized Decimal instances.
-    Example: Decimal('1.230'), normalize=False -> 3 decimal places, 4 digits
-    Example: decimal=Decimal('0.00123'), normalize=True -> 5 decimal places, 3 digits
+    Example: Decimal('1.2300'), normalize=False -> 4 decimal places, 5 digits
+    Example: decimal=Decimal('1.2300'), normalize=True -> 2 decimal places, 3 digits
 
     Args:
         decimal (Decimal): The decimal number to analyze.

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -335,6 +335,8 @@ def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[in
     """Modeled after the `pydanitc-core` implementation of this function.
 
     See https://github.com/pydantic/pydantic-core/blob/f389728432949ecceddecb1f59bb503b0998e9aa/src/validators/decimal.rs#L85.
+    Though this could be divided into two separate functions, the logic is easier to follow if we couple the computation
+    of the number of decimals and digits together.
     """
     normalized_decimal = decimal.normalize() if normalized else decimal
     _, digit_tuple, exponent = normalized_decimal.as_tuple()
@@ -359,9 +361,6 @@ def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[in
 
 
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
-    if not isinstance(x, Decimal):
-        raise TypeError(f"Unable to apply constraint 'max_digits' to supplied value {x}")
-
     _, digits = _extract_decimal_digits_info(x, False)
     _, normalized_digits = _extract_decimal_digits_info(x, True)
 
@@ -377,9 +376,6 @@ def max_digits_validator(x: Any, max_digits: Any) -> Any:
 
 
 def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
-    if not isinstance(x, Decimal):
-        raise TypeError(f"Unable to apply constraint 'decimal_places' to supplied value {x}")
-
     decimals, _ = _extract_decimal_digits_info(x, False)
     normalized_decimals, _ = _extract_decimal_digits_info(x, True)
 

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -331,18 +331,14 @@ def max_length_validator(x: Any, max_length: Any) -> Any:
         raise TypeError(f"Unable to apply constraint 'max_length' to supplied value {x}")
 
 
-def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[int, int]:
+def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
     """Compute the total number of digits and decimal places for a given [`Decimal`][decimal.Decimal] instance.
 
     This function handles both normalized and non-normalized Decimal instances.
-    Example: Decimal('1.2300'), normalize=False -> 4 decimal places, 5 digits
-    Example: decimal=Decimal('1.2300'), normalize=True -> 2 decimal places, 3 digits
+    Example: Decimal('1.230'), normalize=False -> 4 digits, 3 decimal places
 
     Args:
         decimal (Decimal): The decimal number to analyze.
-        normalized (bool): If True, the decimal is normalized before computing its digits and places.
-            Normalization implies that trailing zeros are removed and the exponent is adjusted to reflect
-            the new number of digits and decimal places.
 
     Returns:
         tuple[int, int]: A tuple containing the number of decimal places and total digits.
@@ -353,8 +349,7 @@ def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[in
     Though this could be divided into two separate functions, the logic is easier to follow if we couple the computation
     of the number of decimals and digits together.
     """
-    normalized_decimal = decimal.normalize() if normalized else decimal
-    _, digit_tuple, exponent = normalized_decimal.as_tuple()
+    _, digit_tuple, exponent = decimal.as_tuple()
 
     exponent = int(exponent)
     digits = len(digit_tuple)
@@ -378,8 +373,8 @@ def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[in
 
 
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
-    _, digits = _extract_decimal_digits_info(x, False)
-    _, normalized_digits = _extract_decimal_digits_info(x, True)
+    _, digits = _extract_decimal_digits_info(x)
+    _, normalized_digits = _extract_decimal_digits_info(x.normalize())
 
     try:
         if (digits > max_digits) and (normalized_digits > max_digits):
@@ -393,8 +388,8 @@ def max_digits_validator(x: Any, max_digits: Any) -> Any:
 
 
 def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
-    decimal_places, _ = _extract_decimal_digits_info(x, False)
-    normalized_decimal_places, _ = _extract_decimal_digits_info(x, True)
+    decimal_places, _ = _extract_decimal_digits_info(x)
+    normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize())
 
     try:
         if (decimal_places > decimal_places) and (normalized_decimal_places > decimal_places):

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -335,7 +335,7 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
     """Compute the total number of digits and decimal places for a given [`Decimal`][decimal.Decimal] instance.
 
     This function handles both normalized and non-normalized Decimal instances.
-    Example: Decimal('1.230'), normalize=False -> 4 digits, 3 decimal places
+    Example: Decimal('1.230') -> 4 digits, 3 decimal places
 
     Args:
         decimal (Decimal): The decimal number to analyze.

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -331,11 +331,18 @@ def max_length_validator(x: Any, max_length: Any) -> Any:
         raise TypeError(f"Unable to apply constraint 'max_length' to supplied value {x}")
 
 
-def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
+def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[int, int]:
     """Compute the total number of digits and decimal places for a given [`Decimal`][decimal.Decimal] instance.
+
+    This function handles both normalized and non-normalized Decimal instances.
+    Example: Decimal('1.2300'), normalize=False -> 4 decimal places, 5 digits
+    Example: decimal=Decimal('1.2300'), normalize=True -> 2 decimal places, 3 digits
 
     Args:
         decimal (Decimal): The decimal number to analyze.
+        normalized (bool): If True, the decimal is normalized before computing its digits and places.
+            Normalization implies that trailing zeros are removed and the exponent is adjusted to reflect
+            the new number of digits and decimal places.
 
     Returns:
         tuple[int, int]: A tuple containing the number of decimal places and total digits.
@@ -346,7 +353,8 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
     Though this could be divided into two separate functions, the logic is easier to follow if we couple the computation
     of the number of decimals and digits together.
     """
-    _, digit_tuple, exponent = decimal.as_tuple()
+    normalized_decimal = decimal.normalize() if normalized else decimal
+    _, digit_tuple, exponent = normalized_decimal.as_tuple()
 
     exponent = int(exponent)
     digits = len(digit_tuple)
@@ -370,10 +378,11 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
 
 
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
-    _, normalized_digits = _extract_decimal_digits_info(x.normalize())
+    _, digits = _extract_decimal_digits_info(x, False)
+    _, normalized_digits = _extract_decimal_digits_info(x, True)
 
     try:
-        if normalized_digits > max_digits:
+        if (digits > max_digits) and (normalized_digits > max_digits):
             raise PydanticKnownError(
                 'decimal_max_digits',
                 {'max_digits': max_digits},
@@ -384,10 +393,11 @@ def max_digits_validator(x: Any, max_digits: Any) -> Any:
 
 
 def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
-    normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize())
+    decimal_places, _ = _extract_decimal_digits_info(x, False)
+    normalized_decimal_places, _ = _extract_decimal_digits_info(x, True)
 
     try:
-        if normalized_decimal_places > decimal_places:
+        if (decimal_places > decimal_places) and (normalized_decimal_places > decimal_places):
             raise PydanticKnownError(
                 'decimal_max_places',
                 {'decimal_places': decimal_places},

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -347,7 +347,9 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
     of the number of decimals and digits together.
     """
     decimal_tuple = decimal.as_tuple()
-    exponent = int(decimal_tuple.exponent)
+    if not isinstance(decimal_tuple.exponent, int):
+        raise TypeError(f'Unable to extract decimal digits info from supplied value {decimal}')
+    exponent = decimal_tuple.exponent
     num_digits = len(decimal_tuple.digits)
 
     if exponent >= 0:

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -388,11 +388,11 @@ def max_digits_validator(x: Any, max_digits: Any) -> Any:
 
 
 def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
-    decimal_places, _ = _extract_decimal_digits_info(x)
+    decimal_places_, _ = _extract_decimal_digits_info(x)
     normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize())
 
     try:
-        if (decimal_places > decimal_places) and (normalized_decimal_places > decimal_places):
+        if (decimal_places_ > decimal_places) and (normalized_decimal_places > decimal_places):
             raise PydanticKnownError(
                 'decimal_max_places',
                 {'decimal_places': decimal_places},

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -361,14 +361,16 @@ def _extract_decimal_digits_info(decimal: Decimal, normalized: bool) -> tuple[in
 
     if exponent >= 0:
         # A positive exponent adds that many trailing zeros
+        # Ex: digit_tuple=(1, 2, 3), exponent=2 -> 12300 -> 0 decimal places, 5 digits
         digits += exponent
         decimal_places = 0
     else:
-        #  If the absolute value of the negative exponent is larger than the
-        #  number of digits, then it's the same as the number of digits,
-        #  because it'll consume all the digits in digit_tuple and then
-        #  add abs(exponent) - len(digit_tuple) leading zeros after the
-        #  decimal point.
+        # If the absolute value of the negative exponent is larger than the
+        # number of digits, then it's the same as the number of digits,
+        # because it'll consume all the digits in digit_tuple and then
+        # add abs(exponent) - len(digit_tuple) leading zeros after the decimal point.
+        # Ex: digit_tuple=(1, 2, 3), exponent=-2 -> 1.23 -> 2 decimal places, 3 digits
+        # Ex: digit_tuple=(1, 2, 3), exponent=-4 -> 0.0123 -> 4 decimal places, 4 digits
         decimal_places = abs(exponent)
         digits = max(digits, decimal_places)
 

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -343,21 +343,17 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
     Returns:
         tuple[int, int]: A tuple containing the number of decimal places and total digits.
 
-    Modeled after the `pydanitc-core` implementation of this function.
-    See https://github.com/pydantic/pydantic-core/blob/f389728432949ecceddecb1f59bb503b0998e9aa/src/validators/decimal.rs#L85.
-
     Though this could be divided into two separate functions, the logic is easier to follow if we couple the computation
     of the number of decimals and digits together.
     """
-    _, digit_tuple, exponent = decimal.as_tuple()
-
-    exponent = int(exponent)
-    digits = len(digit_tuple)
+    decimal_tuple = decimal.as_tuple()
+    exponent = int(decimal_tuple.exponent)
+    num_digits = len(decimal_tuple.digits)
 
     if exponent >= 0:
         # A positive exponent adds that many trailing zeros
         # Ex: digit_tuple=(1, 2, 3), exponent=2 -> 12300 -> 0 decimal places, 5 digits
-        digits += exponent
+        num_digits += exponent
         decimal_places = 0
     else:
         # If the absolute value of the negative exponent is larger than the
@@ -367,17 +363,17 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
         # Ex: digit_tuple=(1, 2, 3), exponent=-2 -> 1.23 -> 2 decimal places, 3 digits
         # Ex: digit_tuple=(1, 2, 3), exponent=-4 -> 0.0123 -> 4 decimal places, 4 digits
         decimal_places = abs(exponent)
-        digits = max(digits, decimal_places)
+        num_digits = max(num_digits, decimal_places)
 
-    return decimal_places, digits
+    return decimal_places, num_digits
 
 
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
-    _, digits = _extract_decimal_digits_info(x)
-    _, normalized_digits = _extract_decimal_digits_info(x.normalize())
+    _, num_digits = _extract_decimal_digits_info(x)
+    _, normalized_num_digits = _extract_decimal_digits_info(x.normalize())
 
     try:
-        if (digits > max_digits) and (normalized_digits > max_digits):
+        if (num_digits > max_digits) and (normalized_num_digits > max_digits):
             raise PydanticKnownError(
                 'decimal_max_digits',
                 {'max_digits': max_digits},

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import sys
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any, Callable, Generic, Iterator, List, Optional, Set, TypeVar
 
 import pytest
@@ -644,3 +645,18 @@ def test_compatible_metadata_raises_correct_validation_error() -> None:
     ta = TypeAdapter(Annotated[str, BeforeValidator(lambda x: x), Field(pattern='abc')])
     with pytest.raises(ValidationError, match="String should match pattern 'abc'"):
         ta.validate_python('def')
+
+
+def test_decimal_constraints_after_annotation() -> None:
+    DecimalAnnotation = Annotated[Decimal, BeforeValidator(lambda v: v), Field(max_digits=10, decimal_places=4)]
+
+    ta = TypeAdapter(DecimalAnnotation)
+    assert ta.validate_python(Decimal('123.4567')) == Decimal('123.4567')
+
+    with pytest.raises(ValidationError) as e:
+        ta.validate_python(Decimal('123.45678'))
+        assert e.value.errors()[0]['type'] == 'decimal_max_places'
+
+    with pytest.raises(ValidationError) as e:
+        ta.validate_python(Decimal('12345678.901'))
+        assert e.value.errors()[0]['type'] == 'decimal_max_digits'

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -655,8 +655,10 @@ def test_decimal_constraints_after_annotation() -> None:
 
     with pytest.raises(ValidationError) as e:
         ta.validate_python(Decimal('123.45678'))
-        assert e.value.errors()[0]['type'] == 'decimal_max_places'
+
+    assert e.value.errors()[0]['type'] == 'decimal_max_places'
 
     with pytest.raises(ValidationError) as e:
         ta.validate_python(Decimal('12345678.901'))
-        assert e.value.errors()[0]['type'] == 'decimal_max_digits'
+
+    assert e.value.errors()[0]['type'] == 'decimal_max_digits'

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -212,14 +212,19 @@ def test_schema_is_valid():
 
 
 @pytest.mark.parametrize(
-    'decimal,decimal_places,digits',
+    'decimal,normalize,decimal_places,digits',
     [
-        (Decimal('0.0'), 0, 1),
-        (Decimal('0.000'), 0, 1),
-        (Decimal('0.0001'), 4, 4),
-        (Decimal('123.123'), 3, 6),
-        (Decimal('123.1230'), 3, 6),
+        (Decimal('0.0'), False, 1, 1),
+        (Decimal('0.0'), True, 0, 1),
+        (Decimal('0.000'), False, 3, 3),
+        (Decimal('0.000'), True, 0, 1),
+        (Decimal('0.0001'), False, 4, 4),
+        (Decimal('0.0001'), True, 4, 4),
+        (Decimal('123.123'), False, 3, 6),
+        (Decimal('123.123'), True, 3, 6),
+        (Decimal('123.1230'), False, 4, 7),
+        (Decimal('123.1230'), True, 3, 6),
     ],
 )
-def test_decimal_digits_calculation(decimal: Decimal, decimal_places: int, digits: int) -> None:
-    assert _extract_decimal_digits_info(decimal.normalize()) == (decimal_places, digits)
+def test_decimal_digits_calculation(decimal: Decimal, normalize: bool, decimal_places: int, digits: int) -> None:
+    assert _extract_decimal_digits_info(decimal, normalize) == (decimal_places, digits)

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -227,4 +227,4 @@ def test_schema_is_valid():
     ],
 )
 def test_decimal_digits_calculation(decimal: Decimal, normalize: bool, decimal_places: int, digits: int) -> None:
-    assert _extract_decimal_digits_info(decimal, normalize) == (decimal_places, digits)
+    assert _extract_decimal_digits_info(decimal.normalize() if normalize else decimal) == (decimal_places, digits)

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -212,19 +212,14 @@ def test_schema_is_valid():
 
 
 @pytest.mark.parametrize(
-    'decimal,normalize,decimal_places,digits',
+    'decimal,decimal_places,digits',
     [
-        (Decimal('0.0'), False, 1, 1),
-        (Decimal('0.0'), True, 0, 1),
-        (Decimal('0.000'), False, 3, 3),
-        (Decimal('0.000'), True, 0, 1),
-        (Decimal('0.0001'), False, 4, 4),
-        (Decimal('0.0001'), True, 4, 4),
-        (Decimal('123.123'), False, 3, 6),
-        (Decimal('123.123'), True, 3, 6),
-        (Decimal('123.1230'), False, 4, 7),
-        (Decimal('123.1230'), True, 3, 6),
+        (Decimal('0.0'), 0, 1),
+        (Decimal('0.000'), 0, 1),
+        (Decimal('0.0001'), 4, 4),
+        (Decimal('123.123'), 3, 6),
+        (Decimal('123.1230'), 3, 6),
     ],
 )
-def test_decimal_digits_calculation(decimal: Decimal, normalize: bool, decimal_places: int, digits: int) -> None:
-    assert _extract_decimal_digits_info(decimal, normalize) == (decimal_places, digits)
+def test_decimal_digits_calculation(decimal: Decimal, decimal_places: int, digits: int) -> None:
+    assert _extract_decimal_digits_info(decimal.normalize()) == (decimal_places, digits)

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -212,19 +212,16 @@ def test_schema_is_valid():
 
 
 @pytest.mark.parametrize(
-    'decimal,normalize,decimal_places,digits',
+    'decimal,decimal_places,digits',
     [
-        (Decimal('0.0'), False, 1, 1),
-        (Decimal('0.0'), True, 0, 1),
-        (Decimal('0.000'), False, 3, 3),
-        (Decimal('0.000'), True, 0, 1),
-        (Decimal('0.0001'), False, 4, 4),
-        (Decimal('0.0001'), True, 4, 4),
-        (Decimal('123.123'), False, 3, 6),
-        (Decimal('123.123'), True, 3, 6),
-        (Decimal('123.1230'), False, 4, 7),
-        (Decimal('123.1230'), True, 3, 6),
+        (Decimal('0.0'), 1, 1),
+        (Decimal('0.'), 0, 1),
+        (Decimal('0.000'), 3, 3),
+        (Decimal('0.0001'), 4, 4),
+        (Decimal('.0001'), 4, 4),
+        (Decimal('123.123'), 3, 6),
+        (Decimal('123.1230'), 4, 7),
     ],
 )
-def test_decimal_digits_calculation(decimal: Decimal, normalize: bool, decimal_places: int, digits: int) -> None:
-    assert _extract_decimal_digits_info(decimal.normalize() if normalize else decimal) == (decimal_places, digits)
+def test_decimal_digits_calculation(decimal: Decimal, decimal_places: int, digits: int) -> None:
+    assert _extract_decimal_digits_info(decimal) == (decimal_places, digits)


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/10498

This specifically addresses issues where there is annotated metadata applied between the type and the decimal constraints.

For this sample:

```py
import decimal
from pydantic import BaseModel, Field, BeforeValidator, ValidationError
from typing import Annotated

DecimalAnnotation = Annotated[decimal.Decimal, BeforeValidator(lambda v: v)]


class ExampleSchema(BaseModel):
    example_value: Annotated[DecimalAnnotation, Field(max_digits=10, decimal_places=4)] | None

e = ExampleSchema(example_value=decimal.Decimal('123.4567'))

try:
    ExampleSchema(example_value=decimal.Decimal('123.45678'))
except ValidationError as e:
    print(e)
    """
    example_value
    Decimal input should have no more than 4 decimal places [type=decimal_max_places, input_value=Decimal('123.45678'), input_type=Decimal]
        For further information visit https://errors.pydantic.dev/2.10/v/decimal_max_places
    """

try:
    ExampleSchema(example_value=decimal.Decimal('12345678.901'))
except ValidationError as e:
    print(e)
    """
    example_value
    Decimal input should have no more than 10 digits in total [type=decimal_max_digits, input_value=Decimal('12345678.901'), input_type=Decimal]
        For further information visit https://errors.pydantic.dev/2.10/v/decimal_max_digits
    """
```

The output used to be:

```py
  File "/Users/programming/pydantic_work/pydantic/pydantic/_internal/_known_annotated_metadata.py", line 293, in apply_known_metadata
    raise RuntimeError(f"Unable to apply constraint '{constraint}' to schema of type '{schema_type}'")
RuntimeError: Unable to apply constraint 'max_digits' to schema of type 'function-before'
```