### PR TITLE
Fix handling of `Literal` in `has_instance_in_type`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1265,7 +1265,7 @@ class GenerateSchema:
         # Update FieldInfo annotation if appropriate:
         FieldInfo = import_cached_field_info()
 
-        if has_instance_in_type(field_info.annotation, ForwardRef):
+        if has_instance_in_type(field_info.annotation, (ForwardRef, str)):
             types_namespace = self._types_namespace
             if self._typevars_map:
                 types_namespace = (types_namespace or {}).copy()

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -14,7 +14,7 @@ import typing_extensions
 
 from ._core_utils import get_type_ref
 from ._forward_ref import PydanticRecursiveRef
-from ._typing_extra import TypeVarType, typing_base
+from ._typing_extra import LITERAL_TYPES, TypeVarType, typing_base
 from ._utils import all_identical, is_model_class
 
 if sys.version_info >= (3, 10):
@@ -357,6 +357,8 @@ def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
     if origin_type is typing_extensions.Annotated:
         annotated_type, *annotations = type_args
         return has_instance_in_type(annotated_type, isinstance_target)
+    elif origin_type in LITERAL_TYPES:
+        return False
 
     # Having type args is a good indicator that this is a typing module
     # class instantiation or a generic alias of some sort.

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -100,6 +100,8 @@ def literal_values(type_: type[Any]) -> tuple[Any, ...]:
     return get_args(type_)
 
 
+# TODO remove when we drop support for Python 3.8
+# (see https://docs.python.org/3/whatsnew/3.9.html#id4).
 def all_literal_values(type_: type[Any]) -> list[Any]:
     """This method is used to retrieve all Literal values as
     Literal can be used recursively (see https://www.python.org/dev/peps/pep-0586)


### PR DESCRIPTION
Also add a comment about a method that will become unnecessary when we drop support for Python 3.8.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Reverts https://github.com/pydantic/pydantic/pull/10317, as it turns out my analysis was wrong: `list["forward"]` does not result in `"forward"` being wrapped in a `ForwardRef` instance.

I updated the logic of the function to not check for literals, so we at least get a more accurate output for this function.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
