### PR TITLE
Only fetch `__pydantic_core_schema__` from the current class during schema generation

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -813,9 +813,12 @@ class GenerateSchema:
                 source, CallbackGetCoreSchemaHandler(self._generate_schema_inner, self, ref_mode=ref_mode)
             )
         elif (
-            (existing_schema := getattr(obj, '__pydantic_core_schema__', None)) is not None
+            hasattr(obj, '__dict__')
+            # In some cases (e.g. a stdlib dataclass subclassing a Pydantic dataclass),
+            # doing an attribute access to get the schema will result in the parent schema
+            # being fetched. Thus, only look for the current obj's dict:
+            and (existing_schema := obj.__dict__.get('__pydantic_core_schema__')) is not None
             and not isinstance(existing_schema, MockCoreSchema)
-            and existing_schema.get('cls', None) is obj
         ):
             schema = existing_schema
         elif (validators := getattr(obj, '__get_validators__', None)) is not None:


### PR DESCRIPTION
In some cases, the core schema of a class is not the right one:

```python
from pydantic.dataclasses import dataclass as pd_dc

from dataclasses import dataclass as stdlib_dc

@pd_dc
class A:
    a: int

@stdlib_dc
class B(A):
    b: str

B.__pydantic_core_schema__
#> Core schema of `A`
```

Until now, we had the `existing_schema.get('cls', None) is obj` check to avoid incorrectly using the core schema in this case. However, this doesn't work if the core schema is of type `definitions`, in which case `existing_schema.get('cls', None) is obj` is `False` even though it is the correct schema. This was found during the ns refactor.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
