### PR TITLE
Fix `stacklevel` on deprecation warnings for `BaseModel`

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -351,7 +351,9 @@ class ModelMetaclass(ABCMeta):
     @deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.', category=None)
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn(
-            'The `__fields__` attribute is deprecated, use `model_fields` instead.', PydanticDeprecatedSince20
+            'The `__fields__` attribute is deprecated, use `model_fields` instead.',
+            PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         return self.model_fields
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1116,7 +1116,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     )
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn(
-            'The `__fields__` attribute is deprecated, use `model_fields` instead.', category=PydanticDeprecatedSince20
+            'The `__fields__` attribute is deprecated, use `model_fields` instead.',
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         return self.model_fields
 
@@ -1129,6 +1131,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The `__fields_set__` attribute is deprecated, use `model_fields_set` instead.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         return self.__pydantic_fields_set__
 
@@ -1143,7 +1146,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> Dict[str, Any]:  # noqa UP006
-        warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', category=PydanticDeprecatedSince20)
+        warnings.warn(
+            'The `dict` method is deprecated; use `model_dump` instead.',
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
+        )
         return self.model_dump(
             include=include,
             exclude=exclude,
@@ -1168,7 +1175,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         **dumps_kwargs: Any,
     ) -> str:
         warnings.warn(
-            'The `json` method is deprecated; use `model_dump_json` instead.', category=PydanticDeprecatedSince20
+            'The `json` method is deprecated; use `model_dump_json` instead.',
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         if encoder is not PydanticUndefined:
             raise TypeError('The `encoder` argument is no longer supported; use field serializers instead.')
@@ -1189,7 +1198,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The `parse_obj` method is deprecated; use `model_validate` instead.', category=None)
     def parse_obj(cls, obj: Any) -> Self:  # noqa: D102
         warnings.warn(
-            'The `parse_obj` method is deprecated; use `model_validate` instead.', category=PydanticDeprecatedSince20
+            'The `parse_obj` method is deprecated; use `model_validate` instead.',
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         return cls.model_validate(obj)
 
@@ -1212,6 +1223,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             'The `parse_raw` method is deprecated; if your data is JSON use `model_validate_json`, '
             'otherwise load the data then use `model_validate` instead.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         from .deprecated import parse
 
@@ -1265,6 +1277,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             'The `parse_file` method is deprecated; load the data from file, then if your data is JSON '
             'use `model_validate_json`, otherwise `model_validate` instead.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         from .deprecated import parse
 
@@ -1288,6 +1301,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             'The `from_orm` method is deprecated; set '
             "`model_config['from_attributes']=True` and use `model_validate` instead.",
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         if not cls.model_config.get('from_attributes', None):
             raise PydanticUserError(
@@ -1299,7 +1313,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The `construct` method is deprecated; use `model_construct` instead.', category=None)
     def construct(cls, _fields_set: set[str] | None = None, **values: Any) -> Self:  # noqa: D102
         warnings.warn(
-            'The `construct` method is deprecated; use `model_construct` instead.', category=PydanticDeprecatedSince20
+            'The `construct` method is deprecated; use `model_construct` instead.',
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         return cls.model_construct(_fields_set=_fields_set, **values)
 
@@ -1342,6 +1358,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             'The `copy` method is deprecated; use `model_copy` instead. '
             'See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         from .deprecated import copy_internals
 
@@ -1385,7 +1402,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         cls, by_alias: bool = True, ref_template: str = DEFAULT_REF_TEMPLATE
     ) -> Dict[str, Any]:  # noqa UP006
         warnings.warn(
-            'The `schema` method is deprecated; use `model_json_schema` instead.', category=PydanticDeprecatedSince20
+            'The `schema` method is deprecated; use `model_json_schema` instead.',
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         return cls.model_json_schema(by_alias=by_alias, ref_template=ref_template)
 
@@ -1400,6 +1419,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The `schema_json` method is deprecated; use `model_json_schema` and json.dumps instead.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         import json
 
@@ -1415,7 +1435,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @typing_extensions.deprecated('The `validate` method is deprecated; use `model_validate` instead.', category=None)
     def validate(cls, value: Any) -> Self:  # noqa: D102
         warnings.warn(
-            'The `validate` method is deprecated; use `model_validate` instead.', category=PydanticDeprecatedSince20
+            'The `validate` method is deprecated; use `model_validate` instead.',
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         return cls.model_validate(value)
 
@@ -1428,6 +1450,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The `update_forward_refs` method is deprecated; use `model_rebuild` instead.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         if localns:  # pragma: no cover
             raise TypeError('`localns` arguments are not longer accepted.')
@@ -1440,6 +1463,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The private method `_iter` will be removed and should no longer be used.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         from .deprecated import copy_internals
 
@@ -1453,6 +1477,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The private method `_copy_and_set_values` will be removed and should no longer be used.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         from .deprecated import copy_internals
 
@@ -1467,6 +1492,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The private method `_get_value` will be removed and should no longer be used.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         from .deprecated import copy_internals
 
@@ -1480,6 +1506,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         warnings.warn(
             'The private method `_calculate_keys` will be removed and should no longer be used.',
             category=PydanticDeprecatedSince20,
+            stacklevel=2,
         )
         from .deprecated import copy_internals
 


### PR DESCRIPTION
Warnings now display when deprecated attributes are accessed :)