### PR TITLE
Refactor namespace logic for annotations evaluation

### DIFF
--- a/docs/concepts/experimental.md
+++ b/docs/concepts/experimental.md
@@ -51,7 +51,7 @@ from datetime import datetime
 from typing_extensions import Annotated
 
 from pydantic import BaseModel
-from pydantic.experimental.pipeline import validate_as, validate_as_deferred
+from pydantic.experimental.pipeline import validate_as
 
 
 class User(BaseModel):
@@ -71,10 +71,6 @@ class User(BaseModel):
         ),
     ]
     friends: Annotated[list[User], validate_as(...).len(0, 100)]  # (6)!
-    family: Annotated[  # (7)!
-        list[User],
-        validate_as_deferred(lambda: list[User]).transform(lambda x: x[1:]),
-    ]
     bio: Annotated[
         datetime,
         validate_as(int)
@@ -89,8 +85,7 @@ class User(BaseModel):
 4. You can also use the lower level transform, constrain and predicate methods.
 5. Use the `|` or `&` operators to combine steps (like a logical OR or AND).
 6. Calling `validate_as(...)` with `Ellipsis`, `...` as the first positional argument implies `validate_as(<field type>)`. Use `validate_as(Any)` to accept any type.
-7. For recursive types you can use `validate_as_deferred` to reference the type itself before it's defined.
-8. You can call `validate_as()` before or after other steps to do pre or post processing.
+7. You can call `validate_as()` before or after other steps to do pre or post processing.
 
 ### Mapping from `BeforeValidator`, `AfterValidator` and `WrapValidator`
 

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -112,7 +112,8 @@ def complete_dataclass(
         parent_namespace: Extra namespace to use as locals, with lowest priority.
             This is provided in most cases as the locals of a function, where the dataclass
             is defined.
-        ns_resolver: The namespace resolver instance to use during schema building.
+        ns_resolver: The namespace resolver instance to use when collecting dataclass fields
+            and during schema building.
         _force_build: Whether to force building the dataclass, no matter if
             [`defer_build`][pydantic.config.ConfigDict.defer_build] is set.
 

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -24,7 +24,7 @@ from ._fields import collect_dataclass_fields
 from ._generate_schema import GenerateSchema
 from ._generics import get_standard_typevars_map
 from ._mock_val_ser import set_dataclass_mocks
-from ._namespace_utils import MappingNamespace, NsResolver
+from ._namespace_utils import NsResolver
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
 
@@ -71,21 +71,21 @@ else:
 
 def set_dataclass_fields(
     cls: type[StandardDataclass],
-    parent_namespace: MappingNamespace | None = None,
+    ns_resolver: NsResolver | None = None,
     config_wrapper: _config.ConfigWrapper | None = None,
 ) -> None:
     """Collect and set `cls.__pydantic_fields__`.
 
     Args:
         cls: The class.
-        parent_namespace: Extra namespace to use as locals, with lowest priority.
+        ns_resolver: Extra namespace to use as locals, with lowest priority.
             This is provided in most cases as the locals of a function, where the dataclass
             is defined.
         config_wrapper: The config wrapper instance, defaults to `None`.
     """
     typevars_map = get_standard_typevars_map(cls)
     fields = collect_dataclass_fields(
-        cls, parent_namespace=parent_namespace, typevars_map=typevars_map, config_wrapper=config_wrapper
+        cls, ns_resolver=ns_resolver, typevars_map=typevars_map, config_wrapper=config_wrapper
     )
 
     cls.__pydantic_fields__ = fields  # type: ignore
@@ -96,7 +96,6 @@ def complete_dataclass(
     config_wrapper: _config.ConfigWrapper,
     *,
     raise_errors: bool = True,
-    parent_namespace: MappingNamespace | None = None,
     ns_resolver: NsResolver | None = None,
     _force_build: bool = False,
 ) -> bool:
@@ -146,7 +145,7 @@ def complete_dataclass(
             'Support for `__post_init_post_parse__` has been dropped, the method will not be called', DeprecationWarning
         )
 
-    set_dataclass_fields(cls, parent_namespace, config_wrapper=config_wrapper)
+    set_dataclass_fields(cls, ns_resolver, config_wrapper=config_wrapper)
 
     typevars_map = get_standard_typevars_map(cls)
     gen_schema = GenerateSchema(

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -19,20 +19,23 @@ from typing_extensions import TypeGuard
 from ..errors import PydanticUndefinedAnnotation
 from ..plugin._schema_validator import PluggableSchemaValidator, create_schema_validator
 from ..warnings import PydanticDeprecatedSince20
-from . import _config, _decorators, _typing_extra
+from . import _config, _decorators
 from ._fields import collect_dataclass_fields
 from ._generate_schema import GenerateSchema
 from ._generics import get_standard_typevars_map
 from ._mock_val_ser import set_dataclass_mocks
+from ._namespace_utils import MappingNamespace, NsResolver
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
 
 if typing.TYPE_CHECKING:
+    from dataclasses import Field
+
     from ..config import ConfigDict
     from ..fields import FieldInfo
 
     class StandardDataclass(typing.Protocol):
-        __dataclass_fields__: ClassVar[dict[str, Any]]
+        __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
         __dataclass_params__: ClassVar[Any]  # in reality `dataclasses._DataclassParams`
         __post_init__: ClassVar[Callable[..., None]]
 
@@ -68,18 +71,22 @@ else:
 
 def set_dataclass_fields(
     cls: type[StandardDataclass],
-    types_namespace: dict[str, Any] | None = None,
+    parent_namespace: MappingNamespace | None = None,
     config_wrapper: _config.ConfigWrapper | None = None,
 ) -> None:
     """Collect and set `cls.__pydantic_fields__`.
 
     Args:
         cls: The class.
-        types_namespace: The types namespace, defaults to `None`.
+        parent_namespace: Extra namespace to use as locals, with lowest priority.
+            This is provided in most cases as the locals of a function, where the dataclass
+            is defined.
         config_wrapper: The config wrapper instance, defaults to `None`.
     """
     typevars_map = get_standard_typevars_map(cls)
-    fields = collect_dataclass_fields(cls, types_namespace, typevars_map=typevars_map, config_wrapper=config_wrapper)
+    fields = collect_dataclass_fields(
+        cls, parent_namespace=parent_namespace, typevars_map=typevars_map, config_wrapper=config_wrapper
+    )
 
     cls.__pydantic_fields__ = fields  # type: ignore
 
@@ -89,7 +96,8 @@ def complete_dataclass(
     config_wrapper: _config.ConfigWrapper,
     *,
     raise_errors: bool = True,
-    types_namespace: dict[str, Any] | None,
+    parent_namespace: MappingNamespace | None = None,
+    ns_resolver: NsResolver | None = None,
     _force_build: bool = False,
 ) -> bool:
     """Finish building a pydantic dataclass.
@@ -102,7 +110,10 @@ def complete_dataclass(
         cls: The class.
         config_wrapper: The config wrapper instance.
         raise_errors: Whether to raise errors, defaults to `True`.
-        types_namespace: The types namespace.
+        parent_namespace: Extra namespace to use as locals, with lowest priority.
+            This is provided in most cases as the locals of a function, where the dataclass
+            is defined.
+        ns_resolver: The namespace resolver instance to use during schema building.
         _force_build: Whether to force building the dataclass, no matter if
             [`defer_build`][pydantic.config.ConfigDict.defer_build] is set.
 
@@ -135,16 +146,13 @@ def complete_dataclass(
             'Support for `__post_init_post_parse__` has been dropped, the method will not be called', DeprecationWarning
         )
 
-    if types_namespace is None:
-        types_namespace = _typing_extra.merge_cls_and_parent_ns(cls)
-
-    set_dataclass_fields(cls, types_namespace, config_wrapper=config_wrapper)
+    set_dataclass_fields(cls, parent_namespace, config_wrapper=config_wrapper)
 
     typevars_map = get_standard_typevars_map(cls)
     gen_schema = GenerateSchema(
         config_wrapper,
-        types_namespace,
-        typevars_map,
+        ns_resolver=ns_resolver,
+        typevars_map=typevars_map,
     )
 
     # This needs to be called before we change the __init__

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -78,9 +78,7 @@ def set_dataclass_fields(
 
     Args:
         cls: The class.
-        ns_resolver: Extra namespace to use as locals, with lowest priority.
-            This is provided in most cases as the locals of a function, where the dataclass
-            is defined.
+        ns_resolver: Namespace resolver to use when getting dataclass annotations.
         config_wrapper: The config wrapper instance, defaults to `None`.
     """
     typevars_map = get_standard_typevars_map(cls)
@@ -109,9 +107,6 @@ def complete_dataclass(
         cls: The class.
         config_wrapper: The config wrapper instance.
         raise_errors: Whether to raise errors, defaults to `True`.
-        parent_namespace: Extra namespace to use as locals, with lowest priority.
-            This is provided in most cases as the locals of a function, where the dataclass
-            is defined.
         ns_resolver: The namespace resolver instance to use when collecting dataclass fields
             and during schema building.
         _force_build: Whether to force building the dataclass, no matter if

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -15,6 +15,7 @@ from typing_extensions import Literal, TypeAlias, is_typeddict
 from ..errors import PydanticUserError
 from ._core_utils import get_type_ref
 from ._internal_dataclass import slots_true
+from ._namespace_utils import GlobalsNamespace, MappingNamespace
 from ._typing_extra import get_function_type_hints
 
 if TYPE_CHECKING:
@@ -752,7 +753,10 @@ def unwrap_wrapped_function(
 
 
 def get_function_return_type(
-    func: Any, explicit_return_type: Any, types_namespace: dict[str, Any] | None = None
+    func: Any,
+    explicit_return_type: Any,
+    globalns: GlobalsNamespace | None = None,
+    localns: MappingNamespace | None = None,
 ) -> Any:
     """Get the function return type.
 
@@ -762,7 +766,8 @@ def get_function_return_type(
     Args:
         func: The function to get its return type.
         explicit_return_type: The explicit return type.
-        types_namespace: The types namespace, defaults to `None`.
+        globalns: The globals namespace to use during type annotation evaluation.
+        localns: The locals namespace to use during type annotation evaluation.
 
     Returns:
         The function return type.
@@ -770,7 +775,10 @@ def get_function_return_type(
     if explicit_return_type is PydanticUndefined:
         # try to get it from the type annotation
         hints = get_function_type_hints(
-            unwrap_wrapped_function(func), include_keys={'return'}, types_namespace=types_namespace
+            unwrap_wrapped_function(func),
+            include_keys={'return'},
+            globalns=globalns,
+            localns=localns,
         )
         return hints.get('return', PydanticUndefined)
     else:

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -278,7 +278,7 @@ def collect_dataclass_fields(
 
     Args:
         cls: dataclass.
-        ns_resolver: Namespace resolver to use when getting model annotations.
+        ns_resolver: Namespace resolver to use when getting dataclass annotations.
             Defaults to an empty instance.
         typevars_map: A dictionary mapping type variables to their concrete types.
         config_wrapper: The config wrapper instance.
@@ -290,6 +290,7 @@ def collect_dataclass_fields(
 
     fields: dict[str, FieldInfo] = {}
     ns_resolver = ns_resolver or NsResolver()
+    dataclass_fields = cls.__dataclass_fields__
 
     # The logic here is similar to `_typing_extra.get_cls_type_hints`,
     # although we do it manually as stdlib dataclasses already have annotations
@@ -297,8 +298,6 @@ def collect_dataclass_fields(
     for base in reversed(cls.__mro__):
         if not _typing_extra.is_dataclass(base):
             continue
-
-        dataclass_fields = cls.__dataclass_fields__
 
         with ns_resolver.push(base):
             for ann_name, dataclass_field in dataclass_fields.items():

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -295,7 +295,7 @@ def collect_dataclass_fields(
 
     # The logic here is similar to `_typing_extra.get_cls_type_hints_lenient`,
     # although we do it manually as stdlib dataclasses already have annotations
-    # collected in each field:
+    # collected in each class:
     for base in reversed(cls.__mro__):
         if not _typing_extra.is_dataclass(base):
             continue

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -234,7 +234,7 @@ def collect_model_fields(  # noqa: C901
 
     if typevars_map:
         for field in fields.values():
-            field.apply_typevars_map(typevars_map, {})
+            field.apply_typevars_map(typevars_map)
 
     _update_fields_from_docstrings(cls, fields, config_wrapper)
     return fields, class_vars
@@ -346,10 +346,10 @@ def collect_dataclass_fields(
 
     if typevars_map:
         for field in fields.values():
-            # We pass an empty ns, as `field.annotation`
+            # We don't pass any ns, as `field.annotation`
             # was already evaluated. TODO: is this method relevant?
             # Can't we juste use `_generics.replace_types`?
-            field.apply_typevars_map(typevars_map, {})
+            field.apply_typevars_map(typevars_map)
 
     if config_wrapper is not None:
         _update_fields_from_docstrings(cls, fields, config_wrapper)

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -87,9 +87,7 @@ def collect_model_fields(  # noqa: C901
         cls: BaseModel or dataclass.
         bases: Parents of the class, generally `cls.__bases__`.
         config_wrapper: The config wrapper instance.
-        ns_resolver: Extra namespace to use as locals, with lowest priority.
-            This is provided in most cases as the locals of a function, where the model
-            is defined.
+        ns_resolver: Namespace resolver to use when getting model annotations.
         typevars_map: A dictionary mapping type variables to their concrete types.
 
     Returns:
@@ -280,9 +278,8 @@ def collect_dataclass_fields(
 
     Args:
         cls: dataclass.
-        parent_namespace: Extra namespace to use as locals, with lowest priority.
-            This is provided in most cases as the locals of a function, where the dataclass
-            is defined.
+        ns_resolver: Namespace resolver to use when getting model annotations.
+            Defaults to an empty instance.
         typevars_map: A dictionary mapping type variables to their concrete types.
         config_wrapper: The config wrapper instance.
 

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -301,7 +301,7 @@ def collect_dataclass_fields(
 
         with ns_resolver.push(base):
             for ann_name, dataclass_field in dataclass_fields.items():
-                if ann_name not in base.__annotations__:
+                if ann_name not in base.__dict__.get('__annotations__', {}):
                     # `__dataclass_fields__`contains every field, even the ones from base classes.
                     # Only collect the ones defined on `base`.
                     continue

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1458,9 +1458,12 @@ class GenerateSchema:
                 else:
                     field_docstrings = None
 
-                for field_name, annotation in get_cls_type_hints(
-                    typed_dict_cls, ns_resolver=self._ns_resolver, lenient=False
-                ).items():
+                try:
+                    annotations = get_cls_type_hints(typed_dict_cls, ns_resolver=self._ns_resolver, lenient=False)
+                except NameError as e:
+                    raise PydanticUndefinedAnnotation.from_name_error(e) from e
+
+                for field_name, annotation in annotations.items():
                     annotation = replace_types(annotation, typevars_map)
                     required = field_name in required_keys
 
@@ -1522,9 +1525,10 @@ class GenerateSchema:
             if origin is not None:
                 namedtuple_cls = origin
 
-            annotations: dict[str, Any] = get_cls_type_hints(
-                namedtuple_cls, ns_resolver=self._ns_resolver, lenient=False
-            )
+            try:
+                annotations = get_cls_type_hints(namedtuple_cls, ns_resolver=self._ns_resolver, lenient=False)
+            except NameError as e:
+                raise PydanticUndefinedAnnotation.from_name_error(e) from e
             if not annotations:
                 # annotations is empty, happens if namedtuple_cls defined via collections.namedtuple(...)
                 annotations = {k: Any for k in namedtuple_cls._fields}

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1245,8 +1245,7 @@ class GenerateSchema:
         # Update FieldInfo annotation if appropriate:
         FieldInfo = import_cached_field_info()
         if has_instance_in_type(field_info.annotation, (ForwardRef, str)):
-
-            # Can we use field_info.apply_typevars_map here? Shouldn't we error if we encounter name errors here?
+            # TODO Can we use field_info.apply_typevars_map here? Shouldn't we error if we encounter name errors here?
             evaluated = _typing_extra.eval_type_lenient(field_info.annotation, *self._types_namespace)
             evaluated = replace_types(evaluated, self._typevars_map)
             if evaluated is not field_info.annotation and not has_instance_in_type(evaluated, PydanticRecursiveRef):

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1756,7 +1756,7 @@ class GenerateSchema:
             if origin is not None:
                 dataclass = origin
 
-            config = getattr(dataclass, '__pydantic_config__', None)
+            config = getattr(dataclass, '__pydantic_config__', ConfigDict())
 
             from ..dataclasses import is_pydantic_dataclass
 
@@ -1772,7 +1772,6 @@ class GenerateSchema:
                         typevars_map=typevars_map,
                     )
 
-                # disallow combination of init=False on a dataclass field and extra='allow' on a dataclass
                 if self._config_wrapper.extra == 'allow':
                     # disallow combination of init=False on a dataclass field and extra='allow' on a dataclass
                     for field_name, field in fields.items():

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1838,7 +1838,8 @@ class GenerateSchema:
         """
         sig = signature(function)
 
-        type_hints = _typing_extra.get_function_type_hints(function, types_namespace=self._types_namespace)
+        globalns, localns = self._types_namespace
+        type_hints = _typing_extra.get_function_type_hints(function, globalns=globalns, localns=localns)
 
         mode_lookup: dict[_ParameterKind, Literal['positional_only', 'positional_or_keyword', 'keyword_only']] = {
             Parameter.POSITIONAL_ONLY: 'positional_only',

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1371,7 +1371,7 @@ class GenerateSchema:
 
     def _type_alias_type_schema(
         self,
-        obj: Any,  # TypeAliasType
+        obj: TypeAliasType,
     ) -> CoreSchema:
         with self.defs.get_schema_or_ref(obj) as (ref, maybe_schema):
             if maybe_schema is not None:

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -217,7 +217,7 @@ def get_origin(v: Any) -> Any:
     return typing_extensions.get_origin(v)
 
 
-def get_standard_typevars_map(cls: type[Any]) -> dict[TypeVarType, Any] | None:
+def get_standard_typevars_map(cls: Any) -> dict[TypeVarType, Any] | None:
     """Package a generic type's typevars and parametrization (if present) into a dictionary compatible with the
     `replace_types` function. Specifically, this works with standard typing generics and typing._GenericAlias.
     """

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -27,6 +27,7 @@ from ._generate_schema import GenerateSchema
 from ._generics import PydanticGenericMetadata, get_model_typevars_map
 from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._mock_val_ser import set_model_mocks
+from ._namespace_utils import MappingNamespace, NsResolver
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
 from ._typing_extra import (
@@ -34,7 +35,6 @@ from ._typing_extra import (
     eval_type_backport,
     is_annotated,
     is_classvar,
-    merge_cls_and_parent_ns,
     parent_frame_namespace,
 )
 from ._utils import ClassAttribute, SafeGetItemProxy
@@ -213,12 +213,11 @@ class ModelMetaclass(ABCMeta):
 
             if __pydantic_reset_parent_namespace__:
                 cls.__pydantic_parent_namespace__ = build_lenient_weakvaluedict(parent_frame_namespace())
-            parent_namespace = getattr(cls, '__pydantic_parent_namespace__', None)
+            parent_namespace: dict[str, Any] | None = getattr(cls, '__pydantic_parent_namespace__', None)
             if isinstance(parent_namespace, dict):
                 parent_namespace = unpack_lenient_weakvaluedict(parent_namespace)
 
-            types_namespace = merge_cls_and_parent_ns(cls, parent_namespace)
-            set_model_fields(cls, bases, config_wrapper, types_namespace)
+            set_model_fields(cls, bases, config_wrapper, parent_namespace)
 
             if config_wrapper.frozen and '__hash__' not in namespace:
                 set_default_hash_func(cls, bases)
@@ -228,7 +227,6 @@ class ModelMetaclass(ABCMeta):
                 cls_name,
                 config_wrapper,
                 raise_errors=False,
-                types_namespace=types_namespace,
                 create_model_module=_create_model_module,
             )
 
@@ -578,7 +576,10 @@ def make_hash_func(cls: type[BaseModel]) -> Any:
 
 
 def set_model_fields(
-    cls: type[BaseModel], bases: tuple[type[Any], ...], config_wrapper: ConfigWrapper, types_namespace: dict[str, Any]
+    cls: type[BaseModel],
+    bases: tuple[type[Any], ...],
+    config_wrapper: ConfigWrapper,
+    parent_namespace: MappingNamespace | None,
 ) -> None:
     """Collect and set `cls.__pydantic_fields__` and `cls.__class_vars__`.
 
@@ -586,10 +587,12 @@ def set_model_fields(
         cls: BaseModel or dataclass.
         bases: Parents of the class, generally `cls.__bases__`.
         config_wrapper: The config wrapper instance.
-        types_namespace: Optional extra namespace to look for types in.
+        parent_namespace: Extra namespace to use as locals, with lowest priority.
+            This is provided in most cases as the locals of a function, where the model
+            is defined.
     """
     typevars_map = get_model_typevars_map(cls)
-    fields, class_vars = collect_model_fields(cls, bases, config_wrapper, types_namespace, typevars_map=typevars_map)
+    fields, class_vars = collect_model_fields(cls, bases, config_wrapper, parent_namespace, typevars_map=typevars_map)
 
     cls.__pydantic_fields__ = fields
     cls.__class_vars__.update(class_vars)
@@ -613,7 +616,7 @@ def complete_model_class(
     config_wrapper: ConfigWrapper,
     *,
     raise_errors: bool = True,
-    types_namespace: dict[str, Any] | None,
+    ns_resolver: NsResolver | None = None,
     create_model_module: str | None = None,
 ) -> bool:
     """Finish building a model class.
@@ -626,7 +629,7 @@ def complete_model_class(
         cls_name: The model or dataclass name.
         config_wrapper: The config wrapper instance.
         raise_errors: Whether to raise errors.
-        types_namespace: Optional extra namespace to look for types in.
+        ns_resolver: The namespace resolver instance to use during schema building.
         create_model_module: The module of the class to be created, if created by `create_model`.
 
     Returns:
@@ -643,7 +646,7 @@ def complete_model_class(
     typevars_map = get_model_typevars_map(cls)
     gen_schema = GenerateSchema(
         config_wrapper,
-        types_namespace,
+        ns_resolver,
         typevars_map,
     )
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -590,9 +590,7 @@ def set_model_fields(
         cls: BaseModel or dataclass.
         bases: Parents of the class, generally `cls.__bases__`.
         config_wrapper: The config wrapper instance.
-        ns_resolver: Extra namespace to use as locals, with lowest priority.
-            This is provided in most cases as the locals of a function, where the model
-            is defined.
+        ns_resolver: Namespace resolver to use when getting model annotations.
     """
     typevars_map = get_model_typevars_map(cls)
     fields, class_vars = collect_model_fields(cls, bases, config_wrapper, ns_resolver, typevars_map=typevars_map)

--- a/pydantic/_internal/_namespace_utils.py
+++ b/pydantic/_internal/_namespace_utils.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Generator, Mapping
+from collections.abc import Generator
 from contextlib import contextmanager
 from functools import cached_property
-from typing import Any, Callable, Iterator, NamedTuple, TypeVar
+from typing import Any, Callable, Iterator, Mapping, NamedTuple, TypeVar
 
 from typing_extensions import TypeAlias, TypeAliasType
 

--- a/pydantic/_internal/_namespace_utils.py
+++ b/pydantic/_internal/_namespace_utils.py
@@ -151,7 +151,7 @@ class NsResolver:
     for the `parent_namespace` argument and the example for more details.
 
     Args:
-        namespaces_tuple: The default globals and locals to used if no class is present
+        namespaces_tuple: The default globals and locals to use if no class is present
             on the stack. This can be useful when using the `GenerateSchema` class
             with `TypeAdapter`, where the "type" being analyzed is a simple annotation.
         parent_namespace: An optional parent namespace that will be added to the locals
@@ -208,7 +208,7 @@ class NsResolver:
                 # is added to the locals, but it happens to be present in the globals as well
                 # because it is already defined.
                 # Third thing to notice: `Model` is also added in locals. This is a backwards
-                # compatibility workaround that allows for `Sub` to be resolve `'Model'`
+                # compatibility workaround that allows for `Sub` to be able to resolve `'Model'`
                 # correctly (as otherwise models would have to be rebuilt even though this
                 # doesn't look necessary).
         ```
@@ -227,7 +227,7 @@ class NsResolver:
     def types_namespace(self) -> NamespacesTuple:
         """The current global and local namespaces to be used for annotations evaluation."""
         if not self._types_stack:
-            # TODO do we want to merge fallback and override ns here?
+            # TODO do we want to merge `self._parent_ns` here?
             return self._base_ns_tuple
 
         typ = self._types_stack[-1]

--- a/pydantic/_internal/_namespace_utils.py
+++ b/pydantic/_internal/_namespace_utils.py
@@ -17,7 +17,8 @@ MappingNamespace: TypeAlias = Mapping[str, Any]
 """Any kind of namespace.
 
 In most cases, this is a local namespace (e.g. the `__dict__` attribute of a class,
-the [`f_locals`][frame.f_locals] attribute of a frame object).
+the [`f_locals`][frame.f_locals] attribute of a frame object, when dealing with types
+defined inside functions).
 This namespace type is expected as the `locals` argument during annotations evaluation.
 """
 
@@ -43,8 +44,8 @@ class NamespacesTuple(NamedTuple):
 def get_module_ns_of(obj: Any) -> dict[str, Any]:
     """Get the namespace of the module where the object is defined.
 
-    Caution: this function does not return a copy of the module namespace, so it should not be mutated.
-    The burden of enforcing this is on the caller.
+    Caution: this function does not return a copy of the module namespace, so the result
+    should not be mutated. The burden of enforcing this is on the caller.
     """
     module_name = getattr(obj, '__module__', None)
     if module_name:
@@ -116,7 +117,7 @@ def ns_from(obj: Any, parent_namespace: MappingNamespace | None = None) -> Names
     if parent_namespace is not None:
         locals_list.append(parent_namespace)
 
-    global_ns = get_module_ns_of(obj)
+    globalns = get_module_ns_of(obj)
 
     if isinstance(obj, type):
         locals_list.extend(
@@ -140,7 +141,7 @@ def ns_from(obj: Any, parent_namespace: MappingNamespace | None = None) -> Names
         type_params += getattr(obj, '__type_params__', ())
         locals_list.append({t.__name__: t for t in type_params})
 
-    return NamespacesTuple(global_ns, LazyLocalNamespace(*locals_list))
+    return NamespacesTuple(globalns, LazyLocalNamespace(*locals_list))
 
 
 class NsResolver:

--- a/pydantic/_internal/_namespace_utils.py
+++ b/pydantic/_internal/_namespace_utils.py
@@ -4,11 +4,11 @@ import sys
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from functools import cached_property
-from typing import Any, Callable, Iterator, NamedTuple, TypeAlias, TypeVar
+from typing import Any, Callable, Iterator, NamedTuple, TypeVar
 
-from typing_extensions import TypeAliasType
+from typing_extensions import TypeAlias, TypeAliasType
 
-GlobalsNamespace: TypeAlias = dict[str, Any]
+GlobalsNamespace: TypeAlias = 'dict[str, Any]'
 """A global namespace.
 
 In most cases, this is a reference to the `__dict__` attribute of a module.
@@ -120,7 +120,7 @@ def ns_for_function(obj: Callable[..., Any], parent_namespace: MappingNamespace 
     # Note that the `typing._eval_type` function expects type params to be
     # passed as a separate argument. However, internally, `_eval_type` calls
     # `ForwardRef._evaluate` which will merge type params with the localns,
-    # essentially mimicing what we do here.
+    # essentially mimicking what we do here.
     type_params: tuple[TypeVar, ...] = ()
     if parent_namespace is not None:
         # We also fetch type params from the parent namespace. If present, it probably

--- a/pydantic/_internal/_namespace_utils.py
+++ b/pydantic/_internal/_namespace_utils.py
@@ -59,6 +59,8 @@ def get_module_ns_of(obj: Any) -> dict[str, Any]:
     return {}
 
 
+# Note that this class is almost identical to `collections.ChainMap`, but need to enforce
+# immutable mappings here:
 class LazyLocalNamespace(Mapping[str, Any]):
     """A lazily evaluated mapping, to be used as the `locals` argument during annotations evaluation.
 
@@ -83,7 +85,7 @@ class LazyLocalNamespace(Mapping[str, Any]):
         self._namespaces = namespaces
 
     @cached_property
-    def data(self) -> Mapping[str, Any]:
+    def data(self) -> dict[str, Any]:
         return {k: v for ns in self._namespaces for k, v in ns.items()}
 
     def __len__(self) -> int:

--- a/pydantic/_internal/_namespace_utils.py
+++ b/pydantic/_internal/_namespace_utils.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Generator, Mapping
+from contextlib import contextmanager
+from functools import cached_property
+from typing import Any, Iterator, NamedTuple, TypeAlias, TypeVar
+
+GlobalsNamespace: TypeAlias = dict[str, Any]
+"""A global namespace.
+
+In most cases, this is a reference to the `__dict__` attribute of a module.
+This namespace type is expected as the `globals` argument during annotations evaluation.
+"""
+
+MappingNamespace: TypeAlias = Mapping[str, Any]
+"""Any kind of namespace.
+
+In most cases, this is a local namespace (e.g. the `__dict__` attribute of a class,
+the [`f_locals`][frame.f_locals] attribute of a frame object).
+This namespace type is expected as the `locals` argument during annotations evaluation.
+"""
+
+
+class NamespacesTuple(NamedTuple):
+    """A tuple of globals and locals to be used during annotations evaluation.
+
+    This datastructure is defined as a named tuple so that it can easily be unpacked:
+
+    ```python lint="skip" test="skip"
+    def eval_type(typ: type[Any], ns: NamespacesTuple) -> None:
+        return eval(typ, *ns)
+    ```
+    """
+
+    globals: GlobalsNamespace
+    """The namespace to be used as the `globals` argument during annotations evaluation."""
+
+    locals: MappingNamespace
+    """The namespace to be used as the `locals` argument during annotations evaluation."""
+
+
+def get_module_ns_of(obj: Any) -> dict[str, Any]:
+    """Get the namespace of the module where the object is defined.
+
+    Caution: this function does not return a copy of the module namespace, so it should not be mutated.
+    The burden of enforcing this is on the caller.
+    """
+    module_name = getattr(obj, '__module__', None)
+    if module_name:
+        try:
+            return sys.modules[module_name].__dict__
+        except KeyError:
+            # happens occasionally, see https://github.com/pydantic/pydantic/issues/2363
+            return {}
+    return {}
+
+
+class LazyLocalNamespace(Mapping[str, Any]):
+    """A lazily evaluated mapping, to be used as the `locals` argument during annotations evaluation.
+
+    While the [`eval`][eval] function expects a mapping as the `locals` argument, it only
+    performs `__getitem__` calls. The [`Mapping`][collections.abc.Mapping] abstract base class
+    is fully implemented only for type checking purposes.
+
+    Args:
+        *namespaces: The namespaces to consider, in ascending order of priority.
+
+    Example:
+        ```python lint="skip" test="skip"
+        ns = LazyLocalNamespace({'a': 1, 'b': 2}, {'a': 3})
+        ns['a']
+        #> 3
+        ns['b']
+        #> 2
+        ```
+    """
+
+    def __init__(self, *namespaces: MappingNamespace) -> None:
+        self._namespaces = namespaces
+
+    @cached_property
+    def data(self) -> Mapping[str, Any]:
+        return {k: v for ns in self._namespaces for k, v in ns.items()}
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.data[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.data
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.data)
+
+
+# This function is quite similar to the `NsResolver.types_namespace` property, but it also
+# handles functions, while `NsResolver` only deals with type objects. This function should
+# thus only be used when you want to resolve annotations for an object when *not* in a
+# core schema generation context:
+def ns_from(obj: Any, parent_namespace: MappingNamespace | None = None) -> NamespacesTuple:
+    """Return the global and local namespaces to be used when evaluating annotations for the provided object.
+
+    The global namespace will be the `__dict__` attribute of the module the object was defined in. The
+    local namespace will be constructed depending on the object type:
+    - if it is a type object, use the object's `__dict__` attribute and add the object itself to the locals.
+    - if it is a function, add the `__type_params__` introduced by PEP 695.
+
+    Args:
+        obj: The object to use when building namespaces.
+        parent_namespace: Optional namespace to be added with the lowest priority in the local namespace.
+    """
+    locals_list: list[MappingNamespace] = []
+    if parent_namespace is not None:
+        locals_list.append(parent_namespace)
+
+    global_ns = get_module_ns_of(obj)
+
+    if isinstance(obj, type):
+        locals_list.extend(
+            [
+                vars(obj),  # i.e. `obj.__dict__`
+                {obj.__name__: obj},
+            ]
+        )
+    else:
+        # For functions, get the `__type_params__` attribute introduced by PEP 695.
+        # Note that the typing `_eval_type` function expects type params to be
+        # passed as a separate argument. However, internally, `_eval_type` calls
+        # `ForwardRef._evaluate` which will merge type params with the localns,
+        # essentially mimicing what we do here.
+        type_params: tuple[TypeVar, ...] = ()
+        if parent_namespace is not None:
+            # We also fetch type params from the parent namespace. If present, it probably
+            # means the function was defined in a class. This is to support the following:
+            # https://github.com/python/cpython/issues/124089.
+            type_params += parent_namespace.get('__type_params__', ())
+        type_params += getattr(obj, '__type_params__', ())
+        locals_list.append({t.__name__: t for t in type_params})
+
+    return NamespacesTuple(global_ns, LazyLocalNamespace(*locals_list))
+
+
+class NsResolver:
+    """A class holding the logic to resolve namespaces for annotations evaluation in the context
+    of core schema generation.
+
+    This class handles the namespace logic when evaluating annotations that failed to
+    resolve during the initial inspection/building of the Pydantic model, dataclass, etc.
+
+    It holds a stack of classes that are being inspected during the core schema building,
+    and the `types_namespace` property exposes the globals and locals to be used for
+    type annotation evaluation. Additionally -- if no class is present in the stack -- a
+    fallback globals and locals can be provided with the `namespaces_tuple` argument.
+
+    This is only meant to be used alongside with the `GenerateSchema` class.
+
+    Args:
+        namespaces_tuple: The default globals and locals to used if no class is present
+            on the stack. This can be useful when using the `GenerateSchema` class
+            with `TypeAdapter`, where the "type" being analyzed is a simple annotation.
+        fallback_namespace: A namespace to use as a last resort if a name wasn't found
+            in the locals nor the globals. This is mainly used when rebuilding a core
+            schema for a Pydantic model or dataclass, where the parent namespace is used.
+        override_namespace: A namespace to use first when resolving forward annotations.
+            This is mainly used when rebuilding a core schema for a Pydantic model or
+            dataclass, where an explicit namespace can be provided to resolve annotations
+            that failed to resolve during the initial schema building.
+
+    Example:
+        ```python lint="skip" test="skip"
+        ns_resolver = NsResolver(
+            namespaces_tuple=NamespacesTuple({'my_global': 1}, {}),
+            fallback_namespace={'fallback': 2, 'my_global': 3},
+        )
+
+        ns_resolver.types_namespace
+        #> NamespacesTuple({'my_global': 1}, {})
+
+
+        class MyType:
+            some_local = 4
+
+
+        with ns_resolver.push(MyType):
+            ns_resolver.types_namespace
+            #> NamespacesTuple({'my_global': 1, 'fallback': 2}, {'some_local': 4})
+        ```
+    """
+
+    def __init__(
+        self,
+        namespaces_tuple: NamespacesTuple | None = None,
+        fallback_namespace: MappingNamespace | None = None,
+        override_namespace: MappingNamespace | None = None,
+    ) -> None:
+        self._base_ns_tuple = namespaces_tuple or NamespacesTuple({}, {})
+        self._fallback_ns = fallback_namespace
+        self._override_ns = override_namespace
+        self._types_stack: list[type[Any]] = []
+
+    @cached_property
+    def types_namespace(self) -> NamespacesTuple:
+        """The current global and local namespaces to be used for annotations evaluation."""
+        if not self._types_stack:
+            # TODO do we want to merge fallback and override ns here?
+            return self._base_ns_tuple
+
+        typ = self._types_stack[-1]
+
+        globalns = get_module_ns_of(typ)
+        # TODO check len(self._types_stack) == 1? As we specified,
+        # fallback_namespace should only be used for the class being rebuilt.
+        # However, it might be good to keep this for now to avoid having too
+        # many breaking changes.
+        if self._fallback_ns is not None:
+            globalns = {**self._fallback_ns, **globalns}
+
+        locals_list: list[MappingNamespace] = [vars(typ), {typ.__name__: typ}]
+        if self._override_ns is not None:
+            locals_list.append(self._override_ns)
+
+        return NamespacesTuple(globalns, LazyLocalNamespace(*locals_list))
+
+    @contextmanager
+    def push(self, typ: type[Any], /) -> Generator[None]:
+        """Push a type to the stack."""
+        self._types_stack.append(typ)
+        # Reset the cached property:
+        self.__dict__.pop('types_namespace', None)
+        try:
+            yield
+        finally:
+            self._types_stack.pop()
+            self.__dict__.pop('types_namespace', None)

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ..json_schema import GenerateJsonSchema, JsonSchemaValue
     from ._core_utils import CoreSchemaOrField
     from ._generate_schema import GenerateSchema
+    from ._namespace_utils import NamespacesTuple
 
     GetJsonSchemaFunction = Callable[[CoreSchemaOrField, GetJsonSchemaHandler], JsonSchemaValue]
     HandlerOverride = Callable[[CoreSchemaOrField], JsonSchemaValue]
@@ -90,7 +91,7 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
         else:  # ref_mode = 'unpack
             return self.resolve_ref_schema(schema)
 
-    def _get_types_namespace(self) -> dict[str, Any] | None:
+    def _get_types_namespace(self) -> NamespacesTuple:
         return self._generate_schema._types_namespace
 
     def generate_schema(self, source_type: Any, /) -> core_schema.CoreSchema:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -272,6 +272,18 @@ def eval_type(
         return value
 
 
+@deprecated(
+    '`eval_type_lenient` is deprecated, use `eval_type` with `lenient=True` instead.',
+    category=None,
+)
+def eval_type_lenient(
+    value: Any,
+    globalns: GlobalsNamespace | None = None,
+    localns: MappingNamespace | None = None,
+) -> Any:
+    return eval_type(value, globalns, localns, lenient=True)
+
+
 def eval_type_backport(
     value: Any,
     globalns: GlobalsNamespace | None = None,

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -409,8 +409,8 @@ def get_function_type_hints(
         globalns = get_module_ns_of(function)
     type_params: tuple[Any, ...] | None = None
     if localns is None:
-        # If localns was specified, it is assumed to already contain type params.
-        # This is because Pydantic has more advanced logic to do so (see `_namespace_utils.ns_from`).
+        # If localns was specified, it is assumed to already contain type params. This is because
+        # Pydantic has more advanced logic to do so (see `_namespace_utils.ns_for_function`).
         type_params = getattr(function, '__type_params__', ())
 
     type_hints = {}

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -233,12 +233,13 @@ def get_cls_type_hints(
     ns_resolver = ns_resolver or NsResolver()
 
     for base in reversed(obj.__mro__):
-        ann = base.__dict__.get('__annotations__')
+        ann: dict[str, Any] | None = base.__dict__.get('__annotations__')
+        if not ann or isinstance(ann, GetSetDescriptorType):
+            continue
         with ns_resolver.push(base):
             globalns, localns = ns_resolver.types_namespace
-            if ann is not None and ann is not GetSetDescriptorType:
-                for name, value in ann.items():
-                    hints[name] = eval_type(value, globalns, localns, lenient=lenient)
+            for name, value in ann.items():
+                hints[name] = eval_type(value, globalns, localns, lenient=lenient)
     return hints
 
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -339,7 +339,12 @@ def _eval_type_backport(
                 '`typing` constructs or install the `eval_type_backport` package.'
             ) from e
 
-        return eval_type_backport(value, globalns, localns, try_default=False)
+        return eval_type_backport(
+            value,
+            globalns,
+            localns,  # pyright: ignore[reportArgumentType], waiting on a new `eval_type_backport` release.
+            try_default=False,
+        )
 
 
 def _eval_type(

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -10,7 +10,7 @@ from ..config import ConfigDict
 from ..plugin._schema_validator import create_schema_validator
 from . import _generate_schema
 from ._config import ConfigWrapper
-from ._namespace_utils import MappingNamespace, NsResolver, ns_from
+from ._namespace_utils import MappingNamespace, NsResolver, ns_for_function
 
 
 class ValidateCallWrapper:
@@ -43,7 +43,7 @@ class ValidateCallWrapper:
             self.__qualname__ = function.__qualname__
             self.__module__ = function.__module__
 
-        ns_resolver = NsResolver(namespaces_tuple=ns_from(schema_type, parent_namespace=parent_namespace))
+        ns_resolver = NsResolver(namespaces_tuple=ns_for_function(schema_type, parent_namespace=parent_namespace))
 
         config_wrapper = ConfigWrapper(config)
         gen_schema = _generate_schema.GenerateSchema(config_wrapper, ns_resolver)

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -8,8 +8,9 @@ import pydantic_core
 
 from ..config import ConfigDict
 from ..plugin._schema_validator import create_schema_validator
-from . import _generate_schema, _typing_extra
+from . import _generate_schema
 from ._config import ConfigWrapper
+from ._namespace_utils import MappingNamespace, NsResolver, ns_from
 
 
 class ValidateCallWrapper:
@@ -28,7 +29,7 @@ class ValidateCallWrapper:
         function: Callable[..., Any],
         config: ConfigDict | None,
         validate_return: bool,
-        namespace: dict[str, Any] | None,
+        parent_namespace: MappingNamespace | None,
     ):
         if isinstance(function, partial):
             func = function.func
@@ -42,18 +43,10 @@ class ValidateCallWrapper:
             self.__qualname__ = function.__qualname__
             self.__module__ = function.__module__
 
-        global_ns = _typing_extra.get_module_ns_of(function)
-        # TODO: this is a bit of a hack, we should probably have a better way to handle this
-        # specifically, we shouldn't be pumping the namespace full of type_params
-        # when we take namespace and type_params arguments in eval_type_backport
-        type_params = (namespace or {}).get('__type_params__', ()) + getattr(schema_type, '__type_params__', ())
-        namespace = {
-            **{param.__name__: param for param in type_params},
-            **(global_ns or {}),
-            **(namespace or {}),
-        }
+        ns_resolver = NsResolver(namespaces_tuple=ns_from(schema_type, parent_namespace=parent_namespace))
+
         config_wrapper = ConfigWrapper(config)
-        gen_schema = _generate_schema.GenerateSchema(config_wrapper, namespace)
+        gen_schema = _generate_schema.GenerateSchema(config_wrapper, ns_resolver)
         schema = gen_schema.clean_schema(gen_schema.generate_schema(function))
         core_config = config_wrapper.core_config(self.__name__)
 
@@ -70,7 +63,7 @@ class ValidateCallWrapper:
         if validate_return:
             signature = inspect.signature(function)
             return_type = signature.return_annotation if signature.return_annotation is not signature.empty else Any
-            gen_schema = _generate_schema.GenerateSchema(config_wrapper, namespace)
+            gen_schema = _generate_schema.GenerateSchema(config_wrapper, ns_resolver)
             schema = gen_schema.clean_schema(gen_schema.generate_schema(return_type))
             validator = create_schema_validator(
                 schema,

--- a/pydantic/annotated_handlers.py
+++ b/pydantic/annotated_handlers.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Union
 from pydantic_core import core_schema
 
 if TYPE_CHECKING:
+    from ._internal._namespace_utils import NamespacesTuple
     from .json_schema import JsonSchemaMode, JsonSchemaValue
 
     CoreSchemaOrField = Union[
@@ -116,6 +117,6 @@ class GetCoreSchemaHandler:
         """Get the name of the closest field to this validator."""
         raise NotImplementedError
 
-    def _get_types_namespace(self) -> dict[str, Any] | None:
+    def _get_types_namespace(self) -> NamespacesTuple:
         """Internal method used during type resolution for serializer annotations."""
         raise NotImplementedError

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -10,9 +10,8 @@ from warnings import warn
 
 from typing_extensions import Literal, TypeGuard, dataclass_transform
 
-from ._internal import _config, _decorators, _typing_extra
+from ._internal import _config, _decorators, _namespace_utils, _typing_extra
 from ._internal import _dataclasses as _pydantic_dataclasses
-from ._internal._namespace_utils import MappingNamespace, NsResolver
 from ._migration import getattr_migration
 from .config import ConfigDict
 from .errors import PydanticUserError
@@ -20,6 +19,7 @@ from .fields import Field, FieldInfo, PrivateAttr
 
 if TYPE_CHECKING:
     from ._internal._dataclasses import PydanticDataclass
+    from ._internal._namespace_utils import MappingNamespace
 
 __all__ = 'dataclass', 'rebuild_dataclass'
 
@@ -334,7 +334,7 @@ def rebuild_dataclass(
     else:
         rebuild_ns = {}
 
-    ns_resolver = NsResolver(
+    ns_resolver = _namespace_utils.NsResolver(
         parent_namespace=rebuild_ns,
     )
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -270,8 +270,9 @@ def dataclass(
         cls.__module__ = original_cls.__module__
         cls.__qualname__ = original_cls.__qualname__
         cls.__pydantic_complete__ = False  # `complete_dataclass` will set it to `True` if successful.
-        # TODO parent_namespace is currently None, but we could do the same thing as Pydantic models,
-        # even if we don't save it under an attribute for reuse:
+        # TODO `parent_namespace` is currently None, but we could do the same thing as Pydantic models:
+        # fetch the parent ns using `parent_frame_namespace` (if the dataclass was defined in a function),
+        # and possibly cache it (see the `__pydantic_parent_namespace__` logic for models).
         _pydantic_dataclasses.complete_dataclass(cls, config_wrapper, raise_errors=False, parent_namespace=None)
         return cls
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -618,7 +618,7 @@ class FieldInfo(_repr.Representation):
             pydantic._internal._generics.replace_types is used for replacing the typevars with
                 their concrete types.
         """
-        annotation = _typing_extra.eval_type_lenient(self.annotation, globalns, localns)
+        annotation = _typing_extra.eval_type(self.annotation, globalns, localns, lenient=True)
         self.annotation = _generics.replace_types(annotation, typevars_map)
 
     def __repr_args__(self) -> ReprArgs:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -19,6 +19,7 @@ from typing_extensions import Literal, TypeAlias, Unpack, deprecated
 
 from . import types
 from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra, _utils
+from ._internal._namespace_utils import GlobalsNamespace, MappingNamespace
 from .aliases import AliasChoices, AliasPath
 from .config import JsonDict
 from .errors import PydanticUserError
@@ -596,7 +597,12 @@ class FieldInfo(_repr.Representation):
             # Annotated arguments must be a tuple
             return typing_extensions.Annotated[(self.annotation, *self.metadata)]  # type: ignore
 
-    def apply_typevars_map(self, typevars_map: dict[Any, Any] | None, types_namespace: dict[str, Any] | None) -> None:
+    def apply_typevars_map(
+        self,
+        typevars_map: dict[Any, Any] | None,
+        globalns: GlobalsNamespace | None = None,
+        localns: MappingNamespace | None = None,
+    ) -> None:
         """Apply a `typevars_map` to the annotation.
 
         This method is used when analyzing parametrized generic types to replace typevars with their concrete types.
@@ -605,13 +611,14 @@ class FieldInfo(_repr.Representation):
 
         Args:
             typevars_map: A dictionary mapping type variables to their concrete types.
-            types_namespace (dict | None): A dictionary containing related types to the annotated type.
+            globalns: The globals namespace to use during type annotation evaluation.
+            localns: The locals namespace to use during type annotation evaluation.
 
         See Also:
             pydantic._internal._generics.replace_types is used for replacing the typevars with
                 their concrete types.
         """
-        annotation = _typing_extra.eval_type_lenient(self.annotation, types_namespace)
+        annotation = _typing_extra.eval_type_lenient(self.annotation, globalns, localns)
         self.annotation = _generics.replace_types(annotation, typevars_map)
 
     def __repr_args__(self) -> ReprArgs:

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -63,9 +63,13 @@ class PlainSerializer:
             The Pydantic core schema.
         """
         schema = handler(source_type)
+        globalns, localns = handler._get_types_namespace()
         try:
             return_type = _decorators.get_function_return_type(
-                self.func, self.return_type, handler._get_types_namespace()
+                self.func,
+                self.return_type,
+                globalns=globalns,
+                localns=localns,
             )
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
@@ -160,9 +164,13 @@ class WrapSerializer:
             The generated core schema of the class.
         """
         schema = handler(source_type)
+        globalns, localns = handler._get_types_namespace()
         try:
             return_type = _decorators.get_function_return_type(
-                self.func, self.return_type, handler._get_types_namespace()
+                self.func,
+                self.return_type,
+                globalns=globalns,
+                localns=localns,
             )
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -790,7 +790,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 # Attempt to rebuild the origin in case new types have been defined
                 try:
                     # depth 3 gets you above this __class_getitem__ call
-                    origin.model_rebuild(_parent_namespace_depth=3)
+                    origin.model_rebuild(_parent_namespace_depth=0)
                 except PydanticUndefinedAnnotation:
                     # It's okay if it fails, it just means there are still undefined types
                     # that could be evaluated later.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -43,6 +43,7 @@ from ._internal import (
     _typing_extra,
     _utils,
 )
+from ._internal._namespace_utils import MappingNamespace, NsResolver
 from ._migration import getattr_migration
 from .aliases import AliasChoices, AliasPath
 from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
@@ -545,7 +546,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         force: bool = False,
         raise_errors: bool = True,
         _parent_namespace_depth: int = 2,
-        _types_namespace: dict[str, Any] | None = None,
+        _types_namespace: MappingNamespace | None = None,
     ) -> bool | None:
         """Try to rebuild the pydantic-core schema for the model.
 
@@ -564,37 +565,31 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
         if not force and cls.__pydantic_complete__:
             return None
-        else:
-            if '__pydantic_core_schema__' in cls.__dict__:
-                delattr(cls, '__pydantic_core_schema__')  # delete cached value to ensure full rebuild happens
-            if _types_namespace is not None:
-                types_namespace: dict[str, Any] | None = _types_namespace.copy()
-            else:
-                if _parent_namespace_depth > 0:
-                    frame_parent_ns = (
-                        _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth, force=True) or {}
-                    )
-                    cls_parent_ns = (
-                        _model_construction.unpack_lenient_weakvaluedict(cls.__pydantic_parent_namespace__) or {}
-                    )
-                    types_namespace = {**cls_parent_ns, **frame_parent_ns}
-                    cls.__pydantic_parent_namespace__ = _model_construction.build_lenient_weakvaluedict(types_namespace)
-                else:
-                    types_namespace = _model_construction.unpack_lenient_weakvaluedict(
-                        cls.__pydantic_parent_namespace__
-                    )
 
-                types_namespace = _typing_extra.merge_cls_and_parent_ns(cls, types_namespace)
+        if '__pydantic_core_schema__' in cls.__dict__:
+            delattr(cls, '__pydantic_core_schema__')  # delete cached value to ensure full rebuild happens
 
-            # manually override defer_build so complete_model_class doesn't skip building the model again
-            config = {**cls.model_config, 'defer_build': False}
-            return _model_construction.complete_model_class(
-                cls,
-                cls.__name__,
-                _config.ConfigWrapper(config, check=False),
-                raise_errors=raise_errors,
-                types_namespace=types_namespace,
+        fallback_namespace: MappingNamespace | None = None
+        override_namespace: MappingNamespace | None = None
+
+        if _types_namespace is not None:
+            override_namespace = _types_namespace
+        elif _parent_namespace_depth > 0:
+            fallback_namespace = (
+                _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth, force=True) or {}
             )
+
+        ns_resolver = NsResolver(fallback_namespace=fallback_namespace, override_namespace=override_namespace)
+
+        # manually override defer_build so complete_model_class doesn't skip building the model again
+        config = {**cls.model_config, 'defer_build': False}
+        return _model_construction.complete_model_class(
+            cls,
+            cls.__name__,
+            _config.ConfigWrapper(config, check=False),
+            raise_errors=raise_errors,
+            ns_resolver=ns_resolver,
+        )
 
     @classmethod
     def model_validate(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -39,11 +39,11 @@ from ._internal import (
     _import_utils,
     _mock_val_ser,
     _model_construction,
+    _namespace_utils,
     _repr,
     _typing_extra,
     _utils,
 )
-from ._internal._namespace_utils import MappingNamespace, NsResolver
 from ._migration import getattr_migration
 from .aliases import AliasChoices, AliasPath
 from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 
     from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator
 
+    from ._internal._namespace_utils import MappingNamespace
     from ._internal._utils import AbstractSetIntStr, MappingIntStrAny
     from .deprecated.parse import Protocol as DeprecatedParseProtocol
     from .fields import ComputedFieldInfo, FieldInfo, ModelPrivateAttr
@@ -578,7 +579,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         parent_ns = _model_construction.unpack_lenient_weakvaluedict(cls.__pydantic_parent_namespace__) or {}
 
-        ns_resolver = NsResolver(
+        ns_resolver = _namespace_utils.NsResolver(
             parent_namespace={**rebuild_ns, **parent_ns},
         )
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -86,11 +86,11 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
 
     But at the very least this behavior is _subtly_ different from `BaseModel`'s.
     """
-    local_ns = _typing_extra.parent_frame_namespace(parent_depth=parent_depth)
+    localns = _typing_extra.parent_frame_namespace(parent_depth=parent_depth)
     globalns = sys._getframe(max(parent_depth - 1, 1)).f_globals
     ns_resolver = _namespace_utils.NsResolver(
-        namespaces_tuple=_namespace_utils.NamespacesTuple(globalns, local_ns or {}),
-        parent_namespace=local_ns,
+        namespaces_tuple=_namespace_utils.NamespacesTuple(globalns, localns or {}),
+        parent_namespace=localns,
     )
     gen = _generate_schema.GenerateSchema(config_wrapper, ns_resolver=ns_resolver, typevars_map={})
     schema = gen.generate_schema(type_)

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -88,9 +88,9 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
     But at the very least this behavior is _subtly_ different from `BaseModel`'s.
     """
     local_ns = _typing_extra.parent_frame_namespace(parent_depth=parent_depth)
-    global_ns = sys._getframe(max(parent_depth - 1, 1)).f_globals
+    globalns = sys._getframe(max(parent_depth - 1, 1)).f_globals
     ns_resolver = NsResolver(
-        namespaces_tuple=NamespacesTuple(global_ns, local_ns or {}),
+        namespaces_tuple=NamespacesTuple(globalns, local_ns or {}),
         fallback_namespace=local_ns,
     )
     gen = _generate_schema.GenerateSchema(config_wrapper, ns_resolver=ns_resolver, typevars_map={})

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -25,8 +25,7 @@ from typing_extensions import Concatenate, ParamSpec, is_typeddict
 from pydantic.errors import PydanticUserError
 from pydantic.main import BaseModel, IncEx
 
-from ._internal import _config, _generate_schema, _mock_val_ser, _typing_extra, _utils
-from ._internal._namespace_utils import NamespacesTuple, NsResolver
+from ._internal import _config, _generate_schema, _mock_val_ser, _namespace_utils, _typing_extra, _utils
 from .config import ConfigDict
 from .json_schema import (
     DEFAULT_REF_TEMPLATE,
@@ -89,8 +88,8 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
     """
     local_ns = _typing_extra.parent_frame_namespace(parent_depth=parent_depth)
     globalns = sys._getframe(max(parent_depth - 1, 1)).f_globals
-    ns_resolver = NsResolver(
-        namespaces_tuple=NamespacesTuple(globalns, local_ns or {}),
+    ns_resolver = _namespace_utils.NsResolver(
+        namespaces_tuple=_namespace_utils.NamespacesTuple(globalns, local_ns or {}),
         parent_namespace=local_ns,
     )
     gen = _generate_schema.GenerateSchema(config_wrapper, ns_resolver=ns_resolver, typevars_map={})

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -91,7 +91,7 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
     globalns = sys._getframe(max(parent_depth - 1, 1)).f_globals
     ns_resolver = NsResolver(
         namespaces_tuple=NamespacesTuple(globalns, local_ns or {}),
-        fallback_namespace=local_ns,
+        parent_namespace=local_ns,
     )
     gen = _generate_schema.GenerateSchema(config_wrapper, ns_resolver=ns_resolver, typevars_map={})
     schema = gen.generate_schema(type_)

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -26,6 +26,7 @@ from pydantic.errors import PydanticUserError
 from pydantic.main import BaseModel, IncEx
 
 from ._internal import _config, _generate_schema, _mock_val_ser, _typing_extra, _utils
+from ._internal._namespace_utils import NamespacesTuple, NsResolver
 from .config import ConfigDict
 from .json_schema import (
     DEFAULT_REF_TEMPLATE,
@@ -87,9 +88,12 @@ def _get_schema(type_: Any, config_wrapper: _config.ConfigWrapper, parent_depth:
     But at the very least this behavior is _subtly_ different from `BaseModel`'s.
     """
     local_ns = _typing_extra.parent_frame_namespace(parent_depth=parent_depth)
-    global_ns = sys._getframe(max(parent_depth - 1, 1)).f_globals.copy()
-    global_ns.update(local_ns or {})
-    gen = _generate_schema.GenerateSchema(config_wrapper, types_namespace=global_ns, typevars_map={})
+    global_ns = sys._getframe(max(parent_depth - 1, 1)).f_globals
+    ns_resolver = NsResolver(
+        namespaces_tuple=NamespacesTuple(global_ns, local_ns or {}),
+        fallback_namespace=local_ns,
+    )
+    gen = _generate_schema.GenerateSchema(config_wrapper, ns_resolver=ns_resolver, typevars_map={})
     schema = gen.generate_schema(type_)
     schema = gen.clean_schema(schema)
     return schema

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -47,14 +47,14 @@ def validate_call(
     Returns:
         The decorated function.
     """
-    local_ns = _typing_extra.parent_frame_namespace()
+    parent_namespace = _typing_extra.parent_frame_namespace()
 
     def validate(function: AnyCallableT) -> AnyCallableT:
         if isinstance(function, (classmethod, staticmethod)):
             name = type(function).__name__
             raise TypeError(f'The `@{name}` decorator should be applied after `@validate_call` (put `@{name}` on top)')
 
-        validate_call_wrapper = _validate_call.ValidateCallWrapper(function, config, validate_return, local_ns)
+        validate_call_wrapper = _validate_call.ValidateCallWrapper(function, config, validate_return, parent_namespace)
 
         if inspect.iscoroutinefunction(function):
 

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1297,8 +1297,8 @@ def test_tmp_9(create_module):
 
     @create_module
     def module_1():
-
         MyStr = str
+
         class Model(BaseModel):
             a: int
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -9,7 +9,7 @@ from typing_extensions import Literal, get_origin
 from pydantic import BaseModel, Field  # noqa: F401
 from pydantic._internal._typing_extra import (
     NoneType,
-    eval_type_lenient,
+    eval_type,
     get_function_type_hints,
     is_classvar,
     is_literal_type,
@@ -64,7 +64,7 @@ def test_is_none_type():
     'union',
     [
         typing.Union[int, str],
-        eval_type_lenient('int | str'),
+        eval_type('int | str'),
         *([int | str] if sys.version_info >= (3, 10) else []),
     ],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This can be reviewed commit per commit, with details added in each commit message.

There are some similarities with https://github.com/pydantic/pydantic/pull/10425, but here are the main things that differ:

- As said in https://github.com/pydantic/pydantic/pull/10425#issuecomment-2379370544, we are no longer only using the local argument. Instead, the `NamespacesTuple` (name TBD) is used to tightly couple globals and locals together.
- The `NsResolver` class is still present, but is closer to the `TypesNamespaceStack` we had previously and simplified. It is not a mapping. The lazy evaluation capability is still available for the locals, thanks to the `LazyLocalNamespace` mapping. It also supports the concept of a fallback and override namespace, as we [specified](https://gist.github.com/Viicos/2ee3dee31acb362331a5fe0bb8ffb848#extra-namespace-used-when-rebuilding-a-model).

The `NsResolver` can be used in two ways:

- By explicitly specifying globals and locals. This is used for example when generating a schema from `validate_call` or from `TypeAdapter`. For `validate_call`, the globals and locals are fetched using `ns_from` and when we enter  `GenerateSchema._callable_schema`, the explicitly passed globals and locals will be used.
- By not specifying any globals or locals. This is used for example when generating a schema when a Pydantic model is created. In this case, `NsResolver.push` will be called when we enter `GenerateSchema._model_schema`, and the initial globals and locals are then irrelevant.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
