### PR TITLE
Sanitise names of module files created in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,11 @@ def _extract_source_code_from_function(function: FunctionType):
 
 
 def _create_module_file(code: str, tmp_path: Path, name: str) -> tuple[str, str]:
-    name = f'{name}_{secrets.token_hex(5)}'
+    # Max path length in Windows is 260. Leaving some buffer here
+    max_name_len = 240 - len(str(tmp_path))
+    # Windows does not allow these characters in paths. Linux bans slashes only.
+    sanitized_name = re.sub('[' + re.escape('<>:"/\\|?*') + ']', '-', name)[:max_name_len]
+    name = f'{sanitized_name}_{secrets.token_hex(5)}'
     path = tmp_path / f'{name}.py'
     path.write_text(code)
     return name, str(path)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Sanitise names of module files created in tests by removing specific characters that might not be allowed in file paths.

It's possible to create temporary module files in tests so that models and relevant dependencies can be isolated and loaded properly. This can be achieved by calling the fixture `create_module`. The module file is named after the test cases. The current problem is that test cases might contain characters that are not allowed to be in file paths. This would lead to `OSError`s and fail the tests. For instance, one such module name can be `test_type_alias_with_type_statement[[{'a': [{'foo': 'bar'}]}]-None]_1210fb5a6f.py` as in #10457. This test failed because colons are not allowed in file paths in Windows.

## Related issue number

Split from #10457 as requested.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
