### PR TITLE
Add unit tests for ImportError handling and ValidationError on unbound SocketPath

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3719,6 +3719,25 @@ def test_socket_exists(tmp_path):
         assert Model(path=target).path == target
 
 
+def test_socket_not_exists(tmp_path):
+    target = tmp_path / 's'
+
+    class Model(BaseModel):
+        path: SocketPath
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(path=target)
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'path_not_socket',
+            'loc': ('path',),
+            'msg': 'Path does not point to a socket',
+            'input': target,
+        }
+    ]
+
+
 @pytest.mark.parametrize('value', ('/nonexistentdir/foo.py', Path('/nonexistentdir/foo.py')))
 def test_new_path_validation_parent_does_not_exist(value):
     class Model(BaseModel):


### PR DESCRIPTION

## Change Summary

This PR introduces new unit tests to enhance the test coverage by covering the following scenarios:

#### ValidationError for Unbound SocketPath:
Added a unit test to verify that a `ValidationError`  is raised when the provided path is not bound by a socket. This ensures that the application correctly handles and reports errors related to unbound socket paths.

#### ImportError Handling for email-validator
Introduced unit tests to verify the proper handling of ImportError scenarios related to the email-validator package. Specifically, the tests cover:
- The expected `ImportError` when `email-validator` is not installed.
- The handling of `ImportError` when there is an invalid installation of `email-validator`.

Related to #7656 


## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle