### PR TITLE
Do not use the previous config from the stack for dataclasses without config

### DIFF
--- a/docs/concepts/dataclasses.md
+++ b/docs/concepts/dataclasses.md
@@ -308,7 +308,7 @@ In this case you can simply add `arbitrary_types_allowed` in the config!
 ```py
 import dataclasses
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 from pydantic.errors import PydanticSchemaGenerationError
 
 
@@ -335,8 +335,6 @@ try:
         dc: DC
         other: str
 
-    # invalid as it is now a pydantic dataclass
-    Model(dc=my_dc, other='other')
 except PydanticSchemaGenerationError as e:
     print(e.message)
     """
@@ -346,16 +344,22 @@ except PydanticSchemaGenerationError as e:
     """
 
 
-class Model(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+@dataclasses.dataclass
+class DC2:
+    a: ArbitraryType
+    b: str
 
-    dc: DC
+    __pydantic_config__ = {'arbitrary_types_allowed': True}
+
+
+class Model(BaseModel):
+    dc: DC2
     other: str
 
 
-m = Model(dc=my_dc, other='other')
+m = Model(dc=DC2(a=ArbitraryType(value=3), b='qwe'), other='other')
 print(repr(m))
-#> Model(dc=DC(a=ArbitraryType(value=3), b='qwe'), other='other')
+#> Model(dc=DC2(a=ArbitraryType(value=3), b='qwe'), other='other')
 ```
 
 ### Checking if a dataclass is a pydantic dataclass

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1791,7 +1791,7 @@ class GenerateSchema:
                 config = None
                 for dataclass_base in reversed(dataclass.__mro__):
                     if dataclasses.is_dataclass(dataclass_base):
-                        config = getattr(dataclass_base, '__pydantic_config__', None)
+                        config = getattr(dataclass_base, '__pydantic_config__', ConfigDict())
                         dataclass_bases_stack.enter_context(self._config_wrapper_stack.push(config))
 
                 core_config = self._config_wrapper.core_config(title=dataclass.__name__)
@@ -1811,7 +1811,7 @@ class GenerateSchema:
                     )
 
                 # disallow combination of init=False on a dataclass field and extra='allow' on a dataclass
-                if self._config_wrapper_stack.tail.extra == 'allow':
+                if self._config_wrapper.extra == 'allow':
                     # disallow combination of init=False on a dataclass field and extra='allow' on a dataclass
                     for field_name, field in fields.items():
                         if field.init is False:
@@ -1846,7 +1846,7 @@ class GenerateSchema:
                 model_validators = decorators.model_validators.values()
                 inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
 
-                title = self._get_model_title_from_config(dataclass, ConfigWrapper(config))
+                title = self._get_model_title_from_config(dataclass, self._config_wrapper)
                 metadata = build_metadata_dict(
                     js_functions=[partial(modify_model_json_schema, cls=dataclass, title=title)]
                 )

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -818,12 +818,14 @@ def test_override_builtin_dataclass_nested():
         modified_date: Optional[datetime]
         seen_count: int
 
+        __pydantic_config__ = {'revalidate_instances': 'always'}
+
     @dataclasses.dataclass
     class File:
         filename: str
         meta: Meta
 
-    FileChecked = pydantic.dataclasses.dataclass(File, config=ConfigDict(revalidate_instances='always'))
+    FileChecked = pydantic.dataclasses.dataclass(File)
     f = FileChecked(filename=b'thefilename', meta=Meta(modified_date='2020-01-01T00:00', seen_count='7'))
     assert f.filename == 'thefilename'
     assert f.meta.modified_date == datetime(2020, 1, 1, 0, 0)


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Also fixed in https://github.com/pydantic/pydantic/pull/10530 but in a separate PR for a cleaner commit history.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
