### PR TITLE
Document `dict(model)` workaround

### DIFF
--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -163,7 +163,7 @@ class FooBarModel(BaseModel):
 
 m = FooBarModel(banana=3.14, foo='hello', bar={'whatever': 123})
 
-print(dict(m))
+print(dict(m))  # (1)!
 #> {'banana': 3.14, 'foo': 'hello', 'bar': BarModel(whatever=123)}
 for name, value in m:
     print(f'{name}: {value}')
@@ -171,6 +171,9 @@ for name, value in m:
     #> foo: hello
     #> bar: whatever=123
 ```
+
+1. You might get an unexpected error if your model defines a field named `keys`. In that case,
+   you can call `dict(iter(m))` as a workaround.
 
 Note also that [`RootModel`](models.md#rootmodel-and-custom-root-types) _does_ get converted to a dictionary with the key `'root'`.
 


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10575

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
