### PR TITLE
ci: add flag to ignore unrecognised schema types

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -14,6 +14,7 @@ from __future__ import annotations as _annotations
 import dataclasses
 import inspect
 import math
+import os
 import re
 import warnings
 from collections import defaultdict
@@ -336,6 +337,8 @@ class GenerateJsonSchema:
             try:
                 mapping[key] = getattr(self, method_name)
             except AttributeError as e:  # pragma: no cover
+                if os.environ['PYDANTIC_PRIVATE_ALLOW_UNHANDLED_SCHEMA_TYPES'] == '1':
+                    continue
                 raise TypeError(
                     f'No method for generating JsonSchema for core_schema.type={key!r} '
                     f'(expected: {type(self).__name__}.{method_name})'


### PR DESCRIPTION
## Change Summary

At the moment in `pydantic-core` the integration tests are failing because there's a new schema type `invalid`. It's super annoying that they get broken by this change until a new `pydantic-core` release is built.

Let's add a flag here to workaround that stage.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
