### PR TITLE
Expose public `sort` method for JSON schema generation

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -1414,6 +1414,67 @@ print(validation_schema)
 """
 ```
 
+### JSON schema sorting
+
+By default, Pydantic recursively sorts JSON schemas by alphabetically sorting keys. Notably, Pydantic skips sorting the values of the `properties` key,
+to preserve the order of the fields as they were defined in the model.
+
+If you would like to customize this behavior, you can override the `sort` method in your custom `GenerateJsonSchema` subclass. The below example
+uses a no-op `sort` method to disable sorting entirely, which is reflected in the preserved order of the model fields and `json_schema_extra` keys:
+
+```py
+import json
+
+from pydantic import BaseModel, Field
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+
+
+class MyGenerateJsonSchema(GenerateJsonSchema):
+    def sort(
+        self, value: JsonSchemaValue, parent_key: str | None = None
+    ) -> JsonSchemaValue:
+        """No-op, we don't want to sort schema values at all."""
+        return value
+
+
+class Bar(BaseModel):
+    c: str
+    b: str
+    a: str = Field(json_schema_extra={'c': 'hi', 'b': 'hello', 'a': 'world'})
+
+
+json_schema = Bar.model_json_schema(schema_generator=MyGenerateJsonSchema)
+print(json.dumps(json_schema, indent=2))
+"""
+{
+  "type": "object",
+  "properties": {
+    "c": {
+      "type": "string",
+      "title": "C"
+    },
+    "b": {
+      "type": "string",
+      "title": "B"
+    },
+    "a": {
+      "type": "string",
+      "c": "hi",
+      "b": "hello",
+      "a": "world",
+      "title": "A"
+    }
+  },
+  "required": [
+    "c",
+    "b",
+    "a"
+  ],
+  "title": "Bar"
+}
+"""
+```
+
 ## Customizing the `$ref`s in JSON Schema
 
 The format of `$ref`s can be altered by calling [`model_json_schema()`][pydantic.main.BaseModel.model_json_schema]


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic/issues/7580

At first, thought we might have to add a flag to fix this. The way I feel about adding flags at this point is about how [edna (from The Incredibles) feels about capes](https://www.youtube.com/watch?v=YL3w73MAuIM&ab_channel=EntertainmentAccess).

Luckily, was able to sidestep the need for a flag by exposing the sort method as a public one in the `GenerateJsonSchema` class.

Did a little bit of refactoring to make things more type checking friendly re the outer sort vs recursive sorts.

