### PR TITLE
Improve email regexp on edge cases

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -722,7 +722,7 @@ def _build_pretty_email_regex() -> re.Pattern[str]:
     name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'
     unquoted_name_group = rf'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
-    email_group = r'<\s*(.+)>'
+    email_group = r'<(.+)>'
     return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -722,7 +722,7 @@ def _build_pretty_email_regex() -> re.Pattern[str]:
     name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'
     unquoted_name_group = rf'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
-    email_group = r'<\s*(.+)\s*>'
+    email_group = r'<\s*(.+)>'
     return re.compile(rf'\s*(?:{unquoted_name_group}|{quoted_name_group})?\s*{email_group}\s*')
 
 

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -908,6 +908,8 @@ def test_json():
         ('FOO bar   <foobar@example.com> ', 'FOO bar', 'foobar@example.com'),
         (' Whatever <foobar@example.com>', 'Whatever', 'foobar@example.com'),
         ('Whatever < foobar@example.com>', 'Whatever', 'foobar@example.com'),
+        ('Whatever <foobar@example.com >', 'Whatever', 'foobar@example.com'),
+        ('Whatever < foobar@example.com >', 'Whatever', 'foobar@example.com'),
         ('<FOOBAR@example.com> ', 'FOOBAR', 'FOOBAR@example.com'),
         ('ñoñó@example.com', 'ñoñó', 'ñoñó@example.com'),
         ('我買@example.com', '我買', '我買@example.com'),


### PR DESCRIPTION
- Drastically improves performance on cases like `"<" + " " * N`
- Last spaces are not needed anyway because this group is stripped later. Also spaces will be caught by `.` anyway.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

I found that one single change in email regexp solves slowdowns on special invalid email strings. See related issue for details

## Related issue number

Fixes #10600 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle