### PR TITLE
Raise an error when `Self` is invalid

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1257,7 +1257,7 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'invalid-self-type'
 ```
 
-The following examples of `validate_call` and `TypeAdapter` will also raise this error, even they are correct from a type-checking perspective. This may be supported in the future.
+The following examples of `validate_call` and `TypeAdapter` will also raise this error, even though they are correct from a type-checking perspective. This may be supported in the future.
 
 ```py
 from typing_extensions import Self

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1065,7 +1065,7 @@ except PydanticUserError as exc_info:
 
 ## Cannot evaluate type annotation {#unevaluable-type-annotation}
 
-Because type annotations are evaluated _after_ assignments, you might get unexpected results when using a type annotation name
+Because type annotations are evaluated *after* assignments, you might get unexpected results when using a type annotation name
 that clashes with one of your fields. We raise an error in the following case:
 
 ```py test="skip"
@@ -1240,7 +1240,7 @@ except PydanticUserError as exc_info:
 
 ## Invalid `Self` type {#invalid-self-type}
 
-Currently, `Self` can only be used to annotate a field of a class (specifically, subclasses of `BaseModel`, `NamedTuple`, `TypedDict`, or classes decorated by `@dataclass`). Attempting to use `Self` in any other ways will raise this error.
+Currently, [`Self`][typing.Self] can only be used to annotate a field of a class (specifically, subclasses of [`BaseModel`][pydantic.BaseModel], [`NamedTuple`][typing.NamedTuple], [`TypedDict`][typing.TypedDict], or dataclasses). Attempting to use [`Self`][typing.Self] in any other ways will raise this error.
 
 ```py
 from typing_extensions import Self
@@ -1257,7 +1257,7 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'invalid-self-type'
 ```
 
-The following examples of `validate_call` and `TypeAdapter` will also raise this error, even though they are correct from a type-checking perspective. This may be supported in the future.
+The following example of [`validate_call()`][pydantic.validate_call] will also raise this error, even though it is correct from a type-checking perspective. This may be supported in the future.
 
 ```py
 from typing_extensions import Self
@@ -1268,22 +1268,8 @@ try:
 
     class A(BaseModel):
         @validate_call
-        def func(self: Self):
+        def func(self, arg: Self):
             pass
-
-except PydanticUserError as exc_info:
-    assert exc_info.code == 'invalid-self-type'
-```
-
-```py
-from typing_extensions import Self
-
-from pydantic import BaseModel, PydanticUserError, TypeAdapter
-
-try:
-
-    class A(BaseModel):
-        adapter = TypeAdapter(Self)
 
 except PydanticUserError as exc_info:
     assert exc_info.code == 'invalid-self-type'

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1238,3 +1238,22 @@ except PydanticUserError as exc_info:
 
 [related specification section]: https://typing.readthedocs.io/en/latest/spec/callables.html#unpack-for-keyword-arguments
 [PEP 692]: https://peps.python.org/pep-0692/
+
+
+## Invalid `Self` type {#invalid-self-type}
+
+This error is raise when `Self` is used outside a class scope.
+
+```py
+from typing_extensions import Self,
+
+from pydantic import PydanticUserError, validate_call
+
+try:
+
+    @validate_call
+    def func(self: Self):
+        pass
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'invalid-self-type'

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1262,7 +1262,7 @@ The following examples of `validate_call` and `TypeAdapter` will also raise this
 ```py
 from typing_extensions import Self
 
-from pydantic import PydanticUserError, validate_call
+from pydantic import BaseModel, PydanticUserError, validate_call
 
 try:
 
@@ -1272,13 +1272,13 @@ try:
             pass
 
 except PydanticUserError as exc_info:
-    assert exc_info.code == 'invalid-self-type' -->
+    assert exc_info.code == 'invalid-self-type'
 ```
 
 ```py
 from typing_extensions import Self
 
-from pydantic import PydanticUserError, BaseModel, TypeAdapter
+from pydantic import BaseModel, PydanticUserError, TypeAdapter
 
 try:
 

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -407,7 +407,6 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'callable-discriminator-no-tag'
 ```
 
-
 ## `TypedDict` version {#typed-dict-version}
 
 This error is raised when you use [typing.TypedDict][]
@@ -540,7 +539,6 @@ try:
 except PydanticUserError as exc_info:
     assert exc_info.code == 'invalid-for-json-schema'
 ```
-
 
 ## JSON schema already used {#json-schema-already-used}
 
@@ -1067,7 +1065,7 @@ except PydanticUserError as exc_info:
 
 ## Cannot evaluate type annotation {#unevaluable-type-annotation}
 
-Because type annotations are evaluated *after* assignments, you might get unexpected results when using a type annotation name
+Because type annotations are evaluated _after_ assignments, you might get unexpected results when using a type annotation name
 that clashes with one of your fields. We raise an error in the following case:
 
 ```py test="skip"
@@ -1139,6 +1137,7 @@ pydantic.errors.PydanticUserError: Dataclass field bar has init=False and init_v
 ## `model_config` is used as a model field {#model-config-invalid-field-name}
 
 This error is raised when `model_config` is used as the name of a field.
+
 ```py
 from pydantic import BaseModel, PydanticUserError
 
@@ -1153,7 +1152,7 @@ except PydanticUserError as exc_info:
 
 ## [`with_config`][pydantic.config.with_config] is used on a `BaseModel` subclass {#with-config-on-model}
 
-This error is raised when the [`with_config`][pydantic.config.with_config]  decorator is used on a class which is already a Pydantic model (use the `model_config` attribute instead).
+This error is raised when the [`with_config`][pydantic.config.with_config] decorator is used on a class which is already a Pydantic model (use the `model_config` attribute instead).
 
 ```py
 from pydantic import BaseModel, PydanticUserError, with_config
@@ -1239,13 +1238,12 @@ except PydanticUserError as exc_info:
 [related specification section]: https://typing.readthedocs.io/en/latest/spec/callables.html#unpack-for-keyword-arguments
 [PEP 692]: https://peps.python.org/pep-0692/
 
-
 ## Invalid `Self` type {#invalid-self-type}
 
-This error is raise when `Self` is used outside a class scope.
+Currently, `Self` can only be used to annotate a field of a class (specifically, subclasses of `BaseModel`, `NamedTuple`, `TypedDict`, or classes decorated by `@dataclass`). Attempting to use `Self` in any other ways will raise this error.
 
 ```py
-from typing_extensions import Self,
+from typing_extensions import Self
 
 from pydantic import PydanticUserError, validate_call
 
@@ -1257,3 +1255,36 @@ try:
 
 except PydanticUserError as exc_info:
     assert exc_info.code == 'invalid-self-type'
+```
+
+The following examples of `validate_call` and `TypeAdapter` will also raise this error, even they are correct from a type-checking perspective. This may be supported in the future.
+
+```py
+from typing_extensions import Self
+
+from pydantic import PydanticUserError, validate_call
+
+try:
+
+    class A(BaseModel):
+        @validate_call
+        def func(self: Self):
+            pass
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'invalid-self-type' -->
+```
+
+```py
+from typing_extensions import Self
+
+from pydantic import PydanticUserError, BaseModel, TypeAdapter
+
+try:
+
+    class A(BaseModel):
+        adapter = TypeAdapter(Self)
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'invalid-self-type'
+```

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -778,7 +778,7 @@ class GenerateSchema:
         if is_self_type(obj):
             obj = self.model_type_stack.get()
             if obj is None:
-                raise PydanticUserError('`typing.Self` is not valid outside a class scope', code='invalid-self-type')
+                raise PydanticUserError('`typing.Self` is invalid in this context', code='invalid-self-type')
         with self.defs.get_schema_or_ref(obj) as (_, maybe_schema):
             if maybe_schema is not None:
                 return maybe_schema

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -777,6 +777,8 @@ class GenerateSchema:
         # avoid calling `__get_pydantic_core_schema__` if we've already visited this object
         if is_self_type(obj):
             obj = self.model_type_stack.get()
+            if obj is None:
+                raise PydanticUserError('`typing.Self` is not valid outside a class scope', code='invalid-self-type')
         with self.defs.get_schema_or_ref(obj) as (_, maybe_schema):
             if maybe_schema is not None:
                 return maybe_schema

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -68,6 +68,7 @@ PydanticErrorCodes = Literal[
     'dataclass-on-model',
     'unpack-typed-dict',
     'overlapping-unpack-typed-dict',
+    'invalid-self-type',
 ]
 
 

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -188,10 +188,3 @@ def test_invalid_validate_call_of_method(Self):
             @validate_call
             def foo(self: Self):
                 pass
-
-
-def test_invalid_type_adapter(Self):
-    with pytest.raises(PydanticUserError, match='`typing.Self` is invalid in this context'):
-
-        class A(BaseModel):
-            TypeAdapter(Self)

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -7,7 +7,7 @@ import pytest
 import typing_extensions
 from typing_extensions import NamedTuple, TypedDict
 
-from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+from pydantic import BaseModel, Field, PydanticUserError, TypeAdapter, ValidationError, validate_call
 
 
 @pytest.fixture(
@@ -171,3 +171,27 @@ def test_self_type_in_dataclass(Self):
     assert m.item.ref.x == 2
     with pytest.raises(dataclasses.FrozenInstanceError):
         m.item.ref.x = 3
+
+
+def test_invalid_validate_call(Self):
+    with pytest.raises(PydanticUserError, match='`typing.Self` is invalid in this context'):
+
+        @validate_call
+        def foo(self: Self):
+            pass
+
+
+def test_invalid_validate_call_of_method(Self):
+    with pytest.raises(PydanticUserError, match='`typing.Self` is invalid in this context'):
+
+        class A(BaseModel):
+            @validate_call
+            def foo(self: Self):
+                pass
+
+
+def test_invalid_type_adapter(Self):
+    with pytest.raises(PydanticUserError, match='`typing.Self` is invalid in this context'):
+
+        class A(BaseModel):
+            TypeAdapter(Self)

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -8,7 +8,7 @@ from typing import Any, List, Tuple
 
 import pytest
 from pydantic_core import ArgsKwargs
-from typing_extensions import Annotated, Required, Self, TypedDict, Unpack
+from typing_extensions import Annotated, Required, TypedDict, Unpack
 
 from pydantic import (
     BaseModel,
@@ -1033,11 +1033,3 @@ def test_uses_local_ns():
             return m
 
         assert bar({'z': 1}) == M2(z=1)
-
-
-def test_invalid_self():
-    with pytest.raises(TypeError, match='`typing.Self` is not valid outside a class scope'):
-
-        @validate_call
-        def foo(self: Self):
-            pass

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -8,7 +8,7 @@ from typing import Any, List, Tuple
 
 import pytest
 from pydantic_core import ArgsKwargs
-from typing_extensions import Annotated, Required, TypedDict, Unpack
+from typing_extensions import Annotated, Required, Self, TypedDict, Unpack
 
 from pydantic import (
     BaseModel,
@@ -1033,3 +1033,11 @@ def test_uses_local_ns():
             return m
 
         assert bar({'z': 1}) == M2(z=1)
+
+
+def test_invalid_self():
+    with pytest.raises(TypeError, match='`typing.Self` is not valid outside a class scope'):
+
+        @validate_call
+        def foo(self: Self):
+            pass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Raise an error when `Self` is used but `self.model_type_stack.get()` returns `None`.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
