### PR TITLE
Support usage of `type` with `typing.Self` and type aliases

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -870,6 +870,7 @@ class GenerateSchema:
     def _get_args_resolving_forward_refs(self, obj: Any, required: bool = False) -> tuple[Any, ...] | None:
         args = get_args(obj)
         if args:
+            args = [_typing_extra._make_forward_ref(a) if isinstance(a, str) else a for a in args]
             args = tuple([self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args])
         elif required:  # pragma: no cover
             raise TypeError(f'Expected {obj} to have generic parameters but it had none')

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -870,12 +870,10 @@ class GenerateSchema:
     def _get_args_resolving_forward_refs(self, obj: Any, required: bool = False) -> tuple[Any, ...] | None:
         args = get_args(obj)
         if args:
-            if not _typing_extra.is_literal_type(obj) and not _typing_extra.is_annotated(obj):
-                # This is a rare case, but one example is `obj = list['int']` in Python 3.9-3.11
-                # Other examples are `tuple['int'], type['int']`, etc.
-                # These cases are due to inconsistency between for example `list` and `List` in these versions.
-                args = [_typing_extra._make_forward_ref(a) if isinstance(a, str) else a for a in args]
-            args = tuple([self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args])
+            if isinstance(obj, GenericAlias):
+                # PEP 585 generic aliases don't convert args to ForwardRefs, unlike `typing.List/Dict` etc.
+                args = (_typing_extra._make_forward_ref(a) if isinstance(a, str) else a for a in args)
+            args = (self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args)
         elif required:  # pragma: no cover
             raise TypeError(f'Expected {obj} to have generic parameters but it had none')
         return args

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -870,10 +870,13 @@ class GenerateSchema:
     def _get_args_resolving_forward_refs(self, obj: Any, required: bool = False) -> tuple[Any, ...] | None:
         args = get_args(obj)
         if args:
-            if isinstance(obj, GenericAlias):
-                # PEP 585 generic aliases don't convert args to ForwardRefs, unlike `typing.List/Dict` etc.
-                args = (_typing_extra._make_forward_ref(a) if isinstance(a, str) else a for a in args)
-            args = (self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args)
+            if sys.version_info >= (3, 9):
+                from types import GenericAlias
+
+                if isinstance(obj, GenericAlias):
+                    # PEP 585 generic aliases don't convert args to ForwardRefs, unlike `typing.List/Dict` etc.
+                    args = (_typing_extra._make_forward_ref(a) if isinstance(a, str) else a for a in args)
+            args = tuple(self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args)
         elif required:  # pragma: no cover
             raise TypeError(f'Expected {obj} to have generic parameters but it had none')
         return args
@@ -1666,9 +1669,7 @@ class GenerateSchema:
     def _subclass_schema(self, type_: Any) -> core_schema.CoreSchema:
         """Generate schema for a Type, e.g. `Type[int]`."""
         type_param = self._get_first_arg_or_any(type_)
-        type_param = _typing_extra.eval_type(type_param, *self._types_namespace)
 
-        # Assume `type[Annotated[<typ>, ...]]` is equivalent to `type[<typ>]`:
         type_param = _typing_extra.annotated_type(type_param) or type_param
 
         if type_param == Any:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -870,7 +870,6 @@ class GenerateSchema:
     def _get_args_resolving_forward_refs(self, obj: Any, required: bool = False) -> tuple[Any, ...] | None:
         args = get_args(obj)
         if args:
-            args = [_typing_extra._make_forward_ref(a) if isinstance(a, str) else a for a in args]
             args = tuple([self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args])
         elif required:  # pragma: no cover
             raise TypeError(f'Expected {obj} to have generic parameters but it had none')
@@ -1664,6 +1663,8 @@ class GenerateSchema:
     def _subclass_schema(self, type_: Any) -> core_schema.CoreSchema:
         """Generate schema for a Type, e.g. `Type[int]`."""
         type_param = self._get_first_arg_or_any(type_)
+        type_param = _typing_extra.eval_type(type_param, *self._types_namespace)
+
         # Assume `type[Annotated[<typ>, ...]]` is equivalent to `type[<typ>]`:
         type_param = _typing_extra.annotated_type(type_param) or type_param
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1670,6 +1670,7 @@ class GenerateSchema:
         """Generate schema for a Type, e.g. `Type[int]`."""
         type_param = self._get_first_arg_or_any(type_)
 
+        # Assume `type[Annotated[<typ>, ...]]` is equivalent to `type[<typ>]`:
         type_param = _typing_extra.annotated_type(type_param) or type_param
 
         if type_param == Any:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -862,33 +862,27 @@ class GenerateSchema:
         return obj
 
     @overload
-    def _get_args_resolving_forward_refs(
-        self, obj: Any, *, required: Literal[True], eval_str: bool = True
-    ) -> tuple[Any, ...]: ...
+    def _get_args_resolving_forward_refs(self, obj: Any, required: Literal[True]) -> tuple[Any, ...]: ...
 
     @overload
-    def _get_args_resolving_forward_refs(self, obj: Any, *, eval_str: bool = True) -> tuple[Any, ...] | None: ...
+    def _get_args_resolving_forward_refs(self, obj: Any) -> tuple[Any, ...] | None: ...
 
-    def _get_args_resolving_forward_refs(
-        self, obj: Any, *, required: bool = False, eval_str: bool = True
-    ) -> tuple[Any, ...] | None:
+    def _get_args_resolving_forward_refs(self, obj: Any, required: bool = False) -> tuple[Any, ...] | None:
         args = get_args(obj)
         if args:
-            if eval_str:
-                args = [_typing_extra._make_forward_ref(a) if isinstance(a, str) else a for a in args]
             args = tuple([self._resolve_forward_ref(a) if isinstance(a, ForwardRef) else a for a in args])
         elif required:  # pragma: no cover
             raise TypeError(f'Expected {obj} to have generic parameters but it had none')
         return args
 
-    def _get_first_arg_or_any(self, obj: Any, eval_str: bool = True) -> Any:
-        args = self._get_args_resolving_forward_refs(obj, eval_str=eval_str)
+    def _get_first_arg_or_any(self, obj: Any) -> Any:
+        args = self._get_args_resolving_forward_refs(obj)
         if not args:
             return Any
         return args[0]
 
-    def _get_first_two_args_or_any(self, obj: Any, eval_str: bool = True) -> tuple[Any, Any]:
-        args = self._get_args_resolving_forward_refs(obj, eval_str=eval_str)
+    def _get_first_two_args_or_any(self, obj: Any) -> tuple[Any, Any]:
+        args = self._get_args_resolving_forward_refs(obj)
         if not args:
             return (Any, Any)
         if len(args) < 2:
@@ -1669,6 +1663,7 @@ class GenerateSchema:
     def _subclass_schema(self, type_: Any) -> core_schema.CoreSchema:
         """Generate schema for a Type, e.g. `Type[int]`."""
         type_param = self._get_first_arg_or_any(type_)
+        type_param = _typing_extra.eval_type(type_param, *self._types_namespace)
 
         # Assume `type[Annotated[<typ>, ...]]` is equivalent to `type[<typ>]`:
         type_param = _typing_extra.annotated_type(type_param) or type_param
@@ -2039,14 +2034,10 @@ class GenerateSchema:
         """Generate schema for an Annotated type, e.g. `Annotated[int, Field(...)]` or `Annotated[int, Gt(0)]`."""
         FieldInfo = import_cached_field_info()
 
-        # We don't want to eval string annotations as type,
-        # because there may be cases like `Annotated[int, 'not a type']`
         source_type, *annotations = self._get_args_resolving_forward_refs(
             annotated_type,
             required=True,
-            eval_str=False,
         )
-
         schema = self._apply_annotations(source_type, annotations)
         # put the default validator last so that TypeAdapter.get_default_value() works
         # even if there are function validators involved

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -308,7 +308,7 @@ def eval_type_backport(
 
         # If it is a `TypeError` and value isn't a `ForwardRef`, it would have failed during annotation definition.
         # Thus we assert here for type checking purposes:
-        assert isinstance(value, typing.ForwardRef), (value, e)
+        assert isinstance(value, typing.ForwardRef)
 
         message = f'Unable to evaluate type annotation {value.__forward_arg__!r}.'
         if sys.version_info >= (3, 11):

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -308,7 +308,7 @@ def eval_type_backport(
 
         # If it is a `TypeError` and value isn't a `ForwardRef`, it would have failed during annotation definition.
         # Thus we assert here for type checking purposes:
-        assert isinstance(value, typing.ForwardRef)
+        assert isinstance(value, typing.ForwardRef), (value, e)
 
         message = f'Unable to evaluate type annotation {value.__forward_arg__!r}.'
         if sys.version_info >= (3, 11):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1491,10 +1491,10 @@ def test_type_assign():
         Model(v=Different)
     assert exc_info.value.errors(include_url=False) == [
         {
-            'ctx': {'class': 'test_assign_type.<locals>.Parent'},
-            'input': HasRepr("<class 'tests.test_edge_cases.test_assign_type.<locals>.Different'>"),
+            'ctx': {'class': Parent.__qualname__},
+            'input': HasRepr(repr(Different)),
             'loc': ('v',),
-            'msg': 'Input should be a subclass of test_assign_type.<locals>.Parent',
+            'msg': f'Input should be a subclass of {Parent.__qualname__}',
             'type': 'is_subclass_of',
         }
     ]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1414,13 +1414,6 @@ def test_type_on_none():
     ]
 
 
-def test_type_on_annotation_error():
-    with pytest.raises(TypeError, match='Expected a class, got 1'):
-
-        class Model1(BaseModel):
-            a: Type[1]
-
-
 def test_annotated_inside_type():
     class Model(BaseModel):
         a: Type[Annotated[int, ...]]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1394,6 +1394,33 @@ def test_type_on_annotation():
     assert Model.model_fields.keys() == set('abcdefg')
 
 
+def test_type_on_none():
+    class Model(BaseModel):
+        a: Type[None]
+
+    Model(a=type(None))
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a=None)
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'is_subclass_of',
+            'loc': ('a',),
+            'msg': 'Input should be a subclass of NoneType',
+            'input': None,
+            'ctx': {'class': 'NoneType'},
+        }
+    ]
+
+
+def test_type_on_annotation_error():
+    with pytest.raises(TypeError, match='Expected a class, got 1'):
+
+        class Model1(BaseModel):
+            a: Type[1]
+
+
 def test_annotated_inside_type():
     class Model(BaseModel):
         a: Type[Annotated[int, ...]]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1394,6 +1394,16 @@ def test_type_on_annotation():
     assert Model.model_fields.keys() == set('abcdefg')
 
 
+def test_type_union():
+    class Model(BaseModel):
+        a: Type[Union[str, bytes]]
+        b: Type[Union[Any, str]]
+
+    m = Model(a=bytes, b=int)
+    assert m.model_dump() == {'a': bytes, 'b': int}
+    assert m.a == bytes
+
+
 def test_type_on_none():
     class Model(BaseModel):
         a: Type[None]
@@ -1438,7 +1448,7 @@ def test_type_on_typealias():
     ]
 
 
-def test_annotated_inside_type():
+def test_type_on_annotated():
     class Model(BaseModel):
         a: Type[Annotated[int, ...]]
 
@@ -1458,7 +1468,7 @@ def test_annotated_inside_type():
     ]
 
 
-def test_assign_type():
+def test_type_assign():
     class Parent:
         def echo(self):
             return 'parent'
@@ -2660,16 +2670,6 @@ def test_union_literal_with_other_type(literal_type, other_type, data, json_valu
     m = Model(value=data, value_types_reversed=data)
     assert m.model_dump() == {'value': data, 'value_types_reversed': data_reversed}
     assert m.model_dump_json() == f'{{"value":{json_value},"value_types_reversed":{json_value_reversed}}}'
-
-
-def test_type_union():
-    class Model(BaseModel):
-        a: Type[Union[str, bytes]]
-        b: Type[Union[Any, str]]
-
-    m = Model(a=bytes, b=int)
-    assert m.model_dump() == {'a': bytes, 'b': int}
-    assert m.a == bytes
 
 
 def test_model_repr_before_validation():

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -1,5 +1,6 @@
 import dataclasses
 import re
+import sys
 import typing
 from typing import List, Optional, Type, Union
 
@@ -200,12 +201,23 @@ def test_type_of_self(Self):
 
         # make sure forward refs are supported:
         @computed_field
-        def self_types2(self) -> List[Type['Self']]:
+        def self_types2(self) -> list[type['Self']]:
             return [type(self), self.self_type]
 
         @computed_field
         def self_types3(self) -> 'List[Type[Self]]':
             return [type(self), self.self_type]
+
+        if sys.version_info >= (3, 9):
+            # standard container types are supported in 3.9+
+
+            @computed_field
+            def self_types4(self) -> 'list[type[Self]]':
+                return [type(self), self.self_type]
+
+            @computed_field
+            def self_types5(self) -> list['type[Self]']:
+                return [type(self), self.self_type]
 
     class B(A): ...
 

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -201,7 +201,7 @@ def test_type_of_self(Self):
 
         # make sure forward refs are supported:
         @computed_field
-        def self_types2(self) -> list[type['Self']]:
+        def self_types2(self) -> List[Type['Self']]:
             return [type(self), self.self_type]
 
         @computed_field

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -198,12 +198,11 @@ def test_type_of_self(Self):
         def self_types1(self) -> List[Type[Self]]:
             return [type(self), self.self_type]
 
-        # make sure `eval_type` etc. works
+        # make sure forward refs are supported:
         @computed_field
         def self_types2(self) -> List[Type['Self']]:
             return [type(self), self.self_type]
 
-        # make sure `eval_type` etc. works
         @computed_field
         def self_types3(self) -> 'List[Type[Self]]':
             return [type(self), self.self_type]

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 import typing
-from typing import List, Optional, Union
+from typing import List, Optional, Type, Union
 
 import pytest
 import typing_extensions
@@ -192,20 +192,20 @@ def test_invalid_validate_call_of_method(Self):
 
 def test_type_of_self(Self):
     class A(BaseModel):
-        self_type: type[Self]
+        self_type: Type[Self]
 
         @computed_field
-        def self_types1(self) -> list[type[Self]]:
+        def self_types1(self) -> list[Type[Self]]:
             return [type(self), self.self_type]
 
         # make sure `eval_type` etc. works
         @computed_field
-        def self_types2(self) -> list[type['Self']]:
+        def self_types2(self) -> list[Type['Self']]:
             return [type(self), self.self_type]
 
         # make sure `eval_type` etc. works
         @computed_field
-        def self_types3(self) -> 'list[type[Self]]':
+        def self_types3(self) -> 'list[Type[Self]]':
             return [type(self), self.self_type]
 
     class B(A): ...

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -195,17 +195,17 @@ def test_type_of_self(Self):
         self_type: Type[Self]
 
         @computed_field
-        def self_types1(self) -> list[Type[Self]]:
+        def self_types1(self) -> List[Type[Self]]:
             return [type(self), self.self_type]
 
         # make sure `eval_type` etc. works
         @computed_field
-        def self_types2(self) -> list[Type['Self']]:
+        def self_types2(self) -> List[Type['Self']]:
             return [type(self), self.self_type]
 
         # make sure `eval_type` etc. works
         @computed_field
-        def self_types3(self) -> 'list[Type[Self]]':
+        def self_types3(self) -> 'List[Type[Self]]':
             return [type(self), self.self_type]
 
     class B(A): ...


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fix errors caused by these:
```py
TypeAdapter(type[Self])

type MyInt = int
TypeAdapter(type[MyInt])
```

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #10618
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
