### PR TITLE
Prototype: Remove schema traversing (`WalkCoreSchema`) to improve performance of schema building

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import os
 from typing import (
     Any,
-    Callable,
-    Hashable,
-    TypeVar,
     Union,
 )
 
@@ -107,285 +104,11 @@ def get_type_ref(type_: type[Any], args_override: tuple[type[Any], ...] | None =
     return type_ref
 
 
-def get_ref(s: core_schema.CoreSchema) -> None | str:
-    """Get the ref from the schema if it has one.
-    This exists just for type checking to work correctly.
-    """
-    return s.get('ref', None)
-
-
-def collect_definitions(schema: core_schema.CoreSchema) -> dict[str, core_schema.CoreSchema]:
-    defs: dict[str, CoreSchema] = {}
-
-    def _record_valid_refs(s: core_schema.CoreSchema, recurse: Recurse) -> core_schema.CoreSchema:
-        ref = get_ref(s)
-        if ref:
-            defs[ref] = s
-        return recurse(s, _record_valid_refs)
-
-    walk_core_schema(schema, _record_valid_refs, copy=False)
-
-    return defs
-
-
-T = TypeVar('T')
-
-
-Recurse = Callable[[core_schema.CoreSchema, 'Walk'], core_schema.CoreSchema]
-Walk = Callable[[core_schema.CoreSchema, Recurse], core_schema.CoreSchema]
-
-# TODO: Should we move _WalkCoreSchema into pydantic_core proper?
-#   Issue: https://github.com/pydantic/pydantic-core/issues/615
-
-CoreSchemaT = TypeVar('CoreSchemaT')
-
-
-class _WalkCoreSchema:
-    def __init__(self, *, copy: bool = True):
-        self._schema_type_to_method = self._build_schema_type_to_method()
-        self._copy = copy
-
-    def _copy_schema(self, schema: CoreSchemaT) -> CoreSchemaT:
-        return schema.copy() if self._copy else schema  # pyright: ignore[reportAttributeAccessIssue]
-
-    def _build_schema_type_to_method(self) -> dict[core_schema.CoreSchemaType, Recurse]:
-        mapping: dict[core_schema.CoreSchemaType, Recurse] = {}
-        key: core_schema.CoreSchemaType
-        for key in get_args(core_schema.CoreSchemaType):
-            method_name = f"handle_{key.replace('-', '_')}_schema"
-            mapping[key] = getattr(self, method_name, self._handle_other_schemas)
-        return mapping
-
-    def walk(self, schema: core_schema.CoreSchema, f: Walk) -> core_schema.CoreSchema:
-        return f(schema, self._walk)
-
-    def _walk(self, schema: core_schema.CoreSchema, f: Walk) -> core_schema.CoreSchema:
-        schema = self._schema_type_to_method[schema['type']](self._copy_schema(schema), f)
-        ser_schema: core_schema.SerSchema | None = schema.get('serialization')  # type: ignore
-        if ser_schema:
-            schema['serialization'] = self._handle_ser_schemas(ser_schema, f)
-        return schema
-
-    def _handle_other_schemas(self, schema: core_schema.CoreSchema, f: Walk) -> core_schema.CoreSchema:
-        sub_schema = schema.get('schema', None)
-        if sub_schema is not None:
-            schema['schema'] = self.walk(sub_schema, f)  # type: ignore
-        return schema
-
-    def _handle_ser_schemas(self, ser_schema: core_schema.SerSchema, f: Walk) -> core_schema.SerSchema:
-        schema: core_schema.CoreSchema | None = ser_schema.get('schema', None)
-        return_schema: core_schema.CoreSchema | None = ser_schema.get('return_schema', None)
-        if schema is not None or return_schema is not None:
-            ser_schema = self._copy_schema(ser_schema)
-            if schema is not None:
-                ser_schema['schema'] = self.walk(schema, f)  # type: ignore
-            if return_schema is not None:
-                ser_schema['return_schema'] = self.walk(return_schema, f)  # type: ignore
-        return ser_schema
-
-    def handle_definitions_schema(self, schema: core_schema.DefinitionsSchema, f: Walk) -> core_schema.CoreSchema:
-        new_definitions: list[core_schema.CoreSchema] = []
-        for definition in schema['definitions']:
-            if 'schema_ref' in definition and 'ref' in definition:
-                # This indicates a purposely indirect reference
-                # We want to keep such references around for implications related to JSON schema, etc.:
-                new_definitions.append(definition)
-                # However, we still need to walk the referenced definition:
-                self.walk(definition, f)
-                continue
-
-            updated_definition = self.walk(definition, f)
-            if 'ref' in updated_definition:
-                # If the updated definition schema doesn't have a 'ref', it shouldn't go in the definitions
-                # This is most likely to happen due to replacing something with a definition reference, in
-                # which case it should certainly not go in the definitions list
-                new_definitions.append(updated_definition)
-        new_inner_schema = self.walk(schema['schema'], f)
-
-        if not new_definitions and len(schema) == 3:
-            # This means we'd be returning a "trivial" definitions schema that just wrapped the inner schema
-            return new_inner_schema
-
-        new_schema = self._copy_schema(schema)
-        new_schema['schema'] = new_inner_schema
-        new_schema['definitions'] = new_definitions
-        return new_schema
-
-    def handle_list_schema(self, schema: core_schema.ListSchema, f: Walk) -> core_schema.CoreSchema:
-        items_schema = schema.get('items_schema')
-        if items_schema is not None:
-            schema['items_schema'] = self.walk(items_schema, f)
-        return schema
-
-    def handle_set_schema(self, schema: core_schema.SetSchema, f: Walk) -> core_schema.CoreSchema:
-        items_schema = schema.get('items_schema')
-        if items_schema is not None:
-            schema['items_schema'] = self.walk(items_schema, f)
-        return schema
-
-    def handle_frozenset_schema(self, schema: core_schema.FrozenSetSchema, f: Walk) -> core_schema.CoreSchema:
-        items_schema = schema.get('items_schema')
-        if items_schema is not None:
-            schema['items_schema'] = self.walk(items_schema, f)
-        return schema
-
-    def handle_generator_schema(self, schema: core_schema.GeneratorSchema, f: Walk) -> core_schema.CoreSchema:
-        items_schema = schema.get('items_schema')
-        if items_schema is not None:
-            schema['items_schema'] = self.walk(items_schema, f)
-        return schema
-
-    def handle_tuple_schema(self, schema: core_schema.TupleSchema, f: Walk) -> core_schema.CoreSchema:
-        schema['items_schema'] = [self.walk(v, f) for v in schema['items_schema']]
-        return schema
-
-    def handle_dict_schema(self, schema: core_schema.DictSchema, f: Walk) -> core_schema.CoreSchema:
-        keys_schema = schema.get('keys_schema')
-        if keys_schema is not None:
-            schema['keys_schema'] = self.walk(keys_schema, f)
-        values_schema = schema.get('values_schema')
-        if values_schema:
-            schema['values_schema'] = self.walk(values_schema, f)
-        return schema
-
-    def handle_function_schema(self, schema: AnyFunctionSchema, f: Walk) -> core_schema.CoreSchema:
-        if not is_function_with_inner_schema(schema):
-            return schema
-        schema['schema'] = self.walk(schema['schema'], f)
-        return schema
-
-    def handle_union_schema(self, schema: core_schema.UnionSchema, f: Walk) -> core_schema.CoreSchema:
-        new_choices: list[CoreSchema | tuple[CoreSchema, str]] = []
-        for v in schema['choices']:
-            if isinstance(v, tuple):
-                new_choices.append((self.walk(v[0], f), v[1]))
-            else:
-                new_choices.append(self.walk(v, f))
-        schema['choices'] = new_choices
-        return schema
-
-    def handle_tagged_union_schema(self, schema: core_schema.TaggedUnionSchema, f: Walk) -> core_schema.CoreSchema:
-        new_choices: dict[Hashable, core_schema.CoreSchema] = {}
-        for k, v in schema['choices'].items():
-            new_choices[k] = v if isinstance(v, (str, int)) else self.walk(v, f)
-        schema['choices'] = new_choices
-        return schema
-
-    def handle_chain_schema(self, schema: core_schema.ChainSchema, f: Walk) -> core_schema.CoreSchema:
-        schema['steps'] = [self.walk(v, f) for v in schema['steps']]
-        return schema
-
-    def handle_lax_or_strict_schema(self, schema: core_schema.LaxOrStrictSchema, f: Walk) -> core_schema.CoreSchema:
-        schema['lax_schema'] = self.walk(schema['lax_schema'], f)
-        schema['strict_schema'] = self.walk(schema['strict_schema'], f)
-        return schema
-
-    def handle_json_or_python_schema(self, schema: core_schema.JsonOrPythonSchema, f: Walk) -> core_schema.CoreSchema:
-        schema['json_schema'] = self.walk(schema['json_schema'], f)
-        schema['python_schema'] = self.walk(schema['python_schema'], f)
-        return schema
-
-    def handle_model_fields_schema(self, schema: core_schema.ModelFieldsSchema, f: Walk) -> core_schema.CoreSchema:
-        extras_schema = schema.get('extras_schema')
-        if extras_schema is not None:
-            schema['extras_schema'] = self.walk(extras_schema, f)
-        replaced_fields: dict[str, core_schema.ModelField] = {}
-        replaced_computed_fields: list[core_schema.ComputedField] = []
-        for computed_field in schema.get('computed_fields', ()):
-            replaced_field = self._copy_schema(computed_field)
-            replaced_field['return_schema'] = self.walk(computed_field['return_schema'], f)
-            replaced_computed_fields.append(replaced_field)
-        if replaced_computed_fields:
-            schema['computed_fields'] = replaced_computed_fields
-        for k, v in schema['fields'].items():
-            replaced_field = self._copy_schema(v)
-            replaced_field['schema'] = self.walk(v['schema'], f)
-            replaced_fields[k] = replaced_field
-        schema['fields'] = replaced_fields
-        return schema
-
-    def handle_typed_dict_schema(self, schema: core_schema.TypedDictSchema, f: Walk) -> core_schema.CoreSchema:
-        extras_schema = schema.get('extras_schema')
-        if extras_schema is not None:
-            schema['extras_schema'] = self.walk(extras_schema, f)
-        replaced_computed_fields: list[core_schema.ComputedField] = []
-        for computed_field in schema.get('computed_fields', ()):
-            replaced_field = self._copy_schema(computed_field)
-            replaced_field['return_schema'] = self.walk(computed_field['return_schema'], f)
-            replaced_computed_fields.append(replaced_field)
-        if replaced_computed_fields:
-            schema['computed_fields'] = replaced_computed_fields
-        replaced_fields: dict[str, core_schema.TypedDictField] = {}
-        for k, v in schema['fields'].items():
-            replaced_field = self._copy_schema(v)
-            replaced_field['schema'] = self.walk(v['schema'], f)
-            replaced_fields[k] = replaced_field
-        schema['fields'] = replaced_fields
-        return schema
-
-    def handle_dataclass_args_schema(self, schema: core_schema.DataclassArgsSchema, f: Walk) -> core_schema.CoreSchema:
-        replaced_fields: list[core_schema.DataclassField] = []
-        replaced_computed_fields: list[core_schema.ComputedField] = []
-        for computed_field in schema.get('computed_fields', ()):
-            replaced_field = self._copy_schema(computed_field)
-            replaced_field['return_schema'] = self.walk(computed_field['return_schema'], f)
-            replaced_computed_fields.append(replaced_field)
-        if replaced_computed_fields:
-            schema['computed_fields'] = replaced_computed_fields
-        for field in schema['fields']:
-            replaced_field = self._copy_schema(field)
-            replaced_field['schema'] = self.walk(field['schema'], f)
-            replaced_fields.append(replaced_field)
-        schema['fields'] = replaced_fields
-        return schema
-
-    def handle_arguments_schema(self, schema: core_schema.ArgumentsSchema, f: Walk) -> core_schema.CoreSchema:
-        replaced_arguments_schema: list[core_schema.ArgumentsParameter] = []
-        for param in schema['arguments_schema']:
-            replaced_param = self._copy_schema(param)
-            replaced_param['schema'] = self.walk(param['schema'], f)
-            replaced_arguments_schema.append(replaced_param)
-        schema['arguments_schema'] = replaced_arguments_schema
-        if 'var_args_schema' in schema:
-            schema['var_args_schema'] = self.walk(schema['var_args_schema'], f)
-        if 'var_kwargs_schema' in schema:
-            schema['var_kwargs_schema'] = self.walk(schema['var_kwargs_schema'], f)
-        return schema
-
-    def handle_call_schema(self, schema: core_schema.CallSchema, f: Walk) -> core_schema.CoreSchema:
-        schema['arguments_schema'] = self.walk(schema['arguments_schema'], f)
-        if 'return_schema' in schema:
-            schema['return_schema'] = self.walk(schema['return_schema'], f)
-        return schema
-
-
-_dispatch = _WalkCoreSchema().walk
-_dispatch_no_copy = _WalkCoreSchema(copy=False).walk
-
-
-def walk_core_schema(schema: core_schema.CoreSchema, f: Walk, *, copy: bool = True) -> core_schema.CoreSchema:
-    """Recursively traverse a CoreSchema.
-
-    Args:
-        schema (core_schema.CoreSchema): The CoreSchema to process, it will not be modified.
-        f (Walk): A function to apply. This function takes two arguments:
-          1. The current CoreSchema that is being processed
-             (not the same one you passed into this function, one level down).
-          2. The "next" `f` to call. This lets you for example use `f=functools.partial(some_method, some_context)`
-             to pass data down the recursive calls without using globals or other mutable state.
-        copy: Whether schema should be recursively copied.
-
-    Returns:
-        core_schema.CoreSchema: A processed CoreSchema.
-    """
-    return f(schema.copy() if copy else schema, _dispatch if copy else _dispatch_no_copy)
-
-
 def _strip_metadata(schema: CoreSchema) -> CoreSchema:
-    def strip_metadata(s: CoreSchema, recurse: Recurse) -> CoreSchema:
+    def strip_metadata(s: dict[str, Any]) -> dict[str, Any]:
         s = s.copy()
         s.pop('metadata', None)
-        if s['type'] == 'model-fields':
+        if s.get('type') == 'model-fields':
             s = s.copy()
             s['fields'] = {k: v.copy() for k, v in s['fields'].items()}
             for field_name, field_schema in s['fields'].items():
@@ -398,7 +121,7 @@ def _strip_metadata(schema: CoreSchema) -> CoreSchema:
                     cf.pop('metadata', None)
             else:
                 s.pop('computed_fields', None)
-        elif s['type'] == 'model':
+        elif s.get('type') == 'model':
             # remove some defaults
             if s.get('custom_init', True) is False:
                 s.pop('custom_init')
@@ -406,10 +129,17 @@ def _strip_metadata(schema: CoreSchema) -> CoreSchema:
                 s.pop('root_model')
             if {'title'}.issuperset(s.get('config', {}).keys()):
                 s.pop('config', None)
+        return s
 
-        return recurse(s, strip_metadata)
+    def traverse(v: Any) -> Any:
+        if isinstance(v, dict):
+            res = {k: traverse(vv) for k, vv in v.items()}
+            return strip_metadata(res)  # type: ignore
+        elif isinstance(v, list):
+            return [traverse(vv) for vv in v]
+        return v
 
-    return walk_core_schema(schema, strip_metadata)
+    return traverse(schema)
 
 
 def pretty_print_core_schema(

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import (
-    Any,
-    Union,
-)
+from typing import Any, Union
 
 from pydantic_core import CoreSchema, core_schema
 from pydantic_core import validate_core_schema as _validate_core_schema
@@ -12,14 +9,6 @@ from typing_extensions import TypeAliasType, TypeGuard, get_args, get_origin
 
 from . import _repr
 from ._typing_extra import is_generic_alias
-
-AnyFunctionSchema = Union[
-    core_schema.AfterValidatorFunctionSchema,
-    core_schema.BeforeValidatorFunctionSchema,
-    core_schema.WrapValidatorFunctionSchema,
-    core_schema.PlainValidatorFunctionSchema,
-]
-
 
 FunctionSchemaWithInnerSchema = Union[
     core_schema.AfterValidatorFunctionSchema,

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -128,22 +128,6 @@ def collect_definitions(schema: core_schema.CoreSchema) -> dict[str, core_schema
     return defs
 
 
-def collect_invalid_schemas(schema: core_schema.CoreSchema) -> bool:
-    invalid = False
-
-    def _is_schema_valid(s: core_schema.CoreSchema, recurse: Recurse) -> core_schema.CoreSchema:
-        nonlocal invalid
-
-        if s['type'] == 'invalid':
-            invalid = True
-            return s
-
-        return recurse(s, _is_schema_valid)
-
-    walk_core_schema(schema, _is_schema_valid, copy=False)
-    return invalid
-
-
 T = TypeVar('T')
 
 

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -104,7 +104,7 @@ def get_type_ref(type_: type[Any], args_override: tuple[type[Any], ...] | None =
     return type_ref
 
 
-def _strip_metadata(schema: CoreSchema) -> CoreSchema:
+def _print_strip_metadata(schema: CoreSchema) -> CoreSchema:
     def strip_metadata(s: dict[str, Any]) -> dict[str, Any]:
         s = s.copy()
         s.pop('metadata', None)
@@ -131,15 +131,15 @@ def _strip_metadata(schema: CoreSchema) -> CoreSchema:
                 s.pop('config', None)
         return s
 
-    def traverse(v: Any) -> Any:
+    def traverse_strip_metadata(v: Any) -> Any:
         if isinstance(v, dict):
-            res = {k: traverse(vv) for k, vv in v.items()}
+            res = {k: traverse_strip_metadata(vv) for k, vv in v.items()}
             return strip_metadata(res)  # type: ignore
         elif isinstance(v, list):
-            return [traverse(vv) for vv in v]
+            return [traverse_strip_metadata(vv) for vv in v]
         return v
 
-    return traverse(schema)
+    return traverse_strip_metadata(schema)
 
 
 def pretty_print_core_schema(
@@ -156,7 +156,7 @@ def pretty_print_core_schema(
     from rich import print  # type: ignore  # install it manually in your dev env
 
     if not include_metadata:
-        schema = _strip_metadata(schema)
+        schema = _print_strip_metadata(schema)
 
     return print(schema)
 

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -172,6 +172,7 @@ def complete_dataclass(
             )
         else:
             schema = gen_schema.generate_schema(cls, from_dunder_get_core_schema=False)
+        schema = gen_schema.clean_schema(schema)
     except PydanticUndefinedAnnotation as e:
         if raise_errors:
             raise
@@ -179,12 +180,6 @@ def complete_dataclass(
         return False
 
     core_config = config_wrapper.core_config(title=cls.__name__)
-
-    try:
-        schema = gen_schema.clean_schema(schema)
-    except gen_schema.CollectedInvalid:
-        set_dataclass_mocks(cls, cls.__name__, 'all referenced types')
-        return False
 
     # We are about to set all the remaining required properties expected for this cast;
     # __pydantic_decorators__ and __pydantic_fields__ should already be set

--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -2,19 +2,14 @@ from __future__ import annotations as _annotations
 
 from typing import TYPE_CHECKING, Any, Hashable, Sequence
 
-from pydantic_core import CoreSchema, core_schema
+from pydantic_core import core_schema
 
 from ..errors import PydanticUserError
 from . import _core_utils
-from ._core_utils import (
-    CoreSchemaField,
-    collect_definitions,
-)
+from ._core_utils import CoreSchemaField
 
 if TYPE_CHECKING:
     from ..types import Discriminator
-
-CORE_SCHEMA_METADATA_DISCRIMINATOR_PLACEHOLDER_KEY = 'pydantic.internal.union_discriminator'
 
 
 class MissingDefinitionForUnionRef(Exception):
@@ -25,37 +20,6 @@ class MissingDefinitionForUnionRef(Exception):
     def __init__(self, ref: str) -> None:
         self.ref = ref
         super().__init__(f'Missing definition for ref {self.ref!r}')
-
-
-def set_discriminator_in_metadata(schema: CoreSchema, discriminator: Any) -> None:
-    schema.setdefault('metadata', {})
-    metadata = schema.get('metadata')
-    assert metadata is not None
-    metadata[CORE_SCHEMA_METADATA_DISCRIMINATOR_PLACEHOLDER_KEY] = discriminator
-
-
-def apply_discriminators(schema: core_schema.CoreSchema) -> core_schema.CoreSchema:
-    # We recursively walk through the `schema` passed to `apply_discriminators`, applying discriminators
-    # where necessary at each level. During this recursion, we allow references to be resolved from the definitions
-    # that are originally present on the original, outermost `schema`. Before `apply_discriminators` is called,
-    # `simplify_schema_references` is called on the schema (in the `clean_schema` function),
-    # which often puts the definitions in the outermost schema.
-    global_definitions: dict[str, CoreSchema] = collect_definitions(schema)
-
-    def inner(s: core_schema.CoreSchema, recurse: _core_utils.Recurse) -> core_schema.CoreSchema:
-        nonlocal global_definitions
-
-        s = recurse(s, inner)
-        if s['type'] == 'tagged-union':
-            return s
-
-        metadata = s.get('metadata', {})
-        discriminator = metadata.pop(CORE_SCHEMA_METADATA_DISCRIMINATOR_PLACEHOLDER_KEY, None)
-        if discriminator is not None:
-            s = apply_discriminator(s, discriminator, global_definitions)
-        return s
-
-    return _core_utils.walk_core_schema(schema, inner, copy=False)
 
 
 def apply_discriminator(
@@ -217,7 +181,7 @@ class _ApplyInferredDiscriminator:
             # was flattened by pydantic_core.
             # However, it still may make sense to apply the discriminator to this schema,
             # as a way to get discriminated-union-style error messages, so we allow this here.
-            schema = core_schema.union_schema([schema])
+            schema = core_schema.union_schema([schema.copy()])
 
         # Reverse the choices list before extending the stack so that they get handled in the order they occur
         choices_schemas = [v[0] if isinstance(v, tuple) else v for v in schema['choices'][::-1]]

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1657,6 +1657,7 @@ class GenerateSchema:
 
         item_type_schema = self.generate_schema(items_type)
         list_schema = core_schema.list_schema(item_type_schema)
+        json_schema = core_schema.list_schema(self.generate_schema(items_type))
 
         python_schema = core_schema.is_instance_schema(typing.Sequence, cls_repr='Sequence')
         if items_type != Any:
@@ -1670,7 +1671,7 @@ class GenerateSchema:
             serialize_sequence_via_list, schema=item_type_schema, info_arg=True
         )
         return core_schema.json_or_python_schema(
-            json_schema=list_schema, python_schema=python_schema, serialization=serialization
+            json_schema=json_schema, python_schema=python_schema, serialization=serialization
         )
 
     def _iterable_schema(self, type_: Any) -> core_schema.GeneratorSchema:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -435,11 +435,11 @@ class GenerateSchema:
             )
 
             if self._config_wrapper.use_enum_values:
-                return core_schema.no_info_after_validator_function(
+                enum_schema = core_schema.no_info_after_validator_function(
                     attrgetter('value'), enum_schema, serialization=value_ser_type
                 )
-            else:
-                return self.defs.create_def_ref(enum_ref, enum_schema)
+
+            return enum_schema
 
         else:
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2174,7 +2174,7 @@ class GenerateSchema:
         schema: core_schema.CoreSchema,
         serializers: list[Decorator[FieldSerializerDecoratorInfo]],
     ) -> core_schema.CoreSchema:
-        """Apply field serializers to a schema. Mutates the schema."""
+        """Apply field serializers to a schema."""
         if serializers:
             if schema['type'] == 'definitions':
                 inner_schema = schema['schema']
@@ -2184,6 +2184,8 @@ class GenerateSchema:
                 ref = typing.cast('str|None', schema.get('ref', None))
                 if ref is not None:
                     schema = self.defs.create_def_ref(ref, schema)
+                elif schema['type'] != 'definition-ref':
+                    schema = schema.copy()
 
             # use the last serializer to make it easy to override a serializer set on a parent model
             serializer = serializers[-1]

--- a/pydantic/_internal/_mock_val_ser.py
+++ b/pydantic/_internal/_mock_val_ser.py
@@ -59,9 +59,9 @@ class MockCoreSchema(Mapping[str, Any]):
     def rebuild(self) -> CoreSchema | None:
         self._built_memo = None
         if self._attempt_rebuild:
-            val_ser = self._attempt_rebuild()
-            if val_ser is not None:
-                return val_ser
+            schema = self._attempt_rebuild()
+            if schema is not None:
+                return schema
             else:
                 raise PydanticUserError(self._error_message, code=self._code)
         return None

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -657,20 +657,15 @@ def complete_model_class(
         ref_mode='unpack',
     )
 
+    core_config = config_wrapper.core_config(title=cls.__name__)
+
     try:
         schema = cls.__get_pydantic_core_schema__(cls, handler)
+        schema = gen_schema.clean_schema(schema)
     except PydanticUndefinedAnnotation as e:
         if raise_errors:
             raise
         set_model_mocks(cls, cls_name, f'`{e.name}`')
-        return False
-
-    core_config = config_wrapper.core_config(title=cls.__name__)
-
-    try:
-        schema = gen_schema.clean_schema(schema)
-    except gen_schema.CollectedInvalid:
-        set_model_mocks(cls, cls_name)
         return False
 
     # debug(schema)

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -85,10 +85,9 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
         ref = schema.get('ref')
         if self._ref_mode == 'to-def':
             if ref is not None:
-                self._generate_schema.defs.definitions[ref] = schema
-                return core_schema.definition_reference_schema(ref)
+                return self._generate_schema.defs.create_def_ref(ref, schema)
             return schema
-        else:  # ref_mode = 'unpack
+        else:  # ref_mode = 'unpack'
             return self.resolve_ref_schema(schema)
 
     def _get_types_namespace(self) -> NamespacesTuple:
@@ -115,12 +114,12 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
         """
         if maybe_ref_schema['type'] == 'definition-ref':
             ref = maybe_ref_schema['schema_ref']
-            if ref not in self._generate_schema.defs.definitions:
+            if ref not in self._generate_schema.defs._definitions:
                 raise LookupError(
                     f'Could not find a ref for {ref}.'
                     ' Maybe you tried to call resolve_ref_schema from within a recursive model?'
                 )
-            return self._generate_schema.defs.definitions[ref]
+            return self._generate_schema.defs._definitions[ref]
         elif maybe_ref_schema['type'] == 'definitions':
             return self.resolve_ref_schema(maybe_ref_schema['schema'])
         return maybe_ref_schema

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -114,12 +114,13 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
         """
         if maybe_ref_schema['type'] == 'definition-ref':
             ref = maybe_ref_schema['schema_ref']
-            if ref not in self._generate_schema.defs._definitions:
+            definition = self._generate_schema.defs.get_def(ref)
+            if definition is None:
                 raise LookupError(
                     f'Could not find a ref for {ref}.'
                     ' Maybe you tried to call resolve_ref_schema from within a recursive model?'
                 )
-            return self._generate_schema.defs._definitions[ref]
+            return definition
         elif maybe_ref_schema['type'] == 'definitions':
             return self.resolve_ref_schema(maybe_ref_schema['schema'])
         return maybe_ref_schema

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -337,7 +337,7 @@ class GenerateJsonSchema:
             try:
                 mapping[key] = getattr(self, method_name)
             except AttributeError as e:  # pragma: no cover
-                if os.environ['PYDANTIC_PRIVATE_ALLOW_UNHANDLED_SCHEMA_TYPES'] == '1':
+                if os.environ.get('PYDANTIC_PRIVATE_ALLOW_UNHANDLED_SCHEMA_TYPES') == '1':
                     continue
                 raise TypeError(
                     f'No method for generating JsonSchema for core_schema.type={key!r} '

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -687,11 +687,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # This is why we check `cls.__dict__` and don't use `cls.__pydantic_core_schema__` or similar.
         schema = cls.__dict__.get('__pydantic_core_schema__')
         if schema is not None and not isinstance(schema, _mock_val_ser.MockCoreSchema):
-            # Due to the way generic classes are built, it's possible that an invalid schema may be temporarily
-            # set on generic classes. I think we could resolve this to ensure that we get proper schema caching
-            # for generics, but for simplicity for now, we just always rebuild if the class has a generic origin.
-            if not cls.__pydantic_generic_metadata__['origin']:
-                return cls.__pydantic_core_schema__
+            return schema
 
         return handler(source)
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2596,11 +2596,9 @@ def test_multiple_enums():
 
     ta = TypeAdapter(MyModel)
     assert ta.validate_json('{"a": 1, "b": 1}') == {'a': MyEnum.a, 'b': MyEnum.a}
-    assert ta.core_schema['type'] == 'definitions'
-    assert len(ta.core_schema['definitions']) == 1
-    assert ta.core_schema['definitions'][0]['type'] == 'enum'
-    ref = ta.core_schema['definitions'][0]['ref']
-    assert ta.core_schema['schema']['fields']['a']['schema']['schema']['schema_ref'] == ref
+    for k in ['a', 'b']:
+        assert ta.core_schema['fields'][k]['schema']['schema']['type'] == 'enum'
+        assert ta.core_schema['fields'][k]['schema']['schema']['cls'] is MyEnum
 
 
 @pytest.mark.parametrize(

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2594,7 +2594,13 @@ def test_multiple_enums():
         a: Optional[MyEnum]
         b: Optional[MyEnum]
 
-    TypeAdapter(MyModel)
+    ta = TypeAdapter(MyModel)
+    assert ta.validate_json('{"a": 1, "b": 1}') == {'a': MyEnum.a, 'b': MyEnum.a}
+    assert ta.core_schema['type'] == 'definitions'
+    assert len(ta.core_schema['definitions']) == 1
+    assert ta.core_schema['definitions'][0]['type'] == 'enum'
+    ref = ta.core_schema['definitions'][0]['ref']
+    assert ta.core_schema['schema']['fields']['a']['schema']['schema']['schema_ref'] == ref
 
 
 @pytest.mark.parametrize(

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1125,10 +1125,10 @@ class Foo(BaseModel):
         """
     )
 
-    extras_schema = module_2.Foo.__pydantic_core_schema__['schema']['fields']['bar']['schema']['schema'][
-        'extras_schema'
-    ]
-
+    assert len(module_2.Foo.__pydantic_core_schema__['definitions']) == 1
+    ref = module_2.Foo.__pydantic_core_schema__['schema']['schema']['fields']['bar']['schema']['schema_ref']
+    assert module_2.Foo.__pydantic_core_schema__['definitions'][0]['ref'] == ref
+    extras_schema = module_2.Foo.__pydantic_core_schema__['definitions'][0]['schema']['extras_schema']
     assert extras_schema == {'type': 'int'}
 
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -2268,9 +2268,13 @@ def test_generic_recursion_contextvar():
     assert not recursively_defined_type_refs()
     try:
         with generic_recursion_self_type(Model, (int,)):
-            # Make sure that something has been added to the contextvar-managed recursive types cache
-            assert recursively_defined_type_refs()
-            raise TestingException
+            assert not recursively_defined_type_refs()
+            with generic_recursion_self_type(Model, (float,)):
+                assert not recursively_defined_type_refs()  # Not added as generic param is different
+                with generic_recursion_self_type(Model, (int,)):
+                    # Make sure that something has been added to the contextvar-managed recursive types cache
+                    assert recursively_defined_type_refs()
+                    raise TestingException
     except TestingException:
         pass
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -63,7 +63,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic._internal._core_utils import collect_invalid_schemas
 from pydantic._internal._generics import (
     _GENERIC_TYPES_CACHE,
     _LIMITED_DICT_SIZE,
@@ -1811,10 +1810,7 @@ def test_generic_recursive_models_with_a_concrete_parameter(create_module):
 
         M1.model_rebuild()
 
-    M1 = module.M1
-
-    # assert M1.__pydantic_core_schema__ == {}
-    assert collect_invalid_schemas(M1.__pydantic_core_schema__) is False
+    assert module.M1
 
 
 def test_generic_recursive_models_complicated(create_module):
@@ -1872,9 +1868,7 @@ def test_generic_recursive_models_complicated(create_module):
 
         M1.model_rebuild()
 
-    M1 = module.M1
-
-    assert collect_invalid_schemas(M1.__pydantic_core_schema__) is False
+    assert module.M1
 
 
 def test_generic_recursive_models_in_container(create_module):

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -6,13 +6,12 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 import pytest
-from pydantic_core import CoreSchema, SchemaValidator
+from pydantic_core import CoreSchema
 from pydantic_core import core_schema as cs
 
 from pydantic._internal._core_utils import (
     Walk,
     collect_invalid_schemas,
-    simplify_schema_references,
     walk_core_schema,
 )
 from pydantic._internal._repr import Representation
@@ -26,161 +25,6 @@ def remove_metadata(schema: CoreSchema) -> CoreSchema:
         return recurse(s, inner)
 
     return walk_core_schema(schema, inner)
-
-
-@pytest.mark.parametrize(
-    'input_schema,inlined',
-    [
-        # Test case 1: Simple schema with no references
-        (cs.list_schema(cs.int_schema()), cs.list_schema(cs.int_schema())),
-        # Test case 2: Schema with single-level nested references
-        (
-            cs.definitions_schema(
-                cs.list_schema(cs.definition_reference_schema('list_of_ints')),
-                definitions=[
-                    cs.list_schema(cs.definition_reference_schema('int'), ref='list_of_ints'),
-                    cs.int_schema(ref='int'),
-                ],
-            ),
-            cs.list_schema(cs.list_schema(cs.int_schema(ref='int'), ref='list_of_ints')),
-        ),
-        # Test case 3: Schema with multiple single-level nested references
-        (
-            cs.list_schema(
-                cs.definitions_schema(cs.definition_reference_schema('int'), definitions=[cs.int_schema(ref='int')])
-            ),
-            cs.list_schema(cs.int_schema(ref='int')),
-        ),
-        # Test case 4: A simple recursive schema
-        (
-            cs.list_schema(cs.definition_reference_schema(schema_ref='list'), ref='list'),
-            cs.definitions_schema(
-                cs.definition_reference_schema(schema_ref='list'),
-                definitions=[cs.list_schema(cs.definition_reference_schema(schema_ref='list'), ref='list')],
-            ),
-        ),
-        # Test case 5: Deeply nested schema with multiple references
-        (
-            cs.definitions_schema(
-                cs.list_schema(cs.definition_reference_schema('list_of_lists_of_ints')),
-                definitions=[
-                    cs.list_schema(cs.definition_reference_schema('list_of_ints'), ref='list_of_lists_of_ints'),
-                    cs.list_schema(cs.definition_reference_schema('int'), ref='list_of_ints'),
-                    cs.int_schema(ref='int'),
-                ],
-            ),
-            cs.list_schema(
-                cs.list_schema(
-                    cs.list_schema(cs.int_schema(ref='int'), ref='list_of_ints'), ref='list_of_lists_of_ints'
-                )
-            ),
-        ),
-        # Test case 6: More complex recursive schema
-        (
-            cs.definitions_schema(
-                cs.list_schema(cs.definition_reference_schema(schema_ref='list_of_ints_and_lists')),
-                definitions=[
-                    cs.list_schema(
-                        cs.definitions_schema(
-                            cs.definition_reference_schema(schema_ref='int_or_list'),
-                            definitions=[
-                                cs.int_schema(ref='int'),
-                                cs.tuple_variable_schema(
-                                    cs.definition_reference_schema(schema_ref='list_of_ints_and_lists'), ref='a tuple'
-                                ),
-                            ],
-                        ),
-                        ref='list_of_ints_and_lists',
-                    ),
-                    cs.int_schema(ref='int_or_list'),
-                ],
-            ),
-            cs.list_schema(cs.list_schema(cs.int_schema(ref='int_or_list'), ref='list_of_ints_and_lists')),
-        ),
-        # Test case 7: Schema with multiple definitions and nested references, some of which are unused
-        (
-            cs.definitions_schema(
-                cs.list_schema(cs.definition_reference_schema('list_of_ints')),
-                definitions=[
-                    cs.list_schema(
-                        cs.definitions_schema(
-                            cs.definition_reference_schema('int'), definitions=[cs.int_schema(ref='int')]
-                        ),
-                        ref='list_of_ints',
-                    )
-                ],
-            ),
-            cs.list_schema(cs.list_schema(cs.int_schema(ref='int'), ref='list_of_ints')),
-        ),
-        # Test case 8: Reference is used in multiple places
-        (
-            cs.definitions_schema(
-                cs.union_schema(
-                    [
-                        cs.definition_reference_schema('list_of_ints'),
-                        cs.tuple_variable_schema(cs.definition_reference_schema('int')),
-                    ]
-                ),
-                definitions=[
-                    cs.list_schema(cs.definition_reference_schema('int'), ref='list_of_ints'),
-                    cs.int_schema(ref='int'),
-                ],
-            ),
-            cs.definitions_schema(
-                cs.union_schema(
-                    [
-                        cs.list_schema(cs.definition_reference_schema('int'), ref='list_of_ints'),
-                        cs.tuple_variable_schema(cs.definition_reference_schema('int')),
-                    ]
-                ),
-                definitions=[cs.int_schema(ref='int')],
-            ),
-        ),
-        # Test case 9: https://github.com/pydantic/pydantic/issues/6270
-        (
-            cs.definitions_schema(
-                cs.definition_reference_schema('model'),
-                definitions=[
-                    cs.typed_dict_schema(
-                        {
-                            'a': cs.typed_dict_field(
-                                cs.nullable_schema(
-                                    cs.int_schema(ref='ref'),
-                                ),
-                            ),
-                            'b': cs.typed_dict_field(
-                                cs.nullable_schema(
-                                    cs.int_schema(ref='ref'),
-                                ),
-                            ),
-                        },
-                        ref='model',
-                    ),
-                ],
-            ),
-            cs.definitions_schema(
-                cs.typed_dict_schema(
-                    {
-                        'a': cs.typed_dict_field(
-                            cs.nullable_schema(cs.definition_reference_schema(schema_ref='ref')),
-                        ),
-                        'b': cs.typed_dict_field(
-                            cs.nullable_schema(cs.definition_reference_schema(schema_ref='ref')),
-                        ),
-                    },
-                    ref='model',
-                ),
-                definitions=[
-                    cs.int_schema(ref='ref'),
-                ],
-            ),
-        ),
-    ],
-)
-def test_build_schema_defs(input_schema: cs.CoreSchema, inlined: cs.CoreSchema):
-    actual_inlined = remove_metadata(simplify_schema_references(input_schema))
-    assert actual_inlined == inlined
-    SchemaValidator(actual_inlined)  # check for validity
 
 
 def test_representation_integrations():

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -6,20 +6,9 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 import pytest
-from pydantic_core import CoreSchema
 
-from pydantic._internal._core_utils import Walk, walk_core_schema
 from pydantic._internal._repr import Representation
 from pydantic._internal._validators import _extract_decimal_digits_info
-
-
-def remove_metadata(schema: CoreSchema) -> CoreSchema:
-    def inner(s: CoreSchema, recurse: Walk) -> CoreSchema:
-        s = s.copy()
-        s.pop('metadata', None)
-        return recurse(s, inner)
-
-    return walk_core_schema(schema, inner)
 
 
 def test_representation_integrations():

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -7,13 +7,8 @@ from decimal import Decimal
 
 import pytest
 from pydantic_core import CoreSchema
-from pydantic_core import core_schema as cs
 
-from pydantic._internal._core_utils import (
-    Walk,
-    collect_invalid_schemas,
-    walk_core_schema,
-)
+from pydantic._internal._core_utils import Walk, walk_core_schema
 from pydantic._internal._repr import Representation
 from pydantic._internal._validators import _extract_decimal_digits_info
 
@@ -44,12 +39,6 @@ def test_representation_integrations():
         '    ) (Obj)',
     ]
     assert list(obj.__rich_repr__()) == [('int_attr', 42), ('str_attr', 'Marvin')]
-
-
-def test_schema_is_valid():
-    assert collect_invalid_schemas(cs.none_schema()) is False
-    assert collect_invalid_schemas(cs.invalid_schema()) is True
-    assert collect_invalid_schemas(cs.nullable_schema(cs.invalid_schema())) is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -51,6 +51,11 @@ def check_schema(schema: CoreSchema) -> None:
     assert schema['type'] == 'model'
     assert schema['root_model'] is True
     assert schema['custom_init'] is False
+    # assert schema['type'] == 'definitions'
+    # root = next(s for s in schema['definitions'] if s['root_model'] is True)
+    # assert root['type'] == 'model'
+    # assert root['root_model'] is True
+    # assert root['custom_init'] is False
 
 
 @parametrize_root_model()

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -51,11 +51,6 @@ def check_schema(schema: CoreSchema) -> None:
     assert schema['type'] == 'model'
     assert schema['root_model'] is True
     assert schema['custom_init'] is False
-    # assert schema['type'] == 'definitions'
-    # root = next(s for s in schema['definitions'] if s['root_model'] is True)
-    # assert root['type'] == 'model'
-    # assert root['root_model'] is True
-    # assert root['custom_init'] is False
 
 
 @parametrize_root_model()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ from typing_extensions import Annotated, Literal
 
 from pydantic import BaseModel
 from pydantic._internal import _repr
-from pydantic._internal._core_utils import _WalkCoreSchema, pretty_print_core_schema
+from pydantic._internal._core_utils import pretty_print_core_schema
 from pydantic._internal._typing_extra import all_literal_values, get_origin, is_new_type
 from pydantic._internal._utils import (
     BUILTIN_COLLECTIONS,
@@ -555,131 +555,6 @@ def test_to_camel_from_camel() -> None:
     assert to_camel('alreadyCamel') == 'alreadyCamel'
 
 
-def test_handle_tuple_schema():
-    schema = core_schema.tuple_schema([core_schema.float_schema(), core_schema.int_schema()])
-
-    def walk(s, recurse):
-        # change extra_schema['type'] to 'str'
-        if s['type'] == 'float':
-            s['type'] = 'str'
-        return s
-
-    schema = _WalkCoreSchema().handle_tuple_schema(schema, walk)
-    assert schema == {
-        'items_schema': [{'type': 'str'}, {'type': 'int'}],
-        'type': 'tuple',
-    }
-
-
-@pytest.mark.parametrize(
-    'params,expected_extra_schema',
-    (
-        pytest.param({}, {}, id='Model fields without extra_validator'),
-        pytest.param(
-            {'extras_schema': core_schema.float_schema()},
-            {'extras_schema': {'type': 'str'}},
-            id='Model fields with extra_validator',
-        ),
-    ),
-)
-def test_handle_model_fields_schema(params, expected_extra_schema):
-    schema = core_schema.model_fields_schema(
-        {
-            'foo': core_schema.model_field(core_schema.int_schema()),
-        },
-        **params,
-    )
-
-    def walk(s, recurse):
-        # change extra_schema['type'] to 'str'
-        if s['type'] == 'float':
-            s['type'] = 'str'
-        return s
-
-    schema = _WalkCoreSchema().handle_model_fields_schema(schema, walk)
-    assert schema == {
-        **expected_extra_schema,
-        'type': 'model-fields',
-        'fields': {'foo': {'type': 'model-field', 'schema': {'type': 'int'}}},
-    }
-
-
-@pytest.mark.parametrize(
-    'params,expected_extra_schema',
-    (
-        pytest.param({}, {}, id='Typeddict without extra_validator'),
-        pytest.param(
-            {'extras_schema': core_schema.float_schema()},
-            {'extras_schema': {'type': 'str'}},
-            id='Typeddict with extra_validator',
-        ),
-    ),
-)
-def test_handle_typed_dict_schema(params, expected_extra_schema):
-    schema = core_schema.typed_dict_schema(
-        {
-            'foo': core_schema.model_field(core_schema.int_schema()),
-        },
-        **params,
-    )
-
-    def walk(s, recurse):
-        # change extra_validator['type'] to 'str'
-        if s['type'] == 'float':
-            s['type'] = 'str'
-        return s
-
-    schema = _WalkCoreSchema().handle_typed_dict_schema(schema, walk)
-    assert schema == {
-        **expected_extra_schema,
-        'type': 'typed-dict',
-        'fields': {'foo': {'type': 'model-field', 'schema': {'type': 'int'}}},
-    }
-
-
-def test_handle_function_schema():
-    schema = core_schema.with_info_before_validator_function(
-        lambda v, _info: v, core_schema.float_schema(), field_name='field_name'
-    )
-
-    def walk(s, recurse):
-        # change type to str
-        if s['type'] == 'float':
-            s['type'] = 'str'
-        return s
-
-    schema = _WalkCoreSchema().handle_function_schema(schema, walk)
-    assert schema['type'] == 'function-before'
-    assert schema['schema'] == {'type': 'str'}
-
-    def walk1(s, recurse):
-        # this is here to make sure this function is not called
-        assert False
-
-    schema = _WalkCoreSchema().handle_function_schema(core_schema.int_schema(), walk1)
-    assert schema['type'] == 'int'
-
-
-def test_handle_call_schema():
-    param_a = core_schema.arguments_parameter(name='a', schema=core_schema.str_schema(), mode='positional_only')
-    args_schema = core_schema.arguments_schema([param_a])
-
-    schema = core_schema.call_schema(
-        arguments=args_schema,
-        function=lambda a: int(a),
-        return_schema=core_schema.str_schema(),
-    )
-
-    def walk(s, recurse):
-        # change return schema
-        if 'return_schema' in schema:
-            schema['return_schema']['type'] = 'int'
-        return s
-
-    schema = _WalkCoreSchema().handle_call_schema(schema, walk)
-    assert schema['return_schema'] == {'type': 'int'}
-
-
 class TestModel:
     __slots__ = (
         '__dict__',
@@ -738,7 +613,6 @@ class TestModel:
                             'fields': {'a': {'type': 'model-field', 'schema': {'type': 'str'}}},
                         },
                         'alias': 'comp_field_1',
-                        'metadata': {'comp_field_key': 'comp_field_data'},
                     }
                 ],
                 'ref': 'meta_schema',


### PR DESCRIPTION
## Change Summary

This PR is a prototype for showing how the expensive core schema walking via `_WalkCoreSchema` could be removed completely. This approaches the problem by directly substituting eg the `definition-ref`s schema nodes when schemas are "inlined". Similarly discriminated unions are handled by directly substituting the appropriate schema node. This also removes completely unnecessary schema walking with invalid generics (`HAS_INVALID_SCHEMAS_METADATA_KEY`). That particular logic was pretty strange as it didnt really need any traversing at all.

Directly mutating the schema nodes like this is a bit "hacky" and current logic doesnt really support it well. You may not use this as-is because of the existing complexity in schema building logic. But this type of direct replacement of schema nodes is a possible solution for completely getting rid of repeated retraversing of complex schema dicts.

Used big model file to run benchmarks https://gist.github.com/Viicos/bd9b3b0e3fbee62838626b07b311f3af.
PR reduces the load time of the big model file (on my MB Pro M3 Max):
Old load time: 3.44s
New load time: 2.65s

Perf difference maybe even large with complex sets of generic models. Didnt yet test this.

This also looks very good:
<img width="806" alt="Screenshot 2024-10-15 at 9 05 35" src="https://github.com/user-attachments/assets/d4edc695-9ec5-4e97-98dd-29e04a3e79c1">


## Related issue number

Partially relates to https://github.com/pydantic/pydantic/issues/6768 but is not a complete fix.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle