### PR TITLE
Add test for deprecation warning in V1 isinstance check

### DIFF
--- a/pydantic/v1/main.py
+++ b/pydantic/v1/main.py
@@ -301,7 +301,7 @@ class ModelMetaclass(ABCMeta):
 
         See #3829 and python/cpython#92810
         """
-        return hasattr(instance, '__post_root_validators__') and super().__instancecheck__(instance)
+        return hasattr(instance, '__fields__') and super().__instancecheck__(instance)
 
 
 object_setattr = object.__setattr__

--- a/pydantic/v1/main.py
+++ b/pydantic/v1/main.py
@@ -301,7 +301,7 @@ class ModelMetaclass(ABCMeta):
 
         See #3829 and python/cpython#92810
         """
-        return hasattr(instance, '__fields__') and super().__instancecheck__(instance)
+        return hasattr(instance, '__post_root_validators__') and super().__instancecheck__(instance)
 
 
 object_setattr = object.__setattr__

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -1,5 +1,7 @@
 import warnings
 
+import pytest
+
 from pydantic import VERSION
 from pydantic import BaseModel as V2BaseModel
 from pydantic.v1 import VERSION as V1_VERSION
@@ -26,6 +28,7 @@ def test_root_validator():
     assert model.v == 'value-v1'
 
 
+@pytest.mark.xfail(reason='Pending merge of fix from v1 branch')
 def test_isinstance_does_not_raise_deprecation_warnings():
     class V1Model(V1BaseModel):
         v: int

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -1,4 +1,7 @@
+import warnings
+
 from pydantic import VERSION
+from pydantic import BaseModel as V2BaseModel
 from pydantic.v1 import VERSION as V1_VERSION
 from pydantic.v1 import BaseModel as V1BaseModel
 from pydantic.v1 import root_validator as v1_root_validator
@@ -21,3 +24,22 @@ def test_root_validator():
 
     model = Model(v='value')
     assert model.v == 'value-v1'
+
+
+def test_isinstance_does_not_raise_deprecation_warnings():
+    class V1Model(V1BaseModel):
+        v: int
+
+    class V2Model(V2BaseModel):
+        v: int
+
+    v1_obj = V1Model(v=1)
+    v2_obj = V2Model(v=2)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+
+        assert isinstance(v1_obj, V1BaseModel)
+        assert not isinstance(v1_obj, V2BaseModel)
+        assert not isinstance(v2_obj, V1BaseModel)
+        assert isinstance(v2_obj, V2BaseModel)


### PR DESCRIPTION
## Change Summary

The v1 ModelMetaclass isinstance check first looks for a `__fields__` attribute before delegating to the costly ABC superclass's implementation. Unfortunately, this attribute raises a DeprecationWarning if a v2 model is passed into isinstance.

#10645 changes the logic to check the `__post_root_validators__` attribute, which is not present on v2 models. However, it cannot include a test, as the test needs access to V2 models. This PR adds the test that will start passing once the change is merged into the main branch, marked as xfail for now. (See https://github.com/pydantic/pydantic/pull/10642#issuecomment-2419287314)

## Related issue number

Fixes #10497 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
