### PR TITLE
Fix deprecation warning in V1 isinstance check

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -301,7 +301,7 @@ class ModelMetaclass(ABCMeta):
 
         See #3829 and python/cpython#92810
         """
-        return hasattr(instance, '__fields__') and super().__instancecheck__(instance)
+        return hasattr(instance, '__post_root_validators__') and super().__instancecheck__(instance)
 
 
 object_setattr = object.__setattr__


### PR DESCRIPTION
## Change Summary

The v1 ModelMetaclass isinstance check first looks for a `__fields__` attribute before delegating to the costly ABC superclass's implementation. Unfortunately, this attribute raises a DeprecationWarning if a v2 model is passed into isinstance. Instead, check the `__post_root_validators__` attribute, which is not present on v2 models.

This is a backport of the fix from #10642, which will be modified to only contain the tests (which cannot be backported as they require V2 models).

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/10497

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist  &mdash;  yes, in #10642 
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle