### PR TITLE
Make `validate_call` return `ValidateCallWrapper`

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -825,6 +825,7 @@ def unpack_lenient_weakvaluedict(d: dict[str, Any] | None) -> dict[str, Any] | N
 
 @lru_cache(maxsize=None)
 def default_ignored_types() -> tuple[type[Any], ...]:
+    from .._internal._validate_call import ValidateCallWrapper
     from ..fields import ComputedFieldInfo
 
     ignored_types = [
@@ -834,6 +835,7 @@ def default_ignored_types() -> tuple[type[Any], ...]:
         staticmethod,
         PydanticDescriptorProxy,
         ComputedFieldInfo,
+        ValidateCallWrapper,
     ]
 
     if sys.version_info >= (3, 12):

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -4,28 +4,16 @@ import functools
 import inspect
 from functools import partial
 from types import BuiltinFunctionType, BuiltinMethodType, FunctionType, LambdaType, MethodType
-from typing import Any, Awaitable, Callable, Union, get_args
+from typing import Any, Awaitable, Callable, Union, cast, get_args
 
-import pydantic_core
+from pydantic_core import ArgsKwargs, SchemaValidator
+from typing_extensions import ParamSpec, TypeVar, TypeVarTuple
 
 from ..config import ConfigDict
-from ..plugin._schema_validator import create_schema_validator
+from ..plugin._schema_validator import PluggableSchemaValidator, create_schema_validator
 from . import _generate_schema
 from ._config import ConfigWrapper
 from ._namespace_utils import MappingNamespace, NsResolver, ns_for_function
-
-# Note: This does not play very well with type checkers. For example,
-# `a: LambdaType = lambda x: x` will raise a type error by Pyright.
-ValidateCallSupportedTypes = Union[
-    LambdaType,
-    FunctionType,
-    MethodType,
-    BuiltinFunctionType,
-    BuiltinMethodType,
-    functools.partial,
-]
-
-VALIDATE_CALL_SUPPORTED_TYPES = get_args(ValidateCallSupportedTypes)
 
 
 def extract_function_name(func: ValidateCallSupportedTypes) -> str:
@@ -62,7 +50,49 @@ def update_wrapper_attributes(wrapped: ValidateCallSupportedTypes, wrapper: Call
 class ValidateCallWrapper:
     """This is a wrapper around a function that validates the arguments passed to it, and optionally the return value."""
 
-    __slots__ = ('__pydantic_validator__', '__return_pydantic_validator__')
+    __slots__ = (
+        #
+        # Below are attributes similar to `wraps`.
+        # The commented out attributes may conflict with the class variables;
+        # so they are actually stored in `__dict__` at instance level.
+        #
+        # '__module__',
+        '__name__',
+        '__qualname__',
+        # '__doc__',
+        # '__annotations__',
+        '__type_params__',
+        '__dict__',
+        #
+        '__pydantic_validator__',
+        '__return_pydantic_validator__',
+        #
+        'raw_function',
+        'config',
+        'validate_return',
+        'parent_namespace',
+    )
+
+    __module__: str
+    __name__: str
+    __qualname__: str
+    __doc__: str | None
+    # # TODO: test this
+    __annotations__: dict[str, type]
+    # # TODO: test this
+    __type_params__: tuple[TypeVar | ParamSpec | TypeVarTuple, ...] | None
+
+    __pydantic_validator__: SchemaValidator | PluggableSchemaValidator
+    __return_pydantic_validator__: Callable[[Any], Any] | None
+
+    raw_function: ValidateCallSupportedTypes
+    config: ConfigDict | None
+    validate_return: bool
+    parent_namespace: MappingNamespace | None
+    _repr_dummy: Callable
+
+    _name: str | None = None
+    _owner: type[Any] | None = None
 
     def __init__(
         self,
@@ -73,11 +103,29 @@ class ValidateCallWrapper:
     ) -> None:
         if isinstance(function, partial):
             schema_type = function.func
-            module = function.func.__module__
+            wrapped = function.func
         else:
             schema_type = function
-            module = function.__module__
+            wrapped = function
+
+        module = wrapped.__module__
+        function_name = extract_function_name(function)
         qualname = extract_function_qualname(function)
+
+        # `functools.wraps` do most of the work here except for `__name__` and `__qualname__`.
+        functools.wraps(wrapped)(self)
+        self.__name__ = function_name
+        self.__qualname__ = qualname
+
+        self.raw_function = function
+        self.config = config
+        self.validate_return = validate_return
+        self.parent_namespace = parent_namespace
+
+        self._repr_dummy = functools.wraps(self)(lambda: ...)
+
+        if inspect.iscoroutinefunction(function):
+            inspect.markcoroutinefunction(self)
 
         ns_resolver = NsResolver(namespaces_tuple=ns_for_function(schema_type, parent_namespace=parent_namespace))
 
@@ -122,8 +170,75 @@ class ValidateCallWrapper:
             self.__return_pydantic_validator__ = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
+        res = self.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs))
         if self.__return_pydantic_validator__:
             return self.__return_pydantic_validator__(res)
         else:
             return res
+
+    def __get__(self, obj: Any, objtype: type[Any] | None = None) -> ValidateCallWrapper:
+        """Bind the raw function and return another ValidateCallWrapper wrapping that."""
+        objtype = objtype or cast(type, obj.__class__)
+        if obj is None:
+            # It's possible this wrapper is dynamically applied to a class attribute not allowing
+            # name to be populated by __set_name__. In this case, we'll manually acquire the name
+            # from the function reference.
+            if self._name is None:
+                self._name = extract_function_name(self.raw_function)
+            try:
+                # Handle the case where a method is accessed as a class attribute
+                return objtype.__getattribute__(objtype, self._name)  # type: ignore
+            except AttributeError:
+                # This will happen the first time the attribute is accessed
+                pass
+
+        bound_func = cast(Callable, self.raw_function).__get__(obj, objtype)
+        validated_func = self.__class__(bound_func, self.config, self.validate_return, self.parent_namespace)
+
+        # skip binding to instance when obj or objtype has __slots__ attribute
+        slots = getattr(obj, '__slots__', getattr(objtype, '__slots__', None))
+        # if hasattr(obj, '__slots__') or hasattr(objtype, '__slots__'):
+        if slots is not None and self._name not in slots:
+            return validated_func
+
+        if self._name is not None:
+            if obj is None:
+                object.__setattr__(objtype, self._name, validated_func)
+            elif objtype is self._owner:
+                object.__setattr__(obj, self._name, validated_func)
+        return validated_func
+
+    def __set_name__(self, owner: Any, name: str) -> None:
+        # TODO: handle more the case this is not called
+        self._owner = owner
+        self._name = name
+
+    def __repr__(self) -> str:
+        # TODO: test this
+        # return f'ValidateCallWrapper({self.raw_function})'
+        return repr(self._repr_dummy)
+
+    def __eq__(self, value: object) -> bool:
+        # TODO: test this
+        if isinstance(value, ValidateCallWrapper):
+            return self.raw_function == value.raw_function
+        return False
+
+    def __hash__(self):
+        # TODO: test this
+        return hash(self.raw_function)
+
+
+# Note: This does not play very well with type checkers. For example,
+# `a: LambdaType = lambda x: x` will raise a type error by Pyright.
+ValidateCallSupportedTypes = Union[
+    LambdaType,
+    FunctionType,
+    MethodType,
+    BuiltinFunctionType,
+    BuiltinMethodType,
+    functools.partial,
+    ValidateCallWrapper,
+]
+
+VALIDATE_CALL_SUPPORTED_TYPES = get_args(ValidateCallSupportedTypes)

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -199,7 +199,7 @@ class ValidateCallWrapper:
             self.validate_return,
             self.parent_namespace,
             # ! WARNING: This cannot deal with staticmethod (although it is currently banned from here)
-            obj if obj is not None else objtype,
+            obj if obj is not None else _UNBOUND,
         )
 
         # TODO: is this correct?
@@ -207,9 +207,9 @@ class ValidateCallWrapper:
             validated_func.__set_name__(objtype, self._name)
 
         # TODO: BaseModel have slots; maybe check having __dict__?
+        # TODO: do we want to use global cache here?
         # skip binding to instance when obj or objtype has __slots__ attribute
         slots = getattr(obj, '__slots__', getattr(objtype, '__slots__', None))
-        # if hasattr(obj, '__slots__') or hasattr(objtype, '__slots__'):
         if slots is not None and self._name not in slots:
             return validated_func
 
@@ -225,19 +225,17 @@ class ValidateCallWrapper:
         self._owner = owner
         self._name = name
 
+    # For `__repr__`, `__eq__`, and `__hash__`,
+    # we want to maintain a similar behavior to `functools.wraps` for now.
+
     def __repr__(self) -> str:
-        # TODO: test this
         return repr(self._repr_dummy)
 
     def __eq__(self, value: object) -> bool:
-        # TODO: test this
-        if isinstance(value, ValidateCallWrapper):
-            return self.raw_function == value.raw_function
-        return False
+        return super().__eq__(value)
 
     def __hash__(self):
-        # TODO: test this
-        return hash(self.raw_function)
+        return super().__hash__()
 
 
 # Note: This does not play very well with type checkers. For example,

--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -26,27 +26,6 @@ def extract_function_qualname(func: ValidateCallSupportedTypes) -> str:
     return f'partial({func.func.__qualname__})' if isinstance(func, functools.partial) else func.__qualname__
 
 
-def update_wrapper_attributes(wrapped: ValidateCallSupportedTypes, wrapper: Callable[..., Any]):
-    """Update the `wrapper` function with the attributes of the `wrapped` function. Return the updated function."""
-    if inspect.iscoroutinefunction(wrapped):
-
-        @functools.wraps(wrapped)
-        async def wrapper_function(*args, **kwargs):  # type: ignore
-            return await wrapper(*args, **kwargs)
-    else:
-
-        @functools.wraps(wrapped)
-        def wrapper_function(*args, **kwargs):
-            return wrapper(*args, **kwargs)
-
-    # We need to manually update this because `partial` object has no `__name__` and `__qualname__`.
-    wrapper_function.__name__ = extract_function_name(wrapped)
-    wrapper_function.__qualname__ = extract_function_qualname(wrapped)
-    wrapper_function.raw_function = wrapped  # type: ignore
-
-    return wrapper_function
-
-
 class ValidateCallWrapper:
     """This is a wrapper around a function that validates the arguments passed to it, and optionally the return value."""
 

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -104,7 +104,7 @@ def validate_call(
         validate_call_wrapper = _validate_call.ValidateCallWrapper(
             cast(_validate_call.ValidateCallSupportedTypes, function), config, validate_return, parent_namespace
         )
-        return _validate_call.update_wrapper_attributes(function, validate_call_wrapper.__call__)  # type: ignore
+        return cast(Any, validate_call_wrapper)
 
     if func is not None:
         return validate(func)

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -102,7 +102,10 @@ def validate_call(
     def validate(function: AnyCallableT) -> AnyCallableT:
         _check_function_type(function)
         validate_call_wrapper = _validate_call.ValidateCallWrapper(
-            cast(_validate_call.ValidateCallSupportedTypes, function), config, validate_return, parent_namespace
+            cast(_validate_call.ValidateCallSupportedTypes, function),
+            config,
+            validate_return,
+            parent_namespace,
         )
         return cast(Any, validate_call_wrapper)
 

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -545,14 +545,9 @@ def test_item_method():
     with pytest.raises(ValidationError) as exc_info:
         x.foo()
 
-    # assert exc_info.value.errors(include_url=False) == [
-    #     {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
-    #     {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
-    # ]
-
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
+        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((x,))},
     ]
 
 
@@ -571,14 +566,9 @@ def test_class_method():
     with pytest.raises(ValidationError) as exc_info:
         x.foo()
 
-    # assert exc_info.value.errors(include_url=False) == [
-    #     {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
-    #     {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
-    # ]
-
     assert exc_info.value.errors(include_url=False) == [
-        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
-        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs(())},
+        {'type': 'missing_argument', 'loc': ('a',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
+        {'type': 'missing_argument', 'loc': ('b',), 'msg': 'Missing required argument', 'input': ArgsKwargs((X,))},
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This is sort of the revert of #8268. The reason to switch back to `ValidateCallWrapper` is because I found that [supporting `Self` in `validate_call`](https://github.com/kc0506/pydantic/tree/support-validate-call-self) (WIP) can be much simplified with descriptors, since we now have access to `objtype` from `__get__`. 


<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
