### PR TITLE
Recommend against using `Ellipsis` (`...`) with `Field`

### DIFF
--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -65,9 +65,9 @@ For validation and serialization, you can define an alias for a field.
 
 There are three ways to define an alias:
 
-* `Field(..., alias='foo')`
-* `Field(..., validation_alias='foo')`
-* `Field(..., serialization_alias='foo')`
+* `Field(alias='foo')`
+* `Field(validation_alias='foo')`
+* `Field(serialization_alias='foo')`
 
 The `alias` parameter is used for both validation _and_ serialization. If you want to use
 _different_ aliases for validation and serialization respectively, you can use the`validation_alias`
@@ -80,7 +80,7 @@ from pydantic import BaseModel, Field
 
 
 class User(BaseModel):
-    name: str = Field(..., alias='username')
+    name: str = Field(alias='username')
 
 
 user = User(username='johndoe')  # (1)!
@@ -107,7 +107,7 @@ from pydantic import BaseModel, Field
 
 
 class User(BaseModel):
-    name: str = Field(..., validation_alias='username')
+    name: str = Field(validation_alias='username')
 
 
 user = User(username='johndoe')  # (1)!
@@ -127,7 +127,7 @@ from pydantic import BaseModel, Field
 
 
 class User(BaseModel):
-    name: str = Field(..., serialization_alias='username')
+    name: str = Field(serialization_alias='username')
 
 
 user = User(name='johndoe')  # (1)!
@@ -158,7 +158,7 @@ print(user.model_dump(by_alias=True))  # (2)!
 
 
     class User(BaseModel):
-        name: str = Field(..., alias='username')
+        name: str = Field(alias='username')
 
 
     user = User(username='johndoe')  # (1)!
@@ -177,7 +177,7 @@ print(user.model_dump(by_alias=True))  # (2)!
     class User(BaseModel):
         model_config = ConfigDict(populate_by_name=True)
 
-        name: str = Field(..., alias='username')
+        name: str = Field(alias='username')
 
 
     user = User(name='johndoe')  # (1)!
@@ -195,7 +195,7 @@ print(user.model_dump(by_alias=True))  # (2)!
     class User(BaseModel):
         model_config = ConfigDict(populate_by_name=True)
 
-        name: str = Field(..., alias=str('username'))  # noqa: UP018
+        name: str = Field(alias=str('username'))  # noqa: UP018
 
 
     user = User(name='johndoe')  # (1)!
@@ -219,7 +219,7 @@ print(user.model_dump(by_alias=True))  # (2)!
 
 
     class MyModel(BaseModel):
-        my_field: int = Field(..., validation_alias='myValidationAlias')
+        my_field: int = Field(validation_alias='myValidationAlias')
     ```
     with:
     ```py

--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -75,7 +75,7 @@ class MainModel(BaseModel):
     foo_bar: FooBar
     gender: Annotated[Union[Gender, None], Field(alias='Gender')] = None
     snap: int = Field(
-        42,
+        default=42,
         title='The Snap',
         description='this is the value of snap',
         gt=30,
@@ -410,7 +410,7 @@ try:
     # this won't work since `PositiveInt` takes precedence over the
     # constraints defined in `Field`, meaning they're ignored
     class Model(BaseModel):
-        foo: PositiveInt = Field(..., lt=10)
+        foo: PositiveInt = Field(lt=10)
 
 except ValueError as e:
     print(e)
@@ -422,7 +422,7 @@ except ValueError as e:
 class ModelB(BaseModel):
     # Here both constraints will be applied and the schema
     # will be generated correctly
-    foo: int = Field(..., gt=0, lt=10)
+    foo: int = Field(gt=0, lt=10)
 
 
 print(ModelB.model_json_schema())
@@ -634,11 +634,11 @@ from typing_extensions import Annotated, TypeAlias
 from pydantic import Field, TypeAdapter
 
 ExternalType: TypeAlias = Annotated[
-    int, Field(..., json_schema_extra={'key1': 'value1'})
+    int, Field(json_schema_extra={'key1': 'value1'})
 ]
 
 ta = TypeAdapter(
-    Annotated[ExternalType, Field(..., json_schema_extra={'key2': 'value2'})]
+    Annotated[ExternalType, Field(json_schema_extra={'key2': 'value2'})]
 )
 print(json.dumps(ta.json_schema(), indent=2))
 """
@@ -664,7 +664,7 @@ from pydantic import Field, TypeAdapter
 from pydantic.json_schema import JsonDict
 
 ExternalType: TypeAlias = Annotated[
-    int, Field(..., json_schema_extra={'key1': 'value1', 'key2': 'value2'})
+    int, Field(json_schema_extra={'key1': 'value1', 'key2': 'value2'})
 ]
 
 
@@ -675,7 +675,7 @@ def finalize_schema(s: JsonDict) -> None:
 
 
 ta = TypeAdapter(
-    Annotated[ExternalType, Field(..., json_schema_extra=finalize_schema)]
+    Annotated[ExternalType, Field(json_schema_extra=finalize_schema)]
 )
 print(json.dumps(ta.json_schema(), indent=2))
 """

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -1096,12 +1096,12 @@ from pydantic import BaseModel, Field, create_model
 
 DynamicModel = create_model(
     'DynamicModel',
-    foo=(str, Field(..., description='foo description', alias='FOO')),
+    foo=(str, Field(description='foo description', alias='FOO')),
 )
 
 
 class StaticModel(BaseModel):
-    foo: str = Field(..., description='foo description', alias='FOO')
+    foo: str = Field(description='foo description', alias='FOO')
 ```
 
 The special keyword arguments `__config__` and `__base__` can be used to customize the new model.
@@ -1359,12 +1359,8 @@ print(error_locations)
 
 ## Required fields
 
-To declare a field as required, you may declare it using an annotation, or an annotation in combination with a `Field` specification.
-You may also use `Ellipsis`/`...` to emphasize that a field is required, especially when using the `Field` constructor.
-
-The [`Field`](fields.md) function is primarily used to configure settings like `alias` or `description` for an attribute.
-The constructor supports `Ellipsis`/`...` as the sole positional argument.
-This is used as a way to indicate that said field is mandatory, though it's the type hint that enforces this requirement.
+To declare a field as required, you may declare it using an annotation, or an annotation in combination with a
+[`Field`][pydantic.Field] function (without specifying any `default` or `default_factory` argument).
 
 ```py
 from pydantic import BaseModel, Field
@@ -1372,12 +1368,13 @@ from pydantic import BaseModel, Field
 
 class Model(BaseModel):
     a: int
-    b: int = ...
+    b: int = Field(alias='B')
     c: int = Field(..., alias='C')
 ```
 
-Here `a`, `b` and `c` are all required. However, this use of `b: int = ...` does not work properly with
-[mypy](../integrations/mypy.md), and as of **v1.0** should be avoided in most cases.
+Here `a`, `b` and `c` are all required. The field `c` uses the [ellipsis][Ellipsis] as a default argument,
+emphasizing on the fact that it is required. However, the usage of the [ellipsis][Ellipsis] is discouraged
+as it doesn't play well with type checkers.
 
 !!! note
     In Pydantic V1, fields annotated with `Optional` or `Any` would be given an implicit default of `None` even if no

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -810,7 +810,7 @@ The same holds for the `model_dump_json` method.
 In addition to the explicit arguments `exclude` and `include` passed to `model_dump` and `model_dump_json` methods,
 we can also pass the `exclude: bool` arguments directly to the `Field` constructor:
 
-Setting `exclude` on the field constructor (`Field(..., exclude=True)`) takes priority over the
+Setting `exclude` on the field constructor (`Field(exclude=True)`) takes priority over the
 `exclude`/`include` on `model_dump` and `model_dump_json`:
 
 ```py
@@ -820,7 +820,7 @@ from pydantic import BaseModel, Field, SecretStr
 class User(BaseModel):
     id: int
     username: str
-    password: SecretStr = Field(..., exclude=True)
+    password: SecretStr = Field(exclude=True)
 
 
 class Transaction(BaseModel):
@@ -841,7 +841,7 @@ print(t.model_dump(include={'id': True, 'value': True}))  # (1)!
 
 1. `value` excluded from the output because it excluded in `Field`.
 
-That being said, setting `exclude` on the field constructor (`Field(..., exclude=True)`) does not take priority
+That being said, setting `exclude` on the field constructor (`Field(exclude=True)`) does not take priority
 over the `exclude_unset`, `exclude_none`, and `exclude_default` parameters on `model_dump` and `model_dump_json`:
 
 ```py

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -222,7 +222,7 @@ class Lizard(BaseModel):
 
 
 class Model(BaseModel):
-    pet: Union[Cat, Dog, Lizard] = Field(..., discriminator='pet_type')
+    pet: Union[Cat, Dog, Lizard] = Field(discriminator='pet_type')
     n: int
 
 

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -184,7 +184,7 @@ class Dog(BaseModel):
 try:
 
     class Model(BaseModel):
-        pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
         number: int
 
 except PydanticUserError as exc_info:
@@ -216,7 +216,7 @@ class Dog(BaseModel):
 try:
 
     class Model(BaseModel):
-        pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
         number: int
 
 except PydanticUserError as exc_info:
@@ -246,7 +246,7 @@ class Dog(BaseModel):
 try:
 
     class Model(BaseModel):
-        pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
         number: int
 
 except PydanticUserError as exc_info:
@@ -276,7 +276,7 @@ class Dog(BaseModel):
 try:
 
     class Model(BaseModel):
-        pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
         number: int
 
 except PydanticUserError as exc_info:
@@ -314,7 +314,7 @@ class Dog(BaseModel):
 try:
 
     class Model(BaseModel):
-        pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+        pet: Union[Cat, Dog] = Field(discriminator='pet_type')
         number: int
 
 except PydanticUserError as exc_info:
@@ -1126,7 +1126,7 @@ from pydantic.dataclasses import dataclass
 
 @dataclass
 class Foo:
-    bar: str = Field(..., init=False, init_var=True)
+    bar: str = Field(init=False, init_var=True)
 
 
 """

--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -2020,7 +2020,7 @@ class WhiteCat(BaseModel):
 
 
 class Model(BaseModel):
-    cat: Union[BlackCat, WhiteCat] = Field(..., discriminator='pet_type')
+    cat: Union[BlackCat, WhiteCat] = Field(discriminator='pet_type')
 
 
 try:
@@ -2049,7 +2049,7 @@ class WhiteCat(BaseModel):
 
 
 class Model(BaseModel):
-    cat: Union[BlackCat, WhiteCat] = Field(..., discriminator='pet_type')
+    cat: Union[BlackCat, WhiteCat] = Field(discriminator='pet_type')
 
 
 try:

--- a/docs/integrations/datamodel_code_generator.md
+++ b/docs/integrations/datamodel_code_generator.md
@@ -91,8 +91,8 @@ class Pet(BaseModel):
 
 
 class Person(BaseModel):
-    first_name: str = Field(..., description="The person's first name.")
-    last_name: str = Field(..., description="The person's last name.")
+    first_name: str = Field(description="The person's first name.")
+    last_name: str = Field(description="The person's last name.")
     age: conint(ge=0) | None = Field(None, description='Age in years.')
     pets: list[Pet] | None = None
     comment: Any | None = None

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -209,6 +209,10 @@ class FieldInfo(_repr.Representation):
         default = kwargs.pop('default', PydanticUndefined)
         if default is Ellipsis:
             self.default = PydanticUndefined
+            # Also remove it from the attributes set, otherwise
+            # `GenerateSchema._common_field_schema` mistakenly
+            # uses it:
+            self._attributes_set.pop('default', None)
         else:
             self.default = default
 
@@ -1033,12 +1037,15 @@ class ModelPrivateAttr(_repr.Representation):
             attribute if not provided.
     """
 
-    __slots__ = 'default', 'default_factory'
+    __slots__ = ('default', 'default_factory')
 
     def __init__(
         self, default: Any = PydanticUndefined, *, default_factory: typing.Callable[[], Any] | None = None
     ) -> None:
-        self.default = default
+        if default is Ellipsis:
+            self.default = PydanticUndefined
+        else:
+            self.default = default
         self.default_factory = default_factory
 
     if not typing.TYPE_CHECKING:

--- a/tests/benchmarks/test_discriminated_unions.py
+++ b/tests/benchmarks/test_discriminated_unions.py
@@ -22,7 +22,7 @@ class LeafState(BaseModel):
     state_type: Literal['leaf']
 
 
-AnyState = Annotated[Union[NestedState, LoopState, LeafState], Field(..., discriminator='state_type')]
+AnyState = Annotated[Union[NestedState, LoopState, LeafState], Field(discriminator='state_type')]
 
 
 @pytest.mark.benchmark

--- a/tests/benchmarks/test_model_schema_generation.py
+++ b/tests/benchmarks/test_model_schema_generation.py
@@ -246,7 +246,7 @@ def test_tagged_union_with_str_discriminator_schema_generation(benchmark):
         scales: bool
 
     class Model(DeferredModel):
-        pet: Union[Cat, Dog, Lizard] = Field(..., discriminator='pet_type')
+        pet: Union[Cat, Dog, Lizard] = Field(discriminator='pet_type')
         n: int
 
     benchmark(rebuild_model, Model)

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -141,8 +141,8 @@ def test_alias_override_behavior():
         x: int = Field(alias='x1', gt=0)
 
     class Child(Parent):
-        x: int = Field(..., alias='x2')
-        y: int = Field(..., alias='y2')
+        x: int = Field(alias='x2')
+        y: int = Field(alias='y2')
 
     assert Parent.model_fields['x'].alias == 'x1'
     assert Child.model_fields['x'].alias == 'x2'
@@ -209,7 +209,7 @@ upper_alias_generator = [
 def test_alias_generator_on_parent(alias_generator):
     class Parent(BaseModel):
         model_config = ConfigDict(alias_generator=alias_generator)
-        x: bool = Field(..., alias='a_b_c')
+        x: bool = Field(alias='a_b_c')
         y: str
 
     class Child(Parent):
@@ -226,7 +226,7 @@ def test_alias_generator_on_parent(alias_generator):
 @pytest.mark.parametrize('alias_generator', upper_alias_generator)
 def test_alias_generator_on_child(alias_generator):
     class Parent(BaseModel):
-        x: bool = Field(..., alias='abc')
+        x: bool = Field(alias='abc')
         y: str
 
     class Child(Parent):
@@ -245,12 +245,12 @@ def test_alias_generator_used_by_default(alias_generator):
         model_config = ConfigDict(alias_generator=alias_generator)
 
         a: str
-        b: str = Field(..., alias='b_alias')
-        c: str = Field(..., validation_alias='c_val_alias')
-        d: str = Field(..., serialization_alias='d_ser_alias')
-        e: str = Field(..., alias='e_alias', validation_alias='e_val_alias')
-        f: str = Field(..., alias='f_alias', serialization_alias='f_ser_alias')
-        g: str = Field(..., alias='g_alias', validation_alias='g_val_alias', serialization_alias='g_ser_alias')
+        b: str = Field(alias='b_alias')
+        c: str = Field(validation_alias='c_val_alias')
+        d: str = Field(serialization_alias='d_ser_alias')
+        e: str = Field(alias='e_alias', validation_alias='e_val_alias')
+        f: str = Field(alias='f_alias', serialization_alias='f_ser_alias')
+        g: str = Field(alias='g_alias', validation_alias='g_val_alias', serialization_alias='g_ser_alias')
 
     assert {
         name: {k: getattr(f, k) for k in ('alias', 'validation_alias', 'serialization_alias')}
@@ -301,9 +301,9 @@ def test_alias_generator_used_by_default(alias_generator):
 @pytest.mark.parametrize('alias_generator', upper_alias_generator)
 def test_low_priority_alias(alias_generator):
     class Parent(BaseModel):
-        w: bool = Field(..., alias='w_', validation_alias='w_val_alias', serialization_alias='w_ser_alias')
+        w: bool = Field(alias='w_', validation_alias='w_val_alias', serialization_alias='w_ser_alias')
         x: bool = Field(
-            ..., alias='abc', alias_priority=1, validation_alias='x_val_alias', serialization_alias='x_ser_alias'
+            alias='abc', alias_priority=1, validation_alias='x_val_alias', serialization_alias='x_ser_alias'
         )
         y: str
 
@@ -403,7 +403,7 @@ def test_populate_by_name_config(
 
     class Foo(BaseModel):
         model_config = ConfigDict(populate_by_name=populate_by_name_config)
-        bar_: int = Field(..., alias='bar')
+        bar_: int = Field(alias='bar')
 
     with expectation:
         if use_construct:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,7 +113,7 @@ class TestsBaseConfig:
         class MyModel(BaseModel):
             id: int
             name: str = 'John Doe'
-            f__: str = Field(..., alias='foo')
+            f__: str = Field(alias='foo')
 
             model_config = ConfigDict(extra='allow')
 
@@ -144,7 +144,7 @@ class TestsBaseConfig:
 
     def test_base_config_use_field_name(self):
         class Foo(BaseModel):
-            foo: str = Field(..., alias='this is invalid')
+            foo: str = Field(alias='this is invalid')
 
             model_config = ConfigDict(populate_by_name=True)
 
@@ -152,7 +152,7 @@ class TestsBaseConfig:
 
     def test_base_config_does_not_use_reserved_word(self):
         class Foo(BaseModel):
-            from_: str = Field(..., alias='from')
+            from_: str = Field(alias='from')
 
             model_config = ConfigDict(populate_by_name=True)
 
@@ -326,7 +326,7 @@ class TestsBaseConfig:
         expected_value: int = 7
 
         class Foo(BaseModel):
-            bar_: int = Field(..., alias='bar')
+            bar_: int = Field(alias='bar')
 
             model_config = dict(populate_by_name=populate_by_name_config)
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2855,7 +2855,7 @@ def test_disallow_init_false_and_init_var_true() -> None:
 
         @pydantic.dataclasses.dataclass
         class Foo:
-            bar: str = Field(..., init=False, init_var=True)
+            bar: str = Field(init=False, init_var=True)
 
 
 def test_annotations_valid_for_field_inheritance() -> None:

--- a/tests/test_discriminated_union.py
+++ b/tests/test_discriminated_union.py
@@ -35,7 +35,7 @@ def test_discriminated_union_type():
     ):
 
         class Model(BaseModel):
-            x: str = Field(..., discriminator='qwe')
+            x: str = Field(discriminator='qwe')
 
 
 @pytest.mark.parametrize('union', [True, False])
@@ -46,9 +46,9 @@ def test_discriminated_single_variant(union):
 
     class Model(BaseModel):
         if union:
-            x: Union[InnerModel] = Field(..., discriminator='qwe')
+            x: Union[InnerModel] = Field(discriminator='qwe')
         else:
-            x: InnerModel = Field(..., discriminator='qwe')
+            x: InnerModel = Field(discriminator='qwe')
 
     assert Model(x={'qwe': 'qwe', 'y': 1}).x.qwe == 'qwe'
     with pytest.raises(ValidationError) as exc_info:
@@ -69,7 +69,7 @@ def test_discriminated_union_single_variant():
         qwe: Literal['qwe']
 
     class Model(BaseModel):
-        x: Union[InnerModel] = Field(..., discriminator='qwe')
+        x: Union[InnerModel] = Field(discriminator='qwe')
 
     assert Model(x={'qwe': 'qwe'}).x.qwe == 'qwe'
 
@@ -80,7 +80,7 @@ def test_discriminated_union_invalid_type():
     ):
 
         class Model(BaseModel):
-            x: Union[str, int] = Field(..., discriminator='qwe')
+            x: Union[str, int] = Field(discriminator='qwe')
 
 
 def test_discriminated_union_defined_discriminator():
@@ -94,7 +94,7 @@ def test_discriminated_union_defined_discriminator():
     with pytest.raises(PydanticUserError, match="Model 'Cat' needs a discriminator field for key 'pet_type'"):
 
         class Model(BaseModel):
-            pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+            pet: Union[Cat, Dog] = Field(discriminator='pet_type')
             number: int
 
 
@@ -110,7 +110,7 @@ def test_discriminated_union_literal_discriminator():
     with pytest.raises(PydanticUserError, match="Model 'Cat' needs field 'pet_type' to be of type `Literal`"):
 
         class Model(BaseModel):
-            pet: Union[Cat, Dog] = Field(..., discriminator='pet_type')
+            pet: Union[Cat, Dog] = Field(discriminator='pet_type')
             number: int
 
 
@@ -126,7 +126,7 @@ def test_discriminated_union_root_same_discriminator():
     class Dog(BaseModel):
         pet_type: Literal['dog']
 
-    CatDog = TypeAdapter(Annotated[Union[Cat, Dog], Field(..., discriminator='pet_type')]).validate_python
+    CatDog = TypeAdapter(Annotated[Union[Cat, Dog], Field(discriminator='pet_type')]).validate_python
     CatDog({'pet_type': 'blackcat'})
     CatDog({'pet_type': 'whitecat'})
     CatDog({'pet_type': 'dog'})
@@ -345,7 +345,7 @@ def test_discriminated_union_basemodel_instance_value():
         foo: Literal['b']
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='foo')
+        sub: Union[A, B] = Field(discriminator='foo')
 
     t = Top(sub=A(foo='a'))
     assert isinstance(t, Top)
@@ -360,7 +360,7 @@ def test_discriminated_union_basemodel_instance_value_with_alias():
         literal: Literal['b'] = Field(alias='lit')
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='literal')
+        sub: Union[A, B] = Field(discriminator='literal')
 
     with pytest.raises(ValidationError) as exc_info:
         Top(sub=A(literal='a'))
@@ -381,7 +381,7 @@ def test_discriminated_union_int():
         m: Literal[2]
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='m')
+        sub: Union[A, B] = Field(discriminator='m')
 
     assert isinstance(Top.model_validate({'sub': {'m': 2}}).sub, B)
     with pytest.raises(ValidationError) as exc_info:
@@ -430,7 +430,7 @@ def test_discriminated_union_enum(base_class, choices):
         m: Literal[EnumValue.b]
 
     class Top(BaseModel):
-        sub: Union[A, B] = Field(..., discriminator='m')
+        sub: Union[A, B] = Field(discriminator='m')
 
     assert isinstance(Top.model_validate({'sub': {'m': EnumValue.b}}).sub, B)
     if isinstance(EnumValue.b, (int, str)):
@@ -497,7 +497,7 @@ def test_nested():
         name: str
 
     class Model(BaseModel):
-        pet: Union[CommonPet, Lizard] = Field(..., discriminator='pet_type')
+        pet: Union[CommonPet, Lizard] = Field(discriminator='pet_type')
         n: int
 
     assert isinstance(Model(**{'pet': {'pet_type': 'dog', 'name': 'Milou'}, 'n': 5}).pet, Dog)
@@ -1973,13 +1973,13 @@ def test_nested_schema_gen_uses_tagged_union_in_ref() -> None:
     class LeafState(BaseModel):
         state_type: Literal['leaf']
 
-    AnyState = Annotated[Union[NestedState, LoopState, LeafState], Field(..., discriminator='state_type')]
+    AnyState = Annotated[Union[NestedState, LoopState, LeafState], Field(discriminator='state_type')]
     adapter = TypeAdapter(AnyState)
 
     assert adapter.core_schema['schema']['type'] == 'tagged-union'
     for definition in adapter.core_schema['definitions']:
         if definition['schema']['model_name'] in ['NestedState', 'LoopState']:
-            assert definition['schema']['fields']['substate']['schema']['schema']['type'] == 'tagged-union'
+            assert definition['schema']['fields']['substate']['schema']['type'] == 'tagged-union'
 
 
 def test_recursive_discriminiated_union_with_typed_dict() -> None:
@@ -2117,7 +2117,7 @@ def test_discriminated_union_with_unsubstituted_type_var() -> None:
         friends: List['GenericPet']
         id: T
 
-    GenericPet = Annotated[Union[Dog[T], Cat[T]], Field(..., discriminator='type_')]
+    GenericPet = Annotated[Union[Dog[T], Cat[T]], Field(discriminator='type_')]
 
     ta = TypeAdapter(Dog[int])
     int_dog = {

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -431,7 +431,7 @@ def test_forward_ref_with_field(create_module):
         Foo = ForwardRef('Foo')
 
         class Foo(BaseModel):
-            c: List[Foo] = Field(..., gt=0)
+            c: List[Foo] = Field(gt=0)
 
         with pytest.raises(TypeError, match=re.escape("Unable to apply constraint 'gt' to supplied value []")):
             Foo(c=[Foo(c=[])])
@@ -446,7 +446,7 @@ from pydantic import BaseModel, Field
 
 
 class Spec(BaseModel):
-    spec_fields: list[str] = Field(..., alias="fields")
+    spec_fields: list[str] = Field(alias="fields")
     filter: str | None = None
     sort: str | None
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -359,7 +359,7 @@ def test_cache_keys_are_hashable(clean_cache):
     assert len(_GENERIC_TYPES_CACHE) == cache_size + 15
 
     class Model(BaseModel):
-        x: MyGenericModel[Callable[[C], Iterable[str]]] = Field(...)
+        x: MyGenericModel[Callable[[C], Iterable[str]]]
 
     models.append(Model)
     assert len(_GENERIC_TYPES_CACHE) == cache_size + 15
@@ -2324,7 +2324,7 @@ def test_construct_generic_model_with_validation():
     class Page(BaseModel, Generic[T]):
         page: int = Field(ge=42)
         items: Sequence[T]
-        unenforced: PositiveInt = Field(..., lt=10)
+        unenforced: PositiveInt = Field(lt=10)
 
     with pytest.raises(ValidationError) as exc_info:
         Page[int](page=41, items=[], unenforced=11)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -222,7 +222,7 @@ def test_sub_model():
 def test_schema_class():
     class Model(BaseModel):
         foo: int = Field(4, title='Foo is Great')
-        bar: str = Field(..., description='this description of bar')
+        bar: str = Field(description='this description of bar')
 
     with pytest.raises(ValidationError):
         Model()
@@ -422,7 +422,7 @@ def test_enum_includes_extra_without_other_params():
 
     class Foo(BaseModel):
         enum: Names
-        extra_enum: Names = Field(..., json_schema_extra={'extra': 'Extra field'})
+        extra_enum: Names = Field(json_schema_extra={'extra': 'Extra field'})
 
     assert Foo.model_json_schema() == {
         '$defs': {
@@ -1483,7 +1483,7 @@ def test_schema_overrides_w_union():
         pass
 
     class Spam(BaseModel):
-        a: Union[Foo, Bar] = Field(..., description='xxx')
+        a: Union[Foo, Bar] = Field(description='xxx')
 
     assert Spam.model_json_schema()['properties'] == {
         'a': {
@@ -2792,7 +2792,7 @@ def test_typeddict_with__callable_json_schema_extra():
 )
 def test_enforced_constraints(annotation, kwargs, field_schema):
     class Model(BaseModel):
-        a: annotation = Field(..., **kwargs)
+        a: annotation = Field(**kwargs)
 
     schema = Model.model_json_schema()
     # debug(schema['properties']['a'])
@@ -2802,7 +2802,7 @@ def test_enforced_constraints(annotation, kwargs, field_schema):
 def test_real_constraints():
     class Model1(BaseModel):
         model_config = ConfigDict(title='Test Model')
-        foo: int = Field(..., gt=123)
+        foo: int = Field(gt=123)
 
     with pytest.raises(ValidationError, match='should be greater than 123'):
         Model1(foo=123)
@@ -3795,7 +3795,7 @@ def test_discriminated_union():
         pet_type: Literal['reptile', 'lizard']
 
     class Model(BaseModel):
-        pet: Union[Cat, Dog, Lizard] = Field(..., discriminator='pet_type')
+        pet: Union[Cat, Dog, Lizard] = Field(discriminator='pet_type')
 
     # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
@@ -3851,7 +3851,7 @@ def test_discriminated_annotated_union():
         pet_type: Literal['reptile', 'lizard']
 
     class Model(BaseModel):
-        pet: Annotated[Union[Cat, Dog, Lizard], Field(..., discriminator='pet_type')]
+        pet: Annotated[Union[Cat, Dog, Lizard], Field(discriminator='pet_type')]
 
     # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
@@ -6169,7 +6169,7 @@ def test_recursive_json_schema_build() -> None:
         VAL2 = 'Val2'
 
     class ModelA(BaseModel):
-        modelA_1: AllowedValues = Field(..., max_length=60)
+        modelA_1: AllowedValues = Field(max_length=60)
 
     class ModelB(ModelA):
         modelB_1: typing.List[ModelA]
@@ -6213,7 +6213,7 @@ def test_required_fields_in_annotated_with_create_model() -> None:
         'test_model',
         foo=(int, ...),
         bar=(Annotated[int, Field(description='Bar description')], ...),
-        baz=(Annotated[int, Field(..., description='Baz description')], ...),
+        baz=(Annotated[int, Field(description='Baz description')], ...),
     )
 
     assert Model.model_json_schema() == {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1511,7 +1511,7 @@ def test_model_export_exclusion_inheritance():
     class Parent(BaseModel):
         model_config = ConfigDict(fields={'a': {'exclude': ...}, 's': {'exclude': {'s1'}}})
         a: int
-        b: int = Field(..., exclude=...)
+        b: int = Field(exclude=...)
         c: int
         d: int
         s: Sub = Sub()
@@ -1777,7 +1777,7 @@ def test_default_factory_parse():
 
 
 def test_reuse_same_field():
-    required_field = Field(...)
+    required_field = Field()
 
     class Model1(BaseModel):
         required: str = required_field
@@ -1952,7 +1952,7 @@ def test_new_union_origin():
 )
 @pytest.mark.parametrize(
     'value',
-    [None, Field(...)],
+    [None, Field()],
     ids=['none', 'field'],
 )
 def test_frozen_field_decl_without_default_val(ann, value):

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -23,7 +23,7 @@ def _equals(a: Union[str, Iterable[str]], b: Union[str, Iterable[str]]) -> bool:
 
 def test_model_signature():
     class Model(BaseModel):
-        a: float = Field(..., title='A')
+        a: float = Field(title='A')
         b: int = Field(10)
 
     sig = signature(Model)
@@ -48,7 +48,7 @@ def test_custom_init_signature():
     class MyModel(BaseModel):
         id: int
         name: str = 'John Doe'
-        f__: str = Field(..., alias='foo')
+        f__: str = Field(alias='foo')
 
         model_config = ConfigDict(extra='allow')
 
@@ -92,7 +92,7 @@ def test_invalid_identifiers_signature():
 
 def test_use_field_name():
     class Foo(BaseModel):
-        foo: str = Field(..., alias='this is invalid')
+        foo: str = Field(alias='this is invalid')
 
         model_config = ConfigDict(populate_by_name=True)
 
@@ -101,7 +101,7 @@ def test_use_field_name():
 
 def test_does_not_use_reserved_word():
     class Foo(BaseModel):
-        from_: str = Field(..., alias='from')
+        from_: str = Field(alias='from')
 
         model_config = ConfigDict(populate_by_name=True)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -392,7 +392,7 @@ def test_constrained_list_item_type_fails():
 
 def test_conlist():
     class Model(BaseModel):
-        foo: List[int] = Field(..., min_length=2, max_length=4)
+        foo: List[int] = Field(min_length=2, max_length=4)
         bar: conlist(str, min_length=1, max_length=4) = None
 
     assert Model(foo=[1, 2], bar=['spoon']).model_dump() == {'foo': [1, 2], 'bar': ['spoon']}
@@ -607,7 +607,7 @@ def test_constrained_set_item_type_fails():
 
 def test_conset():
     class Model(BaseModel):
-        foo: Set[int] = Field(..., min_length=2, max_length=4)
+        foo: Set[int] = Field(min_length=2, max_length=4)
         bar: conset(str, min_length=1, max_length=4) = None
 
     assert Model(foo=[1, 2], bar=['spoon']).model_dump() == {'foo': {1, 2}, 'bar': {'spoon'}}
@@ -656,7 +656,7 @@ def test_conset_not_required():
 
 def test_confrozenset():
     class Model(BaseModel):
-        foo: FrozenSet[int] = Field(..., min_length=2, max_length=4)
+        foo: FrozenSet[int] = Field(min_length=2, max_length=4)
         bar: confrozenset(str, min_length=1, max_length=4) = None
 
     m = Model(foo=[1, 2], bar=['spoon'])
@@ -2809,7 +2809,7 @@ def test_strict_bytes():
 
 def test_strict_bytes_max_length():
     class Model(BaseModel):
-        u: StrictBytes = Field(..., max_length=5)
+        u: StrictBytes = Field(max_length=5)
 
     assert Model(u=b'foo').u == b'foo'
 
@@ -2842,7 +2842,7 @@ def test_strict_str():
 
 def test_strict_str_max_length():
     class Model(BaseModel):
-        u: StrictStr = Field(..., max_length=5)
+        u: StrictStr = Field(max_length=5)
 
     assert Model(u='foo').u == 'foo'
 
@@ -3085,11 +3085,11 @@ def test_uuid_strict() -> None:
         model_config = ConfigDict(strict=True)
 
     class StrictByField(BaseModel):
-        a: UUID1 = Field(..., strict=True)
-        b: UUID3 = Field(..., strict=True)
-        c: UUID4 = Field(..., strict=True)
-        d: UUID5 = Field(..., strict=True)
-        e: uuid.UUID = Field(..., strict=True)
+        a: UUID1 = Field(strict=True)
+        b: UUID3 = Field(strict=True)
+        c: UUID4 = Field(strict=True)
+        d: UUID5 = Field(strict=True)
+        e: uuid.UUID = Field(strict=True)
 
     a = uuid.UUID('7fb48116-ca6b-11ed-a439-3274d3adddac')  # uuid1
     b = uuid.UUID('6fa459ea-ee8a-3ca4-894e-db77e160355e')  # uuid3
@@ -4206,7 +4206,7 @@ def test_compiled_pattern_in_field(use_field):
     if use_field:
 
         class Foobar(BaseModel):
-            str_regex: str = Field(..., pattern=field_pattern)
+            str_regex: str = Field(pattern=field_pattern)
     else:
 
         class Foobar(BaseModel):
@@ -6918,9 +6918,9 @@ def test_constraints_on_str_like() -> None:
         pytest.param(True, FailFast(), id='fail-fast-default'),
         pytest.param(True, FailFast(True), id='fail-fast-true'),
         pytest.param(False, FailFast(False), id='fail-fast-false'),
-        pytest.param(False, Field(...), id='field-default'),
-        pytest.param(True, Field(..., fail_fast=True), id='field-true'),
-        pytest.param(False, Field(..., fail_fast=False), id='field-false'),
+        pytest.param(False, Field(), id='field-default'),
+        pytest.param(True, Field(fail_fast=True), id='field-true'),
+        pytest.param(False, Field(fail_fast=False), id='field-false'),
     ],
 )
 def test_fail_fast(tp, fail_fast, decl) -> None:

--- a/tests/test_types_self.py
+++ b/tests/test_types_self.py
@@ -109,7 +109,7 @@ def test_recursive_model_with_subclass_override(Self):
 def test_self_type_with_field(Self):
     class SelfRef(BaseModel):
         x: int
-        refs: typing.List[Self] = Field(..., gt=0)
+        refs: typing.List[Self] = Field(gt=0)
 
     with pytest.raises(TypeError, match=re.escape("Unable to apply constraint 'gt' to supplied value []")):
         SelfRef(x=1, refs=[SelfRef(x=2, refs=[])])

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -645,7 +645,7 @@ def test_json_schema():
     }
 
     @validate_call
-    def foo(a: Annotated[int, Field(..., alias='A')]):
+    def foo(a: Annotated[int, Field(alias='A')]):
         return a
 
     assert foo(1) == 1

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1816,7 +1816,7 @@ def test_overridden_root_validators():
 
 def test_validating_assignment_pre_root_validator_fail():
     class Model(BaseModel):
-        current_value: float = Field(..., alias='current')
+        current_value: float = Field(alias='current')
         max_value: float
 
         model_config = ConfigDict(validate_assignment=True)
@@ -1844,7 +1844,7 @@ def test_validating_assignment_pre_root_validator_fail():
 
 def test_validating_assignment_model_validator_before_fail():
     class Model(BaseModel):
-        current_value: float = Field(..., alias='current')
+        current_value: float = Field(alias='current')
         max_value: float
 
         model_config = ConfigDict(validate_assignment=True)


### PR DESCRIPTION
Also fix a bug where under certain scenarios, a `Field` function inside `Annotated` metadata would retain the `Ellipsis` as a default value.

Also make `PrivateAttr` on par with `Field` and the special casing of `Ellipsis`.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
