### PR TITLE
docs: respect system colorscheme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,13 @@ theme:
   name: 'material'
   custom_dir: 'docs/theme'
   palette:
+  - media: "(prefers-color-scheme)"
+    scheme: default
+    primary: pink
+    accent: pink
+    toggle:
+      icon: material/lightbulb
+      name: "Switch to light mode"
   - media: "(prefers-color-scheme: light)"
     scheme: default
     primary: pink
@@ -19,8 +26,8 @@ theme:
     primary: pink
     accent: pink
     toggle:
-      icon: material/lightbulb
-      name: "Switch to light mode"
+      icon: material/lightbulb-auto-outline
+      name: "Switch to system preference"
   features:
     - content.tabs.link
     - content.code.annotate


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

https://github.com/user-attachments/assets/f7cf771b-39c1-49c9-bdb5-43c1e49f5ae4

> The left browser window shows the current version of the docs, the right one contains the changes from this PR

This PR makes the docs respect the systems color preference by default. As can be seen in the video, it currently defaults to light mode, even if I've set my OS to dark mode.

This also adds a new option to the theme picker next to the search. This means the cycle is now 
- "auto" (default)
- "always light"
- "always dark"

## Related issue number

Not an issue, but the dark mode seems to have been introduced in https://github.com/pydantic/pydantic/pull/2913. The convention that the button icon and alt text reflects the _action_ instead of the current state is retained. The latest comment on the referenced PR also indicates that other users also expect the systems color preference to be the default.

## Other Related Things

Here is a link to the docs of Mkdocs Material, where they describe the automatic dark/light mode: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] ~Unit tests for the changes exist~
* [x] Tests pass on CI
* [ ] ~Documentation reflects the changes where applicable~
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle