### PR TITLE
Improve string types documentation and add references

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -899,9 +899,10 @@ Allows only `None` value.
 
 ## Strings
 
-[`str`][]: Strings are accepted as-is.
-[`bytes`][] and [`bytearray`][] are converted using the [`decode()`][bytes.decode] method.
-Enums inheriting from [`str`][] are converted using the [`value`][enum.Enum.value] attribute.
+- [`str`][]: Strings are accepted as-is.
+- [`bytes`][] and [`bytearray`][] are converted using the [`decode()`][bytes.decode] method.
+- Enums inheriting from [`str`][] are converted using the [`value`][enum.Enum.value] attribute.
+
 All other types cause an error.
 <!-- * TODO: add note about optional number to string conversion from lig's PR -->
 

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -899,8 +899,10 @@ Allows only `None` value.
 
 ## Strings
 
-`str`: Strings are accepted as-is. `bytes` and `bytearray` are converted using `v.decode()`.
-Enum`s inheriting from `str` are converted using `v.value`. All other types cause an error.
+[`str`][]: Strings are accepted as-is.
+[`bytes`][] and [`bytearray`][] are converted using the [`decode()`][bytes.decode] method.
+Enums inheriting from [`str`][] are converted using the [`value`][enum.Enum.value] attribute.
+All other types cause an error.
 <!-- * TODO: add note about optional number to string conversion from lig's PR -->
 
 !!! warning "Strings aren't Sequences"


### PR DESCRIPTION
## Change Summary

Replace the backtick with an apostrophe since the rendered output is broken.

Add references to the Python documentation for str, bytes, bytearray, bytes.decode, and Enum.value.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle