### PR TITLE
add union to strict constraints

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -80,7 +80,7 @@ constraint_schema_pairings: list[tuple[set[str], tuple[str, ...]]] = [
     (INT_CONSTRAINTS, ('int',)),
     (DATE_TIME_CONSTRAINTS, ('date', 'time', 'datetime', 'timedelta')),
     # TODO: this is a bit redundant, we could probably avoid some of these
-    (STRICT, (*TEXT_SCHEMA_TYPES, *SEQUENCE_SCHEMA_TYPES, *NUMERIC_SCHEMA_TYPES, 'typed-dict', 'model')),
+    (STRICT, (*TEXT_SCHEMA_TYPES, *SEQUENCE_SCHEMA_TYPES, *NUMERIC_SCHEMA_TYPES, 'typed-dict', 'model', 'union')),
     (UNION_CONSTRAINTS, ('union',)),
     (URL_CONSTRAINTS, ('url', 'multi-host-url')),
     (BOOL_CONSTRAINTS, ('bool',)),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Adds union to strict constraints. Before this fix, creating a model with the `strict` property using a union would return
```
RuntimeError: Unable to apply constraint 'strict' to schema of type 'union'
```
This fix adds `union` to the strict `constraint_schema_pairings` so that unions can be used with the `strict` property.

## Related issue number

[fix #10571](https://github.com/pydantic/pydantic/issues/10571)

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
