### PR TITLE
Fix issue where you can't make a field required while merging field infos

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -434,10 +434,10 @@ class FieldInfo(_repr.Representation):
             field_info = copy(field_infos[0])
             field_info._attributes_set.update(overrides)
 
-            default_override = overrides.pop('default', PydanticUndefined)
+            default_override = overrides.pop('default', _default_sentinel)
             if default_override is Ellipsis:
                 default_override = PydanticUndefined
-            if default_override is not PydanticUndefined:
+            if default_override is not _default_sentinel:
                 field_info.default = default_override
 
             for k, v in overrides.items():
@@ -1418,3 +1418,6 @@ def computed_field(
         return dec
     else:
         return dec(func)
+
+
+_default_sentinel = object()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 import pytest
+from pydantic_core import PydanticUndefined
 
 import pydantic.dataclasses
 from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, RootModel, ValidationError, computed_field, fields
@@ -170,3 +171,9 @@ def test_coerce_numbers_to_str_field_precedence(number):
         field: str = Field(coerce_numbers_to_str=True)
 
     assert Model(field=number).field == str(number)
+
+
+def test_merge_field_infos_override_default():
+    my_field = Field(None, description='My Field')
+    merged_field = fields.FieldInfo().merge_field_infos(my_field, default=PydanticUndefined)
+    assert merged_field.is_required()


### PR DESCRIPTION
Issue reported in slack here: https://pydanticlogfire.slack.com/archives/C074GP90D8A/p1729631385488929

>Hi everyone. Is it not possible to set up the default value as PydanticUndefined when using merge_field_infos  anymore?
Starting in 2.7.0, there was a change where if there is a PydanticUndefined passed as a default value in the **overrides, it would not be used anymore at all:
We pop the default value present in the overrides, and if it's not PydanticUndefined or Ellipsis, it would be overriden -> otherwise, it still falls back to the first field default value passed when running merge_field_infos.
https://docs.pydantic.dev/2.7/api/fields/#pydantic.fields.FieldInfo.merge_field_infos
        default_override = overrides.pop('default', PydanticUndefined)
        if default_override is Ellipsis:
            default_override = PydanticUndefined
        if default_override is not PydanticUndefined:
            field_info.default = default_override
If one would like to use the existing Field, while overriding default value to be a PydanticUndefined, how would that work now? ie. in scenarios where we have a bunch of Fields with default=None, and in some cases, we would like to override that (so that the required parameter is True), how would we achieve this now given this change introduced in 2.7.0?

Open to alternative solutions (such as catching a `KeyError`), but I suspect this is the most performant choice, and imo seems like a preferable implementation to how things currently work.

I'm not sure what the use case is for merging field infos and overriding the default like this, maybe it's better not to know 😄, but again this seems to me like a preferable implementation and no existing tests failed for me locally.