### PR TITLE
Add exception handling for clashing validator and field names in crea…

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -625,6 +625,26 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'create-model-field-definitions'
 ```
 
+## `create_model` clashing field names {#create-model-clashing-validator-field-name}
+
+This error is raised when you provide a validator name which clashes with the field name.
+
+```py
+from pydantic import PydanticUserError, create_model, field_validator
+
+
+def bar(s: str) -> str:
+    return s
+
+
+validator = field_validator("bar", mode="before")(bar)
+validators = {"bar": validator}
+try:
+    create_model("Foo", bar=(str, ...), __validators__=validators)
+except PydanticUserError as exc_info:
+    assert exc_info.code == "create-model-clashing-validator-field-name"
+```
+
 ## `create_model` config base {#create-model-config-base}
 
 This error is raised when you use both `__config__` and `__base__` together in `create_model`.

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -44,6 +44,7 @@ PydanticErrorCodes = Literal[
     'schema-for-unknown-type',
     'import-error',
     'create-model-field-definitions',
+    'create-model-clashing-validator-field-name',
     'create-model-config-base',
     'validator-no-fields',
     'validator-invalid-fields',

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1660,6 +1660,12 @@ def create_model(  # noqa: C901
     if __doc__:
         namespace.update({'__doc__': __doc__})
     if __validators__:
+        conflicting_members = __validators__.keys() & fields.keys()
+        if conflicting_members:
+            raise PydanticUserError(
+                f'Clashing validator name with field name found for: {conflicting_members}. Field names and validator names must be different.',
+                code='create-model-clashing-validator-field-name',
+            )
         namespace.update(__validators__)
     namespace.update(fields)
     if __config__:

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -229,6 +229,17 @@ def test_inheritance_validators_all():
     assert model(a=2, b=6).model_dump() == {'a': 4, 'b': 12}
 
 
+def test_create_clashing_field_validator_name_with_field_name():
+    def bar(s: str) -> str:
+        return 'foo' + s
+
+    validator = field_validator('bar', mode='before')(bar)
+    validators = {'bar': validator}
+
+    with pytest.raises(PydanticUserError):
+        create_model('Foo', bar=(str, ...), __validators__=validators)
+
+
 def test_funky_name():
     model = create_model('FooModel', **{'this-is-funky': (int, ...)})
     m = model(**{'this-is-funky': '123'})


### PR DESCRIPTION
## Change Summary
When creating a model using `create_model`, if a field name matches a validator and the field has a default value, the field takes precedence in the namespace. However, in the case of `BaseModel`, the validator takes precedence when defined later, which is expected behavior.

For `create_model`, since the precedence is not obvious to the user, Pydantic should raise an exception to avoid confusion.


## Related issue number
fix #10646

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle