### PR TITLE
feat: add support to return default if input is `None`

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "email", "linting", "memray", "mypy", "testing", "testing-extra", "timezone"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:0fa988af1e0b9ae6e18b2a31a32d54aba8db98db5a9428207aa897831e836b82"
+content_hash = "sha256:826b39abc0c137e0667b85538a372adb07c9c054eec6f39fe34d29ffbda077a8"
 
 [[metadata.targets]]
 requires_python = ">=3.8"

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -89,6 +89,7 @@ class ConfigWrapper:
     validation_error_cause: bool
     use_attribute_docstrings: bool
     cache_strings: bool | Literal['all', 'keys', 'none']
+    none_as_default: bool
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -284,6 +285,7 @@ config_defaults = ConfigDict(
     validation_error_cause=False,
     use_attribute_docstrings=False,
     cache_strings=True,
+    none_as_default=True,
 )
 
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1118,6 +1118,7 @@ class GenerateSchema:
             serialization_alias=common_field['serialization_alias'],
             frozen=common_field['frozen'],
             metadata=common_field['metadata'],
+            none_as_default=field_info.none_as_default,
         )
 
     def _generate_dc_field_schema(

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1012,6 +1012,8 @@ class ConfigDict(TypedDict, total=False):
         as the performance difference is minimal if repeated strings are rare.
     """
 
+    none_as_default: bool
+
 
 _TypeT = TypeVar('_TypeT', bound=type)
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -50,6 +50,7 @@ class _FromFieldInfoInputs(typing_extensions.TypedDict, total=False):
 
     annotation: type[Any] | None
     default_factory: typing.Callable[[], Any] | None
+    none_as_default: bool | None
     alias: str | None
     alias_priority: int | None
     validation_alias: str | AliasPath | AliasChoices | None
@@ -105,6 +106,7 @@ class FieldInfo(_repr.Representation):
         annotation: The type annotation of the field.
         default: The default value of the field.
         default_factory: The factory function used to construct the default for the field.
+        none_as_default: Whether to use default when passed `None`.
         alias: The alias name of the field.
         alias_priority: The priority of the field's alias.
         validation_alias: The validation alias of the field.
@@ -130,6 +132,7 @@ class FieldInfo(_repr.Representation):
     annotation: type[Any] | None
     default: Any
     default_factory: typing.Callable[[], Any] | None
+    none_as_default: bool | None
     alias: str | None
     alias_priority: int | None
     validation_alias: str | AliasPath | AliasChoices | None
@@ -154,6 +157,7 @@ class FieldInfo(_repr.Representation):
         'annotation',
         'default',
         'default_factory',
+        'none_as_default',
         'alias',
         'alias_priority',
         'validation_alias',
@@ -220,7 +224,7 @@ class FieldInfo(_repr.Representation):
 
         if self.default is not PydanticUndefined and self.default_factory is not None:
             raise TypeError('cannot specify both default and default_factory')
-
+        self.none_as_default = kwargs.pop('none_as_default', None)
         self.alias = kwargs.pop('alias', None)
         self.validation_alias = kwargs.pop('validation_alias', None)
         self.serialization_alias = kwargs.pop('serialization_alias', None)
@@ -661,6 +665,7 @@ class _EmptyKwargs(typing_extensions.TypedDict):
 _DefaultValues = {
     'default': ...,
     'default_factory': None,
+    'none_as_default': None,
     'alias': None,
     'alias_priority': None,
     'validation_alias': None,
@@ -818,6 +823,7 @@ def Field(  # noqa: C901
     default: Any = PydanticUndefined,
     *,
     default_factory: Callable[[], Any] | None = _Unset,
+    none_as_default: bool | None = _Unset,
     alias: str | None = _Unset,
     alias_priority: int | None = _Unset,
     validation_alias: str | AliasPath | AliasChoices | None = _Unset,
@@ -866,6 +872,7 @@ def Field(  # noqa: C901
     Args:
         default: Default value if the field is not set.
         default_factory: A callable to generate the default value, such as :func:`~datetime.utcnow`.
+        none_as_default: Whether to use default when passed `None`.
         alias: The name to use for the attribute when validating or serializing by alias.
             This is often used for things like converting between snake and camel case.
         alias_priority: Priority of the alias. This affects whether an alias generator is used.
@@ -984,6 +991,7 @@ def Field(  # noqa: C901
     return FieldInfo.from_field(
         default,
         default_factory=default_factory,
+        none_as_default=none_as_default,
         alias=alias,
         alias_priority=alias_priority,
         validation_alias=validation_alias,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -232,16 +232,7 @@ def test_not_required():
 
     assert Model(a=12.2).a == 12.2
     assert Model().a is None
-    with pytest.raises(ValidationError) as exc_info:
-        Model(a=None)
-    assert exc_info.value.errors(include_url=False) == [
-        {
-            'type': 'float_type',
-            'loc': ('a',),
-            'msg': 'Input should be a valid number',
-            'input': None,
-        },
-    ]
+    assert Model(a=None).a is None
 
 
 def test_allow_extra():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1285,7 +1285,7 @@ class BoolCastable:
         ('bool_check', 'f', False),
         ('bool_check', 'F', False),
         ('bool_check', b'FALSE', False),
-        ('bool_check', None, ValidationError),
+        ('bool_check', None, True),
         ('bool_check', '', ValidationError),
         ('bool_check', [], ValidationError),
         ('bool_check', {}, ValidationError),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Added support to return default value when passing `None` as input.
Previously, passing `None` explicitly to a required field with a default value would raise a `ValidationError`
pydantic-core changes are reflected in https://github.com/pydantic/pydantic-core/pull/1501
<!-- Please give a short summary of the changes. -->

## Related issue number
fix #8972
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

please review