### PR TITLE
Differentiate between `typing` & recent `typing_extensions.TypeAliasType` backport for Python 3.12, 3.13

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -15,7 +15,7 @@ from pydantic_core import validate_core_schema as _validate_core_schema
 from typing_extensions import TypeAliasType, TypeGuard, get_args, get_origin
 
 from . import _repr
-from ._typing_extra import is_generic_alias
+from ._typing_extra import TYPE_ALIAS_TYPES, is_generic_alias
 
 AnyFunctionSchema = Union[
     core_schema.AfterValidatorFunctionSchema,
@@ -85,7 +85,7 @@ def get_type_ref(type_: type[Any], args_override: tuple[type[Any], ...] | None =
         args = generic_metadata['args'] or args
 
     module_name = getattr(origin, '__module__', '<No __module__>')
-    if isinstance(origin, TypeAliasType):
+    if isinstance(origin, TYPE_ALIAS_TYPES):
         type_ref = f'{module_name}.{origin.__name__}:{id(origin)}'
     else:
         try:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -155,6 +155,13 @@ _mode_to_validator: dict[
     FieldValidatorModes, type[BeforeValidator | AfterValidator | PlainValidator | WrapValidator]
 ] = {'before': BeforeValidator, 'after': AfterValidator, 'plain': PlainValidator, 'wrap': WrapValidator}
 
+TYPE_ALIAS_TYPES: tuple[type, ...]
+if hasattr(typing, "TypeAliasType"):
+    from typing import TypeAliasType as typing_TypeAliasType
+    TYPE_ALIAS_TYPES = (TypeAliasType, typing_TypeAliasType)
+else:
+    TYPE_ALIAS_TYPES = (TypeAliasType,)
+
 
 def check_validator_fields_against_field_name(
     info: FieldDecoratorInfo,
@@ -986,7 +993,7 @@ class GenerateSchema:
             return self._sequence_schema(Any)
         elif obj in DICT_TYPES:
             return self._dict_schema(Any, Any)
-        elif isinstance(obj, TypeAliasType):
+        elif isinstance(obj, TYPE_ALIAS_TYPES):
             return self._type_alias_type_schema(obj)
         elif obj is type:
             return self._type_schema()

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -98,7 +98,7 @@ from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._mock_val_ser import MockCoreSchema
 from ._namespace_utils import NamespacesTuple, NsResolver
 from ._schema_generation_shared import CallbackGetCoreSchemaHandler
-from ._typing_extra import get_cls_type_hints, is_annotated, is_finalvar, is_self_type, is_zoneinfo_type
+from ._typing_extra import TYPE_ALIAS_TYPES, get_cls_type_hints, is_annotated, is_finalvar, is_self_type, is_zoneinfo_type
 from ._utils import lenient_issubclass, smart_deepcopy
 from ._validate_call import VALIDATE_CALL_SUPPORTED_TYPES, ValidateCallSupportedTypes
 
@@ -154,13 +154,6 @@ DEQUE_TYPES: list[type] = [collections.deque, typing.Deque]
 _mode_to_validator: dict[
     FieldValidatorModes, type[BeforeValidator | AfterValidator | PlainValidator | WrapValidator]
 ] = {'before': BeforeValidator, 'after': AfterValidator, 'plain': PlainValidator, 'wrap': WrapValidator}
-
-TYPE_ALIAS_TYPES: tuple[type, ...]
-if hasattr(typing, "TypeAliasType"):
-    from typing import TypeAliasType as typing_TypeAliasType
-    TYPE_ALIAS_TYPES = (TypeAliasType, typing_TypeAliasType)
-else:
-    TYPE_ALIAS_TYPES = (TypeAliasType,)
 
 
 def check_validator_fields_against_field_name(
@@ -1057,7 +1050,7 @@ class GenerateSchema:
         if from_property is not None:
             return from_property
 
-        if isinstance(origin, TypeAliasType):
+        if isinstance(origin, TYPE_ALIAS_TYPES):
             return self._type_alias_type_schema(obj)
         elif _typing_extra.origin_is_union(origin):
             return self._union_schema(obj)
@@ -1682,7 +1675,7 @@ class GenerateSchema:
 
         if type_param == Any:
             return self._type_schema()
-        elif isinstance(type_param, TypeAliasType):
+        elif isinstance(type_param, TYPE_ALIAS_TYPES):
             return self.generate_schema(typing.Type[type_param.__value__])
         elif isinstance(type_param, typing.TypeVar):
             if type_param.__bound__:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -78,6 +78,14 @@ if hasattr(warnings, 'deprecated'):
 
 NONE_TYPES: tuple[Any, ...] = (None, NoneType, *(tp[None] for tp in LITERAL_TYPES))
 
+# should check for both variant of types for typing_extensions > 4.12.2
+# https://typing-extensions.readthedocs.io/en/latest/#runtime-use-of-types
+TYPE_ALIAS_TYPES: tuple[type, ...] = (
+    (TypeAliasType, typing.TypeAliasType)
+    if hasattr(typing, 'TypeAliasType')
+    else (TypeAliasType, )
+)
+
 
 TypeVarType = Any  # since mypy doesn't allow the use of TypeVar as a type
 
@@ -594,8 +602,8 @@ def is_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
     return dataclasses.is_dataclass(_cls)
 
 
-def origin_is_type_alias_type(origin: Any) -> TypeGuard[TypeAliasType]:
-    return isinstance(origin, TypeAliasType)
+def origin_is_type_alias_type(origin: Any) -> TypeGuard[TypeAliasType | typing.TypeAliasType]:
+    return isinstance(origin, TYPE_ALIAS_TYPES)
 
 
 if sys.version_info >= (3, 10):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Added support for recent `typing_extensions.TypeAliasType` from https://github.com/python/typing_extensions/pull/477

## Related issue number

fix #10711

https://github.com/python/typing_extensions/issues/493

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
