### PR TITLE
Fix note admonition in mypy integration documentation

### DIFF
--- a/docs/integrations/mypy.md
+++ b/docs/integrations/mypy.md
@@ -71,6 +71,7 @@ To enable the plugin, just add `pydantic.mypy` to the list of plugins in your
     ```
 
 !!! note
+
     If you're using `pydantic.v1` models, you'll need to add `pydantic.v1.mypy` to your list of plugins.
 
 See the [plugin configuration](#configuring-the-plugin) for more details.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes rendering of the note admonition. Currently it looks as follows:

![image](https://github.com/user-attachments/assets/7ab5010b-9b4f-4646-b0a5-499207a47670)

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle