### PR TITLE
Make sure validated urls pass isinstance checks

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -106,7 +106,8 @@ class _BaseUrl(Url):
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         if issubclass(cls, source):
             return core_schema.no_info_after_validator_function(
-                lambda v: source(v), schema=core_schema.url_schema(**cls._constraints.defined_constraints)
+                lambda v: source if isinstance(v, source) else source(v),
+                schema=core_schema.url_schema(**cls._constraints.defined_constraints),
             )
         else:
             schema = handler(source)
@@ -126,7 +127,8 @@ class _BaseMultiHostUrl(MultiHostUrl):
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         if issubclass(cls, source):
             return core_schema.no_info_after_validator_function(
-                lambda v: source(v), schema=core_schema.multi_host_url_schema(**cls._constraints.defined_constraints)
+                lambda v: source if isinstance(v, source) else source(v),
+                schema=core_schema.multi_host_url_schema(**cls._constraints.defined_constraints),
             )
         else:
             schema = handler(source)

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -105,10 +105,7 @@ class _BaseUrl(Url):
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         if issubclass(cls, source):
-            return core_schema.no_info_after_validator_function(
-                lambda v: source if isinstance(v, source) else source(v),
-                schema=core_schema.url_schema(**cls._constraints.defined_constraints),
-            )
+            return core_schema.url_schema(cls=source, **cls._constraints.defined_constraints)
         else:
             schema = handler(source)
             if annotated_type := schema['type'] not in ('url', 'multi-host-url'):
@@ -126,10 +123,7 @@ class _BaseMultiHostUrl(MultiHostUrl):
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         if issubclass(cls, source):
-            return core_schema.no_info_after_validator_function(
-                lambda v: source if isinstance(v, source) else source(v),
-                schema=core_schema.multi_host_url_schema(**cls._constraints.defined_constraints),
-            )
+            return core_schema.multi_host_url_schema(cls=source, **cls._constraints.defined_constraints)
         else:
             schema = handler(source)
             # TODO: this logic is used in types.py as well in the _check_annotated_type function, should we move that to somewhere more central?

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -105,10 +105,11 @@ class _BaseUrl(Url):
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         if issubclass(cls, source):
-            return core_schema.url_schema(**cls._constraints.defined_constraints)
+            return core_schema.no_info_after_validator_function(
+                lambda v: source(v), schema=core_schema.url_schema(**cls._constraints.defined_constraints)
+            )
         else:
             schema = handler(source)
-            # TODO: this logic is used in types.py as well in the _check_annotated_type function, should we move that to somewhere more central?
             if annotated_type := schema['type'] not in ('url', 'multi-host-url'):
                 raise PydanticUserError(
                     f"'{cls.__name__}' cannot annotate '{annotated_type}'.", code='invalid-annotated-type'
@@ -124,7 +125,9 @@ class _BaseMultiHostUrl(MultiHostUrl):
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         if issubclass(cls, source):
-            return core_schema.multi_host_url_schema(**cls._constraints.defined_constraints)
+            return core_schema.no_info_after_validator_function(
+                lambda v: source(v), schema=core_schema.multi_host_url_schema(**cls._constraints.defined_constraints)
+            )
         else:
             schema = handler(source)
             # TODO: this logic is used in types.py as well in the _check_annotated_type function, should we move that to somewhere more central?

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1030,3 +1030,11 @@ def test_name_email_serialization():
 
     obj = json.loads(m.model_dump_json())
     Model(email=obj['email'])
+
+
+def test_isinstance_post_validation() -> None:
+    class MyModel(BaseModel):
+        url: AnyUrl
+
+    m = MyModel(url='http://test.com')
+    assert isinstance(m.url, AnyUrl)


### PR DESCRIPTION
Fix issue @alexmojaki reported:

```py
from pydantic import AnyUrl, BaseModel


class MyModel(BaseModel):
    url: AnyUrl


m = MyModel(url='http://test.com/')
print(isinstance(m.url, AnyUrl))  # False
```

With this PR, the last line now prints `True` :)

Update: things aren't working exactly as expected with the new `pydantic-core` changes - working on a new patch there with a fix before we can merge this.