### PR TITLE
Refactor `_typing_extra` module

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -16,7 +16,7 @@ from typing_extensions import TypeGuard, get_args, get_origin
 
 from . import _repr
 from ._core_metadata import CoreMetadata
-from ._typing_extra import is_generic_alias, is_typealiastype
+from ._typing_extra import is_generic_alias, is_type_alias_type
 
 AnyFunctionSchema = Union[
     core_schema.AfterValidatorFunctionSchema,
@@ -86,7 +86,7 @@ def get_type_ref(type_: type[Any], args_override: tuple[type[Any], ...] | None =
         args = generic_metadata['args'] or args
 
     module_name = getattr(origin, '__module__', '<No __module__>')
-    if is_typealiastype(origin):
+    if is_type_alias_type(origin):
         type_ref = f'{module_name}.{origin.__name__}:{id(origin)}'
     else:
         try:

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -16,7 +16,7 @@ from typing_extensions import TypeGuard, get_args, get_origin
 
 from . import _repr
 from ._core_metadata import CoreMetadata
-from ._typing_extra import TYPE_ALIAS_TYPES, is_generic_alias
+from ._typing_extra import is_generic_alias, is_typealiastype
 
 AnyFunctionSchema = Union[
     core_schema.AfterValidatorFunctionSchema,
@@ -86,7 +86,7 @@ def get_type_ref(type_: type[Any], args_override: tuple[type[Any], ...] | None =
         args = generic_metadata['args'] or args
 
     module_name = getattr(origin, '__module__', '<No __module__>')
-    if isinstance(origin, TYPE_ALIAS_TYPES):
+    if is_typealiastype(origin):
         type_ref = f'{module_name}.{origin.__name__}:{id(origin)}'
     else:
         try:

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -6,7 +6,7 @@ import dataclasses
 import typing
 import warnings
 from functools import partial, wraps
-from typing import Any, Callable, ClassVar
+from typing import Any, ClassVar
 
 from pydantic_core import (
     ArgsKwargs,
@@ -29,18 +29,10 @@ from ._schema_generation_shared import CallbackGetCoreSchemaHandler
 from ._signature import generate_pydantic_signature
 
 if typing.TYPE_CHECKING:
-    from dataclasses import Field
+    from _typeshed import DataclassInstance as StandardDataclass
 
     from ..config import ConfigDict
     from ..fields import FieldInfo
-
-    class StandardDataclass(typing.Protocol):
-        __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
-        __dataclass_params__: ClassVar[Any]  # in reality `dataclasses._DataclassParams`
-        __post_init__: ClassVar[Callable[..., None]]
-
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            pass
 
     class PydanticDataclass(StandardDataclass, typing.Protocol):
         """A protocol containing attributes only available once a class has been decorated as a Pydantic dataclass.

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -932,7 +932,7 @@ class GenerateSchema:
             return self._sequence_schema(Any)
         elif obj in DICT_TYPES:
             return self._dict_schema(Any, Any)
-        elif _typing_extra.is_typealiastype(obj):
+        elif _typing_extra.is_type_alias_type(obj):
             return self._type_alias_type_schema(obj)
         elif obj is type:
             return self._type_schema()
@@ -996,7 +996,7 @@ class GenerateSchema:
         if from_property is not None:
             return from_property
 
-        if _typing_extra.is_typealiastype(origin):
+        if _typing_extra.is_type_alias_type(origin):
             return self._type_alias_type_schema(obj)
         elif _typing_extra.origin_is_union(origin):
             return self._union_schema(obj)
@@ -1612,7 +1612,7 @@ class GenerateSchema:
 
         if _typing_extra.is_any(type_param):
             return self._type_schema()
-        elif _typing_extra.is_typealiastype(type_param):
+        elif _typing_extra.is_type_alias_type(type_param):
             return self.generate_schema(typing.Type[type_param.__value__])
         elif isinstance(type_param, typing.TypeVar):
             if type_param.__bound__:

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -295,8 +295,8 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
 
         if (
             origin_type is not None
-            and isinstance(type_, typing._Final)
-            and not isinstance(origin_type, typing._Final)
+            and isinstance(type_, _typing_extra.typing_base)
+            and not isinstance(origin_type, _typing_extra.typing_base)
             and getattr(type_, '_name', None) is not None
         ):
             # In python < 3.9 generic aliases don't exist so any of these like `list`,
@@ -369,7 +369,11 @@ def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
 
     # Handle special case for typehints that can have lists as arguments.
     # `typing.Callable[[int, str], int]` is an example for this.
-    if isinstance(type_, list):
+    if (
+        isinstance(type_, list)
+        # On Python < 3.10, typing_extensions implements `ParamSpec` as a subclass of `list`:
+        and not isinstance(type_, typing_extensions.ParamSpec)
+    ):
         for element in type_:
             if has_instance_in_type(element, isinstance_target):
                 return True

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -7,14 +7,14 @@ from collections import ChainMap
 from contextlib import contextmanager
 from contextvars import ContextVar
 from types import prepare_class
-from typing import TYPE_CHECKING, Any, Iterator, List, Mapping, MutableMapping, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Iterator, Mapping, MutableMapping, Tuple, TypeVar
 from weakref import WeakValueDictionary
 
 import typing_extensions
 
+from . import _typing_extra
 from ._core_utils import get_type_ref
 from ._forward_ref import PydanticRecursiveRef
-from ._typing_extra import LITERAL_TYPES, TypeVarType, typing_base
 from ._utils import all_identical, is_model_class
 
 if sys.version_info >= (3, 10):
@@ -109,7 +109,7 @@ _GENERIC_TYPES_CACHE = GenericTypesCache()
 class PydanticGenericMetadata(typing_extensions.TypedDict):
     origin: type[BaseModel] | None  # analogous to typing._GenericAlias.__origin__
     args: tuple[Any, ...]  # analogous to typing._GenericAlias.__args__
-    parameters: tuple[type[Any], ...]  # analogous to typing.Generic.__parameters__
+    parameters: tuple[TypeVar, ...]  # analogous to typing.Generic.__parameters__
 
 
 def create_generic_submodel(
@@ -184,7 +184,7 @@ def _get_caller_frame_info(depth: int = 2) -> tuple[str | None, bool]:
 DictValues: type[Any] = {}.values().__class__
 
 
-def iter_contained_typevars(v: Any) -> Iterator[TypeVarType]:
+def iter_contained_typevars(v: Any) -> Iterator[TypeVar]:
     """Recursively iterate through all subtypes and type args of `v` and yield any typevars that are found.
 
     This is inspired as an alternative to directly accessing the `__parameters__` attribute of a GenericAlias,
@@ -217,7 +217,7 @@ def get_origin(v: Any) -> Any:
     return typing_extensions.get_origin(v)
 
 
-def get_standard_typevars_map(cls: Any) -> dict[TypeVarType, Any] | None:
+def get_standard_typevars_map(cls: Any) -> dict[TypeVar, Any] | None:
     """Package a generic type's typevars and parametrization (if present) into a dictionary compatible with the
     `replace_types` function. Specifically, this works with standard typing generics and typing._GenericAlias.
     """
@@ -230,11 +230,11 @@ def get_standard_typevars_map(cls: Any) -> dict[TypeVarType, Any] | None:
     # In this case, we know that cls is a _GenericAlias, and origin is the generic type
     # So it is safe to access cls.__args__ and origin.__parameters__
     args: tuple[Any, ...] = cls.__args__  # type: ignore
-    parameters: tuple[TypeVarType, ...] = origin.__parameters__
+    parameters: tuple[TypeVar, ...] = origin.__parameters__
     return dict(zip(parameters, args))
 
 
-def get_model_typevars_map(cls: type[BaseModel]) -> dict[TypeVarType, Any] | None:
+def get_model_typevars_map(cls: type[BaseModel]) -> dict[TypeVar, Any] | None:
     """Package a generic BaseModel's typevars and concrete parametrization (if present) into a dictionary compatible
     with the `replace_types` function.
 
@@ -274,16 +274,18 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
         return type_
 
     type_args = get_args(type_)
-    origin_type = get_origin(type_)
-    if origin_type is typing_extensions.Annotated:
+
+    if _typing_extra.is_annotated(type_):
         annotated_type, *annotations = type_args
         annotated = replace_types(annotated_type, type_map)
         for annotation in annotations:
             annotated = typing_extensions.Annotated[annotated, annotation]
         return annotated
 
-    # Having type args is a good indicator that this is a typing module
-    # class instantiation or a generic alias of some sort.
+    origin_type = get_origin(type_)
+
+    # Having type args is a good indicator that this is a typing special form
+    # instance or a generic alias of some sort.
     if type_args:
         resolved_type_args = tuple(replace_types(arg, type_map) for arg in type_args)
         if all_identical(type_args, resolved_type_args):
@@ -293,8 +295,8 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
 
         if (
             origin_type is not None
-            and isinstance(type_, typing_base)
-            and not isinstance(origin_type, typing_base)
+            and isinstance(type_, typing._Final)
+            and not isinstance(origin_type, typing._Final)
             and getattr(type_, '_name', None) is not None
         ):
             # In python < 3.9 generic aliases don't exist so any of these like `list`,
@@ -303,13 +305,15 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
             origin_type = getattr(typing, type_._name)
         assert origin_type is not None
 
-        if origin_type is typing.Union or sys.version_info >= (3, 10) and origin_type is types.UnionType:
-            if any(arg is Any for arg in resolved_type_args):
+        if _typing_extra.origin_is_union(origin_type):
+            if any(_typing_extra.is_any(arg) for arg in resolved_type_args):
                 # `Any | T` ~ `Any`:
                 resolved_type_args = (Any,)
             # `Never | T` ~ `T`:
             resolved_type_args = tuple(
-                arg for arg in resolved_type_args if arg not in (typing.NoReturn, typing_extensions.Never)
+                arg
+                for arg in resolved_type_args
+                if not (_typing_extra.is_no_return(arg) or _typing_extra.is_never(arg))
             )
 
         # PEP-604 syntax (Ex.: list | str) is represented with a types.UnionType object that does not have __getitem__.
@@ -333,7 +337,7 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
 
     # Handle special case for typehints that can have lists as arguments.
     # `typing.Callable[[int, str], int]` is an example for this.
-    if isinstance(type_, (List, list)):
+    if isinstance(type_, list):
         resolved_list = [replace_types(element, type_map) for element in type_]
         if all_identical(type_, resolved_list):
             return type_
@@ -350,15 +354,12 @@ def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
     """
     if isinstance(type_, isinstance_target):
         return True
+    if _typing_extra.is_annotated(type_):
+        return has_instance_in_type(type_.__origin__, isinstance_target)
+    if _typing_extra.is_literal(type_):
+        return False
 
     type_args = get_args(type_)
-    origin_type = get_origin(type_)
-
-    if origin_type is typing_extensions.Annotated:
-        annotated_type, *annotations = type_args
-        return has_instance_in_type(annotated_type, isinstance_target)
-    elif origin_type in LITERAL_TYPES:
-        return False
 
     # Having type args is a good indicator that this is a typing module
     # class instantiation or a generic alias of some sort.
@@ -368,7 +369,7 @@ def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
 
     # Handle special case for typehints that can have lists as arguments.
     # `typing.Callable[[int, str], int]` is an example for this.
-    if isinstance(type_, (List, list)) and not isinstance(type_, typing_extensions.ParamSpec):
+    if isinstance(type_, list):
         for element in type_:
             if has_instance_in_type(element, isinstance_target):
                 return True
@@ -500,7 +501,7 @@ def _union_orderings_key(typevar_values: Any) -> Any:
         for value in typevar_values:
             args_data.append(_union_orderings_key(value))
         return tuple(args_data)
-    elif typing_extensions.get_origin(typevar_values) is typing.Union:
+    elif _typing_extra.is_union(typevar_values):
         return get_args(typevar_values)
     else:
         return ()

--- a/pydantic/_internal/_repr.py
+++ b/pydantic/_internal/_repr.py
@@ -102,7 +102,7 @@ def display_as_type(obj: Any) -> str:
     elif isinstance(obj, typing.ForwardRef) or _typing_extra.is_typealiastype(obj):
         return str(obj)
 
-    if not isinstance(obj, (typing._BaseGenericAlias, _typing_extra.WithArgsTypes, type)):  # pyright: ignore[reportAttributeAccessIssue]
+    if not isinstance(obj, (_typing_extra.typing_base, _typing_extra.WithArgsTypes, type)):
         obj = obj.__class__
 
     if _typing_extra.origin_is_union(typing_extensions.get_origin(obj)):
@@ -116,7 +116,7 @@ def display_as_type(obj: Any) -> str:
         try:
             return f'{obj.__qualname__}[{args}]'
         except AttributeError:
-            return str(obj)  # handles TypeAliasType in 3.12
+            return str(obj).replace('typing.', '').replace('typing_extensions.', '')  # handles TypeAliasType in 3.12
     elif isinstance(obj, type):
         return obj.__qualname__
     else:

--- a/pydantic/_internal/_repr.py
+++ b/pydantic/_internal/_repr.py
@@ -99,7 +99,7 @@ def display_as_type(obj: Any) -> str:
         return '...'
     elif isinstance(obj, Representation):
         return repr(obj)
-    elif isinstance(obj, typing.ForwardRef) or _typing_extra.is_typealiastype(obj):
+    elif isinstance(obj, typing.ForwardRef) or _typing_extra.is_type_alias_type(obj):
         return str(obj)
 
     if not isinstance(obj, (_typing_extra.typing_base, _typing_extra.WithArgsTypes, type)):

--- a/pydantic/_internal/_repr.py
+++ b/pydantic/_internal/_repr.py
@@ -99,17 +99,17 @@ def display_as_type(obj: Any) -> str:
         return '...'
     elif isinstance(obj, Representation):
         return repr(obj)
-    elif isinstance(obj, typing_extensions.TypeAliasType):
+    elif isinstance(obj, typing.ForwardRef) or _typing_extra.is_typealiastype(obj):
         return str(obj)
 
-    if not isinstance(obj, (_typing_extra.typing_base, _typing_extra.WithArgsTypes, type)):
+    if not isinstance(obj, (typing._BaseGenericAlias, _typing_extra.WithArgsTypes, type)):  # pyright: ignore[reportAttributeAccessIssue]
         obj = obj.__class__
 
     if _typing_extra.origin_is_union(typing_extensions.get_origin(obj)):
         args = ', '.join(map(display_as_type, typing_extensions.get_args(obj)))
         return f'Union[{args}]'
     elif isinstance(obj, _typing_extra.WithArgsTypes):
-        if typing_extensions.get_origin(obj) == typing_extensions.Literal:
+        if _typing_extra.is_literal(obj):
             args = ', '.join(map(repr, typing_extensions.get_args(obj)))
         else:
             args = ', '.join(map(display_as_type, typing_extensions.get_args(obj)))

--- a/pydantic/_internal/_std_types_schema.py
+++ b/pydantic/_internal/_std_types_schema.py
@@ -164,7 +164,7 @@ class DequeValidator:
     metadata: dict[str, Any]
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
-        if self.item_source_type is Any:
+        if _typing_extra.is_any(self.item_source_type):
             items_schema = None
         else:
             items_schema = handler.generate_schema(self.item_source_type)
@@ -320,11 +320,11 @@ class MappingValidator:
         return handler(v)
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
-        if self.keys_source_type is Any:
+        if _typing_extra.is_any(self.keys_source_type):
             keys_schema = None
         else:
             keys_schema = handler.generate_schema(self.keys_source_type)
-        if self.values_source_type is Any:
+        if _typing_extra.is_any(self.values_source_type):
             values_schema = None
         else:
             values_schema = handler.generate_schema(self.values_source_type)

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -379,13 +379,10 @@ if sys.version_info < (3, 10):
 
     def origin_is_union(tp: Any, /) -> bool:
         """Return whether the provided argument is the `Union` special form."""
-        return is_union(tp)
+        return _is_typing_name(tp, name='Union')
 
     def is_generic_alias(type_: type[Any]) -> bool:
         return isinstance(type_, typing._GenericAlias)  # pyright: ignore[reportAttributeAccessIssue]
-
-    WithArgsTypes: tuple[Any, ...] = (typing._GenericAlias,)  # pyright: ignore[reportAttributeAccessIssue]
-
 
 else:
 
@@ -396,7 +393,19 @@ else:
     def is_generic_alias(tp: Any, /) -> bool:
         return isinstance(tp, (types.GenericAlias, typing._GenericAlias))  # pyright: ignore[reportAttributeAccessIssue]
 
+
+# Ideally, we should avoid relying on the private `typing` constructs:
+
+if sys.version_info < (3, 9):
+    WithArgsTypes: tuple[Any, ...] = (typing._GenericAlias,)  # pyright: ignore[reportAttributeAccessIssue]
+elif sys.version_info < (3, 10):
+    WithArgsTypes: tuple[Any, ...] = (typing._GenericAlias, types.GenericAlias)  # pyright: ignore[reportAttributeAccessIssue]
+else:
     WithArgsTypes: tuple[Any, ...] = (typing._GenericAlias, types.GenericAlias, types.UnionType)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+# Similarly, we shouldn't rely on this `_Final` class, which is even more private than `_GenericAlias`:
+typing_base: Any = typing._Final  # pyright: ignore[reportAttributeAccessIssue]
 
 
 ### Annotation evaluations functions:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -1,192 +1,389 @@
-"""Logic for interacting with type annotations, mostly extensions, shims and hacks to wrap python's typing module."""
+"""Logic for interacting with type annotations, mostly extensions, shims and hacks to wrap Python's typing module."""
 
-from __future__ import annotations as _annotations
+from __future__ import annotations
 
-import dataclasses
+import collections.abc
 import re
 import sys
 import types
 import typing
 import warnings
-from collections.abc import Callable
-from functools import partial
-from types import GetSetDescriptorType
-from typing import TYPE_CHECKING, Any, Final
+from functools import lru_cache, partial
+from typing import Any, Callable
 
-from typing_extensions import Annotated, Literal, TypeAliasType, TypeGuard, Unpack, deprecated, get_args, get_origin
+import typing_extensions
+from typing_extensions import TypeIs, deprecated, get_args, get_origin
 
 from ._namespace_utils import GlobalsNamespace, MappingNamespace, NsResolver, get_module_ns_of
-
-if TYPE_CHECKING:
-    from ._dataclasses import StandardDataclass
-
-try:
-    from typing import _TypingBase  # type: ignore[attr-defined]
-except ImportError:
-    from typing import _Final as _TypingBase  # type: ignore[attr-defined]
-
-typing_base = _TypingBase
-
-
-if sys.version_info < (3, 9):
-    # python < 3.9 does not have GenericAlias (list[int], tuple[str, ...] and so on)
-    TypingGenericAlias = ()
-else:
-    from typing import GenericAlias as TypingGenericAlias  # type: ignore
-
-
-if sys.version_info < (3, 11):
-    from typing_extensions import NotRequired, Required
-else:
-    from typing import NotRequired, Required  # noqa: F401
-
-
-if sys.version_info < (3, 10):
-
-    def origin_is_union(tp: type[Any] | None) -> bool:
-        return tp is typing.Union
-
-    WithArgsTypes = (TypingGenericAlias,)
-
-else:
-
-    def origin_is_union(tp: type[Any] | None) -> bool:
-        return tp is typing.Union or tp is types.UnionType
-
-    WithArgsTypes = typing._GenericAlias, types.GenericAlias, types.UnionType  # type: ignore[attr-defined]
-
 
 if sys.version_info < (3, 10):
     NoneType = type(None)
     EllipsisType = type(Ellipsis)
 else:
+    from types import EllipsisType as EllipsisType
     from types import NoneType as NoneType
 
 
-LITERAL_TYPES: set[Any] = {Literal}
-if hasattr(typing, 'Literal'):
-    LITERAL_TYPES.add(typing.Literal)
-
-UNPACK_TYPES: set[Any] = {Unpack}
-if hasattr(typing, 'Unpack'):
-    UNPACK_TYPES.add(typing.Unpack)  # pyright: ignore[reportAttributeAccessIssue]
-
-# Check if `deprecated` is a type to prevent errors when using typing_extensions < 4.9.0
-DEPRECATED_TYPES: tuple[Any, ...] = (deprecated,) if isinstance(deprecated, type) else ()
-if hasattr(warnings, 'deprecated'):
-    DEPRECATED_TYPES = (*DEPRECATED_TYPES, warnings.deprecated)  # type: ignore
-
-NONE_TYPES: tuple[Any, ...] = (None, NoneType, *(tp[None] for tp in LITERAL_TYPES))
-
-# should check for both variant of types for typing_extensions > 4.12.2
-# https://typing-extensions.readthedocs.io/en/latest/#runtime-use-of-types
-TYPE_ALIAS_TYPES: tuple[type, ...] = (
-    (TypeAliasType, typing.TypeAliasType) if hasattr(typing, 'TypeAliasType') else (TypeAliasType,)
-)
+# See https://typing-extensions.readthedocs.io/en/latest/#runtime-use-of-types:
 
 
-TypeVarType = Any  # since mypy doesn't allow the use of TypeVar as a type
+@lru_cache(maxsize=None)
+def _get_typing_objects_by_name_of(name: str) -> tuple[Any, ...]:
+    result = tuple(getattr(module, name) for module in (typing, typing_extensions) if hasattr(module, name))
+    if not result:
+        raise ValueError(f'Neither typing nor typing_extensions has an object called {name!r}')
+    return result
 
 
-def is_none_type(type_: Any) -> bool:
-    return type_ in NONE_TYPES
+# @lru_cache
+def _is_typing_name(obj: object, name: str) -> bool:
+    return any(obj is thing for thing in _get_typing_objects_by_name_of(name))
 
 
-def is_callable_type(type_: type[Any]) -> bool:
-    return type_ is Callable or get_origin(type_) is Callable
+def is_any(tp: Any, /) -> bool:
+    """Return whether the provided argument is the `Any` special form.
+
+    ```python test="skip" lint="skip"
+    is_any(Any)
+    #> True
+    ```
+    """
+    return _is_typing_name(tp, name='Any')
 
 
-def is_literal_type(type_: type[Any]) -> bool:
-    return Literal is not None and get_origin(type_) in LITERAL_TYPES
+def is_union(tp: Any, /) -> bool:
+    """Return whether the provided argument is the a `Union` special form.
+
+    ```python test="skip" lint="skip"
+    is_union(Union[int, str])
+    #> True
+    is_union(int | str)
+    #> False
+    ```
+    """
+    return _is_typing_name(get_origin(tp), name='Union')
 
 
-def is_deprecated_instance(instance: Any) -> TypeGuard[deprecated]:
-    return isinstance(instance, DEPRECATED_TYPES)
+def is_literal(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `Literal` special form.
+
+    ```python test="skip" lint="skip"
+    is_literal(Literal[42])
+    #> True
+    ```
+    """
+    return _is_typing_name(get_origin(tp), name='Literal')
 
 
-def literal_values(type_: type[Any]) -> tuple[Any, ...]:
-    return get_args(type_)
-
-
-# TODO remove when we drop support for Python 3.8
+# TODO remove and replace with `get_args` when we drop support for Python 3.8
 # (see https://docs.python.org/3/whatsnew/3.9.html#id4).
-def all_literal_values(type_: type[Any]) -> list[Any]:
-    """This method is used to retrieve all Literal values as
-    Literal can be used recursively (see https://www.python.org/dev/peps/pep-0586)
-    e.g. `Literal[Literal[Literal[1, 2, 3], "foo"], 5, None]`.
+def literal_values(tp: Any, /) -> list[Any]:
+    """Return the values contained in the provided `Literal` special form."""
+    if not is_literal(tp):
+        return [tp]
+
+    values = get_args(tp)
+    return [x for value in values for x in literal_values(value)]
+
+
+def is_annotated(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `Annotated` special form.
+
+    ```python test="skip" lint="skip"
+    is_annotated(Annotated[int, ...])
+    #> True
+    ```
     """
-    if not is_literal_type(type_):
-        return [type_]
-
-    values = literal_values(type_)
-    return [x for value in values for x in all_literal_values(value)]
+    return _is_typing_name(get_origin(tp), name='Annotated')
 
 
-def is_annotated(ann_type: Any) -> bool:
-    return get_origin(ann_type) is Annotated
+def annotated_type(tp: Any, /) -> Any | None:
+    """Return the type of the `Annotated` special form, or `None`."""
+    return get_args(tp)[0] if is_annotated(tp) else None
 
 
-def annotated_type(type_: Any) -> Any | None:
-    return get_args(type_)[0] if is_annotated(type_) else None
+def is_unpack(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `Unpack` special form.
 
-
-def is_unpack(type_: Any) -> bool:
-    return get_origin(type_) in UNPACK_TYPES
-
-
-def unpack_type(type_: Any) -> Any | None:
-    return get_args(type_)[0] if is_unpack(type_) else None
-
-
-def is_namedtuple(type_: type[Any]) -> bool:
-    """Check if a given class is a named tuple.
-    It can be either a `typing.NamedTuple` or `collections.namedtuple`.
+    ```python test="skip" lint="skip"
+    is_unpack(Unpack[Ts])
+    #> True
+    ```
     """
-    from ._utils import lenient_issubclass
-
-    return lenient_issubclass(type_, tuple) and hasattr(type_, '_fields')
+    return _is_typing_name(get_origin(tp), name='Unpack')
 
 
-test_new_type = typing.NewType('test_new_type', str)
+def unpack_type(tp: Any, /) -> Any | None:
+    """Return the type wrapped by the `Unpack` special form, or `None`."""
+    return get_args(tp)[0] if is_unpack(tp) else None
 
 
-def is_new_type(type_: type[Any]) -> bool:
-    """Check whether type_ was created using typing.NewType.
+def is_self(tp: Any, /) -> bool:
+    """Return whether the provided argument is the `Self` special form.
 
-    Can't use isinstance because it fails <3.10.
+    ```python test="skip" lint="skip"
+    is_self(Self)
+    #> True
+    ```
     """
-    return isinstance(type_, test_new_type.__class__) and hasattr(type_, '__supertype__')  # type: ignore[arg-type]
+    return _is_typing_name(tp, name='Self')
 
 
-classvar_re = re.compile(r'(\w+\.)?ClassVar\[')
+def is_new_type(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `NewType`.
+
+    ```python test="skip" lint="skip"
+    is_new_type(NewType('MyInt', int))
+    #> True
+    ```
+    """
+    if sys.version_info < (3, 10):
+        # On Python < 3.10, `typing.NewType` is a function
+        return hasattr(tp, '__supertype__')
+    else:
+        return _is_typing_name(type(tp), name='NewType')
 
 
-def _check_classvar(v: type[Any] | None) -> bool:
-    return v is not None and v.__class__ is typing.ClassVar.__class__ and getattr(v, '_name', None) == 'ClassVar'
+def is_hashable(tp: Any, /) -> bool:
+    """Return whether the provided argument is the `Hashable` class.
+
+    ```python test="skip" lint="skip"
+    is_hashable(Hashable)
+    #> True
+    ```
+    """
+    # `get_origin` is documented as normalizing any typing-module aliases to `collections` classes,
+    # hence the second check:
+    return tp is collections.abc.Hashable or get_origin(tp) is collections.abc.Hashable
 
 
-def is_classvar(ann_type: type[Any]) -> bool:
-    if _check_classvar(ann_type) or _check_classvar(get_origin(ann_type)):
+def is_callable(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `Callable`, parametrized or not.
+
+    ```python test="skip" lint="skip"
+    is_callable(Callable[[int], str])
+    #> True
+    is_callable(typing.Callable)
+    #> True
+    is_callable(collections.abc.Callable)
+    #> True
+    ```
+    """
+    # `get_origin` is documented as normalizing any typing-module aliases to `collections` classes,
+    # hence the second check:
+    return tp is collections.abc.Callable or get_origin(tp) is collections.abc.Callable
+
+
+def is_paramspec(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `ParamSpec`.
+
+    ```python test="skip" lint="skip"
+    P = ParamSpec('P')
+    is_paramspec(P)
+    #> True
+    ```
+    """
+    return _is_typing_name(type(tp), name='ParamSpec')
+
+
+def is_typealiastype(tp: Any, /) -> TypeIs[typing_extensions.TypeAliasType]:
+    """Return whether the provided argument is an instance of `TypeAliasType`.
+
+    ```python test="skip" lint="skip"
+    type Int = int
+    is_typealiastype(Int)
+    #> True
+    Str = TypeAliasType('Str', str)
+    is_typealiastype(Str)
+    #> True
+    ```
+    """
+    return _is_typing_name(type(tp), name='TypeAliasType')
+
+
+def is_classvar(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `ClassVar` special form, parametrized or not.
+
+    Note that in most cases, you will want to use the `is_classvar_annotation` function,
+    which is used to check if an annotation (in the context of a Pydantic model or dataclass)
+    should be treated as being a class variable.
+
+    ```python test="skip" lint="skip"
+    is_classvar(ClassVar[int])
+    #> True
+    is_classvar(ClassVar)
+    #> True
+    """
+    # ClassVar is not necessarily parametrized:
+    return _is_typing_name(tp, name='ClassVar') or _is_typing_name(get_origin(tp), name='ClassVar')
+
+
+_classvar_re = re.compile(r'((\w+\.)?Annotated\[)?(\w+\.)?ClassVar\[')
+
+
+def is_classvar_annotation(tp: Any, /) -> bool:
+    """Return whether the provided argument represents a class variable annotation.
+
+    Although not explicitly stated by the typing specification, `ClassVar` can be used
+    inside `Annotated` and as such, this function checks for this specific scenario.
+
+    Because this function is used to detect class variables before evaluating forward references
+    (or because evaluation failed), we also implement a naive regex match implementation. This is
+    required because class variables are inspected before fields are collected, so we try to be
+    as accurate as possible.
+    """
+    if is_classvar(tp) or (anntp := annotated_type(tp)) is not None and is_classvar(anntp):
         return True
 
-    # this is an ugly workaround for class vars that contain forward references and are therefore themselves
-    # forward references, see #3679
-    if ann_type.__class__ == typing.ForwardRef and classvar_re.match(ann_type.__forward_arg__):
+    str_ann: str | None = None
+    if isinstance(tp, typing.ForwardRef):
+        str_ann = tp.__forward_arg__
+    if isinstance(tp, str):
+        str_ann = tp
+
+    if str_ann is not None and _classvar_re.match(str_ann):
+        # stdlib dataclasses do something similar, although a bit more advanced
+        # (see `dataclass._is_type`).
         return True
 
     return False
 
 
-def _check_finalvar(v: type[Any] | None) -> bool:
-    """Check if a given type is a `typing.Final` type."""
-    if v is None:
+# TODO implement `is_finalvar_annotation` as Final can be wrapped with other special forms:
+def is_finalvar(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `Final` special form, parametrized or not.
+
+    ```python test="skip" lint="skip"
+    is_finalvar(Final[int])
+    #> True
+    is_finalvar(Final)
+    #> True
+    """
+    # Final is not necessarily parametrized:
+    return _is_typing_name(tp, name='Final') or _is_typing_name(get_origin(tp), name='Final')
+
+
+def is_required(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `Required` special form.
+
+    ```python test="skip" lint="skip"
+    is_required(Required[int])
+    #> True
+    """
+    return _is_typing_name(get_origin(tp), name='Required')
+
+
+def is_not_required(tp: Any, /) -> bool:
+    """Return whether the provided argument is a `NotRequired` special form.
+
+    ```python test="skip" lint="skip"
+    is_required(Required[int])
+    #> True
+    """
+    return _is_typing_name(get_origin(tp), name='NotRequired')
+
+
+def is_no_return(tp: Any, /) -> bool:
+    """Return whether the provided argument is the `NoReturn` special form.
+
+    ```python test="skip" lint="skip"
+    is_no_return(NoReturn)
+    #> True
+    ```
+    """
+    return _is_typing_name(tp, name='NoReturn')
+
+
+def is_never(tp: Any, /) -> bool:
+    """Return whether the provided argument is the `Never` special form.
+
+    ```python test="skip" lint="skip"
+    is_never(Never)
+    #> True
+    ```
+    """
+    return _is_typing_name(tp, name='Never')
+
+
+_DEPRECATED_TYPES: tuple[type[typing_extensions.deprecated], ...] = (typing_extensions.deprecated,)
+if hasattr(warnings, 'deprecated'):
+    _DEPRECATED_TYPES = (*_DEPRECATED_TYPES, warnings.deprecated)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def is_deprecated_instance(obj: Any, /) -> TypeIs[deprecated]:
+    """Return whether the argument is an instance of the `warnings.deprecated` class or the `typing_extensions` backport."""
+    return isinstance(obj, _DEPRECATED_TYPES)
+
+
+_NONE_TYPES: tuple[Any, ...] = (None, NoneType, typing.Literal[None], typing_extensions.Literal[None])
+
+
+def is_none_type(tp: Any, /) -> bool:
+    """Return whether the argument represents the `None` type as part of an annotation.
+
+    ```python test="skip" lint="skip"
+    is_none_type(None)
+    #> True
+    is_none_type(NoneType)
+    #> True
+    is_none_type(Literal[None])
+    #> True
+    is_none_type(type[None])
+    #> False
+    """
+    return tp in _NONE_TYPES
+
+
+def is_namedtuple(tp: Any, /) -> bool:
+    """Return whether the provided argument is a named tuple class.
+
+    The class can be created using `typing.NamedTuple` or `collections.namedtuple`.
+    Parametrized generic classes are *not* assumed to be named tuples.
+    """
+    from ._utils import lenient_issubclass
+
+    return lenient_issubclass(tp, tuple) and hasattr(tp, '_fields')
+
+
+if sys.version_info < (3, 9):
+
+    def is_zoneinfo_type(tp: Any, /) -> bool:
+        """Return whether the provided argument is the `zoneinfo.ZoneInfo` type."""
         return False
 
-    return v.__class__ == Final.__class__ and (sys.version_info < (3, 8) or getattr(v, '_name', None) == 'Final')
+else:
+    from zoneinfo import ZoneInfo
+
+    def is_zoneinfo_type(tp: Any, /) -> TypeIs[type[ZoneInfo]]:
+        """Return whether the provided argument is the `zoneinfo.ZoneInfo` type."""
+        return tp is ZoneInfo
 
 
-def is_finalvar(ann_type: Any) -> bool:
-    return _check_finalvar(ann_type) or _check_finalvar(get_origin(ann_type))
+if sys.version_info < (3, 10):
+
+    def origin_is_union(tp: Any, /) -> bool:
+        """Return whether the provided argument is the `Union` special form."""
+        return is_union(tp)
+
+    def is_generic_alias(type_: type[Any]) -> bool:
+        return isinstance(type_, typing._GenericAlias)  # pyright: ignore[reportAttributeAccessIssue]
+
+    WithArgsTypes: tuple[Any, ...] = (typing._GenericAlias,)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+else:
+
+    def origin_is_union(tp: Any, /) -> bool:
+        """Return whether the provided argument is the `Union` special form or the `UnionType`."""
+        return _is_typing_name(tp, name='Union') or tp is types.UnionType
+
+    def is_generic_alias(tp: Any, /) -> bool:
+        return isinstance(tp, (types.GenericAlias, typing._GenericAlias))  # pyright: ignore[reportAttributeAccessIssue]
+
+    WithArgsTypes: tuple[Any, ...] = (typing._GenericAlias, types.GenericAlias, types.UnionType)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+### Annotation evaluations functions:
 
 
 def parent_frame_namespace(*, parent_depth: int = 2, force: bool = False) -> dict[str, Any] | None:
@@ -240,7 +437,7 @@ def get_cls_type_hints(
 
     for base in reversed(obj.__mro__):
         ann: dict[str, Any] | None = base.__dict__.get('__annotations__')
-        if not ann or isinstance(ann, GetSetDescriptorType):
+        if not ann or isinstance(ann, types.GetSetDescriptorType):
             continue
         with ns_resolver.push(base):
             globalns, localns = ns_resolver.types_namespace
@@ -592,42 +789,3 @@ else:
                 value = typing.Optional[value]
             hints[name] = value
         return hints if include_extras else {k: typing._strip_annotations(t) for k, t in hints.items()}  # type: ignore
-
-
-def is_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
-    # The dataclasses.is_dataclass function doesn't seem to provide TypeGuard functionality,
-    # so I created this convenience function
-    return dataclasses.is_dataclass(_cls)
-
-
-def origin_is_type_alias_type(origin: Any) -> TypeGuard[TypeAliasType | typing.TypeAliasType]:
-    return isinstance(origin, TYPE_ALIAS_TYPES)
-
-
-if sys.version_info >= (3, 10):
-
-    def is_generic_alias(type_: type[Any]) -> bool:
-        return isinstance(type_, (types.GenericAlias, typing._GenericAlias))  # type: ignore[attr-defined]
-
-else:
-
-    def is_generic_alias(type_: type[Any]) -> bool:
-        return isinstance(type_, typing._GenericAlias)  # type: ignore
-
-
-def is_self_type(tp: Any) -> bool:
-    """Check if a given class is a Self type (from `typing` or `typing_extensions`)"""
-    return isinstance(tp, typing_base) and getattr(tp, '_name', None) == 'Self'
-
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-
-    def is_zoneinfo_type(tp: Any) -> bool:
-        """Check if a give class is a zone_info.ZoneInfo type"""
-        return tp is ZoneInfo
-
-else:
-
-    def is_zoneinfo_type(tp: Any) -> bool:
-        return False

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -204,7 +204,7 @@ def dataclass(
 
         # we warn on conflicting config specifications, but only if the class doesn't have a dataclass base
         # because a dataclass base might provide a __pydantic_config__ attribute that we don't want to warn about
-        has_dataclass_base = any(_typing_extra.is_dataclass(base) for base in cls.__bases__)
+        has_dataclass_base = any(dataclasses.is_dataclass(base) for base in cls.__bases__)
         if not has_dataclass_base and config is not None and hasattr(cls, '__pydantic_config__'):
             warn(
                 f'`config` is set via both the `dataclass` decorator and `__pydantic_config__` for dataclass {cls.__name__}. '

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -19,7 +19,6 @@ import re
 import warnings
 from collections import defaultdict
 from copy import deepcopy
-from dataclasses import is_dataclass
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -309,7 +308,7 @@ class GenerateJsonSchema:
             TypeError: If no method has been defined for generating a JSON schema for a given pydantic core schema type.
         """
         mapping: dict[CoreSchemaOrFieldType, Callable[[CoreSchemaOrField], JsonSchemaValue]] = {}
-        core_schema_types: list[CoreSchemaOrFieldType] = _typing_extra.all_literal_values(
+        core_schema_types: list[CoreSchemaOrFieldType] = _typing_extra.literal_values(
             CoreSchemaOrFieldType  # type: ignore
         )
         for key in core_schema_types:
@@ -1663,6 +1662,8 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
+        from ._internal._dataclasses import is_builtin_dataclass
+
         cls = schema['cls']
         config: ConfigDict = getattr(cls, '__pydantic_config__', cast('ConfigDict', {}))
 
@@ -1672,7 +1673,7 @@ class GenerateJsonSchema:
         self._update_class_schema(json_schema, cls, config)
 
         # Dataclass-specific handling of description
-        if is_dataclass(cls) and not hasattr(cls, '__pydantic_validator__'):
+        if is_builtin_dataclass(cls):
             # vanilla dataclass; don't use cls.__doc__ as it will contain the class signature by default
             description = None
         else:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -759,7 +759,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         _generics.check_parameters_count(cls, typevar_values)
 
         # Build map from generic typevars to passed params
-        typevars_map: dict[_typing_extra.TypeVarType, type[Any]] = dict(
+        typevars_map: dict[TypeVar, type[Any]] = dict(
             zip(cls.__pydantic_generic_metadata__['parameters'], typevar_values)
         )
 

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -576,19 +576,24 @@ def test_class_var_as_string(create_module):
         # language=Python
         """
 from __future__ import annotations
-from typing import ClassVar
+from typing import Annotated, ClassVar, ClassVar as CV
 from pydantic import BaseModel
 
 class Model(BaseModel):
     a: ClassVar[int]
     _b: ClassVar[int]
     _c: ClassVar[Forward]
+    _d: Annotated[ClassVar[int], ...]
+    _e: CV[int]
+    _f: Annotated[CV[int], ...]
+    # Doesn't work as of today:
+    # _g: CV[Forward]
 
 Forward = int
 """
     )
 
-    assert module.Model.__class_vars__ == {'a', '_b', '_c'}
+    assert module.Model.__class_vars__ == {'a', '_b', '_c', '_d', '_e', '_f'}
     assert module.Model.__private_attributes__ == {}
 
 

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -576,7 +576,8 @@ def test_class_var_as_string(create_module):
         # language=Python
         """
 from __future__ import annotations
-from typing import Annotated, ClassVar, ClassVar as CV
+from typing import ClassVar, ClassVar as CV
+from typing_extensions import Annotated
 from pydantic import BaseModel
 
 class Model(BaseModel):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -4,15 +4,15 @@ from collections import namedtuple
 from typing import Callable, ClassVar, ForwardRef, NamedTuple
 
 import pytest
-from typing_extensions import Literal, get_origin
+from typing_extensions import Annotated, Literal, get_origin
 
 from pydantic import BaseModel, Field  # noqa: F401
 from pydantic._internal._typing_extra import (
     NoneType,
     eval_type,
     get_function_type_hints,
-    is_classvar,
-    is_literal_type,
+    is_classvar_annotation,
+    is_literal,
     is_namedtuple,
     is_none_type,
     origin_is_union,
@@ -76,19 +76,19 @@ def test_is_union(union):
 def test_is_literal_with_typing_extension_literal():
     from typing_extensions import Literal
 
-    assert is_literal_type(Literal) is False
-    assert is_literal_type(Literal['foo']) is True
+    assert is_literal(Literal) is False
+    assert is_literal(Literal['foo']) is True
 
 
 def test_is_literal_with_typing_literal():
     from typing import Literal
 
-    assert is_literal_type(Literal) is False
-    assert is_literal_type(Literal['foo']) is True
+    assert is_literal(Literal) is False
+    assert is_literal(Literal['foo']) is True
 
 
 @pytest.mark.parametrize(
-    'ann_type,extepcted',
+    ['ann_type', 'extepcted'],
     (
         (None, False),
         (ForwardRef('Other[int]'), False),
@@ -96,11 +96,15 @@ def test_is_literal_with_typing_literal():
         (ForwardRef('ClassVar[int]'), True),
         (ForwardRef('t.ClassVar[int]'), True),
         (ForwardRef('typing.ClassVar[int]'), True),
+        (ForwardRef('Annotated[ClassVar[int], ...]'), True),
+        (ForwardRef('Annotated[t.ClassVar[int], ...]'), True),
+        (ForwardRef('t.Annotated[t.ClassVar[int], ...]'), True),
         (ClassVar[int], True),
+        (Annotated[ClassVar[int], ...], True),
     ),
 )
-def test_is_classvar(ann_type, extepcted):
-    assert is_classvar(ann_type) is extepcted
+def test_is_classvar_annotation(ann_type, extepcted):
+    assert is_classvar_annotation(ann_type) is extepcted
 
 
 def test_parent_frame_namespace(mocker):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from typing_extensions import Annotated, Literal
 from pydantic import BaseModel
 from pydantic._internal import _repr
 from pydantic._internal._core_utils import _WalkCoreSchema, pretty_print_core_schema
-from pydantic._internal._typing_extra import all_literal_values, get_origin, is_new_type
+from pydantic._internal._typing_extra import get_origin, is_new_type, literal_values
 from pydantic._internal._utils import (
     BUILTIN_COLLECTIONS,
     ClassAttribute,
@@ -380,21 +380,21 @@ def test_class_attribute():
     assert f.attr == 'not foo'
 
 
-def test_all_literal_values():
+def test_literal_values():
     L1 = Literal['1']
-    assert all_literal_values(L1) == ['1']
+    assert literal_values(L1) == ['1']
 
     L2 = Literal['2']
     L12 = Literal[L1, L2]
-    assert all_literal_values(L12) == IsList('1', '2', check_order=False)
+    assert literal_values(L12) == IsList('1', '2', check_order=False)
 
     L312 = Literal['3', Literal[L1, L2]]
-    assert all_literal_values(L312) == IsList('3', '1', '2', check_order=False)
+    assert literal_values(L312) == IsList('3', '1', '2', check_order=False)
 
 
 @pytest.mark.parametrize(
     'obj',
-    (1, 1.0, '1', b'1', int, None, test_all_literal_values, len, test_all_literal_values.__code__, lambda: ..., ...),
+    (1, 1.0, '1', b'1', int, None, test_literal_values, len, test_literal_values.__code__, lambda: ..., ...),
 )
 def test_smart_deepcopy_immutable_non_sequence(obj, mocker):
     # make sure deepcopy is not used


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- Refactor the `_typing_extra` module to:
  - make use of https://typing-extensions.readthedocs.io/en/latest/#runtime-use-of-types. In a lot of places, we are only checking for `some_obj is typing(_extensions).SomeType` which can break at any time if `typing_extensions` backports some changes from Python, in which case `typing.SomeType is not typing_extensions.SomeType`.
  - Cleanup/simplify some `is_*` functions (e.g. `is_newtype`, `is_classvar`).
  - Add a new `is_classvar_annotation` function, that should be used in most cases. This function handles `ClassVar` being wrapped in `Annotated`, and also stringified annotations.
  - Rename `all_literal_values` to `literal_values`, replacing the unused `literal_values` function. When we drop support for Python 3.8, replace usage with a plain `get_args`.
  - Remove unecessary `is_dataclass` function, `dataclasses.is_dataclass` provides a type guard return annotation.
- Adapt the codebase to use the new constructs. In some cases, this does fix some actual bugs

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
