### PR TITLE
Fix documentation code examples not being upgraded

### DIFF
--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -162,7 +162,7 @@ def upgrade_python(markdown: str) -> str:
         else:
             return '\n\n'.join(output)
 
-    return re.sub(r'^(``` *py.*?)\n(.+?)^```(\s+(?:^\d+\. .+?\n)+)', add_tabs, markdown, flags=re.M | re.S)
+    return re.sub(r'^(``` *py.*?)\n(.+?)^```(\s+(?:^\d+\. .+?\n)*)', add_tabs, markdown, flags=re.M | re.S)
 
 
 def _upgrade_code(code: str, min_version: int) -> str:


### PR DESCRIPTION
Noticed while working on #10748.

This affects the `experimental.md` page with #10748, but also probably other pages, meant that code examples lower in the page weren't being translated to newer python.

we should probably switch from pyupgrade to `ruff format` as it'll make for neater python output (or run isort after pyupgrade 🤮 ).