### PR TITLE
Add validation tests for `_internal/_validators.py`

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -346,34 +346,36 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
     Though this could be divided into two separate functions, the logic is easier to follow if we couple the computation
     of the number of decimals and digits together.
     """
-    decimal_tuple = decimal.as_tuple()
-    if not isinstance(decimal_tuple.exponent, int):
+    try:
+        decimal_tuple = decimal.as_tuple()
+
+        assert isinstance(decimal_tuple.exponent, int)
+
+        exponent = decimal_tuple.exponent
+        num_digits = len(decimal_tuple.digits)
+
+        if exponent >= 0:
+            # A positive exponent adds that many trailing zeros
+            # Ex: digit_tuple=(1, 2, 3), exponent=2 -> 12300 -> 0 decimal places, 5 digits
+            num_digits += exponent
+            decimal_places = 0
+        else:
+            # If the absolute value of the negative exponent is larger than the
+            # number of digits, then it's the same as the number of digits,
+            # because it'll consume all the digits in digit_tuple and then
+            # add abs(exponent) - len(digit_tuple) leading zeros after the decimal point.
+            # Ex: digit_tuple=(1, 2, 3), exponent=-2 -> 1.23 -> 2 decimal places, 3 digits
+            # Ex: digit_tuple=(1, 2, 3), exponent=-4 -> 0.0123 -> 4 decimal places, 4 digits
+            decimal_places = abs(exponent)
+            num_digits = max(num_digits, decimal_places)
+
+        return decimal_places, num_digits
+    except (AssertionError, AttributeError):
         raise TypeError(f'Unable to extract decimal digits info from supplied value {decimal}')
-    exponent = decimal_tuple.exponent
-    num_digits = len(decimal_tuple.digits)
-
-    if exponent >= 0:
-        # A positive exponent adds that many trailing zeros
-        # Ex: digit_tuple=(1, 2, 3), exponent=2 -> 12300 -> 0 decimal places, 5 digits
-        num_digits += exponent
-        decimal_places = 0
-    else:
-        # If the absolute value of the negative exponent is larger than the
-        # number of digits, then it's the same as the number of digits,
-        # because it'll consume all the digits in digit_tuple and then
-        # add abs(exponent) - len(digit_tuple) leading zeros after the decimal point.
-        # Ex: digit_tuple=(1, 2, 3), exponent=-2 -> 1.23 -> 2 decimal places, 3 digits
-        # Ex: digit_tuple=(1, 2, 3), exponent=-4 -> 0.0123 -> 4 decimal places, 4 digits
-        decimal_places = abs(exponent)
-        num_digits = max(num_digits, decimal_places)
-
-    return decimal_places, num_digits
 
 
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
     try:
-        if not isinstance(x, Decimal):
-            raise TypeError(f'Expected Decimal, received {type(x).__name__}')
         _, num_digits = _extract_decimal_digits_info(x)
         _, normalized_num_digits = _extract_decimal_digits_info(x.normalize())
         if (num_digits > max_digits) and (normalized_num_digits > max_digits):
@@ -388,8 +390,6 @@ def max_digits_validator(x: Any, max_digits: Any) -> Any:
 
 def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
     try:
-        if not isinstance(x, Decimal):
-            raise TypeError(f'Expected Decimal, received {type(x).__name__}')
         decimal_places_, _ = _extract_decimal_digits_info(x)
         normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize())
         if (decimal_places_ > decimal_places) and (normalized_decimal_places > decimal_places):

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -371,10 +371,11 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
 
 
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
-    _, num_digits = _extract_decimal_digits_info(x)
-    _, normalized_num_digits = _extract_decimal_digits_info(x.normalize())
-
     try:
+        if not isinstance(x, Decimal):
+            raise TypeError(f'Expected Decimal, received {type(x).__name__}')
+        _, num_digits = _extract_decimal_digits_info(x)
+        _, normalized_num_digits = _extract_decimal_digits_info(x.normalize())
         if (num_digits > max_digits) and (normalized_num_digits > max_digits):
             raise PydanticKnownError(
                 'decimal_max_digits',
@@ -386,10 +387,11 @@ def max_digits_validator(x: Any, max_digits: Any) -> Any:
 
 
 def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
-    decimal_places_, _ = _extract_decimal_digits_info(x)
-    normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize())
-
     try:
+        if not isinstance(x, Decimal):
+            raise TypeError(f'Expected Decimal, received {type(x).__name__}')
+        decimal_places_, _ = _extract_decimal_digits_info(x)
+        normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize())
         if (decimal_places_ > decimal_places) and (normalized_decimal_places > decimal_places):
             raise PydanticKnownError(
                 'decimal_max_places',

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -222,3 +222,8 @@ def test_schema_is_valid():
 )
 def test_decimal_digits_calculation(decimal: Decimal, decimal_places: int, digits: int) -> None:
     assert _extract_decimal_digits_info(decimal) == (decimal_places, digits)
+
+
+def test_decimal_digits_calculation_type_error() -> None:
+    with pytest.raises(TypeError, match='Unable to extract decimal digits info from supplied value NaN'):
+        _extract_decimal_digits_info(Decimal.from_float(float('nan')))

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -224,6 +224,10 @@ def test_decimal_digits_calculation(decimal: Decimal, decimal_places: int, digit
     assert _extract_decimal_digits_info(decimal) == (decimal_places, digits)
 
 
-def test_decimal_digits_calculation_type_error() -> None:
-    with pytest.raises(TypeError, match='Unable to extract decimal digits info from supplied value NaN'):
-        _extract_decimal_digits_info(Decimal.from_float(float('nan')))
+@pytest.mark.parametrize(
+    'value',
+    [Decimal.from_float(float('nan')), 1.0],
+)
+def test_decimal_digits_calculation_type_error(value) -> None:
+    with pytest.raises(TypeError, match=f'Unable to extract decimal digits info from supplied value {value}'):
+        _extract_decimal_digits_info(value)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1807,15 +1807,15 @@ def test_enum_with_no_cases() -> None:
     [
         ({'pattern': '^foo$'}, int, 1),
         *[
-            ({constraint_name: 0}, list[int], [1, 2, 3, 4, 5])
+            ({constraint_name: 0}, List[int], [1, 2, 3, 4, 5])
             for constraint_name in ['gt', 'lt', 'ge', 'le', 'multiple_of']
         ]
         + [
-            ({constraint_name: 0}, set[int], {1, 2, 3, 4, 5})
+            ({constraint_name: 0}, Set[int], {1, 2, 3, 4, 5})
             for constraint_name in ['gt', 'lt', 'ge', 'le', 'multiple_of']
         ]
         + [
-            ({constraint_name: 0}, frozenset[int], frozenset({1, 2, 3, 4, 5}))
+            ({constraint_name: 0}, FrozenSet[int], frozenset({1, 2, 3, 4, 5}))
             for constraint_name in ['gt', 'lt', 'ge', 'le', 'multiple_of']
         ]
         + [({constraint_name: 0}, Decimal, Decimal('1.0')) for constraint_name in ['max_length', 'min_length']]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,7 +4,6 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
-from fractions import Fraction
 from functools import partial, partialmethod
 from itertools import product
 from os.path import normcase
@@ -249,18 +248,6 @@ def test_int_overflow_validation(value):
         Model(a=value)
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'finite_number', 'loc': ('a',), 'msg': 'Input should be a finite number', 'input': value}
-    ]
-
-
-@pytest.mark.parametrize('value', ['wrong_format'])
-def test_fraction_validation(value):
-    class Model(BaseModel):
-        a: Fraction
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model(a=value)
-    assert exc_info.value.errors(include_url=False) == [
-        {'type': 'fraction_parsing', 'loc': ('a',), 'msg': 'Input is not a valid fraction', 'input': value}
     ]
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,6 +4,7 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
+from fractions import Fraction
 from functools import partial, partialmethod
 from itertools import product
 from os.path import normcase
@@ -248,6 +249,18 @@ def test_int_overflow_validation(value):
         Model(a=value)
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'finite_number', 'loc': ('a',), 'msg': 'Input should be a finite number', 'input': value}
+    ]
+
+
+@pytest.mark.parametrize('value', ['wrong_format'])
+def test_fraction_validation(value):
+    class Model(BaseModel):
+        a: Fraction
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a=value)
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'fraction_parsing', 'loc': ('a',), 'msg': 'Input is not a valid fraction', 'input': value}
     ]
 
 


### PR DESCRIPTION
## Change Summary

This PR introduces new unit tests to enhance the test coverage by covering the following scenarios:

- Added a type check for decimal validators and the corresponding unit tests.
- Added unit tests to validate numeric constraints (e.g., 'gt', 'lt', etc.).
- Added a unit test to validate the `Fraction` type.

Confirmed that the test coverage for `_internal/_validators.py` increased from 96.43% to 100%

## Related issue number

https://github.com/pydantic/pydantic/issues/7656

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle