### PR TITLE
Fix `isinstance` behavior for urls

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -99,11 +99,6 @@ class UrlConstraints(_fields.PydanticMetadata):
         return {field.name: getattr(self, field.name) for field in fields(self)}
 
 
-@lru_cache
-def _build_type_adapter(cls: type[_BaseUrl | _BaseMultiHostUrl]) -> TypeAdapter:
-    return TypeAdapter(cls)
-
-
 class _BaseUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
     _url: _CoreUrl
@@ -438,6 +433,11 @@ class _BaseMultiHostUrl:
             for constraint_key, constraint_value in cls._constraints.defined_constraints.items():
                 schema[constraint_key] = constraint_value
             return schema
+
+
+@lru_cache
+def _build_type_adapter(cls: type[_BaseUrl | _BaseMultiHostUrl]) -> TypeAdapter:
+    return TypeAdapter(cls)
 
 
 class AnyUrl(_BaseUrl):

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -263,6 +263,8 @@ class _BaseUrl:
         if issubclass(cls, source):
 
             def wrap_val(value, handler):
+                if isinstance(value, source):
+                    return value
                 core_url = handler(value)
                 instance = source.__new__(source)
                 instance._url = core_url
@@ -427,6 +429,8 @@ class _BaseMultiHostUrl:
         if issubclass(cls, source):
 
             def wrap_val(value, handler):
+                if isinstance(value, source):
+                    return value
                 core_url = handler(value)
                 instance = source.__new__(source)
                 instance._url = core_url

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -103,8 +103,8 @@ class _BaseUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
     _url: _CoreUrl
 
-    def __init__(self, url: str | _CoreUrl) -> None:
-        self._url = _build_type_adapter(self.__class__).validate_python(str(url))
+    def __init__(self, url: str | _CoreUrl | _BaseUrl) -> None:
+        self._url = _build_type_adapter(self.__class__).validate_python(url)
 
     @property
     def scheme(self) -> str:
@@ -256,6 +256,8 @@ class _BaseUrl:
             def wrap_val(value, handler):
                 if isinstance(value, source):
                     return value
+                if isinstance(value, _BaseUrl):
+                    value = str(value)
                 core_url = handler(value)
                 instance = source.__new__(source)
                 instance._url = core_url
@@ -282,8 +284,8 @@ class _BaseMultiHostUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
     _url: _CoreMultiHostUrl
 
-    def __init__(self, url: str | _CoreMultiHostUrl) -> None:
-        self._url = _build_type_adapter(self.__class__).validate_python(str(url))
+    def __init__(self, url: str | _CoreMultiHostUrl | _BaseMultiHostUrl) -> None:
+        self._url = _build_type_adapter(self.__class__).validate_python(url)
 
     @property
     def scheme(self) -> str:
@@ -413,6 +415,8 @@ class _BaseMultiHostUrl:
             def wrap_val(value, handler):
                 if isinstance(value, source):
                     return value
+                if isinstance(value, _BaseMultiHostUrl):
+                    value = str(value)
                 core_url = handler(value)
                 instance = source.__new__(source)
                 instance._url = core_url

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -9,7 +9,7 @@ from importlib.metadata import version
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pydantic_core import MultiHostUrl, PydanticCustomError, Url, core_schema
+from pydantic_core import MultiHostHost, MultiHostUrl, PydanticCustomError, Url, core_schema
 from typing_extensions import Annotated, Self, TypeAlias
 
 from pydantic.errors import PydanticUserError
@@ -95,17 +95,159 @@ class UrlConstraints(_fields.PydanticMetadata):
         return {field.name: getattr(self, field.name) for field in fields(self)}
 
 
-# TODO: there's a lot of repeated code in these two base classes - should we consolidate, or does that up
-# the complexity enough that it's not worth saving a few lines?
-
-
-class _BaseUrl(Url):
+class _BaseUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
+    _url: Url
+
+    def __init__(self, url: Url) -> None:
+        self._url = url
+
+    @property
+    def scheme(self) -> str:
+        """The scheme part of the URL.
+
+        e.g. `https` in `https://user:pass@host:port/path?query#fragment`
+        """
+        return self._url.scheme
+
+    @property
+    def username(self) -> str | None:
+        """The username part of the URL, or `None`.
+
+        e.g. `user` in `https://user:pass@host:port/path?query#fragment`
+        """
+        return self._url.username
+
+    @property
+    def password(self) -> str | None:
+        """The password part of the URL, or `None`.
+
+        e.g. `pass` in `https://user:pass@host:port/path?query#fragment`
+        """
+        return self._url.password
+
+    @property
+    def host(self) -> str | None:
+        """The host part of the URL, or `None`.
+
+        If the URL must be punycode encoded, this is the encoded host, e.g if the input URL is `https://£££.com`,
+        `host` will be `xn--9aaa.com`
+        """
+        return self._url.host
+
+    def unicode_host(self) -> str | None:
+        """The host part of the URL as a unicode string, or `None`.
+
+        e.g. `host` in `https://user:pass@host:port/path?query#fragment`
+
+        If the URL must be punycode encoded, this is the decoded host, e.g if the input URL is `https://£££.com`,
+        `unicode_host()` will be `£££.com`
+        """
+        return self._url.unicode_host()
+
+    @property
+    def port(self) -> int | None:
+        """The port part of the URL, or `None`.
+
+        e.g. `port` in `https://user:pass@host:port/path?query#fragment`
+        """
+        return self._url.port
+
+    @property
+    def path(self) -> str | None:
+        """The path part of the URL, or `None`.
+
+        e.g. `/path` in `https://user:pass@host:port/path?query#fragment`
+        """
+        return self._url.path
+
+    @property
+    def query(self) -> str | None:
+        """The query part of the URL, or `None`.
+
+        e.g. `query` in `https://user:pass@host:port/path?query#fragment`
+        """
+        return self._url.query
+
+    def query_params(self) -> list[tuple[str, str]]:
+        """The query part of the URL as a list of key-value pairs.
+
+        e.g. `[('foo', 'bar')]` in `https://user:pass@host:port/path?foo=bar#fragment`
+        """
+        return self._url.query_params()
+
+    @property
+    def fragment(self) -> str | None:
+        """The fragment part of the URL, or `None`.
+
+        e.g. `fragment` in `https://user:pass@host:port/path?query#fragment`
+        """
+
+    def unicode_string(self) -> str:
+        """The URL as a unicode string, unlike `__str__()` this will not punycode encode the host.
+
+        If the URL must be punycode encoded, this is the decoded string, e.g if the input URL is `https://£££.com`,
+        `unicode_string()` will be `https://£££.com`
+        """
+        return self._url.unicode_string()
+
+    def __str__(self) -> str:
+        """The URL as a string, this will punycode encode the host if required."""
+        return str(self._url)
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({str(self._url)})'
+
+    def __deepcopy__(self, memo: dict) -> Self:
+        return self.__class__(self._url)
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        scheme: str,
+        username: str | None = None,
+        password: str | None = None,
+        host: str,
+        port: int | None = None,
+        path: str | None = None,
+        query: str | None = None,
+        fragment: str | None = None,
+    ) -> Self:
+        """Build a new `Url` instance from its component parts.
+
+        Args:
+            scheme: The scheme part of the URL.
+            username: The username part of the URL, or omit for no username.
+            password: The password part of the URL, or omit for no password.
+            host: The host part of the URL.
+            port: The port part of the URL, or omit for no port.
+            path: The path part of the URL, or omit for no path.
+            query: The query part of the URL, or omit for no query.
+            fragment: The fragment part of the URL, or omit for no fragment.
+
+        Returns:
+            An instance of URL
+        """
+        return cls(
+            Url.build(
+                scheme=scheme,
+                username=username,
+                password=password,
+                host=host,
+                port=port,
+                path=path,
+                query=query,
+                fragment=fragment,
+            )
+        )
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         if issubclass(cls, source):
-            return core_schema.url_schema(**cls._constraints.defined_constraints)
+            return core_schema.no_info_after_validator_function(
+                lambda x: source(x), schema=core_schema.url_schema(**cls._constraints.defined_constraints)
+            )
         else:
             schema = handler(source)
             # TODO: this logic is used in types.py as well in the _check_annotated_type function, should we move that to somewhere more central?
@@ -118,8 +260,131 @@ class _BaseUrl(Url):
             return schema
 
 
-class _BaseMultiHostUrl(MultiHostUrl):
+class _BaseMultiHostUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
+    _url: MultiHostUrl
+
+    def __init__(self, url: MultiHostUrl) -> None:
+        self._url = url
+
+    @property
+    def scheme(self) -> str:
+        """The scheme part of the URL.
+
+        e.g. `https` in `https://foo.com,bar.com/path?query#fragment`
+        """
+        return self._url.scheme
+
+    @property
+    def path(self) -> str | None:
+        """The path part of the URL, or `None`.
+
+        e.g. `/path` in `https://foo.com,bar.com/path?query#fragment`
+        """
+        return self._url.path
+
+    @property
+    def query(self) -> str | None:
+        """The query part of the URL, or `None`.
+
+        e.g. `query` in `https://foo.com,bar.com/path?query#fragment`
+        """
+        return self._url.query
+
+    def query_params(self) -> list[tuple[str, str]]:
+        """The query part of the URL as a list of key-value pairs.
+
+        e.g. `[('foo', 'bar')]` in `https://foo.com,bar.com/path?query#fragment`
+        """
+        return self._url.query_params()
+
+    @property
+    def fragment(self) -> str | None:
+        """The fragment part of the URL, or `None`.
+
+        e.g. `fragment` in `https://foo.com,bar.com/path?query#fragment`
+        """
+        return self._url.fragment
+
+    def hosts(self) -> list[MultiHostHost]:
+        '''The hosts of the `MultiHostUrl` as [`MultiHostHost`][pydantic_core.MultiHostHost] typed dicts.
+
+        ```py
+        from pydantic_core import MultiHostUrl
+
+        mhu = MultiHostUrl('https://foo.com:123,foo:bar@bar.com/path')
+        print(mhu.hosts())
+        """
+        [
+            {'username': None, 'password': None, 'host': 'foo.com', 'port': 123},
+            {'username': 'foo', 'password': 'bar', 'host': 'bar.com', 'port': 443}
+        ]
+        ```
+        Returns:
+            A list of dicts, each representing a host.
+        '''
+        return self._url.hosts()
+
+    def unicode_string(self) -> str:
+        """The URL as a unicode string, unlike `__str__()` this will not punycode encode the hosts."""
+        return self._url.unicode_string()
+
+    def __str__(self) -> str:
+        """The URL as a string, this will punycode encode the host if required."""
+        return str(self._url)
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({str(self._url)})'
+
+    def __deepcopy__(self, memo: dict) -> Self:
+        return self.__class__(self._url)
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        scheme: str,
+        hosts: list[MultiHostHost] | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        path: str | None = None,
+        query: str | None = None,
+        fragment: str | None = None,
+    ) -> Self:
+        """Build a new `MultiHostUrl` instance from its component parts.
+
+        This method takes either `hosts` - a list of `MultiHostHost` typed dicts, or the individual components
+        `username`, `password`, `host` and `port`.
+
+        Args:
+            scheme: The scheme part of the URL.
+            hosts: Multiple hosts to build the URL from.
+            username: The username part of the URL.
+            password: The password part of the URL.
+            host: The host part of the URL.
+            port: The port part of the URL.
+            path: The path part of the URL.
+            query: The query part of the URL, or omit for no query.
+            fragment: The fragment part of the URL, or omit for no fragment.
+
+        Returns:
+            An instance of `MultiHostUrl`
+        """
+        return cls(
+            MultiHostUrl.build(
+                scheme=scheme,
+                hosts=hosts,
+                username=username,
+                password=password,
+                host=host,
+                port=port,
+                path=path,
+                query=query,
+                fragment=fragment,
+            )
+        )
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
@@ -162,7 +427,7 @@ class AnyUrl(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class AnyHttpUrl(_BaseUrl):
@@ -177,7 +442,7 @@ class AnyHttpUrl(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class HttpUrl(_BaseUrl):
@@ -263,7 +528,7 @@ class HttpUrl(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class AnyWebsocketUrl(_BaseUrl):
@@ -278,7 +543,7 @@ class AnyWebsocketUrl(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class WebsocketUrl(_BaseUrl):
@@ -294,7 +559,7 @@ class WebsocketUrl(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class FileUrl(_BaseUrl):
@@ -394,7 +659,7 @@ class PostgresDsn(_BaseMultiHostUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class CockroachDsn(_BaseUrl):
@@ -417,7 +682,7 @@ class CockroachDsn(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class AmqpDsn(_BaseUrl):
@@ -450,7 +715,7 @@ class RedisDsn(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class MongoDsn(_BaseMultiHostUrl):
@@ -518,7 +783,7 @@ class MySQLDsn(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class MariaDBDsn(_BaseUrl):
@@ -538,7 +803,7 @@ class MariaDBDsn(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class ClickHouseDsn(_BaseUrl):
@@ -559,7 +824,7 @@ class ClickHouseDsn(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 class SnowflakeDsn(_BaseUrl):
@@ -578,7 +843,7 @@ class SnowflakeDsn(_BaseUrl):
     @property
     def host(self) -> str:
         """The required URL host."""
-        ...
+        return self._url.host  # type: ignore
 
 
 def import_email_validator() -> None:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -108,12 +108,7 @@ class _BaseUrl:
         return TypeAdapter(self.__class__)
 
     def __init__(self, url: str | _CoreUrl) -> None:
-        if isinstance(url, self.__class__):
-            self._url = url._url
-        elif isinstance(url, _CoreUrl):
-            self._url = self._validator.validate_python(str(url))
-        else:
-            self._url = self._validator.validate_python(url)
+        self._url = self._validator.validate_python(str(url))
 
     @property
     def scheme(self) -> str:
@@ -296,12 +291,7 @@ class _BaseMultiHostUrl:
         return TypeAdapter(self.__class__)
 
     def __init__(self, url: str | _CoreMultiHostUrl) -> None:
-        if isinstance(url, self.__class__):
-            self._url = url._url
-        elif isinstance(url, _CoreMultiHostUrl):
-            self._url = self._validator.validate_python(str(url))
-        else:
-            self._url = self._validator.validate_python(url)
+        self._url = self._validator.validate_python(str(url))
 
     @property
     def scheme(self) -> str:

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -99,8 +99,12 @@ class _BaseUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
     _url: Url
 
-    def __init__(self, url: Url) -> None:
-        self._url = url
+    def __init__(self, url: str | Url) -> None:
+        if isinstance(url, Url):
+            self._url = url
+        else:
+            assert isinstance(url, str)
+            self._url = Url(url)
 
     @property
     def scheme(self) -> str:
@@ -267,8 +271,12 @@ class _BaseMultiHostUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
     _url: MultiHostUrl
 
-    def __init__(self, url: MultiHostUrl) -> None:
-        self._url = url
+    def __init__(self, url: str | MultiHostUrl) -> None:
+        if isinstance(url, MultiHostUrl):
+            self._url = url
+        else:
+            assert isinstance(url, str)
+            self._url = MultiHostUrl(url)
 
     @property
     def scheme(self) -> str:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -76,7 +76,15 @@ from pydantic.json_schema import (
     model_json_schema,
     models_json_schema,
 )
-from pydantic.networks import AnyUrl, EmailStr, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork, MultiHostUrl, NameEmail
+from pydantic.networks import (
+    AnyUrl,
+    EmailStr,
+    IPvAnyAddress,
+    IPvAnyInterface,
+    IPvAnyNetwork,
+    NameEmail,
+    _CoreMultiHostUrl,
+)
 from pydantic.type_adapter import TypeAdapter
 from pydantic.types import (
     UUID1,
@@ -933,7 +941,7 @@ def test_str_constrained_types(field_type, expected_schema):
             Annotated[AnyUrl, Field(max_length=2**16)],
             {'title': 'A', 'type': 'string', 'format': 'uri', 'minLength': 1, 'maxLength': 2**16},
         ),
-        (MultiHostUrl, {'title': 'A', 'type': 'string', 'format': 'multi-host-uri', 'minLength': 1}),
+        (_CoreMultiHostUrl, {'title': 'A', 'type': 'string', 'format': 'multi-host-uri', 'minLength': 1}),
     ],
 )
 def test_special_str_types(field_type, expected_schema):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -167,7 +167,7 @@ def validate_url(s):
 def test_any_url_parts():
     url = validate_url('http://example.org')
     assert str(url) == 'http://example.org/'
-    assert repr(url) == "Url('http://example.org/')"
+    assert repr(url) == "AnyUrl('http://example.org/')"
     assert url.scheme == 'http'
     assert url.host == 'example.org'
     assert url.port == 80
@@ -176,7 +176,7 @@ def test_any_url_parts():
 def test_url_repr():
     url = validate_url('http://user:password@example.org:1234/the/path/?query=here#fragment=is;this=bit')
     assert str(url) == 'http://user:password@example.org:1234/the/path/?query=here#fragment=is;this=bit'
-    assert repr(url) == "Url('http://user:password@example.org:1234/the/path/?query=here#fragment=is;this=bit')"
+    assert repr(url) == "AnyUrl('http://user:password@example.org:1234/the/path/?query=here#fragment=is;this=bit')"
     assert url.scheme == 'http'
     assert url.username == 'user'
     assert url.password == 'password'

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1044,3 +1044,12 @@ def test_specialized_urls() -> None:
     assert http_url.path == '/something'
     assert http_url.username is None
     assert http_url.password is None
+
+    http_url2 = ta.validate_python(http_url)
+    assert str(http_url2) == 'http://example.com/something'
+    assert repr(http_url2) == "HttpUrl('http://example.com/something')"
+    assert http_url2.__class__ == HttpUrl
+    assert http_url2.host == 'example.com'
+    assert http_url2.path == '/something'
+    assert http_url2.username is None
+    assert http_url2.password is None

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -24,6 +24,7 @@ from pydantic import (
     RedisDsn,
     SnowflakeDsn,
     Strict,
+    TypeAdapter,
     UrlConstraints,
     ValidationError,
     WebsocketUrl,
@@ -1030,3 +1031,16 @@ def test_name_email_serialization():
 
     obj = json.loads(m.model_dump_json())
     Model(email=obj['email'])
+
+
+def test_specialized_urls() -> None:
+    ta = TypeAdapter(HttpUrl)
+
+    http_url = ta.validate_python('http://example.com/something')
+    assert str(http_url) == 'http://example.com/something'
+    assert repr(http_url) == "HttpUrl('http://example.com/something')"
+    assert http_url.__class__ == HttpUrl
+    assert http_url.host == 'example.com'
+    assert http_url.path == '/something'
+    assert http_url.username is None
+    assert http_url.password is None


### PR DESCRIPTION
This new implementation sort of starts to follow the pattern we'd use for `RustModel` like classes by accessing the `pydantic-core` structure from a wrapper `pydantic` type.

With this new pattern, isinstance checks work properly (they don't in the most recent version of `pydantic`):

```py
from pydantic import HttpUrl, TypeAdapter

http_url = TypeAdapter(HttpUrl).validate_python('http://example.com/something')
print(http_url)
#> http://example.com/something
print(repr(http_url))
#> HttpUrl(http://example.com/something)
print(http_url.__class__)
#> <class 'pydantic.networks.HttpUrl'>
print(http_url.host)
#> example.com
```

I think some more refactoring should be done in `pydantic-core`, but this serves as the `pydantic` end of things, for the most part. In core (future PR), the main thing we can do is simplify the `Url` and `MultiHostUrl` classes (remove docstrings, etc).

Eventually, we should get rid of validation on init, that's pretty gnarly - but that would constitute a breaking change. Should we do this now?