### PR TITLE
fix to rebuild core schema if the class has a generic origin.

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -690,7 +690,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # Due to the way generic classes are built, it's possible that an invalid schema may be temporarily
             # set on generic classes. I think we could resolve this to ensure that we get proper schema caching
             # for generics, but for simplicity for now, we just always rebuild if the class has a generic origin.
-            if not cls.__pydantic_generic_metadata__['origin']:
+            if cls.__pydantic_generic_metadata__['origin']:
                 return cls.__pydantic_core_schema__
 
         return handler(source)


### PR DESCRIPTION
fix condition to rebuild core schema if the class has a generic origin.

## Change Summary

This update fixes the conditional logic for rebuilding the core schema. The condition has been reversed to ensure that the schema is always rebuilt if the class has a generic origin 

## Related issue number

Fixes [#10570](https://github.com/pydantic/pydantic/issues/10570)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle