### PR TITLE
Only evaluate `FieldInfo` annotations if required during schema building

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -117,7 +117,7 @@ def collect_model_fields(  # noqa: C901
     fields: dict[str, FieldInfo] = {}
 
     class_vars: set[str] = set()
-    for ann_name, ann_type in type_hints.items():
+    for ann_name, (ann_type, evaluated) in type_hints.items():
         if ann_name == 'model_config':
             # We never want to treat `model_config` as a field
             # Note: we may need to change this logic if/when we introduce a `BareModel` class with no
@@ -202,6 +202,7 @@ def collect_model_fields(  # noqa: C901
         except AttributeError:
             if ann_name in annotations:
                 field_info = FieldInfo_.from_annotation(ann_type)
+                field_info.evaluated = evaluated
             else:
                 # if field has no default value and is not in __annotations__ this means that it is
                 # defined in a base class and we can take it from there
@@ -214,6 +215,8 @@ def collect_model_fields(  # noqa: C901
                     # generated thanks to models not being fully defined while initializing recursive models.
                     # Nothing stops us from just creating a new FieldInfo for this type hint, so we do this.
                     field_info = FieldInfo_.from_annotation(ann_type)
+                    field_info.evaluated = evaluated
+
         else:
             _warn_on_nested_alias_in_annotation(ann_type, ann_name)
             if isinstance(default, FieldInfo_) and ismethoddescriptor(default.default):
@@ -224,6 +227,7 @@ def collect_model_fields(  # noqa: C901
                 default.default = default.default.__get__(None, cls)
 
             field_info = FieldInfo_.from_annotated_attribute(ann_type, default)
+            field_info.evaluated = evaluated
             # attributes which are fields are removed from the class namespace:
             # 1. To match the behaviour of annotation-only fields
             # 2. To avoid false positives in the NameError check above
@@ -316,7 +320,7 @@ def collect_dataclass_fields(
                     continue
 
                 globalns, localns = ns_resolver.types_namespace
-                ann_type = _typing_extra.eval_type(dataclass_field.type, globalns, localns, lenient=True)
+                ann_type, _ = _typing_extra.try_eval_type(dataclass_field.type, globalns, localns)
 
                 if _typing_extra.is_classvar_annotation(ann_type):
                     continue

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1224,13 +1224,13 @@ class GenerateSchema:
         if not field_info.evaluated:
             # TODO Can we use field_info.apply_typevars_map here?
             try:
-                evaluated = _typing_extra.eval_type(field_info.annotation, *self._types_namespace)
+                evaluated_type = _typing_extra.eval_type(field_info.annotation, *self._types_namespace)
             except NameError as e:
                 raise PydanticUndefinedAnnotation.from_name_error(e) from e
-            evaluated = replace_types(evaluated, self._typevars_map)
+            evaluated_type = replace_types(evaluated_type, self._typevars_map)
             field_info.evaluated = True
-            if not has_instance_in_type(evaluated, PydanticRecursiveRef):
-                new_field_info = FieldInfo.from_annotation(evaluated)
+            if not has_instance_in_type(evaluated_type, PydanticRecursiveRef):
+                new_field_info = FieldInfo.from_annotation(evaluated_type)
                 field_info.annotation = new_field_info.annotation
 
                 # Handle any field info attributes that may have been obtained from now-resolved annotations

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -9,7 +9,7 @@ import types
 import typing
 import warnings
 from functools import lru_cache, partial
-from typing import Any, Callable
+from typing import Any, Callable, Literal, overload
 
 import typing_extensions
 from typing_extensions import TypeIs, deprecated, get_args, get_origin
@@ -449,17 +449,54 @@ def parent_frame_namespace(*, parent_depth: int = 2, force: bool = False) -> dic
     return frame.f_locals
 
 
+def _type_convert(arg: Any) -> Any:
+    """Convert `None` to `NoneType` and strings to `ForwardRef` instances.
+
+    This is a backport of the private `typing._type_convert` function. When
+    evaluating a type, `ForwardRef._evaluate` ends up being called, and is
+    responsible for making this conversion. However, we still have to apply
+    it for the first argument passed to our type evaluation functions, similarly
+    to the `typing.get_type_hints` function.
+    """
+    if arg is None:
+        return NoneType
+    if isinstance(arg, str):
+        # Like `typing.get_type_hints`, assume the arg can be in any context,
+        # hence the proper `is_argument` and `is_class` args:
+        return _make_forward_ref(arg, is_argument=False, is_class=True)
+    return arg
+
+
+@overload
 def get_cls_type_hints(
-    obj: type[Any], *, ns_resolver: NsResolver | None = None, lenient: bool = False
-) -> dict[str, Any]:
+    obj: type[Any],
+    *,
+    ns_resolver: NsResolver | None = None,
+    lenient: Literal[True],
+) -> dict[str, tuple[Any, bool]]: ...
+@overload
+def get_cls_type_hints(
+    obj: type[Any],
+    *,
+    ns_resolver: NsResolver | None = None,
+    lenient: Literal[False] = ...,
+) -> dict[str, Any]: ...
+def get_cls_type_hints(
+    obj: type[Any],
+    *,
+    ns_resolver: NsResolver | None = None,
+    lenient: bool = False,
+) -> dict[str, Any] | dict[str, tuple[Any, bool]]:
     """Collect annotations from a class, including those from parent classes.
 
     Args:
         obj: The class to inspect.
         ns_resolver: A namespace resolver instance to use. Defaults to an empty instance.
-        lenient: Whether to keep unresolvable annotations as is or re-raise the `NameError` exception. Default: re-raise.
+        lenient: Whether to keep unresolvable annotations as is or re-raise the `NameError` exception.
+            If lenient, an extra boolean flag is set for each annotation value to indicate whether the
+            evaluation succeeded or not. Default: re-raise.
     """
-    hints = {}
+    hints: dict[str, Any] | dict[str, tuple[Any, bool]] = {}
     ns_resolver = ns_resolver or NsResolver()
 
     for base in reversed(obj.__mro__):
@@ -469,16 +506,42 @@ def get_cls_type_hints(
         with ns_resolver.push(base):
             globalns, localns = ns_resolver.types_namespace
             for name, value in ann.items():
-                hints[name] = eval_type(value, globalns, localns, lenient=lenient)
+                if lenient:
+                    hints[name] = try_eval_type(value, globalns, localns)
+                else:
+                    hints[name] = eval_type(value, globalns, localns)
     return hints
+
+
+def try_eval_type(
+    value: Any,
+    globalns: GlobalsNamespace | None = None,
+    localns: MappingNamespace | None = None,
+) -> tuple[Any, bool]:
+    """Try evaluating the annotation using the provided namespaces.
+
+    Args:
+        value: The value to evaluate. If `None`, it will be replaced by `type[None]`. If an instance
+            of `str`, it will be converted to a `ForwardRef`.
+        localns: The global namespace to use during annotation evaluation.
+        globalns: The local namespace to use during annotation evaluation.
+
+    Returns:
+        A two-tuple containing the possibly evaluated type and a boolean indicating
+            whether the evaluation succeeded or not.
+    """
+    value = _type_convert(value)
+
+    try:
+        return eval_type_backport(value, globalns, localns), True
+    except NameError:
+        return value, False
 
 
 def eval_type(
     value: Any,
     globalns: GlobalsNamespace | None = None,
     localns: MappingNamespace | None = None,
-    *,
-    lenient: bool = False,
 ) -> Any:
     """Evaluate the annotation using the provided namespaces.
 
@@ -487,24 +550,13 @@ def eval_type(
             of `str`, it will be converted to a `ForwardRef`.
         localns: The global namespace to use during annotation evaluation.
         globalns: The local namespace to use during annotation evaluation.
-        lenient: Whether to keep unresolvable annotations as is or re-raise the `NameError` exception. Default: re-raise.
     """
-    if value is None:
-        value = NoneType
-    elif isinstance(value, str):
-        value = _make_forward_ref(value, is_argument=False, is_class=True)
-
-    try:
-        return eval_type_backport(value, globalns, localns)
-    except NameError:
-        if not lenient:
-            raise
-        # the point of this function is to be tolerant to this case
-        return value
+    value = _type_convert(value)
+    return eval_type_backport(value, globalns, localns)
 
 
 @deprecated(
-    '`eval_type_lenient` is deprecated, use `eval_type` with `lenient=True` instead.',
+    '`eval_type_lenient` is deprecated, use `try_eval_type` instead.',
     category=None,
 )
 def eval_type_lenient(
@@ -512,7 +564,8 @@ def eval_type_lenient(
     globalns: GlobalsNamespace | None = None,
     localns: MappingNamespace | None = None,
 ) -> Any:
-    return eval_type(value, globalns, localns, lenient=True)
+    ev, _ = try_eval_type(value, globalns, localns)
+    return ev
 
 
 def eval_type_backport(

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -154,6 +154,7 @@ class FieldInfo(_repr.Representation):
 
     __slots__ = (
         'annotation',
+        'evaluated',
         'default',
         'default_factory',
         'alias',
@@ -207,6 +208,7 @@ class FieldInfo(_repr.Representation):
         self._attributes_set = {k: v for k, v in kwargs.items() if v is not _Unset}
         kwargs = {k: _DefaultValues.get(k) if v is _Unset else v for k, v in kwargs.items()}  # type: ignore
         self.annotation, annotation_metadata = self._extract_metadata(kwargs.get('annotation'))
+        self.evaluated = False
 
         default = kwargs.pop('default', PydanticUndefined)
         if default is Ellipsis:
@@ -650,7 +652,7 @@ class FieldInfo(_repr.Representation):
             pydantic._internal._generics.replace_types is used for replacing the typevars with
                 their concrete types.
         """
-        annotation = _typing_extra.eval_type(self.annotation, globalns, localns, lenient=True)
+        annotation, _ = _typing_extra.try_eval_type(self.annotation, globalns, localns)
         self.annotation = _generics.replace_types(annotation, typevars_map)
 
     def __repr_args__(self) -> ReprArgs:
@@ -658,9 +660,9 @@ class FieldInfo(_repr.Representation):
         yield 'required', self.is_required()
 
         for s in self.__slots__:
-            if s == '_attributes_set':
-                continue
-            if s == 'annotation':
+            # TODO: properly make use of the protocol (https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol)
+            # By yielding a three-tuple:
+            if s in ('_attributes_set', 'annotation', 'evaluated'):
                 continue
             elif s == 'metadata' and not self.metadata:
                 continue


### PR DESCRIPTION
By adding a new `evaluated` attribute that can be set during model fields collection. Also refactor a bit the utility functions to eval such annotations.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
