### PR TITLE
Support unsubstituted type variables with both a default and a bound or constraints

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1901,11 +1901,11 @@ class GenerateSchema:
             if has_default:
                 return self.generate_schema(typevar.__default__)
 
-        if typevar.__constraints__:
-            return self._union_schema(typing.Union[typevar.__constraints__])
+        if (constraints := typevar.__constraints__):
+            return self._union_schema(typing.Union[constraints])
 
-        if typevar.__bound__:
-            schema = self.generate_schema(typevar.__bound__)
+        if (bound := typevar.__bound__):
+            schema = self.generate_schema(bound)
             schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
                 lambda x, h: h(x),
                 schema=core_schema.any_schema(),

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1901,10 +1901,10 @@ class GenerateSchema:
             if has_default:
                 return self.generate_schema(typevar.__default__)
 
-        if (constraints := typevar.__constraints__):
+        if constraints := typevar.__constraints__:
             return self._union_schema(typing.Union[constraints])
 
-        if (bound := typevar.__bound__):
+        if bound := typevar.__bound__:
             schema = self.generate_schema(bound)
             schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
                 lambda x, h: h(x),

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1899,7 +1899,7 @@ class GenerateSchema:
             pass
         else:
             if has_default:
-                return self.generate_schema(getattr(typevar, '__default__', None))
+                return self.generate_schema(typevar.__default__)
 
         if typevar.__constraints__:
             return self._union_schema(typing.Union[typevar.__constraints__])

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -110,7 +110,7 @@ def test_double_parameterize_error():
 
 
 def test_value_validation():
-    T = TypeVar('T', bound=Dict[Any, Any])
+    T = TypingExtensionsTypeVar('T', bound=Dict[Any, Any], default=Dict[Any, Any])
 
     class Response(BaseModel, Generic[T]):
         data: T
@@ -814,7 +814,7 @@ def test_partial_specification_instantiation():
 
 def test_partial_specification_instantiation_bounded():
     AT = TypeVar('AT')
-    BT = TypeVar('BT', bound=int)
+    BT = TypingExtensionsTypeVar('BT', bound=int, default=int)
 
     class Model(BaseModel, Generic[AT, BT]):
         a: AT
@@ -854,8 +854,8 @@ def test_typevar_parametrization():
         a: AT
         b: BT
 
-    CT = TypeVar('CT', bound=int)
-    DT = TypeVar('DT', bound=int)
+    CT = TypingExtensionsTypeVar('CT', bound=int, default=int)
+    DT = TypingExtensionsTypeVar('DT', bound=int, default=int)
 
     with pytest.raises(ValidationError) as exc_info:
         Model[CT, DT](a='a', b='b')
@@ -1504,7 +1504,7 @@ def test_generic_with_referenced_generic_type_bound():
 
 
 def test_generic_with_referenced_generic_union_type_bound():
-    T = TypeVar('T', bound=Union[str, int])
+    T = TypingExtensionsTypeVar('T', bound=Union[str, int], default=Union[str, int])
 
     class ModelWithType(BaseModel, Generic[T]):
         some_type: Type[T]
@@ -2367,7 +2367,7 @@ def test_construct_other_generic_model_with_validation():
 
 
 def test_generic_enum_bound():
-    T = TypeVar('T', bound=Enum)
+    T = TypingExtensionsTypeVar('T', bound=Enum, default=Enum)
 
     class MyEnum(Enum):
         a = 1
@@ -2419,13 +2419,13 @@ def test_generic_enum_bound():
 
 
 def test_generic_intenum_bound():
-    T = TypeVar('T', bound=IntEnum)
-
     class MyEnum(IntEnum):
         a = 1
 
     class OtherEnum(IntEnum):
         b = 2
+
+    T = TypingExtensionsTypeVar('T', bound=MyEnum, default=IntEnum)
 
     class Model(BaseModel, Generic[T]):
         x: T
@@ -2923,16 +2923,6 @@ def test_typevars_default_model_validation_error() -> None:
             message='We just had an error',
             details=MyErrorDetails(foo='var', bar='baz'),
         )
-
-
-def test_mix_default_and_constraints() -> None:
-    T = TypingExtensionsTypeVar('T', str, int, default=str)
-
-    msg = 'Pydantic does not support mixing more than one of TypeVar constraints and default/bound'
-    with pytest.raises(NotImplementedError, match=msg):
-
-        class _(BaseModel, Generic[T]):
-            x: T
 
 
 def test_generic_with_not_required_in_typed_dict() -> None:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -110,7 +110,7 @@ def test_double_parameterize_error():
 
 
 def test_value_validation():
-    T = TypingExtensionsTypeVar('T', bound=Dict[Any, Any], default=Dict[Any, Any])
+    T = TypeVar('T', bound=Dict[Any, Any])
 
     class Response(BaseModel, Generic[T]):
         data: T
@@ -814,7 +814,7 @@ def test_partial_specification_instantiation():
 
 def test_partial_specification_instantiation_bounded():
     AT = TypeVar('AT')
-    BT = TypingExtensionsTypeVar('BT', bound=int, default=int)
+    BT = TypeVar('BT', bound=int)
 
     class Model(BaseModel, Generic[AT, BT]):
         a: AT
@@ -854,8 +854,8 @@ def test_typevar_parametrization():
         a: AT
         b: BT
 
-    CT = TypingExtensionsTypeVar('CT', bound=int, default=int)
-    DT = TypingExtensionsTypeVar('DT', bound=int, default=int)
+    CT = TypeVar('CT', bound=int)
+    DT = TypeVar('DT', bound=int)
 
     with pytest.raises(ValidationError) as exc_info:
         Model[CT, DT](a='a', b='b')
@@ -1504,7 +1504,7 @@ def test_generic_with_referenced_generic_type_bound():
 
 
 def test_generic_with_referenced_generic_union_type_bound():
-    T = TypingExtensionsTypeVar('T', bound=Union[str, int], default=Union[str, int])
+    T = TypeVar('T', bound=Union[str, int])
 
     class ModelWithType(BaseModel, Generic[T]):
         some_type: Type[T]
@@ -2367,7 +2367,7 @@ def test_construct_other_generic_model_with_validation():
 
 
 def test_generic_enum_bound():
-    T = TypingExtensionsTypeVar('T', bound=Enum, default=Enum)
+    T = TypeVar('T', bound=Enum)
 
     class MyEnum(Enum):
         a = 1
@@ -2419,13 +2419,13 @@ def test_generic_enum_bound():
 
 
 def test_generic_intenum_bound():
+    T = TypeVar('T', bound=IntEnum)
+
     class MyEnum(IntEnum):
         a = 1
 
     class OtherEnum(IntEnum):
         b = 2
-
-    T = TypingExtensionsTypeVar('T', bound=MyEnum, default=IntEnum)
 
     class Model(BaseModel, Generic[T]):
         x: T
@@ -2773,7 +2773,7 @@ def test_serialize_unsubstituted_typevars_bound_default_supported() -> None:
 @pytest.mark.parametrize(
     'type_var',
     [
-        TypingExtensionsTypeVar('ErrorDataT', default=BaseModel, bound=BaseModel),
+        TypingExtensionsTypeVar('ErrorDataT', default=BaseModel),
         TypeVar('ErrorDataT', BaseModel, str),
     ],
     ids=['default', 'constraint'],
@@ -2846,11 +2846,11 @@ def test_serialize_typevars_default_and_bound_with_user_model() -> None:
     class MoreExtendedMyErrorDetails(ExtendedMyErrorDetails):
         suu: str
 
-    type_var = TypingExtensionsTypeVar('type_var', bound=MyErrorDetails, default=ExtendedMyErrorDetails)
+    T = TypingExtensionsTypeVar('T', bound=MyErrorDetails, default=ExtendedMyErrorDetails)
 
-    class Error(BaseModel, Generic[type_var]):
+    class Error(BaseModel, Generic[T]):
         message: str
-        details: type_var
+        details: T
 
     # bound small parent model
     sample_error = Error[MyErrorDetails](
@@ -2912,11 +2912,11 @@ def test_typevars_default_model_validation_error() -> None:
     class ExtendedMyErrorDetails(MyErrorDetails):
         foo: str
 
-    type_var = TypingExtensionsTypeVar('type_var', bound=MyErrorDetails, default=ExtendedMyErrorDetails)
+    T = TypingExtensionsTypeVar('T', bound=MyErrorDetails, default=ExtendedMyErrorDetails)
 
-    class Error(BaseModel, Generic[type_var]):
+    class Error(BaseModel, Generic[T]):
         message: str
-        details: type_var
+        details: T
 
     with pytest.raises(ValidationError):
         Error(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add support for Bound and Default together in TypeVar:
```py
from pydantic import BaseModel

class MyBaseModel(BaseModel):
    field: str

class ExtendedBaseModel(MyBaseModel):
    another_field: str

T = TypeVar('T', bound=MyBaseModel, default=ExtendedBaseModel)
```

## Related issue number
fixes #9418 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle