### PR TITLE
add `bytearray` to `TypeAdapter.validate_json` signature

### DIFF
--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -365,7 +365,7 @@ class TypeAdapter(Generic[T]):
     @_frame_depth(1)
     def validate_json(
         self,
-        data: str | bytes,
+        data: str | bytes | bytearray,
         /,
         *,
         strict: bool | None = None,


### PR DESCRIPTION
This matches the signature of `validate_json` on `SchemaValidator`.