### PR TITLE
Fix bug in __get_attr__ where properties are inaccessible when pydantic_extra is populated

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -878,7 +878,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 except AttributeError:
                     pydantic_extra = None
 
-                if pydantic_extra:
+                if pydantic_extra and item in pydantic_extra:
                     try:
                         return pydantic_extra[item]
                     except KeyError as exc:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -879,10 +879,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                     pydantic_extra = None
 
                 if pydantic_extra and item in pydantic_extra:
-                    try:
-                        return pydantic_extra[item]
-                    except KeyError as exc:
-                        raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
+                    return pydantic_extra[item]
                 else:
                     if hasattr(self.__class__, item):
                         return super().__getattribute__(item)  # Raises AttributeError if appropriate

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import List, Union
 
 import pytest
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -149,24 +149,24 @@ def test_computed_field_raises_correct_attribute_error():
 def test_property_visible_when_extra_present():
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow')
-    
+
         columns: List[str]
-    
+
         @property
         def queried_columns(self) -> List[str]:
             return [c for c in self.columns if c.startswith('query')]
-    
-    
+
+
     class SubModel(Model):
         pass
-    
-    
+
+
     instance = SubModel.model_validate(
         dict(
             columns=['query_1', 'query_2', 'other'],
             test='extra_value',
         ))
-    
+
     assert instance.queried_columns == ['query_1', 'query_2']
     assert instance.__getattribute__('queried_columns') == ['query_1', 'query_2']
     assert instance.__getattr__('queried_columns') == ['query_1', 'query_2']

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, List
 
 import pytest
 
@@ -149,14 +149,27 @@ def test_computed_field_raises_correct_attribute_error():
 def test_property_visible_when_extra_present():
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow')
-
+    
+        columns: List[str]
+    
         @property
-        def test_prop(self) -> str:
-            return 'test'
-
-    instance = Model.model_validate({'extra': 'extra_value'})
-
-    assert instance.test_prop == 'test'
+        def queried_columns(self) -> List[str]:
+            return [c for c in self.columns if c.startswith('query')]
+    
+    
+    class SubModel(Model):
+        pass
+    
+    
+    instance = SubModel.model_validate(
+        dict(
+            columns=['query_1', 'query_2', 'other'],
+            test='extra_value',
+        ))
+    
+    assert instance.queried_columns == ['query_1', 'query_2']
+    assert instance.__getattribute__('queried_columns') == ['query_1', 'query_2']
+    assert instance.__getattr__('queried_columns') == ['query_1', 'query_2']
 
 
 @pytest.mark.parametrize('number', (1, 42, 443, 11.11, 0.553))

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -158,6 +158,7 @@ def test_property_visible_when_extra_present():
 
     assert instance.test_prop == 'test'
 
+
 @pytest.mark.parametrize('number', (1, 42, 443, 11.11, 0.553))
 def test_coerce_numbers_to_str_field_option(number):
     class Model(BaseModel):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -146,6 +146,18 @@ def test_computed_field_raises_correct_attribute_error():
         Model().invalid_field
 
 
+def test_property_visible_when_extra_present():
+    class Model(BaseModel):
+        model_config = ConfigDict(extra='allow')
+
+        @property
+        def test_prop(self) -> str:
+            return 'test'
+    
+    instance = Model.model_validate({'extra': 'extra_value'})
+
+    assert instance.test_prop == 'test'
+
 @pytest.mark.parametrize('number', (1, 42, 443, 11.11, 0.553))
 def test_coerce_numbers_to_str_field_option(number):
     class Model(BaseModel):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -153,7 +153,7 @@ def test_property_visible_when_extra_present():
         @property
         def test_prop(self) -> str:
             return 'test'
-    
+
     instance = Model.model_validate({'extra': 'extra_value'})
 
     assert instance.test_prop == 'test'

--- a/uv.lock
+++ b/uv.lock
@@ -1314,7 +1314,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.0a1"
+version = "2.10.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## Change Summary
Fixes an issue where `__get_attr__` for `BaseModel` prioritizes `pydantic_extra` over general attributes resulting in an inability to access class properties when any extra fields are present.

The fix is to only prioritize `pydantic_extra` if the attribute name is actually present in the extra keys; otherwise, just go straight to attempting to access the attribute with `getattr()`

## Related issue number
fix #9862

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
