### PR TITLE
Ensure class access of method descriptors is performed when used as a default with `Field`

### DIFF
--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from enum import Enum, auto
 from typing import (
     Any,
+    Callable,
     Dict,
     ForwardRef,
     FrozenSet,
@@ -2889,3 +2890,13 @@ class A(BaseModel):
     )
     A = globs['A']
     assert A(a=1).a == 1
+
+
+def test_method_descriptors_default() -> None:
+    class SomeModel(BaseModel):
+        @staticmethod
+        def default_int_factory() -> int: ...
+
+        int_factory: Callable[[], int] = Field(default=default_int_factory)
+
+    assert SomeModel.model_fields['int_factory'].default is SomeModel.default_int_factory


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10551

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
