### PR TITLE
Make `__signature__` a lazy property, do not deepcopy defaults

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -146,7 +146,8 @@ def complete_dataclass(
     sig = generate_pydantic_signature(
         init=original_init,
         fields=cls.__pydantic_fields__,  # type: ignore
-        config_wrapper=config_wrapper,
+        populate_by_name=config_wrapper.populate_by_name,
+        extra=config_wrapper.extra,
         is_dataclass=True,
     )
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -694,7 +694,8 @@ def complete_model_class(
             generate_pydantic_signature,
             init=cls.__init__,
             fields=cls.__pydantic_fields__,
-            config_wrapper=config_wrapper,
+            populate_by_name=config_wrapper.populate_by_name,
+            extra=config_wrapper.extra,
         ),
     )
     return True

--- a/pydantic/_internal/_signature.py
+++ b/pydantic/_internal/_signature.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic_core import PydanticUndefined
 
-from ._config import ConfigWrapper
 from ._utils import is_valid_identifier
 
 if TYPE_CHECKING:
+    from ..config import ExtraValues
     from ..fields import FieldInfo
 
 
@@ -80,7 +80,8 @@ def _process_param_defaults(param: Parameter) -> Parameter:
 def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use a refactor)
     init: Callable[..., None],
     fields: dict[str, FieldInfo],
-    config_wrapper: ConfigWrapper,
+    populate_by_name: bool,
+    extra: ExtraValues | None,
 ) -> dict[str, Parameter]:
     """Generate a mapping of parameter names to Parameter objects for a pydantic BaseModel or dataclass."""
     from itertools import islice
@@ -106,7 +107,7 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
         merged_params[param.name] = param
 
     if var_kw:  # if custom init has no var_kw, fields which are not declared in it cannot be passed through
-        allow_names = config_wrapper.populate_by_name
+        allow_names = populate_by_name
         for field_name, field in fields.items():
             # when alias is a str it should be used for signature generation
             param_name = _field_name_for_signature(field_name, field)
@@ -135,7 +136,7 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
                 default=default,
             )
 
-    if config_wrapper.extra == 'allow':
+    if extra == 'allow':
         use_var_kw = True
 
     if var_kw and use_var_kw:
@@ -161,20 +162,25 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
 
 
 def generate_pydantic_signature(
-    init: Callable[..., None], fields: dict[str, FieldInfo], config_wrapper: ConfigWrapper, is_dataclass: bool = False
+    init: Callable[..., None],
+    fields: dict[str, FieldInfo],
+    populate_by_name: bool,
+    extra: ExtraValues | None,
+    is_dataclass: bool = False,
 ) -> Signature:
     """Generate signature for a pydantic BaseModel or dataclass.
 
     Args:
         init: The class init.
         fields: The model fields.
-        config_wrapper: The config wrapper instance.
+        populate_by_name: The `populate_by_name` value of the config.
+        extra: The `extra` value of the config.
         is_dataclass: Whether the model is a dataclass.
 
     Returns:
         The dataclass/BaseModel subclass signature.
     """
-    merged_params = _generate_signature_parameters(init, fields, config_wrapper)
+    merged_params = _generate_signature_parameters(init, fields, populate_by_name, extra)
 
     if is_dataclass:
         merged_params = {k: _process_param_defaults(v) for k, v in merged_params.items()}

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -299,23 +299,23 @@ class ValueItems(_repr.Representation):
 
 if typing.TYPE_CHECKING:
 
-    def LazyClassAttribute(name: str, value_fetcher: Callable[[], T]) -> T: ...
+    def LazyClassAttribute(name: str, get_value: Callable[[], T]) -> T: ...
 
 else:
 
     class LazyClassAttribute:
-        """A descriptor exposing an attribute only on class access.
+        """A descriptor exposing an attribute only accessible on a class (hidden from instances).
 
         The attribute is lazily computed and cached during the first access.
         """
 
-        def __init__(self, name: str, value_fetcher: Callable[[], Any]) -> None:
+        def __init__(self, name: str, get_value: Callable[[], Any]) -> None:
             self.name = name
-            self.value_fetcher = value_fetcher
+            self.get_value = get_value
 
         @cached_property
         def value(self) -> Any:
-            return self.value_fetcher()
+            return self.get_value()
 
         def __get__(self, instance: Any, owner: type[Any]) -> None:
             if instance is None:

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -25,11 +25,12 @@ def test_model_signature():
     class Model(BaseModel):
         a: float = Field(title='A')
         b: int = Field(10)
+        c: int = Field(default_factory=lambda: 1)
 
     sig = signature(Model)
     assert sig != signature(BaseModel)
-    assert _equals(map(str, sig.parameters.values()), ('a: float', 'b: int = 10'))
-    assert _equals(str(sig), '(*, a: float, b: int = 10) -> None')
+    assert _equals(map(str, sig.parameters.values()), ('a: float', 'b: int = 10', 'c: int = <factory>'))
+    assert _equals(str(sig), '(*, a: float, b: int = 10, c: int = <factory>) -> None')
 
 
 def test_generic_model_signature():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ from pydantic._internal._core_utils import _WalkCoreSchema, pretty_print_core_sc
 from pydantic._internal._typing_extra import get_origin, is_new_type, literal_values
 from pydantic._internal._utils import (
     BUILTIN_COLLECTIONS,
-    ClassAttribute,
+    LazyClassAttribute,
     ValueItems,
     all_identical,
     deep_update,
@@ -368,7 +368,7 @@ def test_undefined_copy():
 
 def test_class_attribute():
     class Foo:
-        attr = ClassAttribute('attr', 'foo')
+        attr = LazyClassAttribute('attr', lambda: 'foo')
 
     assert Foo.attr == 'foo'
 


### PR DESCRIPTION
Also follow stdlib dataclasses for signature parameter defaults. If a default factory is used, the placeholder `'<factory>'` is used.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/10771, https://github.com/pydantic/pydantic/issues/10656

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
