### PR TITLE
Parametrize + check imports in various ways

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -12,9 +12,16 @@ import pydantic
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_init_export():
-    for name in dir(pydantic):
-        getattr(pydantic, name)
+@pytest.mark.parametrize('attr', dir(pydantic))
+def test_init_export(attr) -> None:
+    getattr(pydantic, attr)
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.mark.parametrize('attr', dir(pydantic))
+def test_init_export_direct_import(create_module, attr) -> None:
+    module = create_module(f'from pydantic import {attr}')
+    assert hasattr(module, attr)
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -14,12 +14,14 @@ import pydantic
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('attr', dir(pydantic))
 def test_init_export(attr) -> None:
+    pydantic = importlib.reload(importlib.import_module('pydantic'))
     getattr(pydantic, attr)
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('attr', dir(pydantic))
 def test_init_export_direct_import(create_module, attr) -> None:
+    del sys.modules['pydantic']
     module = create_module(f'from pydantic import {attr}')
     assert hasattr(module, attr)
 


### PR DESCRIPTION
@Viicos, following up on https://github.com/pydantic/pydantic/pull/10807#issuecomment-2469015214.

That being said, I don't think this actually does quite what we want... I can't get this to repro on `v2.10.0b1` with `from pydantic import validate_call`

We can chat about this tomorrow morning 👍 