### PR TITLE
Use standardized factory for `MockCoreSchema` and `MockValSer` generation

### DIFF
--- a/pydantic/_internal/_mock_val_ser.py
+++ b/pydantic/_internal/_mock_val_ser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Generic, Iterator, Mapping, TypeVar, Union
+from functools import partial
+from typing import TYPE_CHECKING, Any, Callable, Generic, Iterator, Mapping, TypeAlias, TypeVar, Union
 
 from pydantic_core import CoreSchema, SchemaSerializer, SchemaValidator
 from typing_extensions import Literal
@@ -13,9 +14,8 @@ if TYPE_CHECKING:
     from ..main import BaseModel
     from ..type_adapter import TypeAdapter
 
-
-ValSer = TypeVar('ValSer', bound=Union[SchemaValidator, PluggableSchemaValidator, SchemaSerializer])
-T = TypeVar('T')
+ValidatorOrSerializer: TypeAlias = Union[SchemaValidator, PluggableSchemaValidator, SchemaSerializer]
+ValSer = TypeVar('ValSer', bound=ValidatorOrSerializer)
 
 
 class MockCoreSchema(Mapping[str, Any]):
@@ -109,6 +109,62 @@ class MockValSer(Generic[ValSer]):
         return None
 
 
+MockContainer = TypeVar('MockContainer', bound=type[BaseModel] | TypeAdapter | type[PydanticDataclass])
+RebuildReturnType = TypeVar('RebuildReturnType', bound=CoreSchema | ValidatorOrSerializer)
+
+
+class MockFactory(Generic[MockContainer]):
+    """Factory for creating `MockCoreSchema`, `MockValSer` and `MockValSer` instances for a given type."""
+
+    __slots__ = '_obj', '_error_message', '_rebuild'
+
+    def __init__(
+        self,
+        obj: MockContainer,
+        error_message: str,
+        rebuild: Callable[[MockContainer], Callable[..., bool | None]],
+    ) -> None:
+        self._obj = obj
+        self._error_message = error_message
+        self._rebuild = rebuild
+
+    def _attempt_rebuild_fn(
+        self, attr_fn: Callable[[MockContainer], RebuildReturnType | None]
+    ) -> Callable[[], RebuildReturnType | None]:
+        def handler() -> RebuildReturnType | None:
+            if self._rebuild(self._obj)(_parent_namespace_depth=5) is not False:
+                return attr_fn(self._obj)
+            else:
+                return None
+
+        return handler
+
+    def mock_core_schema(self, attr_fn: Callable[[MockContainer], CoreSchema | None]) -> MockCoreSchema:
+        return MockCoreSchema(
+            self._error_message,
+            code='class-not-fully-defined',
+            attempt_rebuild=self._attempt_rebuild_fn(attr_fn),
+        )
+
+    def mock_schema_validator(
+        self, attr_fn: Callable[[MockContainer], SchemaValidator | PluggableSchemaValidator | None]
+    ) -> MockValSer:
+        return MockValSer(
+            self._error_message,
+            code='class-not-fully-defined',
+            val_or_ser='validator',
+            attempt_rebuild=self._attempt_rebuild_fn(attr_fn),
+        )
+
+    def mock_schema_serializer(self, attr_fn: Callable[[MockContainer], SchemaSerializer | None]) -> MockValSer:
+        return MockValSer(
+            self._error_message,
+            code='class-not-fully-defined',
+            val_or_ser='serializer',
+            attempt_rebuild=self._attempt_rebuild_fn(attr_fn),
+        )
+
+
 def set_type_adapter_mocks(adapter: TypeAdapter, type_repr: str) -> None:
     """Set `core_schema`, `validator` and `serializer` to mock core types on a type adapter instance.
 
@@ -116,37 +172,17 @@ def set_type_adapter_mocks(adapter: TypeAdapter, type_repr: str) -> None:
         adapter: The type adapter instance to set the mocks on
         type_repr: Name of the type used in the adapter, used in error messages
     """
-    undefined_type_error_message = (
-        f'`TypeAdapter[{type_repr}]` is not fully defined; you should define `{type_repr}` and all referenced types,'
-        f' then call `.rebuild()` on the instance.'
+    mock_factory = MockFactory[TypeAdapter](
+        obj=adapter,
+        error_message=(
+            f'`TypeAdapter[{type_repr}]` is not fully defined; you should define `{type_repr}` and all referenced types,'
+            f' then call `.rebuild()` on the instance.'
+        ),
+        rebuild=lambda ta: partial(ta.rebuild, raise_errors=False),
     )
-
-    def attempt_rebuild_fn(attr_fn: Callable[[TypeAdapter], T]) -> Callable[[], T | None]:
-        def handler() -> T | None:
-            if adapter.rebuild(_parent_namespace_depth=5) is not False:
-                return attr_fn(adapter)
-            else:
-                return None
-
-        return handler
-
-    adapter.core_schema = MockCoreSchema(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        attempt_rebuild=attempt_rebuild_fn(lambda ta: ta.core_schema),
-    )
-    adapter.validator = MockValSer(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        val_or_ser='validator',
-        attempt_rebuild=attempt_rebuild_fn(lambda ta: ta.validator),
-    )
-    adapter.serializer = MockValSer(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        val_or_ser='serializer',
-        attempt_rebuild=attempt_rebuild_fn(lambda ta: ta.serializer),
-    )
+    adapter.core_schema = mock_factory.mock_core_schema(attr_fn=lambda ta: ta.core_schema)  # pyright: ignore[reportAttributeAccessIssue]
+    adapter.validator = mock_factory.mock_schema_validator(attr_fn=lambda ta: ta.validator)  # pyright: ignore[reportAttributeAccessIssue]
+    adapter.serializer = mock_factory.mock_schema_serializer(attr_fn=lambda ta: ta.serializer)  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = 'all referenced types') -> None:
@@ -157,37 +193,18 @@ def set_model_mocks(cls: type[BaseModel], cls_name: str, undefined_name: str = '
         cls_name: Name of the model class, used in error messages
         undefined_name: Name of the undefined thing, used in error messages
     """
-    undefined_type_error_message = (
-        f'`{cls_name}` is not fully defined; you should define {undefined_name},'
-        f' then call `{cls_name}.model_rebuild()`.'
+    mock_factory = MockFactory[type[BaseModel]](
+        obj=cls,
+        error_message=(
+            f'`{cls_name}` is not fully defined; you should define {undefined_name},'
+            f' then call `{cls_name}.model_rebuild()`.'
+        ),
+        rebuild=lambda c: partial(c.model_rebuild, raise_errors=False),
     )
 
-    def attempt_rebuild_fn(attr_fn: Callable[[type[BaseModel]], T]) -> Callable[[], T | None]:
-        def handler() -> T | None:
-            if cls.model_rebuild(raise_errors=False, _parent_namespace_depth=5) is not False:
-                return attr_fn(cls)
-            else:
-                return None
-
-        return handler
-
-    cls.__pydantic_core_schema__ = MockCoreSchema(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_core_schema__),
-    )
-    cls.__pydantic_validator__ = MockValSer(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        val_or_ser='validator',
-        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_validator__),
-    )
-    cls.__pydantic_serializer__ = MockValSer(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        val_or_ser='serializer',
-        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_serializer__),
-    )
+    cls.__pydantic_core_schema__ = mock_factory.mock_core_schema(attr_fn=lambda c: c.__pydantic_core_schema__)  # pyright: ignore[reportAttributeAccessIssue]
+    cls.__pydantic_validator__ = mock_factory.mock_schema_validator(attr_fn=lambda c: c.__pydantic_validator__)  # pyright: ignore[reportAttributeAccessIssue]
+    cls.__pydantic_serializer__ = mock_factory.mock_schema_serializer(attr_fn=lambda c: c.__pydantic_serializer__)  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def set_dataclass_mocks(
@@ -202,34 +219,15 @@ def set_dataclass_mocks(
     """
     from ..dataclasses import rebuild_dataclass
 
-    undefined_type_error_message = (
-        f'`{cls_name}` is not fully defined; you should define {undefined_name},'
-        f' then call `pydantic.dataclasses.rebuild_dataclass({cls_name})`.'
+    mock_factory = MockFactory[type[PydanticDataclass]](
+        obj=cls,
+        error_message=(
+            f'`{cls_name}` is not fully defined; you should define {undefined_name},'
+            f' then call `pydantic.dataclasses.rebuild_dataclass({cls_name})`.'
+        ),
+        rebuild=lambda c: partial(rebuild_dataclass, cls=c, raise_errors=False),
     )
 
-    def attempt_rebuild_fn(attr_fn: Callable[[type[PydanticDataclass]], T]) -> Callable[[], T | None]:
-        def handler() -> T | None:
-            if rebuild_dataclass(cls, raise_errors=False, _parent_namespace_depth=5) is not False:
-                return attr_fn(cls)
-            else:
-                return None
-
-        return handler
-
-    cls.__pydantic_core_schema__ = MockCoreSchema(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_core_schema__),
-    )
-    cls.__pydantic_validator__ = MockValSer(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        val_or_ser='validator',
-        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_validator__),
-    )
-    cls.__pydantic_serializer__ = MockValSer(  # pyright: ignore[reportAttributeAccessIssue]
-        undefined_type_error_message,
-        code='class-not-fully-defined',
-        val_or_ser='serializer',
-        attempt_rebuild=attempt_rebuild_fn(lambda c: c.__pydantic_serializer__),
-    )
+    cls.__pydantic_core_schema__ = mock_factory.mock_core_schema(attr_fn=lambda c: c.__pydantic_core_schema__)  # pyright: ignore[reportAttributeAccessIssue]
+    cls.__pydantic_validator__ = mock_factory.mock_schema_validator(attr_fn=lambda c: c.__pydantic_validator__)  # pyright: ignore[reportAttributeAccessIssue]
+    cls.__pydantic_serializer__ = mock_factory.mock_schema_serializer(attr_fn=lambda c: c.__pydantic_serializer__)  # pyright: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
I find this easier to understand / the reduced repetition here feels nice, but I'm curious to hear what others think.

cc @Viicos, @MarkusSintonen

Contributing to https://github.com/pydantic/pydantic/issues/10831