### PR TITLE
Mark `Final` members as class variables for mypy

### DIFF
--- a/tests/typechecking/root_model.py
+++ b/tests/typechecking/root_model.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 from typing_extensions import assert_type
 
 from pydantic import RootModel
@@ -17,3 +19,8 @@ class StrRootModel(RootModel[str]):
 str_root_model = StrRootModel(root='a')
 
 assert_type(str_root_model.root, str)
+
+
+class A(RootModel[str]):
+    # `a` is final and thus should not be considered to be a field of this root model
+    a: Final = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Mark `Final` members as class variables for mypy so that mypy does not mistake them as fields.

The main change is in line 758 where we also check if a node is a `Final`. I moved this check a bit behind so that type inference for `Final`s without type annotations is still performed when necessary.

A side note: I thought about why `Final` nodes are considered model fields as per the current implementation, but I cannot really figure out what kind of cases this handles. I played with a few different scenarios and mypy could catch type mismatch with changes in this PR, so I suppose this PR won't break anything, but I'm not completely sure if I missed out anything.

## Related issue number

Fixes #10474.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle