### PR TITLE
Improve `__setattr__` performance of Pydantic models by caching setter functions

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -152,6 +152,8 @@ class ModelMetaclass(ABCMeta):
                 None if cls.model_post_init is BaseModel_.model_post_init else 'model_post_init'
             )
 
+            cls.__pydantic_setattr_handlers__ = {}
+
             cls.__pydantic_decorators__ = DecoratorInfos.build(cls)
 
             # Use the getattr below to grab the __parameters__ from the `typing.Generic` parent class

--- a/tests/benchmarks/test_attribute_access.py
+++ b/tests/benchmarks/test_attribute_access.py
@@ -1,0 +1,84 @@
+from functools import cached_property
+
+import pytest
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+class InnerValidateAssignment(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+    inner_field1: str
+    inner_field2: int
+
+
+class Model(BaseModel):
+    field1: str
+    field2: int
+    field3: float
+    inner1: InnerValidateAssignment
+    inner2: InnerValidateAssignment
+
+    _private_field1: str
+    _private_field2: int
+    _private_field3: float
+
+    @cached_property
+    def prop_cached1(self) -> str:
+        return self.field1 + self._private_field1
+
+    @cached_property
+    def prop_cached2(self) -> int:
+        return self.field2 + self._private_field2
+
+    @cached_property
+    def prop_cached3(self) -> float:
+        return self.field3 + self._private_field3
+
+
+def test_setattr(benchmark):
+    def set_attrs(m):
+        m.field1 = 'test1'
+        m.field2 = 43
+        m.field3 = 4.0
+        m.inner1.inner_field1 = 'test inner1'
+        m.inner1.inner_field2 = 421
+        m.inner2.inner_field1 = 'test inner2'
+        m.inner2.inner_field2 = 422
+        m._private_field1 = 'test2'
+        m._private_field2 = 44
+        m._private_field3 = 5.1
+        m.prop_cached1 = 'cache override'
+        m.prop_cached2 = 10
+        m.prop_cached3 = 10.1
+
+    inner = {'inner_field1': 'test inner', 'inner_field2': 420}
+    model = Model(field1='test', field2=42, field3=3.14, inner1=inner, inner2=inner)
+    benchmark(set_attrs, model)
+
+    model.field2 = 'bad'  # check benchmark setup
+    with pytest.raises(ValidationError):
+        model.inner1.field2 = 'bad'
+
+
+def test_getattr(benchmark):
+    def get_attrs(m):
+        _ = m.field1
+        _ = m.field2
+        _ = m.field3
+        _ = m.inner1.inner_field1
+        _ = m.inner1.inner_field2
+        _ = m.inner2.inner_field1
+        _ = m.inner2.inner_field2
+        _ = m._private_field1
+        _ = m._private_field2
+        _ = m._private_field3
+        _ = m.prop_cached1
+        _ = m.prop_cached2
+        _ = m.prop_cached3
+
+    inner = {'inner_field1': 'test inner', 'inner_field2': 420}
+    model = Model(field1='test1', field2=42, field3=3.14, inner1=inner, inner2=inner)
+    model._private_field1 = 'test2'
+    model._private_field2 = 43
+    model._private_field3 = 4.14
+    benchmark(get_attrs, model)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2909,9 +2909,6 @@ def test_setattr_handler_memo_does_not_inherit() -> None:
     class Model2(Model1):
         a: int
 
-    assert not Model1.__pydantic_setattr_handlers__
-    assert not Model2.__pydantic_setattr_handlers__
-
     m1 = Model1(a=1)
     m2 = Model2(a=10)
 
@@ -2927,3 +2924,44 @@ def test_setattr_handler_memo_does_not_inherit() -> None:
     assert 'a' in Model1.__pydantic_setattr_handlers__
     assert Model1.__pydantic_setattr_handlers__['a'] is not handler2
     assert Model2.__pydantic_setattr_handlers__['a'] is handler2
+
+
+def test_setattr_handler_does_not_memoize_unknown_field() -> None:
+    class Model(BaseModel):
+        a: int
+
+    m = Model(a=1)
+    with pytest.raises(ValueError, match='object has no field "unknown"'):
+        m.unknown = 'x'
+    assert not Model.__pydantic_setattr_handlers__
+    m.a = 2
+    assert 'a' in Model.__pydantic_setattr_handlers__
+
+
+def test_setattr_handler_does_not_memoize_unknown_private_field() -> None:
+    class Model(BaseModel):
+        a: int
+        _p: str
+
+    m = Model(a=1)
+    assert not Model.__pydantic_setattr_handlers__
+    m.a = 2
+    assert len(Model.__pydantic_setattr_handlers__) == 1
+    m._unknown = 'x'
+    assert len(Model.__pydantic_setattr_handlers__) == 1
+    m._p = 'y'
+    assert len(Model.__pydantic_setattr_handlers__) == 2
+
+
+def test_setattr_handler_does_not_memoize_on_validate_assignment_field_failure() -> None:
+    class Model(BaseModel, validate_assignment=True):
+        a: int
+
+    m = Model(a=1)
+    with pytest.raises(ValidationError):
+        m.unknown = 'x'
+    with pytest.raises(ValidationError):
+        m.a = 'y'
+    assert not Model.__pydantic_setattr_handlers__
+    m.a = 2
+    assert 'a' in Model.__pydantic_setattr_handlers__

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2922,8 +2922,9 @@ def test_setattr_handler_memo_does_not_inherit() -> None:
 
     m1.a = 2
     assert 'a' in Model1.__pydantic_setattr_handlers__
-    assert Model1.__pydantic_setattr_handlers__['a'] is not handler2
+    assert Model1.__pydantic_setattr_handlers__['a'] is handler2
     assert Model2.__pydantic_setattr_handlers__['a'] is handler2
+    assert m1.a == 2 and m2.a == 11
 
 
 def test_setattr_handler_does_not_memoize_unknown_field() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -735,8 +735,12 @@ def test_validating_assignment_pass(ValidateAssignmentModel):
     assert p.model_dump() == {'a': 2, 'b': 'hi'}
 
 
-def test_validating_assignment_fail(ValidateAssignmentModel):
+@pytest.mark.parametrize('init_valid', [False, True])
+def test_validating_assignment_fail(ValidateAssignmentModel, init_valid: bool):
     p = ValidateAssignmentModel(a=5, b='hello')
+    if init_valid:
+        p.a = 5
+        p.b = 'hello'
 
     with pytest.raises(ValidationError) as exc_info:
         p.a = 'b'


### PR DESCRIPTION
## Change Summary

Attribute setting has been pretty slow for `BaseModel` due to the extensive checks it has been doing for every `__setattr__` call. PR improves performance of `__setattr__` by memoizing the attribute specific handlers to the model class. This makes the attribute assigning some 7x faster. Also add missing benchmarks for attribute usage.

```python
from timeit import timeit
from pydantic import BaseModel

class Model(BaseModel):
    field: int

model = Model(field=1)

def run():
    model.field = 2

# Before 1.048
# After 0.147
print(timeit(run, number=1000000))
```

## Related issue number

fix https://github.com/pydantic/pydantic/issues/10853

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle