### PR TITLE
Consolidating shared get / mock core schema logic

### DIFF
--- a/pydantic/_internal/_mock_val_ser.py
+++ b/pydantic/_internal/_mock_val_ser.py
@@ -109,15 +109,17 @@ class MockValSer(Generic[ValSer]):
         return None
 
 
-def set_type_adapter_mocks(adapter: TypeAdapter) -> None:
+def set_type_adapter_mocks(adapter: TypeAdapter, undefined_name: str | None = None) -> None:
     """Set `core_schema`, `validator` and `serializer` to mock core types on a type adapter instance.
 
     Args:
-        adapter: The type adapter instance to set the mocks on
+        adapter: The type adapter instance on which to set the mocks
+        undefined_name: Name of the undefined thing, used in error messages
     """
-    type_repr = str(adapter._type)
+    if undefined_name is None:
+        undefined_name = str(adapter._type)
     undefined_type_error_message = (
-        f'`TypeAdapter[{type_repr}]` is not fully defined; you should define `{type_repr}` and all referenced types,'
+        f'`{adapter!r}` is not fully defined; you should define `{undefined_name}` and all referenced types,'
         f' then call `.rebuild()` on the instance.'
     )
 

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -159,7 +159,7 @@ def get_schema_or_set_mocks(
                 ),
             )
         else:
-            schema = gen_schema.generate_schema(schema_type, from_dunder_get_core_schema=False)
+            schema = gen_schema.generate_schema(schema_type, from_dunder_get_core_schema=True)
     except PydanticUndefinedAnnotation as e:
         if raise_errors:
             raise
@@ -171,3 +171,5 @@ def get_schema_or_set_mocks(
     except gen_schema.CollectedInvalid:
         set_mocks(schema_container)
         return None
+
+    return schema

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -26,6 +26,7 @@ from ._internal import (
     _generate_schema,
     _mock_val_ser,
     _namespace_utils,
+    _repr,
     _schema_generation_shared,
     _typing_extra,
     _utils,

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -288,6 +288,8 @@ class TypeAdapter(Generic[T]):
             if schema is None:
                 return False
 
+            self.core_schema = schema
+
             core_config = config_wrapper.core_config(None)
 
             self.validator = create_schema_validator(


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10831

Share logic across `BaseModel`s, `dataclass`es, and `TypeAdapter` instances for generating (and potentially setting mocks for) core schema.

@MarkusSintonen suggested we consolidate these in [this comment](https://github.com/pydantic/pydantic/pull/10537#discussion_r1840587129)