### PR TITLE
Update timedelta docs with correct spec

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -135,7 +135,7 @@ print(m.model_dump())
     * `timedelta`; an existing `timedelta` object
     * `int` or `float`; assumed to be seconds
     * `str`; the following formats are accepted:
-        * `[-][DD]D[,][HH:MM:]SS[.ffffff]`
+        * `[-][[DD]D,]HH:MM:SS[.ffffff]`
             * Ex: `'1d,01:02:03.000004'` or `'1D01:02:03.000004'` or `'01:02:03'`
         * `[±]P[DD]DT[HH]H[MM]M[SS]S` ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format for timedelta)
 


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10829

Day spec is optional, hence the additional brackets