### PR TITLE
make `AwareDatetime` and `NaiveDatetime` subclass of `datetime`

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1086,7 +1086,7 @@ if TYPE_CHECKING:
 
 else:
 
-    class AwareDatetime:
+    class AwareDatetime(datetime):
         """A datetime that requires timezone info."""
 
         @classmethod
@@ -1105,7 +1105,7 @@ else:
         def __repr__(self) -> str:
             return 'AwareDatetime'
 
-    class NaiveDatetime:
+    class NaiveDatetime(datetime):
         """A datetime that doesn't require timezone info."""
 
         @classmethod

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -44,12 +44,12 @@ def past_datetime_type(request):
     return request.param
 
 
-@pytest.fixture(scope='module', params=[AwareDatetime, Annotated[datetime, AwareDatetime()]])
+@pytest.fixture(scope='module', params=[AwareDatetime, Annotated[datetime, AwareDatetime(year=1)]])
 def aware_datetime_type(request):
     return request.param
 
 
-@pytest.fixture(scope='module', params=[NaiveDatetime, Annotated[datetime, NaiveDatetime()]])
+@pytest.fixture(scope='module', params=[NaiveDatetime, Annotated[datetime, NaiveDatetime(year=1)]])
 def naive_datetime_type(request):
     return request.param
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -44,12 +44,12 @@ def past_datetime_type(request):
     return request.param
 
 
-@pytest.fixture(scope='module', params=[AwareDatetime, Annotated[datetime, AwareDatetime(year=1)]])
+@pytest.fixture(scope='module', params=[AwareDatetime, Annotated[datetime, AwareDatetime(year=1, month=1, day=1)]])
 def aware_datetime_type(request):
     return request.param
 
 
-@pytest.fixture(scope='module', params=[NaiveDatetime, Annotated[datetime, NaiveDatetime(year=1)]])
+@pytest.fixture(scope='module', params=[NaiveDatetime, Annotated[datetime, NaiveDatetime(year=1, month=1, day=1)]])
 def naive_datetime_type(request):
     return request.param
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

this doesn't change behavior of validation but a DX improvement for pycharm.

pycharm's lsp doesn't consider AwareDatetime/Naive is subclass of datetime and raise warning about it when interactiving with datetime or timedelta.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
