### PR TITLE
Consistency with "```python" rather than "```py"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ see the [Install](https://docs.pydantic.dev/install/) section in the documentati
 
 ## A Simple Example
 
-```py
+```python
 from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -21,7 +21,7 @@ A standard `bool` field will raise a `ValidationError` if the value is not one o
 
 Here is a script demonstrating some of these behaviors:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -63,7 +63,7 @@ types:
         * `int` or `float` as a string (assumed as Unix time)
     * [`datetime.date`][] instances are accepted in lax mode, but not in strict mode
 
-```py
+```python
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -90,7 +90,7 @@ print(event.model_dump())
         * `YYYY-MM-DD`
         * `int` or `float` as a string (assumed as Unix time)
 
-```py
+```python
 from datetime import date
 
 from pydantic import BaseModel
@@ -113,7 +113,7 @@ print(my_birthday.model_dump())
     * `str`; the following formats are accepted:
         * `HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]`
 
-```py
+```python
 from datetime import time
 
 from pydantic import BaseModel
@@ -139,7 +139,7 @@ print(m.model_dump())
             * Ex: `'1d,01:02:03.000004'` or `'1D01:02:03.000004'` or `'01:02:03'`
         * `[±]P[DD]DT[HH]H[MM]M[SS]S` ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format for timedelta)
 
-```py
+```python
 from datetime import timedelta
 
 from pydantic import BaseModel
@@ -180,7 +180,7 @@ Pydantic supports the following numeric types from the Python standard library:
 * Serialization: Pydantic serializes [`Decimal`][decimal.Decimal] types as strings.
 You can use a custom serializer to override this behavior if desired. For example:
 
-```py
+```python
 from decimal import Decimal
 
 from typing_extensions import Annotated
@@ -229,7 +229,7 @@ Pydantic uses Python's standard [`enum`][] classes to define choices.
 `enum.Enum` checks that the value is a valid `Enum` instance.
 Subclass of `enum.Enum` checks that the value is a valid member of the enum.
 
-```py
+```python
 from enum import Enum, IntEnum
 
 from pydantic import BaseModel, ValidationError
@@ -276,7 +276,7 @@ When a generic parameter is provided, the appropriate validation is applied to a
 
 Handled the same as `list` above.
 
-```py
+```python
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -302,7 +302,7 @@ When generic parameters are provided, the appropriate validation is applied to t
 
 Handled the same as `tuple` above.
 
-```py
+```python
 from typing import Optional, Tuple
 
 from pydantic import BaseModel
@@ -326,7 +326,7 @@ Subclasses of [`typing.NamedTuple`][] are similar to `tuple`, but create instanc
 Subclasses of [`collections.namedtuple`][] are similar to subclass of [`typing.NamedTuple`][], but since field types are not specified,
 all fields are treated as having type [`Any`][typing.Any].
 
-```py
+```python
 from typing import NamedTuple
 
 from pydantic import BaseModel, ValidationError
@@ -363,7 +363,7 @@ When generic parameters are provided, the appropriate validation is applied to t
 
 Handled the same as `deque` above.
 
-```py
+```python
 from typing import Deque, Optional
 
 from pydantic import BaseModel
@@ -388,7 +388,7 @@ When a generic parameter is provided, the appropriate validation is applied to a
 
 Handled the same as `set` above.
 
-```py
+```python
 from typing import Optional, Set
 
 from pydantic import BaseModel
@@ -416,7 +416,7 @@ When a generic parameter is provided, the appropriate validation is applied to a
 
 Handled the same as `frozenset` above.
 
-```py
+```python
 from typing import FrozenSet, Optional
 
 from pydantic import BaseModel
@@ -461,7 +461,7 @@ is provided, the post-validation value of a field of type [`typing.Iterable`][] 
 
 Here is a simple example using [`typing.Sequence`][]:
 
-```py
+```python
 from typing import Sequence
 
 from pydantic import BaseModel
@@ -486,7 +486,7 @@ validated against the type parameter of the `Sequence` (e.g. `int` in `Sequence[
 However, if you have a generator that you _don't_ want to be eagerly consumed (e.g. an infinite
 generator or a remote data loader), you can use a field of type [`Iterable`][typing.Iterable]:
 
-```py
+```python
 from typing import Iterable
 
 from pydantic import BaseModel
@@ -572,7 +572,7 @@ except ValidationError as e:
 
 `dict(v)` is used to attempt to convert a dictionary. see [`typing.Dict`][] below for sub-type constraints.
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -597,7 +597,7 @@ except ValidationError as e:
 
 ### [`typing.Dict`][]
 
-```py
+```python
 from typing import Dict
 
 from pydantic import BaseModel, ValidationError
@@ -635,7 +635,7 @@ its instances to have a certain set of keys, where each key is associated with a
 
 It is same as [`dict`][] but Pydantic will validate the dictionary since keys are annotated.
 
-```py
+```python
 from typing_extensions import TypedDict
 
 from pydantic import TypeAdapter, ValidationError
@@ -665,7 +665,7 @@ except ValidationError as e:
 You can define `__pydantic_config__` to change the model inherited from [`TypedDict`][typing.TypedDict].
 See the [`ConfigDict` API reference][pydantic.config.ConfigDict] for more details.
 
-```py
+```python
 from typing import Optional
 
 from typing_extensions import TypedDict
@@ -741,7 +741,7 @@ See below for more detail on parsing and validation
 
 Fields can also be of type [`Callable`][typing.Callable]:
 
-```py
+```python
 from typing import Callable
 
 from pydantic import BaseModel
@@ -800,7 +800,7 @@ that are subclasses of `T`.
 
 Handled the same as `type` above.
 
-```py
+```python
 from typing import Type
 
 from pydantic import BaseModel, ValidationError
@@ -868,7 +868,7 @@ except ValidationError as e:
 
 [`TypeVar`][typing.TypeVar] is supported either unconstrained, constrained or with a bound.
 
-```py
+```python
 from typing import TypeVar
 
 from pydantic import BaseModel
@@ -914,7 +914,7 @@ All other types cause an error.
     As a result, Pydantic raises a `ValidationError` if you attempt to pass a `str` or `bytes` instance into a field of type
     `Sequence[str]` or `Sequence[bytes]`:
 
-```py
+```python
 from typing import Optional, Sequence
 
 from pydantic import BaseModel, ValidationError
@@ -964,7 +964,7 @@ except ValidationError as e:
 
 Pydantic supports the use of [`typing.Literal`][] as a lightweight way to specify that a field may accept only specific literal values:
 
-```py
+```python
 from typing import Literal
 
 from pydantic import BaseModel, ValidationError
@@ -990,7 +990,7 @@ except ValidationError as e:
 One benefit of this field type is that it can be used to check for equality with one or more specific values
 without needing to declare custom validators:
 
-```py
+```python
 from typing import ClassVar, List, Literal, Union
 
 from pydantic import BaseModel, ValidationError
@@ -1029,7 +1029,7 @@ except ValidationError as e:
 
 With proper ordering in an annotated `Union`, you can use this to parse types of decreasing specificity:
 
-```py
+```python
 from typing import Literal, Optional, Union
 
 from pydantic import BaseModel

--- a/docs/concepts/alias.md
+++ b/docs/concepts/alias.md
@@ -107,7 +107,7 @@ want to specify the alias for each field individually.
 
 Here's a basic example using a callable:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict
 
 
@@ -141,7 +141,7 @@ but you don't want to specify the validation and serialization aliases for each 
 
 For example:
 
-```py
+```python
 from pydantic import AliasGenerator, BaseModel, ConfigDict
 
 
@@ -167,7 +167,7 @@ print(t.model_dump(by_alias=True))
 
 If you specify an `alias` on the [`Field`][pydantic.fields.Field], it will take precedence over the generated alias by default:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, Field
 
 

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -4,7 +4,7 @@ and as an argument to [`TypeAdapter`][pydantic.TypeAdapter].
 !!! note
     Before **v2.0**, the `Config` class was used. This is still supported, but **deprecated**.
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -26,7 +26,7 @@ except ValidationError as e:
 ```
 
 Also, you can specify config options as model class kwargs:
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -48,7 +48,7 @@ except ValidationError as e:
 1. See the [Extra Attributes](models.md#extra-fields) section for more details.
 
 Similarly, if using the [`@dataclass`][pydantic.dataclasses] decorator from Pydantic:
-```py
+```python
 from datetime import datetime
 
 from pydantic import ConfigDict, ValidationError
@@ -80,7 +80,7 @@ except ValidationError as e:
 
 If using the `dataclass` from the standard library or `TypedDict`, you should use `__pydantic_config__` instead.
 
-```py
+```python
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -98,7 +98,7 @@ class User:
 
 Alternatively, the [`with_config`][pydantic.config.with_config] decorator can be used to comply with type checkers.
 
-```py
+```python
 from typing_extensions import TypedDict
 
 from pydantic import ConfigDict, with_config
@@ -114,7 +114,7 @@ class Model(TypedDict):
 If you wish to change the behaviour of Pydantic globally, you can create your own custom `BaseModel`
 with custom `model_config` since the config is inherited:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict
 
 
@@ -133,7 +133,7 @@ print(m.model_dump())
 
 If you add a `model_config` to the `Model` class, it will _merge_ with the `model_config` from `Parent`:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict
 
 

--- a/docs/concepts/dataclasses.md
+++ b/docs/concepts/dataclasses.md
@@ -4,7 +4,7 @@
 If you don't want to use Pydantic's [`BaseModel`][pydantic.BaseModel] you can instead get the same data validation
 on standard [dataclasses][dataclasses].
 
-```py
+```python
 from datetime import datetime
 from typing import Optional
 
@@ -52,7 +52,7 @@ you can wrap the dataclass with a [`TypeAdapter`][pydantic.type_adapter.TypeAdap
 
 You can use both the Pydantic's [`Field()`][pydantic.Field] and the stdlib's [`field()`][dataclasses.field] functions:
 
-```py
+```python
 import dataclasses
 from typing import List, Optional
 
@@ -116,7 +116,7 @@ If you want to modify the configuration like you would with a [`BaseModel`][pyda
 * Use the `config` argument of the decorator.
 * Define the configuration with the `__pydantic_config__` attribute.
 
-```py
+```python
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 
@@ -154,7 +154,7 @@ See the [rebuilding model schema](./models.md#rebuilding-model-schema) section f
 Stdlib dataclasses (nested or not) can also be inherited and Pydantic will automatically validate
 all the inherited fields.
 
-```py
+```python
 import dataclasses
 
 import pydantic
@@ -196,7 +196,7 @@ When a standard library dataclass is used within a Pydantic model, a Pydantic da
 validation will be applied (and the [configuration](#dataclass-config) stays the same). This means that using a stdlib or a Pydantic
 dataclass as a field annotation is functionally equivalent.
 
-```py
+```python
 import dataclasses
 from typing import Optional
 
@@ -246,7 +246,7 @@ of custom types, you will get an error when trying to refer to the dataclass. To
 the issue, you can set the [`arbitrary_types_allowed`][pydantic.ConfigDict.arbitrary_types_allowed]
 configuration value on the dataclass:
 
-```py
+```python
 import dataclasses
 
 from pydantic import BaseModel
@@ -309,7 +309,7 @@ Pydantic dataclasses are still considered dataclasses, so using [`dataclasses.is
 if a type is specifically a pydantic dataclass you can use the [`is_pydantic_dataclass`][pydantic.dataclasses.is_pydantic_dataclass]
 function.
 
-```py
+```python
 import dataclasses
 
 import pydantic
@@ -337,7 +337,7 @@ print(pydantic.dataclasses.is_pydantic_dataclass(PydanticDataclass))
 
 Validators also work with Pydantic dataclasses:
 
-```py
+```python
 from pydantic import field_validator
 from pydantic.dataclasses import dataclass
 
@@ -365,7 +365,7 @@ be called between the calls to *before* and *after* model validators.
 
 ??? example
 
-    ```py
+    ```python
     from pydantic_core import ArgsKwargs
     from typing_extensions import Self
 

--- a/docs/concepts/experimental.md
+++ b/docs/concepts/experimental.md
@@ -336,7 +336,7 @@ E.g. in the [above](#2-ignore-errors-in-last) example partial validation works a
 
 But partial validation won't work at all in the follow example because `BaseModel` doesn't support partial validation so it doesn't forward the `allow_partial` instruction down to the list validator in `b`:
 
-```py
+```python
 from typing import List
 
 from annotated_types import MinLen
@@ -372,7 +372,7 @@ The way [jiter](https://github.com/pydantic/jiter) (the JSON parser used by Pyda
 
 This means that some invalid JSON will be accepted by Pydantic when using `experimental_allow_partial`, e.g.:
 
-```py
+```python
 from annotated_types import MinLen
 from typing_extensions import Annotated, TypedDict
 
@@ -408,7 +408,7 @@ As described [above](#2-ignore-errors-in-last), many errors can result from trun
 
 This means clearly invalid data will pass validation if the error is in the last field of the input:
 
-```py
+```python
 from typing import List
 
 from annotated_types import Ge

--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -7,7 +7,7 @@ The [`Field`][pydantic.fields.Field] function is used to customize and add metad
 
 The `default` parameter is used to define a default value for a field.
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -25,7 +25,7 @@ print(user)
 
 You can also use `default_factory` (but not both at the same time) to define a callable that will be called to generate a default value.
 
-```py
+```python
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -37,7 +37,7 @@ class User(BaseModel):
 
 The default factory can also take a single required argument, in which the case the already validated data will be passed as a dictionary.
 
-```py
+```python
 from pydantic import BaseModel, EmailStr, Field
 
 
@@ -59,7 +59,7 @@ The `data` argument will *only* contain the already validated data, based on the
 
 The [`Field`][pydantic.fields.Field] function can also be used together with [`Annotated`][annotated].
 
-```py
+```python
 from uuid import uuid4
 
 from typing_extensions import Annotated
@@ -92,7 +92,7 @@ and `serialization_alias` parameters, which will apply only in their respective 
 
 Here is an example of using the `alias` parameter:
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -119,7 +119,7 @@ print(user.model_dump(by_alias=True))  # (2)!
 
 If you want to use an alias _only_ for validation, you can use the `validation_alias` parameter:
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -139,7 +139,7 @@ print(user.model_dump(by_alias=True))  # (2)!
 
 If you only want to define an alias for _serialization_, you can use the `serialization_alias` parameter:
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -170,7 +170,7 @@ print(user.model_dump(by_alias=True))  # (2)!
     In VSCode, if you use the [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
     extension, you won't see a warning when instantiating a model using a field's alias:
 
-    ```py
+    ```python
     from pydantic import BaseModel, Field
 
 
@@ -187,7 +187,7 @@ print(user.model_dump(by_alias=True))  # (2)!
     [Model Config][pydantic.config.ConfigDict.populate_by_name], VSCode will show a warning when instantiating
     a model using the field name (though it will work at runtime) — in this case, `'name'`:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -205,7 +205,7 @@ print(user.model_dump(by_alias=True))  # (2)!
     To "trick" VSCode into preferring the field name, you can use the `str` function to wrap the alias value.
     With this approach, though, a warning is shown when instantiating a model using the alias for the field:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -231,7 +231,7 @@ print(user.model_dump(by_alias=True))  # (2)!
     in the class initializer, you can instead specify both an `alias` and `serialization_alias`, as the
     `serialization_alias` will override the `alias` during serialization:
 
-    ```py
+    ```python
     from pydantic import BaseModel, Field
 
 
@@ -239,7 +239,7 @@ print(user.model_dump(by_alias=True))  # (2)!
         my_field: int = Field(validation_alias='myValidationAlias')
     ```
     with:
-    ```py
+    ```python
     from pydantic import BaseModel, Field
 
 
@@ -275,7 +275,7 @@ There are some keyword arguments that can be used to constrain numeric values:
 
 Here's an example:
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -363,7 +363,7 @@ positive=1 non_negative=0 negative=-1 non_positive=0 even=2 love_for_pydantic=in
     In case you use field constraints with compound types, an error can happen in some cases. To avoid potential issues,
     you can use `Annotated`:
 
-    ```py
+    ```python
     from typing import Optional
 
     from typing_extensions import Annotated
@@ -390,7 +390,7 @@ There are fields that can be used to constrain strings:
 
 Here's an example:
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -455,7 +455,7 @@ There are fields that can be used to constrain decimals:
 
 Here's an example:
 
-```py
+```python
 from decimal import Decimal
 
 from pydantic import BaseModel, Field
@@ -480,7 +480,7 @@ There are fields that can be used to constrain dataclasses:
 
 Here's an example:
 
-```py
+```python
 from pydantic import BaseModel, Field
 from pydantic.dataclasses import dataclass
 
@@ -509,7 +509,7 @@ The parameter `validate_default` can be used to control whether the default valu
 
 By default, the default value of the field is not validated.
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -533,7 +533,7 @@ except ValidationError as e:
 The parameter `repr` can be used to control whether the field should be included in the string
 representation of the model.
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -557,7 +557,7 @@ approach can be useful when the discriminator fields aren't the same for all the
 
 The following example shows how to use `discriminator` with a field name:
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field
@@ -585,7 +585,7 @@ print(Model.model_validate({'pet': {'pet_type': 'cat', 'age': 12}}))  # (1)!
 
 The following example shows how to use the `discriminator` keyword argument with a `Discriminator` instance:
 
-```py
+```python
 from typing import Literal, Union
 
 from typing_extensions import Annotated
@@ -630,7 +630,7 @@ See the [Discriminated Unions] docs for more details.
 The `strict` parameter on a [`Field`][pydantic.fields.Field] specifies whether the field should be validated in "strict mode".
 In strict mode, Pydantic throws an error during validation instead of coercing data on the field where `strict=True`.
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -658,7 +658,7 @@ assigned a new value after the model is created (immutability).
 
 See the [frozen dataclass documentation] for more details.
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -689,7 +689,7 @@ model when exporting the model.
 
 See the following example:
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -722,7 +722,7 @@ You can set the `deprecated` parameter as one of:
 
 ### `deprecated` as a string
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field
@@ -763,7 +763,7 @@ if Version(importlib.metadata.version('typing_extensions')) >= Version('4.9'):
 
 ### `deprecated` as a boolean
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field
@@ -786,7 +786,7 @@ print(Model.model_json_schema()['properties']['deprecated_field'])
     When accessing a deprecated field inside a validator, the deprecation warning will be emitted. You can use
     [`catch_warnings`][warnings.catch_warnings] to explicitly ignore it:
 
-    ```py
+    ```python
     import warnings
 
     from typing_extensions import Self
@@ -833,7 +833,7 @@ The property will also be taken into account in the JSON Schema (in serializatio
 
 Here's an example of the JSON schema (in serialization mode) generated for a model with a computed field:
 
-```py
+```python
 from pydantic import BaseModel, computed_field
 
 
@@ -866,7 +866,7 @@ print(Box.model_json_schema(mode='serialization'))
 
 Here's an example using the `model_dump` method with a computed field:
 
-```py
+```python
 from pydantic import BaseModel, computed_field
 
 
@@ -892,7 +892,7 @@ print(b.model_dump())
 
 As with regular fields, computed fields can be marked as being deprecated:
 
-```py
+```python
 from typing_extensions import deprecated
 
 from pydantic import BaseModel, computed_field

--- a/docs/concepts/forward_annotations.md
+++ b/docs/concepts/forward_annotations.md
@@ -1,7 +1,7 @@
 Forward annotations (wrapped in quotes) or using the `from __future__ import annotations` [future statement]
 (as introduced in [PEP563](https://www.python.org/dev/peps/pep-0563/)) are supported:
 
-```py
+```python
 from __future__ import annotations
 
 from pydantic import BaseModel
@@ -31,7 +31,7 @@ Models with self-referencing fields are also supported. These annotations will b
 Within the model, you can either add the `from __future__ import annotations` import or wrap the annotation
 in a string:
 
-```py
+```python
 from typing import Optional
 
 from pydantic import BaseModel
@@ -57,7 +57,7 @@ attributes.
 Rather than raising a [`RecursionError`][] while attempting to validate data with cyclic references, Pydantic is able
 to detect the cyclic reference and raise an appropriate [`ValidationError`][pydantic_core.ValidationError]:
 
-```py
+```python
 from typing import Optional
 
 from pydantic import BaseModel, ValidationError
@@ -147,7 +147,7 @@ print(Node.model_validate(node_data))
 Similarly, if Pydantic encounters a recursive reference during _serialization_, rather than waiting
 for the maximum recursion depth to be exceeded, a [`ValueError`][] is raised immediately:
 
-```py
+```python
 from pydantic import TypeAdapter
 
 # Create data with cyclic references representing the graph 1 -> 2 -> 3 -> 1
@@ -166,7 +166,7 @@ except ValueError as exc:
 
 This can also be handled if desired:
 
-```py
+```python
 from dataclasses import field
 from typing import Any, List
 

--- a/docs/concepts/json.md
+++ b/docs/concepts/json.md
@@ -15,7 +15,7 @@ Pydantic provides builtin JSON parsing, which helps achieve:
 
 Here's an example of Pydantic's builtin JSON parsing via the [`model_validate_json`][pydantic.main.BaseModel.model_validate_json] method, showcasing the support for `strict` specifications while parsing JSON data that doesn't match the model's type annotations:
 
-```py
+```python
 from datetime import date
 from typing import Tuple
 
@@ -61,7 +61,7 @@ in the original JSON input which contained the invalid value.
 
 **Starting in v2.7.0**, Pydantic's [JSON parser](https://docs.rs/jiter/latest/jiter/) offers support for partial JSON parsing, which is exposed via [`pydantic_core.from_json`][pydantic_core.from_json]. Here's an example of this feature in action:
 
-```py
+```python
 from pydantic_core import from_json
 
 partial_json_data = '["aa", "bb", "c'  # (1)!
@@ -83,7 +83,7 @@ print(result)  # (3)!
 
 This also works for deserializing partial dictionaries. For example:
 
-```py
+```python
 from pydantic_core import from_json
 
 partial_dog_json = '{"breed": "lab", "name": "fluffy", "friends": ["buddy", "spot", "rufus"], "age'
@@ -102,7 +102,7 @@ In future versions of Pydantic, we expect to expand support for this feature thr
 
 For now, you can use [`pydantic_core.from_json`][pydantic_core.from_json] in combination with [`pydantic.main.BaseModel.model_validate`][pydantic.main.BaseModel.model_validate] to achieve the same result. Here's an example:
 
-```py
+```python
 from pydantic_core import from_json
 
 from pydantic import BaseModel
@@ -127,7 +127,7 @@ Check out the following example for a more in-depth look at how to use default v
 
 !!! example "Using default values with partial JSON parsing"
 
-    ```py
+    ```python
     from typing import Any, Optional, Tuple
 
     import pydantic_core

--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -167,7 +167,7 @@ Pydantic V1 (which is now deprecated).
 
 Here's an example of generating JSON schema from a [`TypeAdapter`][pydantic.type_adapter.TypeAdapter]:
 
-```py
+```python
 from typing import List
 
 from pydantic import TypeAdapter
@@ -266,7 +266,7 @@ The [`JsonSchemaMode`][pydantic.json_schema.JsonSchemaMode] is a type alias that
 
 Here's an example of how to specify the `mode` parameter, and how it affects the generated JSON schema:
 
-```py
+```python
 from decimal import Decimal
 
 from pydantic import BaseModel
@@ -403,7 +403,7 @@ If Pydantic finds constraints which are not being enforced, an error will be rai
 constraint to appear in the schema, even though it's not being checked upon parsing, you can use variadic arguments
 to [`Field`][pydantic.fields.Field] with the raw schema attribute name:
 
-```py
+```python
 from pydantic import BaseModel, Field, PositiveInt
 
 try:
@@ -488,7 +488,7 @@ The `field_title_generator` parameter can be used to programmatically generate t
 
 See the following example:
 
-```py
+```python
 import json
 
 from pydantic import BaseModel, Field
@@ -626,7 +626,7 @@ We viewed this change largely as a bug fix, as it resolves unintentional differe
 between `BaseModel` and `TypeAdapter` instances - see [this issue](https://github.com/pydantic/pydantic/issues/9210)
 for more details.
 
-```py
+```python
 import json
 
 from typing_extensions import Annotated, TypeAlias
@@ -748,7 +748,7 @@ In this case the input is the type and the output is a `core_schema`.
 
 Here is an example of a custom type that *overrides* the generated `core_schema`:
 
-```py
+```python
 from dataclasses import dataclass
 from typing import Any, Dict, List, Type
 
@@ -826,7 +826,7 @@ This will be the case for most custom types, so you almost never want to call in
 The process for `Annotated` metadata is much the same except that you can generally call into `handler` to have
 Pydantic handle generating the schema.
 
-```py
+```python
 from dataclasses import dataclass
 from typing import Any, Sequence, Type
 
@@ -894,7 +894,7 @@ So far we have been wrapping the schema, but if you just want to *modify* it or 
 
 To modify the schema, first call the handler, then mutate the result:
 
-```py
+```python
 from typing import Any, Type
 
 from pydantic_core import ValidationError, core_schema
@@ -936,7 +936,7 @@ except ValidationError as e:
 To override the schema completely, do not call the handler and return your own
 `CoreSchema`:
 
-```py
+```python
 from typing import Any, Type
 
 from pydantic_core import ValidationError, core_schema
@@ -991,7 +991,7 @@ However, if you want to take advantage of storing metadata via `Annotated`, but 
 schema, you can use the following approach with a no-op version of `__get_pydantic_core_schema__` implemented on the
 metadata class:
 
-```py
+```python
 from typing import Type
 
 from pydantic_core import CoreSchema
@@ -1121,7 +1121,7 @@ This is similar to the field level `field_title_generator`, but the `ConfigDict`
 
 See the following example:
 
-```py
+```python
 import json
 
 from pydantic import BaseModel, ConfigDict
@@ -1165,7 +1165,7 @@ and accepts the model class as input.
 
 See the following example:
 
-```py
+```python
 import json
 from typing import Type
 
@@ -1307,7 +1307,7 @@ The various methods that can be used to produce JSON schema accept a keyword arg
 By design, this class breaks the JSON schema generation process into smaller methods that can be easily overridden in
 subclasses to modify the "global" approach to generating JSON schema.
 
-```py
+```python
 from pydantic import BaseModel
 from pydantic.json_schema import GenerateJsonSchema
 
@@ -1338,7 +1338,7 @@ print(MyModel.model_json_schema(schema_generator=MyGenerateJsonSchema))
 
 Below is an approach you can use to exclude any fields from the schema that don't have valid json schemas:
 
-```py
+```python
 from typing import Callable
 
 from pydantic_core import PydanticOmit, core_schema
@@ -1388,7 +1388,7 @@ to preserve the order of the fields as they were defined in the model.
 If you would like to customize this behavior, you can override the `sort` method in your custom `GenerateJsonSchema` subclass. The below example
 uses a no-op `sort` method to disable sorting entirely, which is reflected in the preserved order of the model fields and `json_schema_extra` keys:
 
-```py
+```python
 import json
 from typing import Optional
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -172,7 +172,7 @@ Models possess the following methods and attributes:
 
 More complex hierarchical data structures can be defined using models themselves as types in annotations.
 
-```py
+```python
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -218,7 +218,7 @@ understand the valid types for each field (more information can be found in the 
 However, it might be the case that annotations refer to symbols not defined when the model class is being created.
 To circumvent this issue, the [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild] method can be used:
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError
 
 
@@ -277,7 +277,7 @@ To do this, set the [`from_attributes`][pydantic.config.ConfigDict.from_attribut
 
 The example here uses [SQLAlchemy](https://www.sqlalchemy.org/), but the same approach should work for any ORM.
 
-```py
+```python
 from typing import List
 
 from sqlalchemy import ARRAY, String
@@ -328,7 +328,7 @@ deeper-nested attributes as appropriate.
 
 Here is an example demonstrating the principle:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, ConfigDict
@@ -383,7 +383,7 @@ See [Error Handling](../errors/errors.md) for details on standard and custom err
 
 As a demonstration:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, ValidationError
@@ -424,7 +424,7 @@ Pydantic provides three methods on models classes for parsing data:
   Learn more about JSON parsing in the [JSON](../concepts/json.md) section of the docs.
 * [`model_validate_strings()`][pydantic.main.BaseModel.model_validate_strings]: this takes a dictionary (can be nested) with string keys and values and validates the data in JSON mode so that said strings can be coerced into the correct types.
 
-```py
+```python
 from datetime import datetime
 from typing import Optional
 
@@ -512,7 +512,7 @@ then pass it to [`model_validate`][pydantic.main.BaseModel.model_validate].
     If you don't set this value, then validation will be skipped on model instances. See the below example:
 
     === ":x: `revalidate_instances='never'`"
-        ```py
+        ```python
         from pydantic import BaseModel
 
 
@@ -529,7 +529,7 @@ then pass it to [`model_validate`][pydantic.main.BaseModel.model_validate].
         ```
 
     === ":white_check_mark: `revalidate_instances='always'`"
-        ```py
+        ```python
         from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -610,7 +610,7 @@ In order to declare a generic model, you should follow the following steps:
 
 Here is an example using a generic Pydantic model to create an easily-reused HTTP response payload wrapper:
 
-```py
+```python
 from typing import Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel, ValidationError
@@ -666,7 +666,7 @@ you would expect if you were to declare a distinct type for each parametrization
 To inherit from a generic model and preserve the fact that it is generic, the subclass must also inherit from
 [`Generic`][typing.Generic]:
 
-```py
+```python
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
@@ -690,7 +690,7 @@ print(ChildClass[int](X=1))
 You can also create a generic subclass of a model that partially or fully replaces the type variables in the
 superclass:
 
-```py
+```python
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
@@ -717,7 +717,7 @@ print(ChildClass[str, int](x='1', y='y', z='3'))
 If the name of the concrete subclasses is important, you can also override the default name generation
 by overriding the [`model_parametrized_name()`][pydantic.main.BaseModel.model_parametrized_name] method:
 
-```py
+```python
 from typing import Any, Generic, Tuple, Type, TypeVar
 
 from pydantic import BaseModel
@@ -741,7 +741,7 @@ print(repr(Response[str](data='a')))
 
 You can use parametrized generic models as types in other models:
 
-```py
+```python
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
@@ -774,7 +774,7 @@ Order(id=1, product=ResponseModel[Product](content=Product(name='Apple', price=0
 
 Using the same type variable in nested models allows you to enforce typing relationships at different points in your model:
 
-```py
+```python
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel, ValidationError
@@ -829,7 +829,7 @@ except ValidationError as e:
 
     This adds some validation overhead, but makes things more intuitive for cases like that shown below.
 
-    ```py
+    ```python
     from typing import Any, Generic, TypeVar
 
     from pydantic import BaseModel
@@ -895,7 +895,7 @@ types like [`list`][] and [`dict`][]:
 * If the type variable has a default type (as specified by [PEP 696](https://peps.python.org/pep-0696/)), it will be used.
 * For unbound or unconstrained type variables, Pydantic will fallback to [`Any`][typing.Any].
 
-```py
+```python
 from typing import Generic
 
 from typing_extensions import TypeVar
@@ -933,7 +933,7 @@ except ValidationError as exc:
 
     In some cases, validation against an unparametrized generic model can lead to data loss. Specifically, if a subtype of the type variable upper bound, constraints, or default is being used and the model isn't explicitly parametrized, the resulting type **will not be** the one being provided:
 
-    ```py
+    ```python
     from typing import Generic, TypeVar
 
     from pydantic import BaseModel
@@ -972,7 +972,7 @@ The behavior of serialization differs when using type variables with [upper boun
 
 If a Pydantic model is used in a type variable upper bound and the type variable is never parametrized, then Pydantic will use the upper bound for validation but treat the value as [`Any`][typing.Any] in terms of serialization:
 
-```py
+```python
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
@@ -1023,7 +1023,7 @@ assert error.model_dump() == {
 
 Here's another example of the above behavior, enumerating all permutations regarding bound specification and generic type parametrization:
 
-```py
+```python
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
@@ -1059,7 +1059,7 @@ will be used for both validation and serialization if the type variable is not p
 using [`SerializeAsAny`](./serialization.md#serializeasany-annotation):
 
 
-```py
+```python
 from typing import Generic
 
 from typing_extensions import TypeVar
@@ -1124,7 +1124,7 @@ assert error.model_dump() == {
 There are some occasions where it is desirable to create a model using runtime information to specify the fields.
 For this Pydantic provides the `create_model` function to allow models to be created on the fly:
 
-```py
+```python
 from pydantic import BaseModel, create_model
 
 DynamicFoobarModel = create_model(
@@ -1148,7 +1148,7 @@ Fields are defined by one of the following tuple forms:
 Using a `Field(...)` call as the second argument in the tuple (the default value)
 allows for more advanced field configuration. Thus, the following are analogous:
 
-```py
+```python
 from pydantic import BaseModel, Field, create_model
 
 DynamicModel = create_model(
@@ -1164,7 +1164,7 @@ class StaticModel(BaseModel):
 The special keyword arguments `__config__` and `__base__` can be used to customize the new model.
 This includes extending a base model with extra fields.
 
-```py
+```python
 from pydantic import BaseModel, create_model
 
 
@@ -1243,7 +1243,7 @@ via the first and only argument.
 
 Here's an example of how this works:
 
-```py
+```python
 from typing import Dict, List
 
 from pydantic import RootModel
@@ -1274,7 +1274,7 @@ print(PetsByName.model_validate({'Otis': 'dog', 'Milo': 'cat'}))
 If you want to access items in the `root` field directly or to iterate over the items, you can implement
 custom `__iter__` and `__getitem__` functions, as shown in the following example.
 
-```py
+```python
 from typing import List
 
 from pydantic import RootModel
@@ -1299,7 +1299,7 @@ print([pet for pet in pets])
 
 You can also create subclasses of the parametrized root model directly:
 
-```py
+```python
 from typing import List
 
 from pydantic import RootModel
@@ -1330,7 +1330,7 @@ values of instance attributes will raise errors. See the [API reference][pydanti
     In Python, immutability is not enforced. Developers have the ability to modify objects
     that are conventionally considered "immutable" if they choose to do so.
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -1370,7 +1370,7 @@ immutability of `foobar` doesn't stop `b` from being changed.
 Pydantic models can be used alongside Python's
 [Abstract Base Classes](https://docs.python.org/3/library/abc.html) (ABCs).
 
-```py
+```python
 import abc
 
 from pydantic import BaseModel
@@ -1393,7 +1393,7 @@ Field order affects models in the following ways:
 * field order is preserved in [validation errors](#error-handling)
 * field order is preserved by [`.model_dump()` and `.model_dump_json()` etc.](serialization.md#model_dump)
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1424,7 +1424,7 @@ print(error_locations)
 To declare a field as required, you may declare it using an annotation, or an annotation in combination with a
 [`Field`][pydantic.Field] function (without specifying any `default` or `default_factory` argument).
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 
@@ -1458,7 +1458,7 @@ Pydantic also supports the use of a [`default_factory`](#fields-with-dynamic-def
 values, but it is not required. In the event that the default value is not hashable, Pydantic will deepcopy the default
 value when creating each instance of the model:
 
-```py
+```python
 from typing import Dict, List
 
 from pydantic import BaseModel
@@ -1485,7 +1485,7 @@ To do this, you may want to use a `default_factory`.
 
 Here is an example:
 
-```py
+```python
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
@@ -1514,7 +1514,7 @@ You can find more information in the documentation of the [`Field` function](fie
 Attributes annotated with `typing.ClassVar` are properly treated by Pydantic as class variables, and will not
 become fields on model instances:
 
-```py
+```python
 from typing import ClassVar
 
 from pydantic import BaseModel
@@ -1547,7 +1547,7 @@ calls to `__init__`, `model_validate`, etc.
 
 Here is an example of usage:
 
-```py
+```python
 from datetime import datetime
 from random import randint
 
@@ -1580,7 +1580,7 @@ Pydantic may cast input data to force it to conform to model field types,
 and in some cases this may result in a loss of information.
 For example:
 
-```py
+```python
 from pydantic import BaseModel
 
 
@@ -1603,7 +1603,7 @@ Nevertheless, [strict type checking](strict_mode.md) is also supported.
 
 All Pydantic models will have their signature generated based on their fields:
 
-```py
+```python
 import inspect
 
 from pydantic import BaseModel, Field
@@ -1624,7 +1624,7 @@ An accurate signature is useful for introspection purposes and libraries like `F
 
 The generated signature will also respect custom `__init__` functions:
 
-```py
+```python
 import inspect
 
 from pydantic import BaseModel
@@ -1688,7 +1688,7 @@ coercion.
 In this example, note that the ID of the list changes after the class is constructed because it has been
 copied during validation:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel
@@ -1723,7 +1723,7 @@ print('id(c1.arr) == id(c2.arr):', id(c1.arr) == id(c2.arr))
 
 By default, Pydantic models won't error when you provide data for unrecognized fields, they will just be ignored:
 
-```py
+```python
 from pydantic import BaseModel
 
 
@@ -1738,7 +1738,7 @@ assert m.model_dump() == {'x': 1}
 If you want this to raise an error, you can set the [`extra`][pydantic.ConfigDict.extra] configuration
 value to `'forbid'`:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -1762,7 +1762,7 @@ except ValidationError as exc:
 To instead preserve any extra data provided, you can set [`extra`][pydantic.ConfigDict.extra] to `'allow'`.
 The extra fields will then be stored in `BaseModel.__pydantic_extra__`:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict
 
 
@@ -1779,7 +1779,7 @@ assert m.__pydantic_extra__ == {'y': 'a'}
 By default, no validation will be applied to these extra items, but you can set a type for the values by overriding
 the type annotation for `__pydantic_extra__`:
 
-```py
+```python
 from typing import Dict
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError

--- a/docs/concepts/performance.md
+++ b/docs/concepts/performance.md
@@ -61,7 +61,7 @@ If you know the value is a `dict`, use `dict` instead of `Mapping`.
 
 If you don't need to validate a value, use `Any` to keep the value unchanged.
 
-```py
+```python
 from typing import Any
 
 from pydantic import BaseModel
@@ -78,7 +78,7 @@ model = Model(a=1)
 
 === "Don't do this"
 
-    ```py
+    ```python
     class CompletedStr(str):
         def __init__(self, s: str):
             self.s = s
@@ -87,7 +87,7 @@ model = Model(a=1)
 
 === "Do this"
 
-    ```py
+    ```python
     from pydantic import BaseModel
 
 
@@ -193,7 +193,7 @@ Starting in v2.8+, you can apply the `FailFast` annotation to sequence types to 
 If you use this annotation, you won't get validation errors for the rest of the items in the sequence if one fails, so you're effectively
 trading off visibility for performance.
 
-```py
+```python
 from typing import List
 
 from typing_extensions import Annotated

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -33,7 +33,7 @@ This is the primary way of converting a model to a dictionary. Sub-models will b
 
 Example:
 
-```py
+```python
 from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field, Json
@@ -110,7 +110,7 @@ See [arguments][pydantic.main.BaseModel.model_dump_json] for more information.
     Pydantic can serialize many commonly used types to JSON that would otherwise be incompatible with a simple
     `json.dumps(foobar)` (e.g. `datetime`, `date` or `UUID`) .
 
-```py
+```python
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -147,7 +147,7 @@ sub-models will not be converted to dictionaries.
 
 Example:
 
-```py
+```python
 from pydantic import BaseModel
 
 
@@ -187,7 +187,7 @@ Serialization can be customised on a field using the
 [`@field_serializer`][pydantic.functional_serializers.field_serializer] decorator, and on a model using the
 [`@model_serializer`][pydantic.functional_serializers.model_serializer] decorator.
 
-```py
+```python
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 
@@ -238,7 +238,7 @@ Both serializers accept optional arguments including:
 
 `PlainSerializer` uses a simple function to modify the output of serialization.
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import BaseModel
@@ -263,7 +263,7 @@ print(MyModel(x=1234).model_dump(mode='json'))
 `WrapSerializer` receives the raw inputs along with a handler function that applies the standard serialization
 logic, and can modify the resulting value before returning it as the final output of serialization.
 
-```py
+```python
 from typing import Any
 
 from typing_extensions import Annotated
@@ -294,7 +294,7 @@ print(MyModel(x=1234).model_dump(mode='json'))
 
 While the return value of `.model_dump()` can usually be described as `dict[str, Any]`, through the use of
 `@model_serializer` you can actually cause it to return a value that doesn't match this signature:
-```py
+```python
 from pydantic import BaseModel, model_serializer
 
 
@@ -313,7 +313,7 @@ print(Model(x='not a dict').model_dump())
 If you want to do this and still get proper type-checking for this method, you can override `.model_dump()` in an
 `if TYPE_CHECKING:` block:
 
-```py
+```python
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, model_serializer
@@ -351,7 +351,7 @@ This trick is actually used in [`RootModel`](models.md#rootmodel-and-custom-root
 
 Subclasses of standard types are automatically dumped like their super-classes:
 
-```py
+```python
 from datetime import date, timedelta
 from typing import Any, Type
 
@@ -397,7 +397,7 @@ the default behavior is to serialize the attribute value as though it was an ins
 even if it is a subclass. More specifically, only the fields from the _annotated_ type will be included in the
 dumped object:
 
-```py
+```python
 from pydantic import BaseModel
 
 
@@ -451,7 +451,7 @@ We discuss these options below in more detail:
 
 If you want duck-typing serialization behavior, this can be done using the `SerializeAsAny` annotation on a type:
 
-```py
+```python
 from pydantic import BaseModel, SerializeAsAny
 
 
@@ -505,7 +505,7 @@ which means that fields present in a subclass but not in the original schema wil
 
 For example:
 
-```py
+```python
 from pydantic import BaseModel
 
 
@@ -543,7 +543,7 @@ but not the base class, are not included in serialization.
 
 This setting even takes effect with nested and recursive patterns as well. For example:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel
@@ -601,7 +601,7 @@ You can override the default setting for `serialize_as_any` by configuring a sub
 
 For example, you could do the following if you want to use duck-typing serialization by default:
 
-```py
+```python
 from typing import Any, Dict
 
 from pydantic import BaseModel, SecretStr
@@ -666,7 +666,7 @@ print(m2)
 The `model_dump` and `model_dump_json` methods support `include` and `exclude` arguments which can either be
 sets or dictionaries. This allows nested selection of which fields to export:
 
-```py
+```python
 from pydantic import BaseModel, SecretStr
 
 
@@ -707,7 +707,7 @@ Special care must be taken when including or excluding fields from a list or tup
 In this scenario, `model_dump` and related methods expect integer keys for element-wise inclusion or exclusion.
 To exclude a field from **every** member of a list or tuple, the dictionary key `'__all__'` can be used, as shown here:
 
-```py
+```python
 import datetime
 from typing import List
 
@@ -813,7 +813,7 @@ we can also pass the `exclude: bool` arguments directly to the `Field` construct
 Setting `exclude` on the field constructor (`Field(exclude=True)`) takes priority over the
 `exclude`/`include` on `model_dump` and `model_dump_json`:
 
-```py
+```python
 from pydantic import BaseModel, Field, SecretStr
 
 
@@ -844,7 +844,7 @@ print(t.model_dump(include={'id': True, 'value': True}))  # (1)!
 That being said, setting `exclude` on the field constructor (`Field(exclude=True)`) does not take priority
 over the `exclude_unset`, `exclude_none`, and `exclude_default` parameters on `model_dump` and `model_dump_json`:
 
-```py
+```python
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -915,7 +915,7 @@ Similarly, you can [use a context for validation](../concepts/validators.md#vali
 
 Example:
 
-```py
+```python
 from pydantic import BaseModel
 
 

--- a/docs/concepts/strict_mode.md
+++ b/docs/concepts/strict_mode.md
@@ -14,7 +14,7 @@ and will instead error if the data is not of the correct type.
 
 Here is a brief example showing the difference between validation behavior in strict and the default/"lax" mode:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -54,7 +54,7 @@ will result in raising a `ValidationError`.
 Note that we are looser when validating data from JSON in strict mode. For example, when validating a `UUID` field,
 instances of `str` will be accepted when validating from JSON, but not from python:
 
-```py
+```python
 import json
 from uuid import UUID
 
@@ -325,7 +325,7 @@ such as [`StrictInt`](../api/types.md#pydantic.types.StrictInt).
 If you want to enable strict mode for all fields on a complex input type, you can use
 [`ConfigDict(strict=True)`](../api/config.md#pydantic.config.ConfigDict) in the `model_config`:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -354,7 +354,7 @@ except ValidationError as exc:
     When using `strict=True` through a model's `model_config`, you can still override the strictness
     of individual fields by setting `strict=False` on individual fields:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, Field
 
 

--- a/docs/concepts/type_adapter.md
+++ b/docs/concepts/type_adapter.md
@@ -12,7 +12,7 @@ A [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] instance exposes some of th
 [`BaseModel`][pydantic.main.BaseModel] instance methods for types that do not have such methods
 (such as dataclasses, primitive types, and more):
 
-```py
+```python
 from typing import List
 
 from typing_extensions import TypedDict
@@ -67,7 +67,7 @@ but works with arbitrary Pydantic-compatible types.
 This is especially useful when you want to parse results into a type that is not a direct subclass of
 [`BaseModel`][pydantic.main.BaseModel]. For example:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, TypeAdapter
@@ -113,7 +113,7 @@ Pydantic will defer building the core schema until the first time it is needed (
 In order to manually trigger the building of the core schema, you can call the
 [`rebuild`][pydantic.type_adapter.TypeAdapter.rebuild] method on the [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] instance:
 
-```py
+```python
 from pydantic import ConfigDict, TypeAdapter
 
 ta = TypeAdapter('MyInt', config=ConfigDict(defer_build=True))

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -73,7 +73,7 @@ Pydantic takes advantage of this to allow you to create types that are identical
 
 For example, to create a type representing a positive int:
 
-```py
+```python
 # or `from typing import Annotated` for Python 3.9+
 from typing_extensions import Annotated
 
@@ -99,7 +99,7 @@ except ValidationError as exc:
 Note that you can also use constraints from [annotated-types](https://github.com/annotated-types/annotated-types)
 to make this Pydantic-agnostic:
 
-```py
+```python
 from annotated_types import Gt
 from typing_extensions import Annotated
 
@@ -127,7 +127,7 @@ except ValidationError as exc:
 You can add or override validation, serialization, and JSON schemas to an arbitrary type using the markers that
 Pydantic exports:
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import (
@@ -220,7 +220,7 @@ This means that they will not be able to have a `title` in JSON schemas and thei
 You can use [PEP 695]'s `TypeAliasType` via its [typing-extensions] backport to make named aliases, allowing you to define a new type without creating subclasses.
 This new type can be as simple as a name or have complex validation logic attached to it:
 
-```py
+```python
 from typing import List
 
 from annotated_types import Gt
@@ -287,7 +287,7 @@ print(Model2.model_json_schema())
 
 These named type aliases can also be generic:
 
-```py
+```python
 from typing import Generic, List, TypeVar
 
 from annotated_types import Gt
@@ -323,7 +323,7 @@ except ValidationError as exc:
 
 You can also use `TypeAliasType` to create recursive types:
 
-```py
+```python
 from typing import Any, Dict, List, Union
 
 from pydantic_core import PydanticCustomError
@@ -401,7 +401,7 @@ handler at all.
 The following is an example of a type that uses `__get_pydantic_core_schema__` to customize how it gets validated.
 This is equivalent to implementing `__get_validators__` in Pydantic V1.
 
-```py
+```python
 from typing import Any
 
 from pydantic_core import CoreSchema, core_schema
@@ -431,7 +431,7 @@ Often you'll want to parametrize your custom type by more than just generic type
 
 For example, if you were to implement `pydantic.AfterValidator` (see [Adding validation and serialization](#adding-validation-and-serialization)) yourself, you'd do something similar to the following:
 
-```py
+```python
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -470,7 +470,7 @@ assert Model(name='ABC').name == 'abc'  # (2)!
 
 Another use case for the pattern in the previous section is to handle third party types.
 
-```py
+```python
 from typing import Any
 
 from pydantic_core import core_schema
@@ -609,7 +609,7 @@ You can use this approach to e.g. define behavior for Pandas or Numpy types.
 You may notice that the above examples where we create a marker class require a good amount of boilerplate.
 For many simple cases you can greatly minimize this by using `pydantic.GetPydanticSchema`:
 
-```py
+```python
 from pydantic_core import core_schema
 from typing_extensions import Annotated
 
@@ -659,7 +659,7 @@ Note that we do not do something like `handler(get_args(source_type)[0])` becaus
 schema for that generic parameter, not one that is influenced by the current context of `Annotated` metadata and such.
 This is less important for custom types, but crucial for annotated metadata that modifies schema building.
 
-```py
+```python
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -142,7 +142,7 @@ In this mode, pydantic attempts to select the best match for the input from the 
         3. If validation succeeded on at least one member in "lax" mode, the leftmost match is returned.
         4. Validation failed on all the members, return all the errors.
 
-```py
+```python
 from typing import Union
 from uuid import UUID
 
@@ -200,7 +200,7 @@ To validate models based on that information you can set the same field - let's 
 in each of the models with a discriminated value, which is one (or many) `Literal` value(s).
 For your `Union`, you can set the discriminator in its value: `Field(discriminator='my_discriminator')`.
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field, ValidationError
@@ -261,7 +261,7 @@ This is the perfect use case for a callable `Discriminator`.
     If you don't follow this practice, it's likely that you'll, in the best case, get warnings during serialization,
     and in the worst case, get runtime errors during validation.
 
-```py
+```python
 from typing import Any, Literal, Union
 
 from typing_extensions import Annotated
@@ -325,7 +325,7 @@ ThanksgivingDinner(dessert=PumpkinPie(time_to_cook=40, num_ingredients=6, fillin
 
 For example:
 
-```py
+```python
 from typing import Any, Union
 
 from typing_extensions import Annotated
@@ -411,7 +411,7 @@ except ValidationError as e:
 Only one discriminator can be set for a field but sometimes you want to combine multiple discriminators.
 You can do it by creating nested `Annotated` types, e.g.:
 
-```py
+```python
 from typing import Literal, Union
 
 from typing_extensions import Annotated
@@ -497,7 +497,7 @@ the case with a matching discriminator value.
 You can also customize the error type, message, and context for a `Discriminator` by passing
 these specifications as parameters to the `Discriminator` constructor, as seen in the example below.
 
-```py
+```python
 from typing import Union
 
 from typing_extensions import Annotated
@@ -600,7 +600,7 @@ print(m.model_dump())
 You can also simplify error messages by labeling each case with a [`Tag`][pydantic.types.Tag].
 This is especially useful when you have complex types like those in this example:
 
-```py
+```python
 from typing import Dict, List, Union
 
 from typing_extensions import Annotated

--- a/docs/concepts/validation_decorator.md
+++ b/docs/concepts/validation_decorator.md
@@ -10,7 +10,7 @@ to your code with minimal boilerplate.
 
 Example of usage:
 
-```py
+```python
 from pydantic import ValidationError, validate_call
 
 
@@ -44,7 +44,7 @@ except ValidationError as exc:
 Parameter types are inferred from type annotations on the function, or as [`Any`][typing.Any] if not annotated. All types listed in [types](types.md) can be validated, including Pydantic models and [custom types](types.md#custom-types).
 As with the rest of Pydantic, types are by default coerced by the decorator before they're passed to the actual function:
 
-```py
+```python
 from datetime import date
 
 from pydantic import validate_call
@@ -86,7 +86,7 @@ using all possible [parameter configurations][parameter] and all possible combin
 
 ??? example
 
-    ```py
+    ```python
     from pydantic import validate_call
 
 
@@ -194,7 +194,7 @@ The [`Field()` function](fields.md) can also be used with the decorator to provi
 the field and validations. In general it should be used in a type hint with [Annotated](types.md#composing-types-via-annotated),
 unless `default_factory` is specified, in which case it should be used as the default value of the field:
 
-```py
+```python
 from datetime import datetime
 
 from typing_extensions import Annotated
@@ -229,7 +229,7 @@ print(type(when()))
 
 [Aliases](fields.md#field-aliases) can be used with the decorator as normal:
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import Field, validate_call
@@ -248,7 +248,7 @@ how_many(number=42)
 The original function which was decorated can still be accessed by using the `raw_function` attribute.
 This is useful if in some scenarios you trust your input arguments and want to call the function in the most efficient way (see [notes on performance](#performance) below):
 
-```py
+```python
 from pydantic import validate_call
 
 
@@ -271,7 +271,7 @@ print(b)
 
 [`validate_call()`][pydantic.validate_call] can also be used on async functions:
 
-```py
+```python
 class Connection:
     async def execute(self, sql, *args):
         return 'testing@example.com'
@@ -331,7 +331,7 @@ need to suppress the error using (usually with a `# type: ignore` comment).
 
 Similarly to Pydantic models, the `config` parameter of the decorator can be used to specify a custom configuration:
 
-```py
+```python
 from pydantic import ConfigDict, ValidationError, validate_call
 
 
@@ -375,7 +375,7 @@ This might be useful when a particular function is costly/time consuming.
 
 Here's an example of a workaround you can use for that pattern:
 
-```py
+```python
 from pydantic import validate_call
 
 

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -9,7 +9,7 @@
 Pydantic provides a way to apply validators via use of `Annotated`.
 You should use this whenever you want to bind validation to a type instead of model or field.
 
-```py
+```python
 from typing import Any, List
 
 from typing_extensions import Annotated
@@ -134,7 +134,7 @@ Order of validation metadata within `Annotated` matters.
 Validation goes from right to left and back.
 That is, it goes from right to left running all "before" validators (or calling into "wrap" validators), then left to right back out calling all "after" validators.
 
-```py
+```python
 from typing import Any, Callable, List, cast
 
 from typing_extensions import Annotated, TypedDict
@@ -269,7 +269,7 @@ This applies both to `@field_validator` validators and `Annotated` validators.
 You can force them to run with `Field(validate_default=True)`. Setting `validate_default` to `True` has the closest behavior to using `always=True` in `validator` in Pydantic v1. However, you are generally better off using a `@model_validator(mode='before')` where the function is called before the inner validator is called.
 
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field, field_validator
@@ -302,7 +302,7 @@ print(Model(x='foo', y='bar'))
 
 If you want to attach a validator to a specific field of a model you can use the `@field_validator` decorator.
 
-```py
+```python
 from pydantic import (
     BaseModel,
     ValidationError,
@@ -397,7 +397,7 @@ However, in most cases where you want to perform validation using multiple field
 
 Validation can also be performed on the entire model's data using `@model_validator`.
 
-```py
+```python
 from typing import Any
 
 from typing_extensions import Self
@@ -559,7 +559,7 @@ Pydantic provides a few special types that can be used to customize validation.
 
 - [`InstanceOf`][pydantic.functional_validators.InstanceOf] is a type that can be used to validate that a value is an instance of a given class.
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, InstanceOf, ValidationError
@@ -595,7 +595,7 @@ except ValidationError as e:
 
 - [`SkipValidation`][pydantic.functional_validators.SkipValidation] is a type that can be used to skip validation on a field.
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, SkipValidation
@@ -783,7 +783,7 @@ The "naive" approach would be to write a separate function, then call it from mu
 Obviously, this entails a lot of repetition and boiler plate code.
 The following approach demonstrates how you can reuse a validator so that redundancy is minimized and the models become again almost declarative.
 
-```py
+```python
 from pydantic import BaseModel, field_validator
 
 

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -34,7 +34,7 @@ The first item in the `loc` list will be the field where the error occurred, and
 
 As a demonstration:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, ValidationError, conint
@@ -135,7 +135,7 @@ In your custom data types or validators you should use `ValueError` or `Assertio
 
 See [validators](../concepts/validators.md) for more details on use of the `@validator` decorator.
 
-```py
+```python
 from pydantic import BaseModel, ValidationError, field_validator
 
 
@@ -176,7 +176,7 @@ except ValidationError as e:
 
 You can also use [`PydanticCustomError`][pydantic_core.PydanticCustomError], to fully control the error structure:
 
-```py
+```python
 from pydantic_core import PydanticCustomError
 
 from pydantic import BaseModel, ValidationError, field_validator
@@ -220,7 +220,7 @@ We've provided documentation for default error codes in the following sections:
 
 You can customize error messages by creating a custom error handler.
 
-```py
+```python
 from typing import Dict, List
 
 from pydantic_core import ErrorDetails
@@ -285,7 +285,7 @@ dictionary of translations.
 
 Another example is customizing the way that the `'loc'` value of an error is represented.
 
-```py
+```python
 from typing import Any, Dict, List, Tuple, Union
 
 from pydantic import BaseModel, ValidationError

--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -6,7 +6,7 @@ encounter when working with Pydantic, along with suggestions for addressing the 
 This error is raised when a type referenced in an annotation of a pydantic-validated type
 (such as a subclass of `BaseModel`, or a pydantic `dataclass`) is not defined:
 
-```py
+```python
 from typing import ForwardRef
 
 from pydantic import BaseModel, PydanticUserError
@@ -26,7 +26,7 @@ except PydanticUserError as exc_info:
 
 Or when the type has been defined after usage:
 
-```py
+```python
 from typing import Optional
 
 from pydantic import BaseModel, PydanticUserError
@@ -53,7 +53,7 @@ foo = Foo(a={'b': {'a': None}})
 
 For BaseModel subclasses, it can be fixed by defining the type and then calling `.model_rebuild()`:
 
-```py
+```python
 from typing import Optional
 
 from pydantic import BaseModel
@@ -127,7 +127,7 @@ print(Model.model_json_schema())
 
 This error is raised when you define a decorator with a field that is not valid.
 
-```py
+```python
 from typing import Any
 
 from pydantic import BaseModel, PydanticUserError, field_validator
@@ -147,7 +147,7 @@ except PydanticUserError as exc_info:
 
 You can use `check_fields=False` if you're inheriting from the model and intended this.
 
-```py
+```python
 from typing import Any
 
 from pydantic import BaseModel, create_model, field_validator
@@ -166,7 +166,7 @@ model = create_model('FooModel', a=(str, 'cake'), __base__=Model)
 
 This error is raised when a model in discriminated unions doesn't define a discriminator field.
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field, PydanticUserError
@@ -195,7 +195,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when you define a non-string alias on a discriminator field.
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import AliasChoices, BaseModel, Field, PydanticUserError
@@ -227,7 +227,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when you define a non-`Literal` type on a discriminator field.
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field, PydanticUserError
@@ -257,7 +257,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when you define different aliases on discriminator fields.
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field, PydanticUserError
@@ -290,7 +290,7 @@ This error is raised when you use a before, wrap, or plain validator on a discri
 This is disallowed because the discriminator field is used to determine the type of the model to use for validation,
 so you can't use a validator that might change its value.
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field, PydanticUserError, field_validator
@@ -323,7 +323,7 @@ except PydanticUserError as exc_info:
 
 This can be worked around by using a standard `Union`, dropping the discriminator:
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, field_validator
@@ -355,7 +355,7 @@ assert Model(pet={'pet_type': 'kitten'}).pet.pet_type == 'cat'
 
 This error is raised when a `Union` that uses a callable `Discriminator` doesn't have `Tag` annotations for all cases.
 
-```py
+```python
 from typing import Union
 
 from typing_extensions import Annotated
@@ -416,7 +416,7 @@ instead of `typing_extensions.TypedDict` on Python < 3.12.
 
 This error is raised when a field defined on a base class was overridden by a non-annotated attribute.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError
 
 
@@ -438,7 +438,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when a field doesn't have an annotation.
 
-```py
+```python
 from pydantic import BaseModel, Field, PydanticUserError
 
 try:
@@ -454,7 +454,7 @@ except PydanticUserError as exc_info:
 If the field is not meant to be a field, you may be able to resolve the error
 by annotating it as a `ClassVar`:
 
-```py
+```python
 from typing import ClassVar
 
 from pydantic import BaseModel
@@ -466,7 +466,7 @@ class Model(BaseModel):
 
 Or updating `model_config['ignored_types']`:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict
 
 
@@ -487,7 +487,7 @@ class MyModel(BaseModel):
 
 This error is raised when `class Config` and `model_config` are used together.
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, PydanticUserError
 
 try:
@@ -510,7 +510,7 @@ This error is raised when the keyword arguments are not available in Pydantic V2
 
 For example, `regex` is removed from Pydantic V2:
 
-```py
+```python
 from pydantic import BaseModel, Field, PydanticUserError
 
 try:
@@ -545,7 +545,7 @@ type C = B
 
 This error is raised when Pydantic fails to generate a JSON schema for some `CoreSchema`.
 
-```py
+```python
 from pydantic import BaseModel, ImportString, PydanticUserError
 
 
@@ -568,7 +568,7 @@ You must create a new instance to generate a new JSON schema.
 
 This error is raised when you instantiate `BaseModel` directly. Pydantic models should inherit from `BaseModel`.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError
 
 try:
@@ -581,7 +581,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when handling undefined annotations during `CoreSchema` generation.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUndefinedAnnotation
 
 
@@ -599,7 +599,7 @@ except PydanticUndefinedAnnotation as exc_info:
 
 This error is raised when Pydantic fails to generate a `CoreSchema` for some type.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError
 
 try:
@@ -622,7 +622,7 @@ See the [Migration Guide](../migration.md) for more information.
 
 This error is raised when you provide field definitions input in `create_model` that is not valid.
 
-```py
+```python
 from pydantic import PydanticUserError, create_model
 
 try:
@@ -633,7 +633,7 @@ except PydanticUserError as exc_info:
 
 Or when you use [`typing.Annotated`][] with invalid input
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import PydanticUserError, create_model
@@ -648,7 +648,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when you use both `__config__` and `__base__` together in `create_model`.
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, PydanticUserError, create_model
 
 try:
@@ -664,7 +664,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when you use validator bare (with no fields).
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, field_validator
 
 try:
@@ -682,7 +682,7 @@ except PydanticUserError as exc_info:
 
 Validators should be used with fields and keyword arguments.
 
-```py
+```python
 from pydantic import BaseModel, field_validator
 
 
@@ -698,7 +698,7 @@ class Model(BaseModel):
 
 This error is raised when you use a validator with non-string fields.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, field_validator
 
 try:
@@ -717,7 +717,7 @@ except PydanticUserError as exc_info:
 
 Fields should be passed as separate string arguments:
 
-```py
+```python
 from pydantic import BaseModel, field_validator
 
 
@@ -734,7 +734,7 @@ class Model(BaseModel):
 
 This error is raised when you apply a validator on an instance method.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, field_validator
 
 try:
@@ -755,7 +755,7 @@ except PydanticUserError as exc_info:
 This error is raised when you explicitly specify a value for the `json_schema_input_type`
 argument and `mode` isn't set to either `'before'`, `'plain'` or `'wrap'`.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, field_validator
 
 try:
@@ -792,7 +792,7 @@ Please see the [Migration Guide](../migration.md) for more details.
 
 This error is raised when you apply `model_serializer` on an instance method without `self`:
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, model_serializer
 
 try:
@@ -810,7 +810,7 @@ except PydanticUserError as exc_info:
 
 Or on a class method:
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, model_serializer
 
 try:
@@ -841,7 +841,7 @@ The `field` argument is no longer available.
 
 This error is raised when you use an unsupported signature for Pydantic V1-style validator.
 
-```py
+```python
 import warnings
 
 from pydantic import BaseModel, PydanticUserError, validator
@@ -865,7 +865,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when a `field_validator` or `model_validator` function has the wrong signature.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, field_validator
 
 try:
@@ -886,7 +886,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when the `field_serializer` function has the wrong signature.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, field_serializer
 
 try:
@@ -945,7 +945,7 @@ def ser_x(self, value: Any, handler: SerializerFunctionWrapHandler): ...
 
 This error is raised when the `model_serializer` function has the wrong signature.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, model_serializer
 
 try:
@@ -986,7 +986,7 @@ def mod_ser(self, handler: SerializerFunctionWrapHandler): ...
 
 This error is raised when multiple `model_serializer` functions are defined for a field.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, field_serializer
 
 try:
@@ -1011,7 +1011,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when an annotation cannot annotate a type.
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, FutureDate, PydanticUserError
@@ -1030,7 +1030,7 @@ except PydanticUserError as exc_info:
 You will get this error if you try to pass `config` to `TypeAdapter` when the type is a type that
 has its own config that cannot be overridden (currently this is only `BaseModel`, `TypedDict` and `dataclass`):
 
-```py
+```python
 from typing_extensions import TypedDict
 
 from pydantic import ConfigDict, PydanticUserError, TypeAdapter
@@ -1048,7 +1048,7 @@ except PydanticUserError as exc_info:
 
 Instead you'll need to subclass the type and override or set the config on it:
 
-```py
+```python
 from typing_extensions import TypedDict
 
 from pydantic import ConfigDict, TypeAdapter
@@ -1069,7 +1069,7 @@ TypeAdapter(MyTypedDict)  # ok
 Because `RootModel` is not capable of storing or even accepting extra fields during initialization, we raise an error
 if you try to specify a value for the config setting `'extra'` when creating a subclass of `RootModel`:
 
-```py
+```python
 from pydantic import PydanticUserError, RootModel
 
 try:
@@ -1157,7 +1157,7 @@ pydantic.errors.PydanticUserError: Dataclass field bar has init=False and init_v
 
 This error is raised when `model_config` is used as the name of a field.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError
 
 try:
@@ -1173,7 +1173,7 @@ except PydanticUserError as exc_info:
 
 This error is raised when the [`with_config`][pydantic.config.with_config] decorator is used on a class which is already a Pydantic model (use the `model_config` attribute instead).
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError, with_config
 
 try:
@@ -1191,7 +1191,7 @@ except PydanticUserError as exc_info:
 This error is raised when the Pydantic `dataclass` decorator is used on a class which is already
 a Pydantic model.
 
-```py
+```python
 from pydantic import BaseModel, PydanticUserError
 from pydantic.dataclasses import dataclass
 
@@ -1213,7 +1213,7 @@ except PydanticUserError as exc_info:
 
 These decorators must be put before `validate_call`.
 
-```py
+```python
 from pydantic import PydanticUserError, validate_call
 
 # error
@@ -1238,7 +1238,7 @@ def f2(cls): ...
 
 While classes are callables themselves, `validate_call` can't be applied on them, as it needs to know about which method to use (`__init__` or `__new__`) to fetch type annotations. If you want to validate the constructor of a class, you should put `validate_call` on top of the appropriate method instead.
 
-```py
+```python
 from pydantic import PydanticUserError, validate_call
 
 # error
@@ -1264,7 +1264,7 @@ class A2:
 
 Although you can create custom callable types in Python by implementing a `__call__` method, currently the instances of these types cannot be validated with `validate_call`. This may change in the future, but for now, you should use `validate_call` explicitly on `__call__` instead.
 
-```py
+```python
 from pydantic import PydanticUserError, validate_call
 
 # error
@@ -1289,7 +1289,7 @@ class A2:
 
 This is generally less common, but a possible reason is that you are trying to validate a method that doesn't have at least one argument (usually `self`).
 
-```py
+```python
 from pydantic import PydanticUserError, validate_call
 
 try:
@@ -1309,7 +1309,7 @@ a [`TypedDict`][typing.TypedDict] class object to type hint variadic keyword par
 
 For reference, see the [related specification section] and [PEP 692].
 
-```py
+```python
 from typing_extensions import Unpack
 
 from pydantic import PydanticUserError, validate_call
@@ -1331,7 +1331,7 @@ overlapping with other parameters (unless [positional only][positional-only_para
 
 For reference, see the [related specification section] and [PEP 692].
 
-```py
+```python
 from typing_extensions import TypedDict, Unpack
 
 from pydantic import PydanticUserError, validate_call
@@ -1358,7 +1358,7 @@ except PydanticUserError as exc_info:
 
 Currently, [`Self`][typing.Self] can only be used to annotate a field of a class (specifically, subclasses of [`BaseModel`][pydantic.BaseModel], [`NamedTuple`][typing.NamedTuple], [`TypedDict`][typing.TypedDict], or dataclasses). Attempting to use [`Self`][typing.Self] in any other ways will raise this error.
 
-```py
+```python
 from typing_extensions import Self
 
 from pydantic import PydanticUserError, validate_call
@@ -1375,7 +1375,7 @@ except PydanticUserError as exc_info:
 
 The following example of [`validate_call()`][pydantic.validate_call] will also raise this error, even though it is correct from a type-checking perspective. This may be supported in the future.
 
-```py
+```python
 from typing_extensions import Self
 
 from pydantic import BaseModel, PydanticUserError, validate_call

--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -7,7 +7,7 @@ This error is raised when an object that would be passed as arguments to a funct
 a `tuple`, `list`, or `dict`. Because `NamedTuple` uses function calls in its implementation, that is one way to
 produce this error:
 
-```py
+```python
 from typing import NamedTuple
 
 from pydantic import BaseModel, ValidationError
@@ -32,7 +32,7 @@ except ValidationError as exc:
 
 This error is raised when a failing `assert` statement is encountered during validation:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError, field_validator
 
 
@@ -57,7 +57,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is a string that is not valid for coercion to a boolean:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -78,7 +78,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `bool` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -98,7 +98,7 @@ except ValidationError as exc:
 This error is raised when a `bytes` value is invalid under the configured encoding.
 In the following example, `b'a'` is invalid hex (odd number of digits).
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -120,7 +120,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the length of a `bytes` value is greater than the field's `max_length` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -139,7 +139,7 @@ except ValidationError as exc:
 
 This error is raised when the length of a `bytes` value is less than the field's `min_length` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -158,7 +158,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `bytes` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -179,7 +179,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the input value is not valid as a `Callable`:
 
-```py
+```python
 from typing import Any, Callable
 
 from pydantic import BaseModel, ImportString, ValidationError
@@ -203,7 +203,7 @@ except ValidationError as exc:
 This error is raised when the input value is a string but cannot be parsed as a complex number because
 it does not follow the [rule](https://docs.python.org/3/library/functions.html#complex) in Python:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -224,7 +224,7 @@ except ValidationError as exc:
 
 This error is raised when the input value cannot be interpreted as a complex number:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -243,7 +243,7 @@ except ValidationError as exc:
 
 This error is raised when validating a dataclass with `strict=True` and the input is not an instance of the dataclass:
 
-```py
+```python
 import pydantic.dataclasses
 from pydantic import TypeAdapter, ValidationError
 
@@ -271,7 +271,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not valid for a `dataclass` field:
 
-```py
+```python
 from pydantic import ValidationError, dataclasses
 
 
@@ -299,7 +299,7 @@ except ValidationError as exc:
 This error is raised when the input `datetime` value provided for a `date` field has a nonzero time component.
 For a timestamp to parse into a field of type `date`, the time components must all be zero:
 
-```py
+```python
 from datetime import date, datetime
 
 from pydantic import BaseModel, ValidationError
@@ -323,7 +323,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is a string that cannot be parsed for a `date` field:
 
-```py
+```python
 from datetime import date
 
 from pydantic import BaseModel, ValidationError
@@ -344,7 +344,7 @@ except ValidationError as exc:
 
 This error is raised when the input value provided for a `FutureDate` field is not in the future:
 
-```py
+```python
 from datetime import date
 
 from pydantic import BaseModel, FutureDate, ValidationError
@@ -365,7 +365,7 @@ except ValidationError as exc:
 
 This error is raised when validating JSON where the input value is string that cannot be parsed for a `date` field:
 
-```py
+```python
 import json
 from datetime import date
 
@@ -387,7 +387,7 @@ except ValidationError as exc:
 
 This error is raised when the value provided for a `PastDate` field is not in the past:
 
-```py
+```python
 from datetime import date, timedelta
 
 from pydantic import BaseModel, PastDate, ValidationError
@@ -408,7 +408,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `date` field:
 
-```py
+```python
 from datetime import date
 
 from pydantic import BaseModel, ValidationError
@@ -434,7 +434,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the input value is a string that cannot be parsed for a `datetime` field:
 
-```py
+```python
 from datetime import datetime
 
 from pydantic import BaseModel, ValidationError
@@ -456,7 +456,7 @@ except ValidationError as exc:
 
 This error is raised when the value provided for a `FutureDatetime` field is not in the future:
 
-```py
+```python
 from datetime import datetime
 
 from pydantic import BaseModel, FutureDatetime, ValidationError
@@ -477,7 +477,7 @@ except ValidationError as exc:
 
 This error is raised when something about the `datetime` object is not valid:
 
-```py
+```python
 from datetime import datetime, tzinfo
 
 from pydantic import AwareDatetime, BaseModel, ValidationError
@@ -505,7 +505,7 @@ except ValidationError as exc:
 
 This error is raised when the value is a string that cannot be parsed for a `datetime` field:
 
-```py
+```python
 import json
 from datetime import datetime
 
@@ -527,7 +527,7 @@ except ValidationError as exc:
 
 This error is raised when the value provided for a `PastDatetime` field is not in the past:
 
-```py
+```python
 from datetime import datetime, timedelta
 
 from pydantic import BaseModel, PastDatetime, ValidationError
@@ -548,7 +548,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `datetime` field:
 
-```py
+```python
 from datetime import datetime
 
 from pydantic import BaseModel, ValidationError
@@ -571,7 +571,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the value provided for a `Decimal` has too many digits:
 
-```py
+```python
 from decimal import Decimal
 
 from pydantic import BaseModel, Field, ValidationError
@@ -592,7 +592,7 @@ except ValidationError as exc:
 
 This error is raised when the value provided for a `Decimal` has too many digits after the decimal point:
 
-```py
+```python
 from decimal import Decimal
 
 from pydantic import BaseModel, Field, ValidationError
@@ -613,7 +613,7 @@ except ValidationError as exc:
 
 This error is raised when the value provided for a `Decimal` could not be parsed as a decimal number:
 
-```py
+```python
 from decimal import Decimal
 
 from pydantic import BaseModel, Field, ValidationError
@@ -634,7 +634,7 @@ except ValidationError as exc:
 
 This error is raised when the value provided for a `Decimal` is of the wrong type:
 
-```py
+```python
 from decimal import Decimal
 
 from pydantic import BaseModel, Field, ValidationError
@@ -657,7 +657,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the value provided for a `Decimal` has more digits before the decimal point than `max_digits` - `decimal_places` (as long as both are specified):
 
-```py
+```python
 from decimal import Decimal
 
 from pydantic import BaseModel, Field, ValidationError
@@ -680,7 +680,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the input value's type is not `dict` for a `dict` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -699,7 +699,7 @@ except ValidationError as exc:
 
 This error is raised when the input value does not exist in an `enum` field members:
 
-```py
+```python
 from enum import Enum
 
 from pydantic import BaseModel, ValidationError
@@ -724,7 +724,7 @@ except ValidationError as exc:
 
 This error is raised when the input value contains extra fields, but `model_config['extra'] == 'forbid'`:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -748,7 +748,7 @@ You can read more about the `extra` configuration in the [Extra Attributes][pyda
 This error is raised when the value is infinite, or too large to be represented as a 64-bit floating point number
 during validation:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -767,7 +767,7 @@ except ValidationError as exc:
 
 This error is raised when the value is a string that can't be parsed as a `float`:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -786,7 +786,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `float` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -805,7 +805,7 @@ except ValidationError as exc:
 
 This error is raised when you attempt to assign a value to a field with `frozen=True`, or to delete such a field:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -833,7 +833,7 @@ except ValidationError as exc:
 This error is raised when `model_config['frozen] == True` and you attempt to delete or assign a new value to
 any of the fields:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -862,7 +862,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `frozenset` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -881,7 +881,7 @@ except ValidationError as exc:
 
 This error is raised when `model_config['from_attributes'] == True` and an error is raised while reading the attributes:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -912,7 +912,7 @@ except ValidationError as exc:
 
 This error is raised when the value is not greater than the field's `gt` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -931,7 +931,7 @@ except ValidationError as exc:
 
 This error is raised when the value is not greater than or equal to the field's `ge` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -950,7 +950,7 @@ except ValidationError as exc:
 
 This error is raised when you provide a `float` value for an `int` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -969,7 +969,7 @@ except ValidationError as exc:
 
 This error is raised when the value can't be parsed as `int`:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -989,7 +989,7 @@ except ValidationError as exc:
 This error is raised when attempting to parse a python or JSON value from a string outside the maximum range that Python
 `str` to `int` parsing permits:
 
-```py
+```python
 import json
 
 from pydantic import BaseModel, ValidationError
@@ -1021,7 +1021,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for an `int` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1040,7 +1040,7 @@ except ValidationError as exc:
 
 This error is raised when attempting to validate a `dict` that has a key that is not an instance of `str`:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -1061,7 +1061,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not an instance of the expected type:
 
-```py
+```python
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -1086,7 +1086,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not a subclass of the expected type:
 
-```py
+```python
 from typing import Type
 
 from pydantic import BaseModel, ValidationError
@@ -1111,7 +1111,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not valid as an `Iterable`:
 
-```py
+```python
 from typing import Iterable
 
 from pydantic import BaseModel, ValidationError
@@ -1132,7 +1132,7 @@ except ValidationError as exc:
 
 This error is raised when an error occurs during iteration:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, ValidationError
@@ -1158,7 +1158,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not a valid JSON string:
 
-```py
+```python
 from pydantic import BaseModel, Json, ValidationError
 
 
@@ -1177,7 +1177,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is of a type that cannot be parsed as JSON:
 
-```py
+```python
 from pydantic import BaseModel, Json, ValidationError
 
 
@@ -1196,7 +1196,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not less than the field's `lt` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -1215,7 +1215,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not less than or equal to the field's `le` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -1234,7 +1234,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `list` field:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, ValidationError
@@ -1255,7 +1255,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not one of the expected literal values:
 
-```py
+```python
 from typing import Literal
 
 from pydantic import BaseModel, ValidationError
@@ -1279,7 +1279,7 @@ except ValidationError as exc:
 This error is raised when a problem occurs during validation due to a failure in a call to the methods from the
 `Mapping` protocol, such as `.items()`:
 
-```py
+```python
 from collections.abc import Mapping
 from typing import Dict
 
@@ -1315,7 +1315,7 @@ except ValidationError as exc:
 
 This error is raised when there are required fields missing from the input value:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1335,7 +1335,7 @@ except ValidationError as exc:
 This error is raised when a required positional-or-keyword argument is not passed to a function decorated with
 `validate_call`:
 
-```py
+```python
 from pydantic import ValidationError, validate_call
 
 
@@ -1355,7 +1355,7 @@ except ValidationError as exc:
 
 This error is raised when a required keyword-only argument is not passed to a function decorated with `validate_call`:
 
-```py
+```python
 from pydantic import ValidationError, validate_call
 
 
@@ -1376,7 +1376,7 @@ except ValidationError as exc:
 This error is raised when a required positional-only argument is not passed to a function decorated with
 `validate_call`:
 
-```py
+```python
 from pydantic import ValidationError, validate_call
 
 
@@ -1396,7 +1396,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not a valid dictionary, model instance, or instance that fields can be extracted from:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1431,7 +1431,7 @@ except ValidationError as exc:
 
 This error is raised when the input to a model is not an instance of the model or dict:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1461,7 +1461,7 @@ except ValidationError as exc:
 This error is raised when you provide multiple values for a single argument while calling a function decorated with
 `validate_call`:
 
-```py
+```python
 from pydantic import ValidationError, validate_call
 
 
@@ -1481,7 +1481,7 @@ except ValidationError as exc:
 
 This error is raised when the input is not a multiple of a field's `multiple_of` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -1501,7 +1501,7 @@ except ValidationError as exc:
 This type of error is raised when validation is attempted from a format that cannot be converted to a Python object.
 For example, we cannot check `isinstance` or `issubclass` from JSON:
 
-```py
+```python
 import json
 from typing import Type
 
@@ -1524,7 +1524,7 @@ except ValidationError as exc:
 This error is raised when `validate_assignment=True` in the config, and you attempt to assign a value to an attribute
 that is not an existing field:
 
-```py
+```python
 from pydantic import ConfigDict, ValidationError, dataclasses
 
 
@@ -1545,7 +1545,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is not `None` for a field that requires `None`:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1582,7 +1582,7 @@ except ValidationError as exc:
 
 This error is raised when a cyclic reference is detected:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, ValidationError
@@ -1605,7 +1605,7 @@ except ValidationError as exc:
 
 This error is raised when the value type is not valid for a `set` field:
 
-```py
+```python
 from typing import Set
 
 from pydantic import BaseModel, ValidationError
@@ -1626,7 +1626,7 @@ except ValidationError as exc:
 
 This error is raised when the input value doesn't match the field's `pattern` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -1645,7 +1645,7 @@ except ValidationError as exc:
 
 This error is raised when the value is an instance of a strict subtype of `str` when the field is strict:
 
-```py
+```python
 from enum import Enum
 
 from pydantic import BaseModel, Field, ValidationError
@@ -1670,7 +1670,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is a string whose length is greater than the field's `max_length` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -1689,7 +1689,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is a string whose length is less than the field's `min_length` constraint:
 
-```py
+```python
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -1708,7 +1708,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `str` field:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1729,7 +1729,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the value cannot be parsed as a Unicode string:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError
 
 
@@ -1748,7 +1748,7 @@ except ValidationError as exc:
 
 This error is raised when the input value is a string that cannot be parsed for a `timedelta` field:
 
-```py
+```python
 from datetime import timedelta
 
 from pydantic import BaseModel, ValidationError
@@ -1769,7 +1769,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `timedelta` field:
 
-```py
+```python
 from datetime import timedelta
 
 from pydantic import BaseModel, ValidationError
@@ -1792,7 +1792,7 @@ This error is also raised for strict fields when the input value is not an insta
 
 This error is raised when the input value is a string that cannot be parsed for a `time` field:
 
-```py
+```python
 from datetime import time
 
 from pydantic import BaseModel, ValidationError
@@ -1813,7 +1813,7 @@ except ValidationError as exc:
 
 This error is raised when the value type is not valid for a `time` field:
 
-```py
+```python
 from datetime import time
 
 from pydantic import BaseModel, ValidationError
@@ -1837,7 +1837,7 @@ This error is also raised for strict fields when the input value is not an insta
 This error is raised when the `datetime` value provided for a timezone-aware `datetime` field
 doesn't have timezone information:
 
-```py
+```python
 from datetime import datetime
 
 from pydantic import AwareDatetime, BaseModel, ValidationError
@@ -1859,7 +1859,7 @@ except ValidationError as exc:
 This error is raised when the `datetime` value provided for a timezone-naive `datetime` field
 has timezone info:
 
-```py
+```python
 from datetime import datetime, timezone
 
 from pydantic import BaseModel, NaiveDatetime, ValidationError
@@ -1880,7 +1880,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's length is greater than the field's `max_length` constraint:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, Field, ValidationError
@@ -1901,7 +1901,7 @@ except ValidationError as exc:
 
 This error is raised when the value length is less than the field's `min_length` constraint:
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, Field, ValidationError
@@ -1922,7 +1922,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a `tuple` field:
 
-```py
+```python
 from typing import Tuple
 
 from pydantic import BaseModel, ValidationError
@@ -1946,7 +1946,7 @@ This error is also raised for strict fields when the input value is not an insta
 This error is raised when you provide a value by keyword for a positional-only
 argument while calling a function decorated with `validate_call`:
 
-```py
+```python
 from pydantic import ValidationError, validate_call
 
 
@@ -1964,7 +1964,7 @@ except ValidationError as exc:
 
 It is also raised when using pydantic.dataclasses and `extra=forbid`:
 
-```py
+```python
 from pydantic import TypeAdapter, ValidationError
 from pydantic.dataclasses import dataclass
 
@@ -1986,7 +1986,7 @@ except ValidationError as exc:
 This error is raised when you provide a positional value for a keyword-only
 argument while calling a function decorated with `validate_call`:
 
-```py
+```python
 from pydantic import ValidationError, validate_call
 
 
@@ -2006,7 +2006,7 @@ except ValidationError as exc:
 
 This error is raised when the input's discriminator is not one of the expected values:
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field, ValidationError
@@ -2035,7 +2035,7 @@ except ValidationError as exc:
 
 This error is raised when it is not possible to extract a discriminator value from the input:
 
-```py
+```python
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field, ValidationError
@@ -2064,7 +2064,7 @@ except ValidationError as exc:
 
 This error is raised when the input value cannot be parsed as a URL:
 
-```py
+```python
 from pydantic import AnyUrl, BaseModel, ValidationError
 
 
@@ -2083,7 +2083,7 @@ except ValidationError as exc:
 
 This error is raised when the URL scheme is not valid for the URL type of the field:
 
-```py
+```python
 from pydantic import BaseModel, HttpUrl, ValidationError
 
 
@@ -2102,7 +2102,7 @@ except ValidationError as exc:
 
 This error is raised when the URL syntax is not valid:
 
-```py
+```python
 from pydantic import BaseModel, Field, HttpUrl, ValidationError
 
 
@@ -2121,7 +2121,7 @@ except ValidationError as exc:
 
 This error is raised when the URL length is greater than 2083:
 
-```py
+```python
 from pydantic import BaseModel, HttpUrl, ValidationError
 
 
@@ -2140,7 +2140,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a URL field:
 
-```py
+```python
 from pydantic import BaseModel, HttpUrl, ValidationError
 
 
@@ -2159,7 +2159,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid for a UUID field:
 
-```py
+```python
 from uuid import UUID
 
 from pydantic import BaseModel, ValidationError
@@ -2180,7 +2180,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not valid instance for a UUID field (str, bytes or UUID):
 
-```py
+```python
 from uuid import UUID
 
 from pydantic import BaseModel, ValidationError
@@ -2201,7 +2201,7 @@ except ValidationError as exc:
 
 This error is raised when the input value's type is not match UUID version:
 
-```py
+```python
 from pydantic import UUID5, BaseModel, ValidationError
 
 
@@ -2220,7 +2220,7 @@ except ValidationError as exc:
 
 This error is raised when a `ValueError` is raised during validation:
 
-```py
+```python
 from pydantic import BaseModel, ValidationError, field_validator
 
 

--- a/docs/examples/custom_validators.md
+++ b/docs/examples/custom_validators.md
@@ -11,7 +11,7 @@ The custom validator supports string specification of the timezone, and will rai
 
 We use `__get_pydantic_core_schema__` in the validator to customize the schema of the annotated type (in this case, [`datetime`][datetime.datetime]), which allows us to add custom validation logic. Notably, we use a `wrap` validator function so that we can perform operations both before and after the default `pydantic` validation of a [`datetime`][datetime.datetime].
 
-```py
+```python
 import datetime as dt
 from dataclasses import dataclass
 from pprint import pprint
@@ -100,7 +100,7 @@ except ValidationError as ve:
 We can also enforce UTC offset constraints in a similar way.  Assuming we have a `lower_bound` and an `upper_bound`, we can create a custom validator to ensure our `datetime` has a UTC offset that is inclusive within the boundary we define:
 
 
-```py
+```python
 import datetime as dt
 from dataclasses import dataclass
 from pprint import pprint
@@ -177,7 +177,7 @@ In this example, we construct a validator that checks that each user's password 
 
 One way to do this is to place a custom validator on the outer model:
 
-```py
+```python
 from typing import List
 
 from typing_extensions import Self
@@ -228,7 +228,7 @@ Alternatively, a custom validator can be used in the nested model class (`User`)
 !!! warning
     The ability to mutate the context within a validator adds a lot of power to nested validation, but can also lead to confusing or hard-to-debug code. Use this approach at your own risk!
 
-```py
+```python
 from typing import List
 
 from pydantic import BaseModel, ValidationError, ValidationInfo, field_validator

--- a/docs/examples/orms.md
+++ b/docs/examples/orms.md
@@ -12,7 +12,7 @@ Pydantic can pair with SQLAlchemy, as it can be used to define the schema of the
 If you'd prefer to use pure Pydantic with SQLAlchemy, we recommend using Pydantic models alongside of SQLAlchemy models
 as shown in the example below. In this case, we take advantage of Pydantic's aliases feature to name a `Column` after a reserved SQLAlchemy field, thus avoiding conflicts.
 
-```py
+```python
 import typing
 
 import sqlalchemy as sa

--- a/docs/integrations/visual_studio_code.md
+++ b/docs/integrations/visual_studio_code.md
@@ -129,13 +129,13 @@ Below are several techniques to achieve it.
 
 You can disable the errors for a specific line using a comment of:
 
-```py
+```python
 # type: ignore
 ```
 
 or (to be specific to pylance/pyright):
 
-```py
+```python
 # pyright: ignore
 ```
 
@@ -260,7 +260,7 @@ in a model that is "frozen".
 
 Pylance/pyright requires `default` to be a keyword argument to `Field` in order to infer that the field is optional.
 
-```py
+```python
 from pydantic import BaseModel, Field
 
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -188,7 +188,7 @@ to help ease migration, but calling them will emit `DeprecationWarning`s.
 If you'd still like to use said arguments, you can use [this workaround](https://github.com/pydantic/pydantic/issues/8825#issuecomment-1946206415).
 * JSON serialization of non-string key values is generally done with `str(key)`, leading to some changes in behavior such as the following:
 
-```py
+```python
 from typing import Dict, Optional
 
 from pydantic import BaseModel as V2BaseModel
@@ -218,7 +218,7 @@ print(v2_model.model_dump_json())
 * `model_dump_json()` results are compacted in order to save space, and don't always exactly match that of `json.dumps()` output.
 That being said, you can easily modify the separators used in `json.dumps()` results in order to align the two outputs:
 
-```py
+```python
 import json
 from typing import List
 
@@ -677,7 +677,7 @@ The following table describes the behavior of field annotations in V2:
     Any default value if provided makes a field not required.
 
 Here is a code example demonstrating the above:
-```py
+```python
 from typing import Optional
 
 from pydantic import BaseModel, ValidationError
@@ -838,7 +838,7 @@ Some of the URL validation differs slightly from the previous behavior in V1.
 One notable difference is that the new `Url` types append slashes to the validated version if no path is included,
 even if a slash is not specified in the argument to a `Url` type constructor. See the example below for this behavior:
 
-```py
+```python
 from pydantic import AnyUrl
 
 assert str(AnyUrl(url='https://google.com')) == 'https://google.com/'
@@ -868,7 +868,7 @@ class Model(BaseModel):
 
 ...becomes:
 
-```py
+```python
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field

--- a/docs/why.md
+++ b/docs/why.md
@@ -137,7 +137,7 @@ In all three modes, the output can be customized by excluding specific fields, e
 
 ??? example "Example - Serialization 3 ways"
 
-    ```py
+    ```python
     from datetime import datetime
 
     from pydantic import BaseModel
@@ -167,7 +167,7 @@ A [JSON Schema](https://json-schema.org/) can be generated for any Pydantic sche
 
 ??? example "Example - JSON Schema"
 
-    ```py
+    ```python
     from datetime import datetime
 
     from pydantic import BaseModel
@@ -236,7 +236,7 @@ implemented in Rust, it's also very performant.
 
 ??? example "Example - Strict mode that's actually useful"
 
-    ```py
+    ```python
     from datetime import datetime
 
     from pydantic import BaseModel, ValidationError
@@ -288,7 +288,7 @@ Pydantic provides four ways to create schemas and perform validation and seriali
 
 ??? example "Example - schema based on a [`TypedDict`][typing.TypedDict]"
 
-    ```py
+    ```python
     from datetime import datetime
 
     from typing_extensions import NotRequired, TypedDict
@@ -338,7 +338,7 @@ Functional validators and serializers, as well as a powerful protocol for custom
 ??? example "Customisation Example - wrap validators"
     "wrap validators" are new in Pydantic V2 and are one of the most powerful ways to customize validation.
 
-    ```py
+    ```python
     from datetime import datetime, timezone
     from typing import Any
 

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -216,7 +216,7 @@ def is_builtin_dataclass(_cls: type[Any]) -> TypeGuard[type[StandardDataclass]]:
     - `_cls` does not inherit from a processed pydantic dataclass (and thus have a `__pydantic_validator__`)
     - `_cls` does not have any annotations that are not dataclass fields
     e.g.
-    ```py
+    ```python
     import dataclasses
 
     import pydantic.dataclasses

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -261,7 +261,7 @@ def replace_types(type_: Any, type_map: Mapping[Any, Any] | None) -> Any:
         `typevar_map` keys recursively replaced.
 
     Example:
-        ```py
+        ```python
         from typing import List, Tuple, Union
 
         from pydantic._internal._generics import replace_types

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -112,7 +112,7 @@ def expand_grouped_metadata(annotations: Iterable[Any]) -> Iterable[Any]:
         An iterable of expanded annotations.
 
     Example:
-        ```py
+        ```python
         from annotated_types import Ge, Len
 
         from pydantic._internal._known_annotated_metadata import expand_grouped_metadata
@@ -338,7 +338,7 @@ def collect_known_metadata(annotations: Iterable[Any]) -> tuple[dict[str, Any], 
         A tuple contains a dict of known metadata and a list of unknown annotations.
 
     Example:
-        ```py
+        ```python
         from annotated_types import Gt, Len
 
         from pydantic._internal._known_annotated_metadata import collect_known_metadata

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -68,7 +68,7 @@ class ConfigDict(TypedDict, total=False):
     * `forbid` - Forbid any extra attributes.
     * `ignore` - Ignore any extra attributes.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict
 
     class User(BaseModel):
@@ -86,7 +86,7 @@ class ConfigDict(TypedDict, total=False):
 
     Instead, with `extra='allow'`, the `age` argument is included:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict
 
     class User(BaseModel):
@@ -103,7 +103,7 @@ class ConfigDict(TypedDict, total=False):
 
     With `extra='forbid'`, an error is raised:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, ValidationError
 
     class User(BaseModel):
@@ -142,7 +142,7 @@ class ConfigDict(TypedDict, total=False):
         The name of this configuration setting was changed in **v2.0** from
         `allow_population_by_field_name` to `populate_by_name`.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, Field
 
     class User(BaseModel):
@@ -174,7 +174,7 @@ class ConfigDict(TypedDict, total=False):
         for said Field to ensure that the `use_enum_values` flag takes effect on the default, as extracting an
         enum's value occurs during validation, not serialization.
 
-    ```py
+    ```python
     from enum import Enum
     from typing import Optional
 
@@ -211,7 +211,7 @@ class ConfigDict(TypedDict, total=False):
 
     In case the user changes the data after the model is created, the model is _not_ revalidated.
 
-    ```py
+    ```python
     from pydantic import BaseModel
 
     class User(BaseModel):
@@ -230,7 +230,7 @@ class ConfigDict(TypedDict, total=False):
 
     In case you want to revalidate the model when the data is changed, you can use `validate_assignment=True`:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ValidationError
 
     class User(BaseModel, validate_assignment=True):  # (1)!
@@ -259,7 +259,7 @@ class ConfigDict(TypedDict, total=False):
     """
     Whether arbitrary types are allowed for field types. Defaults to `False`.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, ValidationError
 
     # This is not a pydantic model, it's an arbitrary class
@@ -331,7 +331,7 @@ class ConfigDict(TypedDict, total=False):
     you can automatically generate aliases using `alias_generator`. Here's an example with
     a basic callable:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict
     from pydantic.alias_generators import to_pascal
 
@@ -351,7 +351,7 @@ class ConfigDict(TypedDict, total=False):
     If you want to use different alias generators for validation and serialization, you can use
     [`AliasGenerator`][pydantic.aliases.AliasGenerator].
 
-    ```py
+    ```python
     from pydantic import AliasGenerator, BaseModel, ConfigDict
     from pydantic.alias_generators import to_camel, to_pascal
 
@@ -412,7 +412,7 @@ class ConfigDict(TypedDict, total=False):
 
     To configure strict mode for all fields on a model, you can set `strict=True` on the model.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict
 
     class Model(BaseModel):
@@ -440,7 +440,7 @@ class ConfigDict(TypedDict, total=False):
 
     By default, model and dataclass instances are not revalidated during validation.
 
-    ```py
+    ```python
     from typing import List
 
     from pydantic import BaseModel
@@ -477,7 +477,7 @@ class ConfigDict(TypedDict, total=False):
     If you want to revalidate instances during validation, you can set `revalidate_instances` to `'always'`
     in the model's config.
 
-    ```py
+    ```python
     from typing import List
 
     from pydantic import BaseModel, ValidationError
@@ -520,7 +520,7 @@ class ConfigDict(TypedDict, total=False):
     It's also possible to set `revalidate_instances` to `'subclass-instances'` to only revalidate instances
     of subclasses of the model.
 
-    ```py
+    ```python
     from typing import List
 
     from pydantic import BaseModel
@@ -617,7 +617,7 @@ class ConfigDict(TypedDict, total=False):
 
     For more details, see https://github.com/pydantic/pydantic/issues/10315.
 
-    ```py
+    ```python
     import warnings
 
     from pydantic import BaseModel
@@ -676,7 +676,7 @@ class ConfigDict(TypedDict, total=False):
     While Pydantic will only emit a warning when an item is in a protected namespace but does not actually have a collision,
     an error _is_ raised if there is an actual collision with an existing attribute:
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict
 
     try:
@@ -700,7 +700,7 @@ class ConfigDict(TypedDict, total=False):
 
     Pydantic shows the input value and type when it raises `ValidationError` during the validation.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ValidationError
 
     class Model(BaseModel):
@@ -719,7 +719,7 @@ class ConfigDict(TypedDict, total=False):
 
     You can hide the input value and type by setting the `hide_input_in_errors` config to `True`.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, ValidationError
 
     class Model(BaseModel):
@@ -773,7 +773,7 @@ class ConfigDict(TypedDict, total=False):
     between validation and serialization, and don't mind fields with defaults being marked as not required during
     serialization. See [#7209](https://github.com/pydantic/pydantic/issues/7209) for more details.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict
 
     class Model(BaseModel):
@@ -816,7 +816,7 @@ class ConfigDict(TypedDict, total=False):
     the validation and serialization schemas (since both will use the specified schema), and so prevents the suffixes
     from being added to the definition references.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, Json
 
     class Model(BaseModel):
@@ -862,7 +862,7 @@ class ConfigDict(TypedDict, total=False):
 
     Pydantic doesn't allow number types (`int`, `float`, `Decimal`) to be coerced as type `str` by default.
 
-    ```py
+    ```python
     from decimal import Decimal
 
     from pydantic import BaseModel, ConfigDict, ValidationError
@@ -908,7 +908,7 @@ class ConfigDict(TypedDict, total=False):
         If you use a compiled regex pattern, the python-re engine will be used regardless of this setting.
         This is so that flags such as `re.IGNORECASE` are respected.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
     class Model(BaseModel):
@@ -949,7 +949,7 @@ class ConfigDict(TypedDict, total=False):
 
     Available in Pydantic v2.7+.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -1013,7 +1013,7 @@ def with_config(config: ConfigDict) -> Callable[[_TypeT], _TypeT]:
 
     !!! example "Usage"
 
-        ```py
+        ```python
         from typing_extensions import TypedDict
 
         from pydantic import ConfigDict, TypeAdapter, with_config

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1314,7 +1314,7 @@ def computed_field(
 
     This is useful for fields that are computed from other fields, or for fields that are expensive to compute and should be cached.
 
-    ```py
+    ```python
     from pydantic import BaseModel, computed_field
 
     class Rectangle(BaseModel):
@@ -1342,7 +1342,7 @@ def computed_field(
 
         [pyright](https://github.com/microsoft/pyright) supports `@computed_field` without error.
 
-    ```py
+    ```python
     import random
 
     from pydantic import BaseModel, computed_field
@@ -1382,7 +1382,7 @@ def computed_field(
         `mypy` complains about this behavior if allowed, and `dataclasses` doesn't allow this pattern either.
         See the example below:
 
-    ```py
+    ```python
     from pydantic import BaseModel, computed_field
 
     class Parent(BaseModel):
@@ -1403,7 +1403,7 @@ def computed_field(
 
     Private properties decorated with `@computed_field` have `repr=False` by default.
 
-    ```py
+    ```python
     from functools import cached_property
 
     from pydantic import BaseModel, computed_field

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -34,7 +34,7 @@ class AfterValidator:
         func: The validator function.
 
     Example:
-        ```py
+        ```python
         from typing_extensions import Annotated
 
         from pydantic import AfterValidator, BaseModel, ValidationError
@@ -96,7 +96,7 @@ class BeforeValidator:
             JSON Schema (in validation mode).
 
     Example:
-        ```py
+        ```python
         from typing_extensions import Annotated
 
         from pydantic import BaseModel, BeforeValidator
@@ -174,7 +174,7 @@ class PlainValidator:
             JSON Schema (in validation mode). If not provided, will default to `Any`.
 
     Example:
-        ```py
+        ```python
         from typing import Union
 
         from typing_extensions import Annotated
@@ -273,7 +273,7 @@ class WrapValidator:
         json_schema_input_type: The input type of the function. This is only used to generate the appropriate
             JSON Schema (in validation mode).
 
-    ```py
+    ```python
     from datetime import datetime
 
     from typing_extensions import Annotated
@@ -437,7 +437,7 @@ def field_validator(
     Decorate methods on the class indicating that they should be used to validate fields.
 
     Example usage:
-    ```py
+    ```python
     from typing import Any
 
     from pydantic import (
@@ -694,7 +694,7 @@ def model_validator(
     Decorate model methods for validation purposes.
 
     Example usage:
-    ```py
+    ```python
     from typing_extensions import Self
 
     from pydantic import BaseModel, ValidationError, model_validator
@@ -756,7 +756,7 @@ else:
         '''Generic type for annotating a type that is an instance of a given class.
 
         Example:
-            ```py
+            ```python
             from pydantic import BaseModel, InstanceOf
 
             class Foo:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2572,7 +2572,7 @@ else:
         Add this as an annotation on a field to skip generating a JSON schema for that field.
 
         Example:
-            ```py
+            ```python
             from typing import Union
 
             from pydantic import BaseModel

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1089,7 +1089,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             """This signature is included purely to help type-checkers check arguments to class declaration, which
             provides a way to conveniently set model_config key/value pairs.
 
-            ```py
+            ```python
             from pydantic import BaseModel
 
             class MyModel(BaseModel, extra='allow'): ...
@@ -1378,7 +1378,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         If you need `include` or `exclude`, use:
 
-        ```py {test="skip" lint="skip"}
+        ```python {test="skip" lint="skip"}
         data = self.model_dump(include=include, exclude=exclude, round_trip=True)
         data = {**data, **(update or {})}
         copied = self.model_validate(data)

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -332,7 +332,7 @@ class _BaseMultiHostUrl:
     def hosts(self) -> list[MultiHostHost]:
         '''The hosts of the `MultiHostUrl` as [`MultiHostHost`][pydantic_core.MultiHostHost] typed dicts.
 
-        ```py
+        ```python
         from pydantic_core import MultiHostUrl
 
         mhu = MultiHostUrl('https://foo.com:123,foo:bar@bar.com/path')
@@ -499,7 +499,7 @@ class HttpUrl(AnyUrl):
     * Host required
     * Max length 2083
 
-    ```py
+    ```python
     from pydantic import BaseModel, HttpUrl, ValidationError
 
     class MyModel(BaseModel):
@@ -536,7 +536,7 @@ class HttpUrl(AnyUrl):
     [punycode](https://en.wikipedia.org/wiki/Punycode) (see
     [this article](https://www.xudongz.com/blog/2017/idn-phishing/) for a good description of why this is important):
 
-    ```py
+    ```python
     from pydantic import BaseModel, HttpUrl
 
     class MyModel(BaseModel):
@@ -638,7 +638,7 @@ class PostgresDsn(_BaseMultiHostUrl):
 
     If further validation is required, these properties can be used by validators to enforce specific behaviour:
 
-    ```py
+    ```python
     from pydantic import (
         BaseModel,
         HttpUrl,
@@ -894,7 +894,7 @@ else:
 
         Validate email addresses.
 
-        ```py
+        ```python
         from pydantic import BaseModel, EmailStr
 
         class Model(BaseModel):
@@ -943,7 +943,7 @@ class NameEmail(_repr.Representation):
     The `NameEmail` has two properties: `name` and `email`.
     In case the `name` is not provided, it's inferred from the email address.
 
-    ```py
+    ```python
     from pydantic import BaseModel, NameEmail
 
     class User(BaseModel):
@@ -1029,7 +1029,7 @@ else:
     class IPvAnyAddress:
         """Validate an IPv4 or IPv6 address.
 
-        ```py
+        ```python
         from pydantic import BaseModel
         from pydantic.networks import IPvAnyAddress
 

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -187,7 +187,7 @@ class TypeAdapter(Generic[T]):
             Depending on the type used, `mypy` might raise an error when instantiating a `TypeAdapter`. As a workaround, you can explicitly
             annotate your variable:
 
-            ```py
+            ```python
             from typing import Union
 
             from pydantic import TypeAdapter

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -165,7 +165,7 @@ def conint(
         The reason is that `conint` returns a type, which doesn't play well with static analysis tools.
 
         === ":x: Don't do this"
-            ```py
+            ```python
             from pydantic import BaseModel, conint
 
             class Foo(BaseModel):
@@ -173,7 +173,7 @@ def conint(
             ```
 
         === ":white_check_mark: Do this"
-            ```py
+            ```python
             from typing_extensions import Annotated
 
             from pydantic import BaseModel, Field
@@ -195,7 +195,7 @@ def conint(
     Returns:
         The wrapped integer type.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ValidationError, conint
 
     class ConstrainedExample(BaseModel):
@@ -235,7 +235,7 @@ def conint(
 PositiveInt = Annotated[int, annotated_types.Gt(0)]
 """An integer that must be greater than zero.
 
-```py
+```python
 from pydantic import BaseModel, PositiveInt, ValidationError
 
 class Model(BaseModel):
@@ -266,7 +266,7 @@ except ValidationError as e:
 NegativeInt = Annotated[int, annotated_types.Lt(0)]
 """An integer that must be less than zero.
 
-```py
+```python
 from pydantic import BaseModel, NegativeInt, ValidationError
 
 class Model(BaseModel):
@@ -297,7 +297,7 @@ except ValidationError as e:
 NonPositiveInt = Annotated[int, annotated_types.Le(0)]
 """An integer that must be less than or equal to zero.
 
-```py
+```python
 from pydantic import BaseModel, NonPositiveInt, ValidationError
 
 class Model(BaseModel):
@@ -328,7 +328,7 @@ except ValidationError as e:
 NonNegativeInt = Annotated[int, annotated_types.Ge(0)]
 """An integer that must be greater than or equal to zero.
 
-```py
+```python
 from pydantic import BaseModel, NonNegativeInt, ValidationError
 
 class Model(BaseModel):
@@ -359,7 +359,7 @@ except ValidationError as e:
 StrictInt = Annotated[int, Strict()]
 """An integer that must be validated in strict mode.
 
-```py
+```python
 from pydantic import BaseModel, StrictInt, ValidationError
 
 class StrictIntModel(BaseModel):
@@ -425,7 +425,7 @@ def confloat(
         The reason is that `confloat` returns a type, which doesn't play well with static analysis tools.
 
         === ":x: Don't do this"
-            ```py
+            ```python
             from pydantic import BaseModel, confloat
 
             class Foo(BaseModel):
@@ -433,7 +433,7 @@ def confloat(
             ```
 
         === ":white_check_mark: Do this"
-            ```py
+            ```python
             from typing_extensions import Annotated
 
             from pydantic import BaseModel, Field
@@ -456,7 +456,7 @@ def confloat(
     Returns:
         The wrapped float type.
 
-    ```py
+    ```python
     from pydantic import BaseModel, ValidationError, confloat
 
     class ConstrainedExample(BaseModel):
@@ -496,7 +496,7 @@ def confloat(
 PositiveFloat = Annotated[float, annotated_types.Gt(0)]
 """A float that must be greater than zero.
 
-```py
+```python
 from pydantic import BaseModel, PositiveFloat, ValidationError
 
 class Model(BaseModel):
@@ -527,7 +527,7 @@ except ValidationError as e:
 NegativeFloat = Annotated[float, annotated_types.Lt(0)]
 """A float that must be less than zero.
 
-```py
+```python
 from pydantic import BaseModel, NegativeFloat, ValidationError
 
 class Model(BaseModel):
@@ -558,7 +558,7 @@ except ValidationError as e:
 NonPositiveFloat = Annotated[float, annotated_types.Le(0)]
 """A float that must be less than or equal to zero.
 
-```py
+```python
 from pydantic import BaseModel, NonPositiveFloat, ValidationError
 
 class Model(BaseModel):
@@ -589,7 +589,7 @@ except ValidationError as e:
 NonNegativeFloat = Annotated[float, annotated_types.Ge(0)]
 """A float that must be greater than or equal to zero.
 
-```py
+```python
 from pydantic import BaseModel, NonNegativeFloat, ValidationError
 
 class Model(BaseModel):
@@ -620,7 +620,7 @@ except ValidationError as e:
 StrictFloat = Annotated[float, Strict(True)]
 """A float that must be validated in strict mode.
 
-```py
+```python
 from pydantic import BaseModel, StrictFloat, ValidationError
 
 class StrictFloatModel(BaseModel):
@@ -640,7 +640,7 @@ except ValidationError as e:
 FiniteFloat = Annotated[float, AllowInfNan(False)]
 """A float that must be finite (not ``-inf``, ``inf``, or ``nan``).
 
-```py
+```python
 from pydantic import BaseModel, FiniteFloat
 
 class Model(BaseModel):
@@ -762,7 +762,7 @@ def constr(
         The reason is that `constr` returns a type, which doesn't play well with static analysis tools.
 
         === ":x: Don't do this"
-            ```py
+            ```python
             from pydantic import BaseModel, constr
 
             class Foo(BaseModel):
@@ -770,7 +770,7 @@ def constr(
             ```
 
         === ":white_check_mark: Do this"
-            ```py
+            ```python
             from typing_extensions import Annotated
 
             from pydantic import BaseModel, StringConstraints
@@ -786,7 +786,7 @@ def constr(
 
     A wrapper around `str` that allows for additional constraints.
 
-    ```py
+    ```python
     from pydantic import BaseModel, constr
 
     class Foo(BaseModel):
@@ -916,7 +916,7 @@ else:
         On model instantiation, pointers will be evaluated and imported. There is
         some nuance to this behavior, demonstrated in the examples below.
 
-        ```py
+        ```python
         import math
 
         from pydantic import BaseModel, Field, ImportString, ValidationError
@@ -970,7 +970,7 @@ else:
 
         Serializing an `ImportString` type to json is also possible.
 
-        ```py
+        ```python
         from pydantic import BaseModel, ImportString
 
         class ImportThings(BaseModel):
@@ -1056,7 +1056,7 @@ def condecimal(
         The reason is that `condecimal` returns a type, which doesn't play well with static analysis tools.
 
         === ":x: Don't do this"
-            ```py
+            ```python
             from pydantic import BaseModel, condecimal
 
             class Foo(BaseModel):
@@ -1064,7 +1064,7 @@ def condecimal(
             ```
 
         === ":white_check_mark: Do this"
-            ```py
+            ```python
             from decimal import Decimal
 
             from typing_extensions import Annotated
@@ -1088,7 +1088,7 @@ def condecimal(
         decimal_places: The number of decimal places. Defaults to `None`.
         allow_inf_nan: Whether to allow infinity and NaN. Defaults to `None`.
 
-    ```py
+    ```python
     from decimal import Decimal
 
     from pydantic import BaseModel, ValidationError, condecimal
@@ -1180,7 +1180,7 @@ class UuidVersion:
 UUID1 = Annotated[UUID, UuidVersion(1)]
 """A [UUID](https://docs.python.org/3/library/uuid.html) that must be version 1.
 
-```py
+```python
 import uuid
 
 from pydantic import UUID1, BaseModel
@@ -1194,7 +1194,7 @@ Model(uuid1=uuid.uuid1())
 UUID3 = Annotated[UUID, UuidVersion(3)]
 """A [UUID](https://docs.python.org/3/library/uuid.html) that must be version 3.
 
-```py
+```python
 import uuid
 
 from pydantic import UUID3, BaseModel
@@ -1208,7 +1208,7 @@ Model(uuid3=uuid.uuid3(uuid.NAMESPACE_DNS, 'pydantic.org'))
 UUID4 = Annotated[UUID, UuidVersion(4)]
 """A [UUID](https://docs.python.org/3/library/uuid.html) that must be version 4.
 
-```py
+```python
 import uuid
 
 from pydantic import UUID4, BaseModel
@@ -1222,7 +1222,7 @@ Model(uuid4=uuid.uuid4())
 UUID5 = Annotated[UUID, UuidVersion(5)]
 """A [UUID](https://docs.python.org/3/library/uuid.html) that must be version 5.
 
-```py
+```python
 import uuid
 
 from pydantic import UUID5, BaseModel
@@ -1300,7 +1300,7 @@ class PathType:
 FilePath = Annotated[Path, PathType('file')]
 """A path that must point to a file.
 
-```py
+```python
 from pathlib import Path
 
 from pydantic import BaseModel, FilePath, ValidationError
@@ -1342,7 +1342,7 @@ except ValidationError as e:
 DirectoryPath = Annotated[Path, PathType('dir')]
 """A path that must point to a directory.
 
-```py
+```python
 from pathlib import Path
 
 from pydantic import BaseModel, DirectoryPath, ValidationError
@@ -1401,7 +1401,7 @@ else:
         You can use the `Json` data type to make Pydantic first load a raw JSON string before
         validating the loaded data into the parametrized type:
 
-        ```py
+        ```python
         from typing import Any, List
 
         from pydantic import BaseModel, Json, ValidationError
@@ -1453,7 +1453,7 @@ else:
         When you dump the model using `model_dump` or `model_dump_json`, the dumped value will be the result of validation,
         not the original JSON string. However, you can use the argument `round_trip=True` to get the original JSON string back:
 
-        ```py
+        ```python
         from typing import List
 
         from pydantic import BaseModel, Json
@@ -1533,7 +1533,7 @@ class Secret(_SecretBase[SecretType]):
 
     1. Directly parametrizing `Secret` with a type:
 
-    ```py
+    ```python
     from pydantic import BaseModel, Secret
 
     SecretBool = Secret[bool]
@@ -1554,7 +1554,7 @@ class Secret(_SecretBase[SecretType]):
 
     2. Subclassing from parametrized `Secret`:
 
-    ```py
+    ```python
     from datetime import date
 
     from pydantic import BaseModel, Secret
@@ -1582,7 +1582,7 @@ class Secret(_SecretBase[SecretType]):
     You can enforce constraints on the underlying type through annotations:
     For example:
 
-    ```py
+    ```python
     from typing_extensions import Annotated
 
     from pydantic import BaseModel, Field, Secret, ValidationError
@@ -1747,7 +1747,7 @@ class SecretStr(_SecretField[str]):
     When the secret value is nonempty, it is displayed as `'**********'` instead of the underlying value in
     calls to `repr()` and `str()`. If the value _is_ empty, it is displayed as `''`.
 
-    ```py
+    ```python
     from pydantic import BaseModel, SecretStr
 
     class User(BaseModel):
@@ -1770,7 +1770,7 @@ class SecretStr(_SecretField[str]):
     You can use the [`field_serializer`][pydantic.functional_serializers.field_serializer] to dump the
     secret as plain-text when serializing to json.
 
-    ```py
+    ```python
     from pydantic import BaseModel, SecretBytes, SecretStr, field_serializer
 
     class Model(BaseModel):
@@ -1815,7 +1815,7 @@ class SecretBytes(_SecretField[bytes]):
     When the secret value is nonempty, it is displayed as `b'**********'` instead of the underlying value in
     calls to `repr()` and `str()`. If the value _is_ empty, it is displayed as `b''`.
 
-    ```py
+    ```python
     from pydantic import BaseModel, SecretBytes
 
     class User(BaseModel):
@@ -1978,7 +1978,7 @@ class ByteSize(int):
     !!! info
         Note that `1b` will be parsed as "1 byte" and not "1 bit".
 
-    ```py
+    ```python
     from pydantic import BaseModel, ByteSize
 
     class MyModel(BaseModel):
@@ -2417,7 +2417,7 @@ class EncodedBytes:
 
     `EncodedBytes` needs an encoder that implements `EncoderProtocol` to operate.
 
-    ```py
+    ```python
     from typing_extensions import Annotated
 
     from pydantic import BaseModel, EncodedBytes, EncoderProtocol, ValidationError
@@ -2516,7 +2516,7 @@ class EncodedStr:
 
     `EncodedStr` needs an encoder that implements `EncoderProtocol` to operate.
 
-    ```py
+    ```python
     from typing_extensions import Annotated
 
     from pydantic import BaseModel, EncodedStr, EncoderProtocol, ValidationError
@@ -2627,7 +2627,7 @@ Warning:
     If you'd still like to use these legacy encoders / decoders, you can achieve this by creating a custom annotated type,
     like follows:
 
-    ```py
+    ```python
     import base64
     from typing import Literal
 
@@ -2659,7 +2659,7 @@ Warning:
     LegacyBase64Bytes = Annotated[bytes, EncodedBytes(encoder=LegacyBase64Encoder)]
     ```
 
-```py
+```python
 from pydantic import Base64Bytes, BaseModel, ValidationError
 
 class Model(BaseModel):
@@ -2706,7 +2706,7 @@ Warning:
     See the [`Base64Bytes`][pydantic.types.Base64Bytes] type for more information on how to
     replicate the old behavior with the legacy encoders / decoders.
 
-```py
+```python
 from pydantic import Base64Str, BaseModel, ValidationError
 
 class Model(BaseModel):
@@ -2745,7 +2745,7 @@ Note:
     As a result, the `Base64UrlBytes` type can be used to faithfully decode "vanilla" base64 data
     (using `'+'` and `'/'`).
 
-```py
+```python
 from pydantic import Base64UrlBytes, BaseModel
 
 class Model(BaseModel):
@@ -2766,7 +2766,7 @@ Note:
 
     As a result, the `Base64UrlStr` type can be used to faithfully decode "vanilla" base64 data (using `'+'` and `'/'`).
 
-```py
+```python
 from pydantic import Base64UrlStr, BaseModel
 
 class Model(BaseModel):
@@ -2845,7 +2845,7 @@ class Tag:
     The primary role of the `Tag` here is to map the return value from the callable `Discriminator` function to
     the appropriate member of the `Union` in question.
 
-    ```py
+    ```python
     from typing import Any, Union
 
     from typing_extensions import Annotated, Literal
@@ -2934,7 +2934,7 @@ class Discriminator:
     Consider this example, which is much more performant with the use of `Discriminator` and thus a `TaggedUnion`
     than it would be as a normal `Union`.
 
-    ```py
+    ```python
     from typing import Any, Union
 
     from typing_extensions import Annotated, Literal
@@ -3130,7 +3130,7 @@ if TYPE_CHECKING:
     The following example demonstrates how to use `JsonValue` to validate JSON data,
     and what kind of errors to expect when input data is not json serializable.
 
-    ```py
+    ```python
     import json
 
     from pydantic import BaseModel, JsonValue, ValidationError
@@ -3208,7 +3208,7 @@ class FailFast(_fields.PydanticMetadata, BaseMetadata):
     You might want to enable this setting if you want to validate your data faster (basically, if you use this,
     validation will be more performant with the caveat that you get less information).
 
-    ```py
+    ```python
     from typing import List
 
     from typing_extensions import Annotated


### PR DESCRIPTION
As @Viicos started working on in https://github.com/pydantic/pydantic/pull/10898