### PR TITLE
Relax check for validated data in default factory utils

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -599,7 +599,7 @@ class FieldInfo(_repr.Representation):
             if _fields.takes_validated_data_argument(self.default_factory):
                 if validated_data is None:
                     raise ValueError(
-                       "The default factory requires the 'validated_data' argument, which was not provided when calling 'get_default'."
+                        "The default factory requires the 'validated_data' argument, which was not provided when calling 'get_default'."
                     )
                 return self.default_factory(validated_data)
             else:

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -594,9 +594,11 @@ class FieldInfo(_repr.Representation):
         if self.default_factory is None:
             return _utils.smart_deepcopy(self.default)
         elif call_default_factory:
-            if validated_data is None:
-                raise ValueError("'validated_data' must be provided if 'call_default_factory' is True.")
             if _fields.takes_validated_data_argument(self.default_factory):
+                if validated_data is None:
+                    raise ValueError(
+                        "'validated_data' is missing but should be provided. This is a bug, please report this."
+                    )
                 return self.default_factory(validated_data)
             else:
                 fac = cast(Callable[[], Any], self.default_factory)  # Pyright doesn't narrow correctly

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -572,7 +572,9 @@ class FieldInfo(_repr.Representation):
         return self.deprecated if isinstance(self.deprecated, str) else self.deprecated.message
 
     @overload
-    def get_default(self, *, call_default_factory: Literal[True], validated_data: dict[str, Any]) -> Any: ...
+    def get_default(
+        self, *, call_default_factory: Literal[True], validated_data: dict[str, Any] | None = None
+    ) -> Any: ...
 
     @overload
     def get_default(self, *, call_default_factory: Literal[False] = ...) -> Any: ...


### PR DESCRIPTION
Following up on https://github.com/pydantic/pydantic/pull/10678#discussion_r1815062438

cc @Viicos, breaking for this case: https://github.com/pydantic/pydantic/issues/10905#issuecomment-2489644844

I think moving inside here makes sense. Though, I understood your original point in the comment 👍 

Fixes https://github.com/pydantic/pydantic/issues/10912