### PR TITLE
Support `TypeAliasType` usage of `Annotated` with `Field`s

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -493,8 +493,6 @@ class GenerateJsonSchema:
                     json_schema = generate_for_schema_type(schema_or_field)
                 else:
                     raise TypeError(f'Unexpected schema type: schema={schema_or_field}')
-            if _core_utils.is_core_schema(schema_or_field):
-                json_schema = populate_defs(schema_or_field, json_schema)
             return json_schema
 
         current_handler = _schema_generation_shared.GenerateJsonSchemaHandler(self, handler_func)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -31,14 +31,13 @@ from typing import (
     Union,
 )
 from uuid import UUID
-from typing_extensions import TypeAliasType
 
 import pytest
 from dirty_equals import HasRepr
 from packaging.version import Version
 from pydantic_core import CoreSchema, SchemaValidator, core_schema, to_jsonable_python
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
-from typing_extensions import Annotated, Literal, Self, TypedDict, deprecated
+from typing_extensions import Annotated, Literal, Self, TypeAliasType, TypedDict, deprecated
 
 import pydantic
 from pydantic import (

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6621,7 +6621,10 @@ def test_annotated_typealiastype() -> None:
     )
 
     class Model(BaseModel):
-        tat: TAT_TOO
+        tat_one: TAT_TOO
+        tat_two: TAT_TOO = Field(
+            description='a mark, figure, design, or word intentionally fixed or placed on the skin'
+        )
 
     assert Model.model_json_schema() == {
         '$defs': {
@@ -6631,8 +6634,14 @@ def test_annotated_typealiastype() -> None:
                 'examples': ['Wireframe of a pyramid with lines in it'],
             }
         },
-        'properties': {'tat': {'$ref': '#/$defs/TAT_TOO'}},
-        'required': ['tat'],
+        'properties': {
+            'tat_one': {'$ref': '#/$defs/TAT_TOO'},
+            'tat_two': {
+                '$ref': '#/$defs/TAT_TOO',
+                'description': 'a mark, figure, design, or word intentionally fixed or placed on the skin',
+            },
+        },
+        'required': ['tat_one', 'tat_two'],
         'title': 'Model',
         'type': 'object',
     }

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -31,6 +31,7 @@ from typing import (
     Union,
 )
 from uuid import UUID
+from typing_extensions import TypeAliasType
 
 import pytest
 from dirty_equals import HasRepr
@@ -6609,3 +6610,29 @@ def test_warn_on_mixed_compose() -> None:
 
         class Model(BaseModel):
             field: Annotated[int, Field(json_schema_extra={'a': 'dict'}), Field(json_schema_extra=lambda x: x.pop('a'))]  # type: ignore
+
+
+def test_annotated_typealiastype() -> None:
+    TAT_TOO = TypeAliasType(
+        'TAT_TOO',
+        Annotated[
+            str, Field(description='a design made by tattooing', examples=['Wireframe of a pyramid with lines in it'])
+        ],
+    )
+
+    class Model(BaseModel):
+        tat: TAT_TOO
+
+    assert Model.model_json_schema() == {
+        '$defs': {
+            'TAT_TOO': {
+                'type': 'string',
+                'description': 'a design made by tattooing',
+                'examples': ['Wireframe of a pyramid with lines in it'],
+            }
+        },
+        'properties': {'tat': {'$ref': '#/$defs/TAT_TOO'}},
+        'required': ['tat'],
+        'title': 'Model',
+        'type': 'object',
+    }

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -314,13 +314,11 @@ def test_recursive_generic_type_alias_annotated_defs() -> None:
     }
 
 
-@pytest.mark.xfail(reason='description is currently dropped')
 def test_field() -> None:
     SomeAlias = TypeAliasType('SomeAlias', Annotated[int, Field(description='number')])
 
     ta = TypeAdapter(Annotated[SomeAlias, Field(title='abc')])
 
-    # insert_assert(ta.json_schema())
     assert ta.json_schema() == {
         '$defs': {'SomeAlias': {'type': 'integer', 'description': 'number'}},
         '$ref': '#/$defs/SomeAlias',


### PR DESCRIPTION
## Change Summary

Well, this ended up with me mostly removing the `populate_defs` call inside `handler_func` (inside `generate_inner`) and that's it.

Why?

The `json_schema` at this point would be `{type: <inner>}` without the extra fields because the `pydantic_js_annotation_functions` haven't been called yet and _that_ schema without metadata applied is what becomes the `$defs` definition.

(Later, the annotations __will__ be applied, but to the field (ref) schema. But then that just gets blasted away by code that replaces the `ref` schema with the `$ref` one)

## Related issue number

fix #6352

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review


Selected Reviewer: @sydney-runkle