### PR TITLE
Use the parent configuration during schema generation for stdlib dataclasses

### DIFF
--- a/docs/concepts/dataclasses.md
+++ b/docs/concepts/dataclasses.md
@@ -249,7 +249,7 @@ configuration value on the dataclass:
 ```python
 import dataclasses
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from pydantic.errors import PydanticSchemaGenerationError
 
 
@@ -276,6 +276,9 @@ try:
         dc: DC
         other: str
 
+    # invalid as dc is now validated with pydantic, and ArbitraryType is not a known type
+    Model(dc=my_dc, other='other')
+
 except PydanticSchemaGenerationError as e:
     print(e.message)
     """
@@ -285,22 +288,17 @@ except PydanticSchemaGenerationError as e:
     """
 
 
-@dataclasses.dataclass
-class DC2:
-    a: ArbitraryType
-    b: str
-
-    __pydantic_config__ = {'arbitrary_types_allowed': True}
-
-
+# valid as we set arbitrary_types_allowed=True, and that config pushes down to the nested vanilla dataclass
 class Model(BaseModel):
-    dc: DC2
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    dc: DC
     other: str
 
 
-m = Model(dc=DC2(a=ArbitraryType(value=3), b='qwe'), other='other')
+m = Model(dc=my_dc, other='other')
 print(repr(m))
-#> Model(dc=DC2(a=ArbitraryType(value=3), b='qwe'), other='other')
+#> Model(dc=DC(a=ArbitraryType(value=3), b='qwe'), other='other')
 ```
 
 ### Checking if a dataclass is a Pydantic dataclass

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1411,6 +1411,8 @@ class GenerateSchema:
                 )
 
             try:
+                # if (plain) dataclass doesn't have config, we use the parent's config, hence a default of `None`
+                # see https://github.com/pydantic/pydantic/issues/10917
                 config: ConfigDict | None = get_attribute_from_bases(typed_dict_cls, '__pydantic_config__')
             except AttributeError:
                 config = None
@@ -1738,7 +1740,9 @@ class GenerateSchema:
             if origin is not None:
                 dataclass = origin
 
-            config = getattr(dataclass, '__pydantic_config__', ConfigDict())
+            # if (plain) dataclass doesn't have config, we use the parent's config, hence a default of `None`
+            # see https://github.com/pydantic/pydantic/issues/10917
+            config = getattr(dataclass, '__pydantic_config__', None)
 
             from ..dataclasses import is_pydantic_dataclass
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -3072,3 +3072,17 @@ def test_do_not_leak_config_from_other_types_during_building() -> None:
 
             dc: DC
             other: str
+
+
+def test_config_pushdown_vanilla_dc() -> None:
+    class ArbitraryType:
+        pass
+
+    @dataclasses.dataclass
+    class DC:
+        a: ArbitraryType
+
+    class Model(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        dc: DC

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -21,7 +21,6 @@ from pydantic import (
     BeforeValidator,
     ConfigDict,
     PydanticDeprecatedSince20,
-    PydanticSchemaGenerationError,
     PydanticUndefinedAnnotation,
     PydanticUserError,
     RootModel,
@@ -3052,26 +3051,6 @@ def test_warns_on_double_config() -> None:
         @pydantic.dataclasses.dataclass(config=ConfigDict(title='from decorator'))
         class Foo:
             __pydantic_config__ = ConfigDict(title='from __pydantic_config__')
-
-
-def test_do_not_leak_config_from_other_types_during_building() -> None:
-    """Regression test, where dataclasses without any config would use the precedent type's config."""
-
-    class ArbitraryType:
-        pass
-
-    @dataclasses.dataclass
-    class DC:
-        a: ArbitraryType
-        b: str
-
-    with pytest.raises(PydanticSchemaGenerationError):
-
-        class Model(BaseModel):
-            model_config = ConfigDict(arbitrary_types_allowed=True)
-
-            dc: DC
-            other: str
 
 
 def test_config_pushdown_vanilla_dc() -> None:

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -916,3 +916,16 @@ def test_typeddict_with_config_decorator():
     ta = TypeAdapter(Model)
 
     assert ta.validate_python({'x': 'ABC'}) == {'x': 'abc'}
+
+
+def test_config_pushdown_typed_dict() -> None:
+    class ArbitraryType:
+        pass
+
+    class TD(TypedDict):
+        a: ArbitraryType
+
+    class Model(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        td: TD


### PR DESCRIPTION
Sort of reverting https://github.com/pydantic/pydantic/pull/10576

Fixes https://github.com/pydantic/pydantic/issues/10917