### PR TITLE
Use the globals of the function when evaluating the return type of serializers and computed_fields

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1920,7 +1920,12 @@ class GenerateSchema:
         field_serializers: dict[str, Decorator[FieldSerializerDecoratorInfo]],
     ) -> core_schema.ComputedField:
         try:
-            return_type = _decorators.get_function_return_type(d.func, d.info.return_type, *self._types_namespace)
+            # Do not pass in globals as the function could be defined in a different module.
+            # Instead, let `get_function_return_type` infer the globals to use, but still pass
+            # in locals that may contain a parent/rebuild namespace:
+            return_type = _decorators.get_function_return_type(
+                d.func, d.info.return_type, localns=self._types_namespace.locals
+            )
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
         if return_type is PydanticUndefined:
@@ -2155,8 +2160,11 @@ class GenerateSchema:
             is_field_serializer, info_arg = inspect_field_serializer(serializer.func, serializer.info.mode)
 
             try:
+                # Do not pass in globals as the function could be defined in a different module.
+                # Instead, let `get_function_return_type` infer the globals to use, but still pass
+                # in locals that may contain a parent/rebuild namespace:
                 return_type = _decorators.get_function_return_type(
-                    serializer.func, serializer.info.return_type, *self._types_namespace
+                    serializer.func, serializer.info.return_type, localns=self._types_namespace.locals
                 )
             except NameError as e:
                 raise PydanticUndefinedAnnotation.from_name_error(e) from e
@@ -2195,8 +2203,11 @@ class GenerateSchema:
             info_arg = inspect_model_serializer(serializer.func, serializer.info.mode)
 
             try:
+                # Do not pass in globals as the function could be defined in a different module.
+                # Instead, let `get_function_return_type` infer the globals to use, but still pass
+                # in locals that may contain a parent/rebuild namespace:
                 return_type = _decorators.get_function_return_type(
-                    serializer.func, serializer.info.return_type, *self._types_namespace
+                    serializer.func, serializer.info.return_type, localns=self._types_namespace.locals
                 )
             except NameError as e:
                 raise PydanticUndefinedAnnotation.from_name_error(e) from e

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1302,14 +1302,12 @@ def test_validate_call_does_not_override_the_global_ns_with_the_local_ns_where_i
         func_val(a=1)
 
 
-@pytest.mark.xfail(
-    reason='In `GenerateSchema`, only the current class module is taken into account. '
-    'This is similar to `test_uses_the_correct_globals_to_resolve_model_forward_refs`.'
-)
 def test_uses_the_correct_globals_to_resolve_forward_refs_on_serializers(create_module):
+    # Note: unlike `test_uses_the_correct_globals_to_resolve_model_forward_refs`,
+    # we use the globals of the underlying func to resolve the return type.
     @create_module
     def module_1():
-        from pydantic import BaseModel, field_serializer  # or model_serializer
+        from pydantic import BaseModel, field_serializer  # or model_serializer, computed_field
 
         MyStr = str
 
@@ -1317,7 +1315,7 @@ def test_uses_the_correct_globals_to_resolve_forward_refs_on_serializers(create_
             a: int
 
             @field_serializer('a')
-            def ser(self) -> 'MyStr':
+            def ser(self, value) -> 'MyStr':
                 return str(self.a)
 
     class Sub(module_1.Model):


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10919

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
