### PR TITLE
Fix URL equality with different validation methods

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -222,7 +222,7 @@ class _BaseUrl:
         return self.__class__(self._url)
 
     def __eq__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url == other._url
+        return self.__class__ is other.__class__ and str(self._url) == str(other._url)
 
     @classmethod
     def build(
@@ -366,7 +366,7 @@ class _BaseMultiHostUrl:
         return self.__class__(self._url)
 
     def __eq__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url == other._url
+        return self.__class__ is other.__class__ and str(self._url) == str(other._url)
 
     @classmethod
     def build(

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -119,7 +119,7 @@ class _BaseUrl:
     _url: _CoreUrl
 
     def __init__(self, url: str | _CoreUrl | _BaseUrl) -> None:
-        self._url = _build_type_adapter(self.__class__).validate_python(url)
+        self._url = _build_type_adapter(self.__class__).validate_python(url)._url
 
     @property
     def scheme(self) -> str:
@@ -222,7 +222,7 @@ class _BaseUrl:
         return self.__class__(self._url)
 
     def __eq__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and str(self._url) == str(other._url)
+        return self.__class__ is other.__class__ and self._url == other._url
 
     @classmethod
     def build(
@@ -291,7 +291,7 @@ class _BaseMultiHostUrl:
     _url: _CoreMultiHostUrl
 
     def __init__(self, url: str | _CoreMultiHostUrl | _BaseMultiHostUrl) -> None:
-        self._url = _build_type_adapter(self.__class__).validate_python(url)
+        self._url = _build_type_adapter(self.__class__).validate_python(url)._url
 
     @property
     def scheme(self) -> str:
@@ -366,7 +366,7 @@ class _BaseMultiHostUrl:
         return self.__class__(self._url)
 
     def __eq__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and str(self._url) == str(other._url)
+        return self.__class__ is other.__class__ and self._url == other._url
 
     @classmethod
     def build(

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1066,6 +1066,15 @@ def test_url_equality() -> None:
     )
 
 
+def test_equality_independent_of_init() -> None:
+    ta = TypeAdapter(HttpUrl)
+    from_str = ta.validate_python('http://example.com/something')
+    from_url = ta.validate_python(HttpUrl('http://example.com/something'))
+    from_validated = ta.validate_python(from_str)
+
+    assert from_str == from_url == from_validated
+
+
 def test_url_subclasses_any_url() -> None:
     http_url = AnyHttpUrl('https://localhost')
     assert isinstance(http_url, AnyUrl)


### PR DESCRIPTION
Currently, less than ideal fix for https://github.com/pydantic/pydantic/issues/10932

Looking for a better workaround now, then will include this in v2.10.1