### PR TITLE
Fix JSON schema title when specified as `''`

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1495,7 +1495,7 @@ class GenerateJsonSchema:
         from .main import BaseModel
         from .root_model import RootModel
 
-        if config_title := config.get('title'):
+        if (config_title := config.get('title')) is not None:
             json_schema.setdefault('title', config_title)
         elif model_title_generator := config.get('model_title_generator'):
             title = model_title_generator(cls)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6609,3 +6609,12 @@ def test_warn_on_mixed_compose() -> None:
 
         class Model(BaseModel):
             field: Annotated[int, Field(json_schema_extra={'a': 'dict'}), Field(json_schema_extra=lambda x: x.pop('a'))]  # type: ignore
+
+
+def test_blank_title_is_respected() -> None:
+    class Model(BaseModel):
+        x: int
+
+        model_config = ConfigDict(title='')
+
+    assert Model.model_json_schema()['title'] == ''


### PR DESCRIPTION
Sort of edge case condition here, but easy to fix https://github.com/pydantic/pydantic/issues/10935