### PR TITLE
Revert "ci: use locally built pydantic-core with debug symbols

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   codspeed-profiling:
     name: CodSpeed profiling
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -26,55 +26,10 @@ jobs:
       # Using this action is still necessary for CodSpeed to work:
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-
-      - id: core-version
-        name: resolve pydantic-core tag
-        run: |
-          set -uex -o pipefail
-
-          echo core-ref=$(python -c "
-          import re
-          import tomllib
-
-          pyproject_toml = tomllib.loads(open('pyproject.toml').read())
-          core = next(d for d in pyproject_toml['project']['dependencies'] if d.startswith('pydantic-core'))
-
-          if (result := re.search(r'==(.+)', core)) is not None:
-            print(f'v{result.group(1)}')
-          elif (result := re.search(r'@ git\+https://github\.com/pydantic/pydantic-core\.git@(.+)', core)) is not None:
-            print(result.group(1))
-          else:
-            raise RuntimeError('Could not resolve pydantic-core ref')
-          ") >> $GITHUB_OUTPUT
+          python-version: '3.12'
 
       - name: install deps
         run: uv sync --python 3.12 --group testing-extra --extra email --frozen
-
-      - name: checkout pydantic-core
-        uses: actions/checkout@v4
-        with:
-          repository: pydantic/pydantic-core
-          ref: ${{ steps.core-version.outputs.core-ref }}
-          path: pydantic-core
-
-      - name: install rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools
-
-      - name: cache rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: pydantic-core
-
-      - name: install pydantic-core with profiling symbols
-        run: |
-          uv pip install pip
-          uv run bash -c "cd pydantic-core && pip install -r tests/requirements.txt && pip uninstall --yes pytest-speed && make build-pgo"
-        env:
-          CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
-          CARGO_PROFILE_RELEASE_STRIP: "false"
 
       - name: Run CodSpeed benchmarks
         uses: CodSpeedHQ/action@v3


### PR DESCRIPTION
Codspeed broken with changes, temporarily reverting so we can do perf analysis in the meantime