### PR TITLE
Support serialization as any for `Secret` types and `Url` types

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -10,7 +10,7 @@ from importlib.metadata import version
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pydantic_core import MultiHostHost, PydanticCustomError, core_schema
+from pydantic_core import MultiHostHost, PydanticCustomError, SchemaSerializer, core_schema
 from pydantic_core import MultiHostUrl as _CoreMultiHostUrl
 from pydantic_core import Url as _CoreUrl
 from typing_extensions import Annotated, Self, TypeAlias
@@ -285,6 +285,8 @@ class _BaseUrl:
             serialization=core_schema.to_string_ser_schema(),
         )
 
+    __pydantic_serializer__ = SchemaSerializer(core_schema.any_schema(serialization=core_schema.to_string_ser_schema()))
+
 
 class _BaseMultiHostUrl:
     _constraints: ClassVar[UrlConstraints] = UrlConstraints()
@@ -434,6 +436,8 @@ class _BaseMultiHostUrl:
             schema=core_schema.multi_host_url_schema(**cls._constraints.defined_constraints),
             serialization=core_schema.to_string_ser_schema(),
         )
+
+    __pydantic_serializer__ = SchemaSerializer(core_schema.any_schema(serialization=core_schema.to_string_ser_schema()))
 
 
 @lru_cache

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -33,7 +33,7 @@ from uuid import UUID
 
 import annotated_types
 from annotated_types import BaseMetadata, MaxLen, MinLen
-from pydantic_core import CoreSchema, PydanticCustomError, core_schema
+from pydantic_core import CoreSchema, PydanticCustomError, SchemaSerializer, core_schema
 from typing_extensions import Annotated, Literal, Protocol, TypeAlias, TypeAliasType, deprecated
 
 from ._internal import _core_utils, _fields, _internal_dataclass, _typing_extra, _utils, _validators
@@ -1524,6 +1524,13 @@ class _SecretBase(Generic[SecretType]):
         raise NotImplementedError
 
 
+def _serialize_secret(value: Secret[SecretType], info: core_schema.SerializationInfo) -> str | Secret[SecretType]:
+    if info.mode == 'json':
+        return str(value)
+    else:
+        return value
+
+
 class Secret(_SecretBase[SecretType]):
     """A generic base class used for defining a field with sensitive information that you do not want to be visible in logging or tracebacks.
 
@@ -1660,12 +1667,6 @@ class Secret(_SecretBase[SecretType]):
             validated_inner = handler(value)
             return cls(validated_inner)
 
-        def serialize(value: Secret[SecretType], info: core_schema.SerializationInfo) -> str | Secret[SecretType]:
-            if info.mode == 'json':
-                return str(value)
-            else:
-                return value
-
         return core_schema.json_or_python_schema(
             python_schema=core_schema.no_info_wrap_validator_function(
                 validate_secret_value,
@@ -1673,15 +1674,36 @@ class Secret(_SecretBase[SecretType]):
             ),
             json_schema=core_schema.no_info_after_validator_function(lambda x: cls(x), inner_schema),
             serialization=core_schema.plain_serializer_function_ser_schema(
-                serialize,
+                _serialize_secret,
                 info_arg=True,
                 when_used='always',
             ),
         )
 
+    __pydantic_serializer__ = SchemaSerializer(
+        core_schema.any_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                _serialize_secret,
+                info_arg=True,
+                when_used='always',
+            )
+        )
+    )
+
 
 def _secret_display(value: SecretType) -> str:  # type: ignore
     return '**********' if value else ''
+
+
+def _serialize_secret_field(
+    value: _SecretField[SecretType], info: core_schema.SerializationInfo
+) -> str | _SecretField[SecretType]:
+    if info.mode == 'json':
+        # we want the output to always be string without the `b'` prefix for bytes,
+        # hence we just use `secret_display`
+        return _secret_display(value.get_secret_value())
+    else:
+        return value
 
 
 class _SecretField(_SecretBase[SecretType]):
@@ -1690,16 +1712,6 @@ class _SecretField(_SecretBase[SecretType]):
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
-        def serialize(
-            value: _SecretField[SecretType], info: core_schema.SerializationInfo
-        ) -> str | _SecretField[SecretType]:
-            if info.mode == 'json':
-                # we want the output to always be string without the `b'` prefix for bytes,
-                # hence we just use `secret_display`
-                return _secret_display(value.get_secret_value())
-            else:
-                return value
-
         def get_json_schema(_core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
             json_schema = handler(cls._inner_schema)
             _utils.update_not_none(
@@ -1727,10 +1739,10 @@ class _SecretField(_SecretBase[SecretType]):
                 ),
                 json_schema=json_schema,
                 serialization=core_schema.plain_serializer_function_ser_schema(
-                    serialize,
+                    _serialize_secret_field,
                     info_arg=True,
                     return_schema=core_schema.str_schema(),
-                    when_used='json',
+                    when_used='always',
                 ),
             )
 
@@ -1739,6 +1751,16 @@ class _SecretField(_SecretBase[SecretType]):
             strict_schema=get_secret_schema(strict=True),
             metadata={'pydantic_js_functions': [get_json_schema]},
         )
+
+    __pydantic_serializer__ = SchemaSerializer(
+        core_schema.any_schema(
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                _serialize_secret_field,
+                info_arg=True,
+                when_used='always',
+            )
+        )
+    )
 
 
 class SecretStr(_SecretField[str]):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union
+from typing import Any, Union
 
 import pytest
 from pydantic_core import PydanticCustomError, Url
@@ -1105,3 +1105,9 @@ def test_after_validator() -> None:
     ]
     ta = TypeAdapter(HttpUrl)
     assert ta.validate_python('https://example.com/') == 'https://example.com'
+
+
+def test_serialize_as_any() -> None:
+    ta = TypeAdapter(Any)
+    assert ta.dump_python(HttpUrl('https://example.com')) == HttpUrl('https://example.com/')
+    assert ta.dump_json('https://example.com') == b'"https://example.com"'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7074,3 +7074,28 @@ def test_base64_with_invalid_min_length(base64_type) -> None:
 
     with pytest.raises(ValidationError):
         Model(**{'base64_value': b'123456'})
+
+
+def test_serialize_as_any_secret_types() -> None:
+    ta_secret_str = TypeAdapter(SecretStr)
+    secret_str = ta_secret_str.validate_python('secret')
+
+    ta_any = TypeAdapter(Any)
+
+    assert ta_any.dump_python(secret_str) == secret_str
+    assert ta_any.dump_python(secret_str, mode='json') == '**********'
+    assert ta_any.dump_json(secret_str) == b'"**********"'
+
+    ta_secret_bytes = TypeAdapter(SecretBytes)
+    secret_bytes = ta_secret_bytes.validate_python(b'secret')
+
+    assert ta_any.dump_python(secret_bytes) == secret_bytes
+    assert ta_any.dump_python(secret_bytes, mode='json') == '**********'
+    assert ta_any.dump_json(secret_bytes) == b'"**********"'
+
+    ta_secret_date = TypeAdapter(SecretDate)
+    secret_date = ta_secret_date.validate_python('2024-01-01')
+
+    assert ta_any.dump_python(secret_date) == secret_date
+    assert ta_any.dump_python(secret_date, mode='json') == '****/**/**'
+    assert ta_any.dump_json(secret_date) == b'"****/**/**"'


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10946
Fixes https://github.com/pydantic/pydantic/issues/9491

This might not be the best approach, but relieves some pressure for now. Leans into the coupling between `pydantic` and `pydantic-core`. I think it's better to lean into this than to pretend it doesn't exist.