### PR TITLE
ISSUE-10955: Added the hash dunder method to _BaseUrl class that is parent of all URL classes.

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -221,6 +221,9 @@ class _BaseUrl:
     def __deepcopy__(self, memo: dict) -> Self:
         return self.__class__(self._url)
 
+    def __hash__(self):
+        return self._url.__hash__()
+
     def __eq__(self, other: Any) -> bool:
         return self.__class__ is other.__class__ and self._url == other._url
 

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1105,3 +1105,14 @@ def test_after_validator() -> None:
     ]
     ta = TypeAdapter(HttpUrl)
     assert ta.validate_python('https://example.com/') == 'https://example.com'
+
+
+def test_any_url_hashable() -> None:
+    example_url_1a = AnyUrl('https://example1.com')
+    example_url_1b = AnyUrl('https://example1.com')
+    example_url_2 = AnyUrl('https://example2.com')
+
+    assert hash(example_url_1a) == hash(example_url_1b)
+    assert example_url_1a is not example_url_1b
+    assert hash(example_url_1a) != hash(example_url_2)
+    assert len({example_url_1a, example_url_1b, example_url_2}) == 2


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Added the __hash__ method to _BaseUrl class that would make all derived classes like AnyUrl, AnyHttpUrl, HttpUrl etc as hashable.

Issue:
Pydantic 2.10.1:

```python
import pydantic
{pydantic.AnyHttpUrl(url="http://hi.ho/")}
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: unhashable type: 'AnyHttpUrl'
```

The fix will eliminate the error, and make all the derived classes hashable.


## Related issue number
fix #10955 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
