### PR TITLE
Add eval-type-backport as dependency when python is <3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     'typing-extensions>=4.12.2',
     'annotated-types>=0.6.0',
     'pydantic-core==2.27.1',
+    'eval-type-backport>=0.2.0;python_version<"3.10"',
 ]
 dynamic = ['version', 'readme']
 


### PR DESCRIPTION
## Change Summary

Python 3.8 or 3.9 allowed to use the type declarations being used like Python 3.10 if the import `from __future__ import annotations` was used. For Pydantic classes this always was requiring to use the old style or adding dependency `eval-type-backport`.
Nevertheless within Pydantic 2.10 the parsing of base classes had been added for consistency which now formed a challenge for existing software that was released and non conforming to types also in base classes, e.g. Apache Airflow 2.8.4. This breaks many type checks with Pydantic 2.10 until the required dependency `eval-type-backport` is installed in Python 3.8 and 3.9.

This PR adds the conditional dependency for Pydantic and therefore once a user uses the new Pydantic will not fall into the trap where a new Pydantic complaints about problems in previously released SW.

## Related issue number

fix #10958

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist - I assume not needed as no code touched?
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle