### PR TITLE
Do not evaluate annotations for private fields

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -109,7 +109,7 @@ def collect_model_fields(  # noqa: C901
         if model_fields := getattr(base, '__pydantic_fields__', None):
             parent_fields_lookup.update(model_fields)
 
-    type_hints = _typing_extra.get_cls_type_hints(cls, ns_resolver=ns_resolver, lenient=True)
+    type_hints = _typing_extra.get_model_type_hints(cls, ns_resolver=ns_resolver)
 
     # https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
     # annotations is only used for finding fields in parent classes
@@ -216,7 +216,6 @@ def collect_model_fields(  # noqa: C901
                     # Nothing stops us from just creating a new FieldInfo for this type hint, so we do this.
                     field_info = FieldInfo_.from_annotation(ann_type)
                     field_info.evaluated = evaluated
-
         else:
             _warn_on_nested_alias_in_annotation(ann_type, ann_name)
             if isinstance(default, FieldInfo_) and ismethoddescriptor(default.default):

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1432,9 +1432,7 @@ class GenerateSchema:
                     field_docstrings = None
 
                 try:
-                    annotations = _typing_extra.get_cls_type_hints(
-                        typed_dict_cls, ns_resolver=self._ns_resolver, lenient=False
-                    )
+                    annotations = _typing_extra.get_cls_type_hints(typed_dict_cls, ns_resolver=self._ns_resolver)
                 except NameError as e:
                     raise PydanticUndefinedAnnotation.from_name_error(e) from e
 
@@ -1496,9 +1494,7 @@ class GenerateSchema:
                 namedtuple_cls = origin
 
             try:
-                annotations = _typing_extra.get_cls_type_hints(
-                    namedtuple_cls, ns_resolver=self._ns_resolver, lenient=False
-                )
+                annotations = _typing_extra.get_cls_type_hints(namedtuple_cls, ns_resolver=self._ns_resolver)
             except NameError as e:
                 raise PydanticUndefinedAnnotation.from_name_error(e) from e
             if not annotations:

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -598,6 +598,13 @@ Forward = int
     assert module.Model.__private_attributes__ == {}
 
 
+def test_private_attr_annotation_not_evaluated() -> None:
+    class Model(BaseModel):
+        _a: 'UnknownAnnotation'
+
+    assert '_a' in Model.__private_attributes__
+
+
 def test_json_encoder_str(create_module):
     module = create_module(
         # language=Python


### PR DESCRIPTION
Doing so fixes https://github.com/pydantic/pydantic/issues/10958 and https://github.com/gtalarico/pyairtable/issues/411. We don't need to evaluate annotation for private fields because we will not make use of the type hint in any way.

---

The `get_cls_type_hints` function is now split up, by defining a new `get_model_type_hints` function that is lenient. `get_cls_type_hints` is made non-lenient because it is used for typed dictionaries and named tuples, where we want to eagerly raise the `NameError`s that can occur during evaluation.

While this may introduce some code duplication, this gives more flexibility in the future. For instance, we know from the namespace management refactor that typed dicts behaves quite differently from normal classes when it comes to using the `__annotations__` attribute (collected from bases by cpython, automatically converted to `ForwardRef` instances, etc). So we might define another separate `get_typed_dict_type_hints` function in the future.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
