### PR TITLE
Fix type hint of `Field.default` to be compatible with Python 3.8 and 3.9

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -734,7 +734,7 @@ _T = TypeVar('_T')
 # to understand the magic that happens at runtime with the following overloads:
 @overload  # type hint the return value as `Any` to avoid type checking regressions when using `...`.
 def Field(
-    default: _typing_extra.EllipsisType,
+    default: ellipsis,  # noqa: F821  # TODO: use `_typing_extra.EllipsisType` when we drop Py3.9
     *,
     alias: str | None = _Unset,
     alias_priority: int | None = _Unset,


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10971.

For Python < 3.10, we define `EllipsisType = type(Ellipsis)` in `_typing_extra`. `EllipsisType` is then used in a type expression but pyright raises an error because `EllipsisType` is defined as variable.

Instead, we make use of the `ellipsis` builtin, only available for type checkers (defined in typeshed) as a compatibility hack.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
