### PR TITLE
Moved `BaseModel.model_post_init` to use `/` over `__` name prefix for positional-only usage

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -557,7 +557,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         params_component = ', '.join(param_names)
         return f'{cls.__name__}[{params_component}]'
 
-    def model_post_init(self, __context: Any) -> None:
+    def model_post_init(self, context: Any, /) -> None:
         """Override this method to perform additional initialization after `__init__` and `model_construct`.
         This is useful if you want to do some validation that requires the entire model to be initialized.
         """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -420,8 +420,8 @@ def test_extra_broken_via_pydantic_extra_interference():
     """
 
     class BrokenExtraBaseModel(BaseModel):
-        def model_post_init(self, __context: Any) -> None:
-            super().model_post_init(__context)
+        def model_post_init(self, context: Any, /) -> None:
+            super().model_post_init(context)
             object.__setattr__(self, '__pydantic_extra__', None)
 
     class Model(BrokenExtraBaseModel):
@@ -2058,8 +2058,8 @@ def test_post_init():
         a: int
         b: int
 
-        def model_post_init(self, __context) -> None:
-            super().model_post_init(__context)  # this is included just to show it doesn't error
+        def model_post_init(self, context, /) -> None:
+            super().model_post_init(context)  # this is included just to show it doesn't error
             assert self.model_dump() == {'a': 3, 'b': 4}
             calls.append('inner_model_post_init')
 
@@ -2068,7 +2068,7 @@ def test_post_init():
         d: int
         sub: InnerModel
 
-        def model_post_init(self, __context) -> None:
+        def model_post_init(self, context, /) -> None:
             assert self.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
             calls.append('model_post_init')
 
@@ -2077,9 +2077,9 @@ def test_post_init():
     assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
 
     class SubModel(Model):
-        def model_post_init(self, __context) -> None:
+        def model_post_init(self, context, /) -> None:
             assert self.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
-            super().model_post_init(__context)
+            super().model_post_init(context)
             calls.append('submodel_post_init')
 
     calls.clear()
@@ -2110,7 +2110,7 @@ def test_post_init_call_signatures(include_private_attribute):
 def test_post_init_not_called_without_override():
     calls = []
 
-    def monkey_patched_model_post_init(cls, __context):
+    def monkey_patched_model_post_init(cls, context, /):
         calls.append('BaseModel.model_post_init')
 
     original_base_model_post_init = BaseModel.model_post_init
@@ -2125,7 +2125,7 @@ def test_post_init_not_called_without_override():
         assert calls == []
 
         class WithOverrideModel(BaseModel):
-            def model_post_init(self, __context: Any) -> None:
+            def model_post_init(self, context: Any, /) -> None:
                 calls.append('WithOverrideModel.model_post_init')
 
         WithOverrideModel()
@@ -2144,7 +2144,7 @@ def test_model_post_init_subclass_private_attrs():
     class A(BaseModel):
         a: int = 1
 
-        def model_post_init(self, __context: Any) -> None:
+        def model_post_init(self, context: Any, /) -> None:
             calls.append(f'{self.__class__.__name__}.model_post_init')
 
     class B(A):
@@ -2165,10 +2165,10 @@ def test_model_post_init_supertype_private_attrs():
         _private: int = 12
 
     class SubModel(Model):
-        def model_post_init(self, __context: Any) -> None:
+        def model_post_init(self, context: Any, /) -> None:
             if self._private == 12:
                 self._private = 13
-            super().model_post_init(__context)
+            super().model_post_init(context)
 
     m = SubModel()
 
@@ -2182,7 +2182,7 @@ def test_model_post_init_subclass_setting_private_attrs():
         _priv1: int = PrivateAttr(91)
         _priv2: int = PrivateAttr(92)
 
-        def model_post_init(self, __context) -> None:
+        def model_post_init(self, context, /) -> None:
             self._priv1 = 100
 
     class SubModel(Model):
@@ -2191,10 +2191,10 @@ def test_model_post_init_subclass_setting_private_attrs():
         _priv5: int = PrivateAttr()
         _priv6: int = PrivateAttr()
 
-        def model_post_init(self, __context) -> None:
+        def model_post_init(self, context, /) -> None:
             self._priv3 = 200
             self._priv5 = 300
-            super().model_post_init(__context)
+            super().model_post_init(context)
 
     m = SubModel()
 
@@ -2217,7 +2217,7 @@ def test_model_post_init_correct_mro():
     class B(BaseModel):
         b: int = 1
 
-        def model_post_init(self, __context: Any) -> None:
+        def model_post_init(self, context: Any, /) -> None:
             calls.append(f'{self.__class__.__name__}.model_post_init')
 
     class C(A, B):


### PR DESCRIPTION
## Change Summary

Moves `BaseModel.model_post_init`'s signature to satisfy [`ruff==0.8.0`'s PYI063](https://docs.astral.sh/ruff/rules/pep484-style-positional-only-parameter/).

A useful question to ask is if this is a breaking change. Previously `model_post_init` didn't allow keyword arguments, only positional arguments. So changing the argument's name from `__context` to `context` should not matter at runtime. However, this will likely break linters looking for an exact match between parent class and child class variable names.

## Related issue number

Resolves https://github.com/pydantic/pydantic/issues/10974

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
