### PR TITLE
Hide `BaseModel.__replace__` definition from type checkers

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -871,10 +871,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         return m
 
-    def __replace__(self, **changes: Any) -> Self:
-        """Creates a new instance of the model, replacing fields with values from changes. Relevant for v3.13+."""
-        return self.model_copy(update=changes)
-
     if not TYPE_CHECKING:
         # We put `__getattr__` in a non-TYPE_CHECKING block because otherwise, mypy allows arbitrary attribute access
         # The same goes for __setattr__ and __delattr__, see: https://github.com/pydantic/pydantic/issues/8643
@@ -995,6 +991,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                     object.__delattr__(self, item)
                 except AttributeError:
                     raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
+
+        # Because we make use of `@dataclass_transform()`, `__replace__` is already synthesized by
+        # type checkers, so we define the implementation in this `if not TYPE_CHECKING:` block:
+        def __replace__(self, **changes: Any) -> Self:
+            return self.model_copy(update=changes)
 
     @classmethod
     def _check_frozen(cls, name: str, value: Any) -> None:


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10970.

Because we make use of `@dataclass_transform()`, the method is synthesized by type checkers already. This fixes an issue with mypy and the Pydantic plugin, as the plugin removes the `dataclass_transform` spec from `BaseModel` subclasses, but not for `RootModel` which uses a different metaclass, and led to override issues with the synthesized `__replace__` for root models and the `BaseModel.__replace__` definition.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
