### PR TITLE
Set fields when `defer_build` is set on Pydantic dataclasses

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -125,6 +125,8 @@ def complete_dataclass(
     cls.__init__ = __init__  # type: ignore
     cls.__pydantic_config__ = config_wrapper.config_dict  # type: ignore
 
+    set_dataclass_fields(cls, ns_resolver, config_wrapper=config_wrapper)
+
     if not _force_build and config_wrapper.defer_build:
         set_dataclass_mocks(cls)
         return False
@@ -134,8 +136,6 @@ def complete_dataclass(
             'Support for `__post_init_post_parse__` has been dropped, the method will not be called', DeprecationWarning
         )
 
-    set_dataclass_fields(cls, ns_resolver, config_wrapper=config_wrapper)
-
     typevars_map = get_standard_typevars_map(cls)
     gen_schema = GenerateSchema(
         config_wrapper,
@@ -143,14 +143,15 @@ def complete_dataclass(
         typevars_map=typevars_map,
     )
 
-    # set __signature__ attr only for model class, but not for its instances
+    # set __signature__ attr only for the class, but not for its instances
     # (because instances can define `__call__`, and `inspect.signature` shouldn't
     # use the `__signature__` attribute and instead generate from `__call__`).
     cls.__signature__ = LazyClassAttribute(
         '__signature__',
         partial(
             generate_pydantic_signature,
-            # It's' important that we reference the original_init here
+            # It's important that we reference the `original_init` here,
+            # as it is the one synthesized by the stdlib `dataclass` module:
             init=original_init,
             fields=cls.__pydantic_fields__,  # type: ignore
             populate_by_name=config_wrapper.populate_by_name,

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -3065,3 +3065,12 @@ def test_config_pushdown_vanilla_dc() -> None:
         model_config = ConfigDict(arbitrary_types_allowed=True)
 
         dc: DC
+
+
+def test_deferred_dataclass_fields_available() -> None:
+    # This aligns with deferred Pydantic models:
+    @pydantic.dataclasses.dataclass(config={'defer_build': True})
+    class A:
+        a: int
+
+    assert 'a' in A.__pydantic_fields__  # pyright: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
This aligns with Pydantic models, where only the schema generation is deferred.

Also fix some comments.

Fixes https://github.com/pydantic/pydantic/issues/10953.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
