### PR TITLE
Allow and merge multiple Field in Annotated for create_model()

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -1139,11 +1139,11 @@ class StaticFoobarModel(BaseModel):
 
 Here `StaticFoobarModel` and `DynamicFoobarModel` are identical.
 
-Fields are defined by one of the following tuple forms:
+Fields are defined by one of the following forms:
 
 * `(<type>, <default value>)`
 * `(<type>, Field(...))`
-* `typing.Annotated[<type>, Field(...)]`
+* `typing.Annotated[<type>, Field(...), ...]`
 
 Using a `Field(...)` call as the second argument in the tuple (the default value)
 allows for more advanced field configuration. Thus, the following are analogous:
@@ -1160,6 +1160,9 @@ DynamicModel = create_model(
 class StaticModel(BaseModel):
     foo: str = Field(description='foo description', alias='FOO')
 ```
+
+The third form, using `typing.Annotated`, accepts multiple `Field(...)` values
+which will be merged.
 
 The special keyword arguments `__config__` and `__base__` can be used to customize the new model.
 This includes extending a base model with extra fields.


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Previously, passing extra arguments (more than two) to Annotated in fields definition for create_model() resulted in them being silently ignored. We now retrieve all FieldInfo annotations and merge them, thus resulting in a similar behaviour to the "static" model creation case. Accordingly, we warn about other unknown annotations.

## Related issue number

fix https://github.com/pydantic/pydantic/issues/11005

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle