### PR TITLE
Use the globals of the function when evaluating the return type for `PlainSerializer` and `WrapSerializer` functions

### DIFF
--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -63,13 +63,14 @@ class PlainSerializer:
             The Pydantic core schema.
         """
         schema = handler(source_type)
-        globalns, localns = handler._get_types_namespace()
         try:
+            # Do not pass in globals as the function could be defined in a different module.
+            # Instead, let `get_function_return_type` infer the globals to use, but still pass
+            # in locals that may contain a parent/rebuild namespace:
             return_type = _decorators.get_function_return_type(
                 self.func,
                 self.return_type,
-                globalns=globalns,
-                localns=localns,
+                localns=handler._get_types_namespace().locals,
             )
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e
@@ -166,11 +167,13 @@ class WrapSerializer:
         schema = handler(source_type)
         globalns, localns = handler._get_types_namespace()
         try:
+            # Do not pass in globals as the function could be defined in a different module.
+            # Instead, let `get_function_return_type` infer the globals to use, but still pass
+            # in locals that may contain a parent/rebuild namespace:
             return_type = _decorators.get_function_return_type(
                 self.func,
                 self.return_type,
-                globalns=globalns,
-                localns=localns,
+                localns=handler._get_types_namespace().locals,
             )
         except NameError as e:
             raise PydanticUndefinedAnnotation.from_name_error(e) from e

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1314,12 +1314,22 @@ def test_uses_the_correct_globals_to_resolve_forward_refs_on_serializers(create_
     # we use the globals of the underlying func to resolve the return type.
     @create_module
     def module_1():
-        from pydantic import BaseModel, field_serializer  # or model_serializer, computed_field
+        from typing_extensions import Annotated
+
+        from pydantic import (
+            BaseModel,
+            PlainSerializer,  # or WrapSerializer
+            field_serializer,  # or model_serializer, computed_field
+        )
 
         MyStr = str
 
+        def ser_func(value) -> 'MyStr':
+            return str(value)
+
         class Model(BaseModel):
             a: int
+            b: Annotated[int, PlainSerializer(ser_func)]
 
             @field_serializer('a')
             def ser(self, value) -> 'MyStr':


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/11004, follow up on https://github.com/pydantic/pydantic/pull/10929.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
