### PR TITLE
Copy `WithJsonSchema` schema to avoid sharing mutated data

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2456,7 +2456,7 @@ class WithJsonSchema:
             # This exception is handled in pydantic.json_schema.GenerateJsonSchema._named_required_fields_schema
             raise PydanticOmit
         else:
-            return self.json_schema
+            return self.json_schema.copy()
 
     def __hash__(self) -> int:
         return hash(type(self.mode))

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6618,3 +6618,15 @@ def test_blank_title_is_respected() -> None:
         model_config = ConfigDict(title='')
 
     assert Model.model_json_schema()['title'] == ''
+
+AnnBool = Annotated[
+    bool | Literal["true", "false"],
+    WithJsonSchema({}),
+]
+def test_with_json_schema_doesnt_share_schema() -> None:
+    # See https://github.com/pydantic/pydantic/issues/11013
+    class Model(BaseModel):
+        field1: BoolLikeT = Field(default=False)
+        field2: BoolLikeT | None = Field(default=None)
+
+    assert Model.model_json_schema()["properties"]["field2"]["anyOf"][0] == dict()

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6619,14 +6619,17 @@ def test_blank_title_is_respected() -> None:
 
     assert Model.model_json_schema()['title'] == ''
 
+
 AnnBool = Annotated[
     bool,
     WithJsonSchema({}),
 ]
+
+
 def test_with_json_schema_doesnt_share_schema() -> None:
     # See https://github.com/pydantic/pydantic/issues/11013
     class Model(BaseModel):
         field1: AnnBool = Field(default=False)
         field2: AnnBool | None = Field(default=None)
 
-    assert Model.model_json_schema()["properties"]["field2"]["anyOf"][0] == dict()
+    assert Model.model_json_schema()['properties']['field2']['anyOf'][0] == dict()

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6620,7 +6620,7 @@ def test_blank_title_is_respected() -> None:
     assert Model.model_json_schema()['title'] == ''
 
 AnnBool = Annotated[
-    bool | Literal["true", "false"],
+    bool,
     WithJsonSchema({}),
 ]
 def test_with_json_schema_doesnt_share_schema() -> None:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6626,7 +6626,7 @@ AnnBool = Annotated[
 def test_with_json_schema_doesnt_share_schema() -> None:
     # See https://github.com/pydantic/pydantic/issues/11013
     class Model(BaseModel):
-        field1: BoolLikeT = Field(default=False)
-        field2: BoolLikeT | None = Field(default=None)
+        field1: AnnBool = Field(default=False)
+        field2: AnnBool | None = Field(default=None)
 
     assert Model.model_json_schema()["properties"]["field2"]["anyOf"][0] == dict()

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6630,6 +6630,6 @@ def test_with_json_schema_doesnt_share_schema() -> None:
     # See https://github.com/pydantic/pydantic/issues/11013
     class Model(BaseModel):
         field1: AnnBool = Field(default=False)
-        field2: AnnBool | None = Field(default=None)
+        field2: Optional[AnnBool] = Field(default=None)
 
     assert Model.model_json_schema()['properties']['field2']['anyOf'][0] == dict()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Quick-and-simple. Just `.copy()` the `return self.json_schema` inside of `WithJsonSchema` so that other parts of the pipeline that modify the schema don't modify the shared object.

## Related issue number

Fix #11013

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle