### PR TITLE
Add decimal precision constraints to JSON schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -676,7 +676,17 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        json_schema = self.str_schema(core_schema.str_schema())
+        max_digits = schema.get('max_digits')
+        decimal_places = schema.get('decimal_places')
+        str_schema = core_schema.str_schema()
+
+        if max_digits is not None and decimal_places is not None:
+            integer_places = max_digits - decimal_places
+            pattern = f'^-?(?:0|[1-9]\\d{{0,{integer_places-1}}})(\\.\\d{{0,{decimal_places}}})?$'
+            str_schema['pattern'] = pattern
+
+        json_schema = self.str_schema(str_schema)
+
         if self.mode == 'validation':
             multiple_of = schema.get('multiple_of')
             le = schema.get('le')

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -933,6 +933,15 @@ def test_str_constrained_types(field_type, expected_schema):
     assert model_schema == base_schema
 
 
+def test_decimal_constraints():
+    constraints = {'max_digits': 5, 'decimal_places': 2, 'ge': 0.0, 'le': 10.0}
+    schema = TypeAdapter(Annotated[Decimal, Field(**constraints)]).json_schema()
+
+    assert 'pattern' in schema['anyOf'][1]
+    assert schema['anyOf'][0]['maximum'] == 10.0
+    assert schema['anyOf'][0]['minimum'] == 0.0
+
+
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR added a decimal precision pattern validation to JSON schema generation. The implementation enforces `max_digits` and `decimal_places` constraints by adding a regex pattern. A corresponding unit test was also added to test the changes. 

## Related issue number

fix #10867 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
