### PR TITLE
Improve and reorganize models and fields documentation

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -1077,7 +1077,7 @@ Allows any value, including `None`.
 
 ## [`typing.Annotated`][]
 
-Allows wrapping another type with arbitrary metadata, as per [PEP-593](https://www.python.org/dev/peps/pep-0593/). The `Annotated` hint may contain a single call to the [`Field` function](../concepts/types.md#composing-types-via-annotated), but otherwise the additional metadata is ignored and the root type is used.
+Allows wrapping another type with arbitrary metadata, as per [PEP-593](https://www.python.org/dev/peps/pep-0593/). The `Annotated` hint may contain a single call to the [`Field` function](../concepts/types.md#using-the-annotated-pattern), but otherwise the additional metadata is ignored and the root type is used.
 
 
 ## [`typing.Pattern`][]

--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -12,19 +12,19 @@ from pydantic import BaseModel, Field
 
 
 class Model(BaseModel):
-    field: str = Field(frozen=True)
+    name: str = Field(frozen=True)
 ```
 
 !!! note
-    Even though `field` is assigned a value, it is still required and has no default value. If you want
+    Even though `name` is assigned a value, it is still required and has no default value. If you want
     to emphasize on the fact that a value must be provided, you can use the [ellipsis][Ellipsis]:
 
     ```python {lint="skip" test="skip"}
     class Model(BaseModel):
-        field: str = Field(..., frozen=True)
+        name: str = Field(..., frozen=True)
     ```
 
-    However, its usage is discouraged as it doesn't play well with type checkers.
+    However, its usage is discouraged as it doesn't play well with static type checkers.
 
 ## The annotated pattern
 
@@ -38,11 +38,11 @@ from pydantic import BaseModel, Field, WithJsonSchema
 
 
 class Model(BaseModel):
-    field: Annotated[str, Field(strict=True), WithJsonSchema({'extra': 'data'})]
+    name: Annotated[str, Field(strict=True), WithJsonSchema({'extra': 'data'})]
 ```
 
-As far as static type checkers are concerned, `field` is still typed as `str`, but Pydantic leverages
-the available metadata to add validation, constraints, etc.
+As far as static type checkers are concerned, `name` is still typed as `str`, but Pydantic leverages
+the available metadata to add validation logic, type constraints, etc.
 
 Using this pattern has some advantages:
 
@@ -77,7 +77,7 @@ class User(BaseModel):
 
 !!! warning
     [In Pydantic V1](../migration.md#required-optional-and-nullable-fields), a type annotated as [`Any`][typing.Any]
-    or wrapped around [`Optional`][typing.Optional] would be given an implicit default of `None` even if no
+    or wrapped by [`Optional`][typing.Optional] would be given an implicit default of `None` even if no
     default was explicitly specified. This is no longer the case in Pydantic V2.
 
 You can also pass a callable to the `default_factory` argument that will be called to generate a default value:

--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -1,29 +1,86 @@
 ??? api "API Documentation"
     [`pydantic.fields.Field`][pydantic.fields.Field]<br>
 
-The [`Field`][pydantic.fields.Field] function is used to customize and add metadata to fields of models.
+In this section, we will go through the available mechanisms to customize Pydantic model fields:
+default values, JSON Schema metadata, constraints, etc.
+
+To do so, the [`Field()`][pydantic.fields.Field] function is used a lot, and behaves the same way as
+the standard library [`field()`][dataclasses.field] function for dataclasses:
+
+```python
+from pydantic import BaseModel, Field
+
+
+class Model(BaseModel):
+    field: str = Field(frozen=True)
+```
+
+!!! note
+    Even though `field` is assigned a value, it is still required and has no default value. If you want
+    to emphasize on the fact that a value must be provided, you can use the [ellipsis][Ellipsis]:
+
+    ```python {lint="skip" test="skip"}
+    class Model(BaseModel):
+        field: str = Field(..., frozen=True)
+    ```
+
+    However, its usage is discouraged as it doesn't play well with type checkers.
+
+## The annotated pattern
+
+To apply constraints or attach [`Field()`][pydantic.fields.Field] functions to a model field, Pydantic
+supports the [`Annotated`][typing.Annotated] typing construct to attach metadata to an annotation:
+
+```python
+from typing_extensions import Annotated
+
+from pydantic import BaseModel, Field, WithJsonSchema
+
+
+class Model(BaseModel):
+    field: Annotated[str, Field(strict=True), WithJsonSchema({'extra': 'data'})]
+```
+
+As far as static type checkers are concerned, `field` is still typed as `str`, but Pydantic leverages
+the available metadata to add validation, constraints, etc.
+
+Using this pattern has some advantages:
+
+- Using the `f: <type> = Field(...)` form can be confusing and might trick users into thinking `f`
+  has a default value, while in reality it is still required.
+- You can provide an arbitrary amount of metadata elements for a field. As shown in the example above,
+  the [`Field()`][pydantic.fields.Field] function only supports a limited set of constraints/metadata,
+  and you may have to use different Pydantic utilities such as [`WithJsonSchema`][pydantic.WithJsonSchema]
+  in some cases.
+- Types can be made reusable (see the documentation on [custom types](./types.md#using-the-annotated-pattern)
+  using this pattern).
+
+However, note that certain arguments to the [`Field()`][pydantic.fields.Field] function (namely, `default`,
+`default_factory`, and `alias`) are taken into account by static type checkers to synthesize a correct
+`__init__` method. The annotated pattern is *not* understood by them, so you should use the normal
+assignment form instead.
 
 ## Default values
 
-The `default` parameter is used to define a default value for a field.
+Default values for fields can be provided using the normal assignment syntax or by providing a value
+to the `default` argument:
 
 ```python
 from pydantic import BaseModel, Field
 
 
 class User(BaseModel):
-    name: str = Field(default='John Doe')
-
-
-user = User()
-print(user)
-#> name='John Doe'
+    # Both fields aren't required:
+    name: str = 'John Doe'
+    age: int = Field(default=20)
 ```
 
-!!! note
-    If you use the [`Optional`][typing.Optional] annotation, it doesn't mean that the field has a default value of `None`!
+!!! warning
+    [In Pydantic V1](../migration.md#required-optional-and-nullable-fields), a type annotated as [`Any`][typing.Any]
+    or wrapped around [`Optional`][typing.Optional] would be given an implicit default of `None` even if no
+    default was explicitly specified. This is no longer the case in Pydantic V2.
 
-You can also use `default_factory` (but not both at the same time) to define a callable that will be called to generate a default value.
+You can also pass a callable to the `default_factory` argument that will be called to generate a default value:
 
 ```python
 from uuid import uuid4
@@ -35,7 +92,7 @@ class User(BaseModel):
     id: str = Field(default_factory=lambda: uuid4().hex)
 ```
 
-The default factory can also take a single required argument, in which the case the already validated data will be passed as a dictionary.
+The default factory can also take a single required argument, in which case the already validated data will be passed as a dictionary.
 
 ```python
 from pydantic import BaseModel, EmailStr, Field
@@ -54,29 +111,41 @@ print(user.username)
 The `data` argument will *only* contain the already validated data, based on the [order of model fields](./models.md#field-ordering)
 (the above example would fail if `username` were to be defined before `email`).
 
+### Mutable default values
 
-## Using `Annotated`
+A common source of bugs in Python is to use a mutable object as a default value for a function or method argument,
+as the same instance ends up being reused in each call.
 
-The [`Field`][pydantic.fields.Field] function can also be used together with [`Annotated`][annotated].
+The [`dataclasses`][dataclasses] module actually raises an error in this case, indicating that you should use
+a [default factory](https://docs.python.org/3/library/dataclasses.html#default-factory-functions) instead.
+
+While the same thing can be done in Pydantic, it is not required. In the event that the default value is not hashable,
+Pydantic will create a deep copy of the default value when creating each instance of the model:
 
 ```python
-from uuid import uuid4
+from typing import Dict, List
 
-from typing_extensions import Annotated
-
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
-class User(BaseModel):
-    id: Annotated[str, Field(default_factory=lambda: uuid4().hex)]
+class Model(BaseModel):
+    item_counts: List[Dict[str, int]] = [{}]
+
+
+m1 = Model()
+m1.item_counts[0]['a'] = 1
+print(m1.item_counts)
+#> [{'a': 1}]
+
+m2 = Model()
+print(m2.item_counts)
+#> [{}]
 ```
 
-!!! note
-    Defaults can be set outside [`Annotated`][annotated] as the assigned value or with `Field.default_factory` inside
-    [`Annotated`][annotated]. The `Field.default` argument is not supported inside [`Annotated`][annotated].
-
-
 ## Field aliases
+
+!!! tip
+    Read more about aliases in the [dedicated section](./alias.md).
 
 For validation and serialization, you can define an alias for a field.
 
@@ -87,7 +156,7 @@ There are three ways to define an alias:
 * `Field(serialization_alias='foo')`
 
 The `alias` parameter is used for both validation _and_ serialization. If you want to use
-_different_ aliases for validation and serialization respectively, you can use the`validation_alias`
+_different_ aliases for validation and serialization respectively, you can use the `validation_alias`
 and `serialization_alias` parameters, which will apply only in their respective use cases.
 
 Here is an example of using the `alias` parameter:
@@ -108,9 +177,7 @@ print(user.model_dump(by_alias=True))  # (2)!
 ```
 
 1. The alias `'username'` is used for instance creation and validation.
-2. We are using `model_dump` to convert the model into a serializable format.
-
-    You can see more details about [`model_dump`][pydantic.main.BaseModel.model_dump] in the API reference.
+2. We are using [`model_dump()`][pydantic.main.BaseModel.model_dump] to convert the model into a serializable format.
 
     Note that the `by_alias` keyword argument defaults to `False`, and must be specified explicitly to dump
     models using the field (serialization) aliases.
@@ -162,13 +229,11 @@ print(user.model_dump(by_alias=True))  # (2)!
     the `validation_alias` will have priority over `alias` for validation, and `serialization_alias` will have priority
     over `alias` for serialization.
 
-    If you use an `alias_generator` in the [Model Config][pydantic.config.ConfigDict.alias_generator], you can control
-    the order of precedence for specified field vs generated aliases via the `alias_priority` setting. You can read more about alias precedence [here](../concepts/alias.md#alias-precedence).
+    If you provide a value for the [`alias_generator`][pydantic.config.ConfigDict.alias_generator] model setting, you can control the order of precedence for field alias and generated aliases via the `alias_priority` field parameter. You can read more about alias precedence [here](../concepts/alias.md#alias-precedence).
 
-
-??? tip "VSCode and Pyright users"
-    In VSCode, if you use the [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
-    extension, you won't see a warning when instantiating a model using a field's alias:
+??? tip "Static type checking/IDE support"
+    If you provide a value for the `alias` field parameter, static type checkers will use this alias instead
+    of the actual field name to synthesize the `__init__` method:
 
     ```python
     from pydantic import BaseModel, Field
@@ -181,11 +246,11 @@ print(user.model_dump(by_alias=True))  # (2)!
     user = User(username='johndoe')  # (1)!
     ```
 
-    1. VSCode will NOT show a warning here.
+    1. Accepted by type checkers.
 
-    When the `'alias'` keyword argument is specified, even if you set `populate_by_name` to `True` in the
-    [Model Config][pydantic.config.ConfigDict.populate_by_name], VSCode will show a warning when instantiating
-    a model using the field name (though it will work at runtime) — in this case, `'name'`:
+    This means that when using the [`populate_by_name`][pydantic.config.ConfigDict.populate_by_name] model
+    setting (which allows both the field name and alias to be used during model validation), type checkers
+    will error when the actual field name is used:
 
     ```python
     from pydantic import BaseModel, ConfigDict, Field
@@ -200,36 +265,36 @@ print(user.model_dump(by_alias=True))  # (2)!
     user = User(name='johndoe')  # (1)!
     ```
 
-    1. VSCode will show a warning here.
+    1. *Not* accepted by type checkers.
 
-    To "trick" VSCode into preferring the field name, you can use the `str` function to wrap the alias value.
-    With this approach, though, a warning is shown when instantiating a model using the alias for the field:
+    If you still want type checkers to use the field name and not the alias, the [annotated pattern](#the-annotated-pattern)
+    can be used (which is only understood by Pydantic):
 
     ```python
+    from typing_extensions import Annotated
+
     from pydantic import BaseModel, ConfigDict, Field
 
 
     class User(BaseModel):
         model_config = ConfigDict(populate_by_name=True)
 
-        name: str = Field(alias=str('username'))  # noqa: UP018
+        name: Annotated[str, Field(alias='username')]
 
 
     user = User(name='johndoe')  # (1)!
     user = User(username='johndoe')  # (2)!
     ```
 
-    1. Now VSCode will NOT show a warning
-    2. VSCode will show a warning here, though
+    1. Accepted by type checkers.
+    2. *Not* accepted by type checkers.
 
-    This is discussed in more detail in [this issue](https://github.com/pydantic/pydantic/issues/5893).
+    <h3>Validation Alias</h3>
 
-    ### Validation Alias
-
-    Even though Pydantic treats `alias` and `validation_alias` the same when creating model instances, VSCode will not
-    use the `validation_alias` in the class initializer signature. If you want VSCode to use the `validation_alias`
-    in the class initializer, you can instead specify both an `alias` and `serialization_alias`, as the
-    `serialization_alias` will override the `alias` during serialization:
+    Even though Pydantic treats `alias` and `validation_alias` the same when creating model instances, type checkers
+    only understand the `alias` field parameter. As a workaround, you can instead specify both an `alias` and
+    serialization_alias` (identical to the field name), as the `serialization_alias` will override the `alias` during
+    serialization:
 
     ```python
     from pydantic import BaseModel, Field
@@ -238,29 +303,24 @@ print(user.model_dump(by_alias=True))  # (2)!
     class MyModel(BaseModel):
         my_field: int = Field(validation_alias='myValidationAlias')
     ```
+
     with:
+
     ```python
     from pydantic import BaseModel, Field
 
 
     class MyModel(BaseModel):
         my_field: int = Field(
-            ...,
             alias='myValidationAlias',
-            serialization_alias='my_serialization_alias',
+            serialization_alias='my_field',
         )
 
 
     m = MyModel(myValidationAlias=1)
     print(m.model_dump(by_alias=True))
-    #> {'my_serialization_alias': 1}
+    #> {'my_field': 1}
     ```
-
-    All of the above will likely also apply to other tools that respect the
-    [`@typing.dataclass_transform`](https://docs.python.org/3/library/typing.html#typing.dataclass_transform)
-    decorator, such as Pyright.
-
-For more information on alias usage, see the [Alias] concepts page.
 
 ## Numeric Constraints
 
@@ -921,4 +981,3 @@ class Box(BaseModel):
 [Serialization]: serialization.md#model-and-field-level-include-and-exclude
 [Customizing JSON Schema]: json_schema.md#field-level-customization
 [annotated]: https://docs.python.org/3/library/typing.html#typing.Annotated
-[Alias]: ../concepts/alias.md

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -15,7 +15,7 @@ Untrusted data can be passed to a model and, after parsing and validation, Pydan
 of the resultant model instance will conform to the field types defined on the model.
 
 !!! note "Validation — a _deliberate_ misnomer"
-    ### TL;DR
+    <h3>TL;DR</h3>
 
     We use the term "validation" to refer to the process of instantiating a model (or other type) that adheres to specified types and
     constraints. This task, which Pydantic is well known for, is most widely recognized as "validation" in colloquial terms,
@@ -23,12 +23,12 @@ of the resultant model instance will conform to the field types defined on the m
 
     ---
 
-    ### The long version
+    <h3>The long version</h3>
 
     The potential confusion around the term "validation" arises from the fact that, strictly speaking, Pydantic's
     primary focus doesn't align precisely with the dictionary definition of "validation":
 
-    > ### validation
+    > <h3>validation</h3>
     > _noun_
     > the action of checking or proving the validity or accuracy of something.
 
@@ -74,6 +74,9 @@ In this example, `User` is a model with two fields:
 * `id`, which is an integer and is required
 * `name`, which is a string and is not required (it has a default value).
 
+Fields can be customized in a number of ways using the [`Field()`][pydantic.Field] function.
+See the [documentation on fields](./fields.md) for more information.
+
 The model can then be instantiated:
 
 ```python {group="basic-model"}
@@ -96,16 +99,16 @@ assert isinstance(user.id, int)
    The [`model_fields_set`][pydantic.BaseModel.model_fields_set] attribute can be
    inspected to check the field names explicitly set during instantiation.
 2. Note that the string `'123'` was coerced to an integer and its value is `123`.
-   More details on Pydantic's coercion logic can be found in the [Data Conversion](#data-conversion) section.
+   More details on Pydantic's coercion logic can be found in the [data conversion](#data-conversion) section.
 
-The model instance can be serialized using the [`model_dump`][pydantic.BaseModel.model_dump] method:
+The model instance can be serialized using the [`model_dump()`][pydantic.BaseModel.model_dump] method:
 
 ```python {group="basic-model"}
 assert user.model_dump() == {'id': 123, 'name': 'Jane Doe'}
 ```
 
 Calling [dict][] on the instance will also provide a dictionary, but nested fields will not be
-recursively converted into dictionaries. [`model_dump`][pydantic.BaseModel.model_dump] also
+recursively converted into dictionaries. [`model_dump()`][pydantic.BaseModel.model_dump] also
 provides numerous arguments to customize the serialization result.
 
 By default, models are mutable and field values can be changed through attribute assignment:
@@ -167,6 +170,53 @@ Models possess the following methods and attributes:
 !!! tip
     See [Changes to `pydantic.BaseModel`](../migration.md#changes-to-pydanticbasemodel) in the
     [Migration Guide](../migration.md) for details on changes from Pydantic V1.
+
+## Data conversion
+
+Pydantic may cast input data to force it to conform to model field types,
+and in some cases this may result in a loss of information.
+For example:
+
+```python
+from pydantic import BaseModel
+
+
+class Model(BaseModel):
+    a: int
+    b: float
+    c: str
+
+
+print(Model(a=3.000, b='2.72', c=b'binary data').model_dump())
+#> {'a': 3, 'b': 2.72, 'c': 'binary data'}
+```
+
+This is a deliberate decision of Pydantic, and is frequently the most useful approach. See
+[here](https://github.com/pydantic/pydantic/issues/578) for a longer discussion on the subject.
+
+This is also the case for collections. In most cases, you shouldn't make use of abstract container classes
+and just use a concrete type, such as [`list`][]:
+
+```python
+from typing import List
+
+from pydantic import BaseModel
+
+
+class Model(BaseModel):
+    items: List[int]  # (1)!
+
+
+print(Model(items=(1, 2, 3)))
+#> items=[1, 2, 3]
+```
+
+1. In this case, you might be tempted to use the abstract [`Sequence`][collections.abc.Sequence] type
+   to allow both lists and tuples. But Pydantic takes care of converting the tuple input to a list, so
+   in most cases this isn't necessary.
+
+Nevertheless, Pydantic provides a [strict mode](strict_mode.md), where no data conversion is performed.
+Values must be of the same type than the declared field type.
 
 ## Nested models
 
@@ -1389,7 +1439,7 @@ class FooBarModel(BaseModel, abc.ABC):
 
 Field order affects models in the following ways:
 
-* field order is preserved in the model [schema](json_schema.md)
+* field order is preserved in the model [JSON Schema](json_schema.md)
 * field order is preserved in [validation errors](#error-handling)
 * field order is preserved by [`.model_dump()` and `.model_dump_json()` etc.](serialization.md#model_dump)
 
@@ -1419,99 +1469,11 @@ print(error_locations)
 #> [('a',), ('b',), ('c',), ('d',), ('e',)]
 ```
 
-## Required fields
-
-To declare a field as required, you may declare it using an annotation, or an annotation in combination with a
-[`Field`][pydantic.Field] function (without specifying any `default` or `default_factory` argument).
-
-```python
-from pydantic import BaseModel, Field
-
-
-class Model(BaseModel):
-    a: int
-    b: int = Field(alias='B')
-    c: int = Field(..., alias='C')
-```
-
-Here `a`, `b` and `c` are all required. The field `c` uses the [ellipsis][Ellipsis] as a default argument,
-emphasizing on the fact that it is required. However, the usage of the [ellipsis][Ellipsis] is discouraged
-as it doesn't play well with type checkers.
-
-!!! note
-    In Pydantic V1, fields annotated with `Optional` or `Any` would be given an implicit default of `None` even if no
-    default was explicitly specified. This behavior has changed in Pydantic V2, and there are no longer any type
-    annotations that will result in a field having an implicit default value.
-
-    See [the migration guide](../migration.md#required-optional-and-nullable-fields) for more details on changes
-    to required and nullable fields.
-
-## Fields with non-hashable default values
-
-A common source of bugs in python is to use a mutable object as a default value for a function or method argument,
-as the same instance ends up being reused in each call.
-
-The `dataclasses` module actually raises an error in this case, indicating that you should use the `default_factory`
-argument to `dataclasses.field`.
-
-Pydantic also supports the use of a [`default_factory`](#fields-with-dynamic-default-values) for non-hashable default
-values, but it is not required. In the event that the default value is not hashable, Pydantic will deepcopy the default
-value when creating each instance of the model:
-
-```python
-from typing import Dict, List
-
-from pydantic import BaseModel
-
-
-class Model(BaseModel):
-    item_counts: List[Dict[str, int]] = [{}]
-
-
-m1 = Model()
-m1.item_counts[0]['a'] = 1
-print(m1.item_counts)
-#> [{'a': 1}]
-
-m2 = Model()
-print(m2.item_counts)
-#> [{}]
-```
-
-## Fields with dynamic default values
-
-When declaring a field with a default value, you may want it to be dynamic (i.e. different for each model).
-To do this, you may want to use a `default_factory`.
-
-Here is an example:
-
-```python
-from datetime import datetime, timezone
-from uuid import UUID, uuid4
-
-from pydantic import BaseModel, Field
-
-
-def datetime_now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-class Model(BaseModel):
-    uid: UUID = Field(default_factory=uuid4)
-    updated: datetime = Field(default_factory=datetime_now)
-
-
-m1 = Model()
-m2 = Model()
-assert m1.uid != m2.uid
-```
-
-You can find more information in the documentation of the [`Field` function](fields.md).
-
 ## Automatically excluded attributes
 
-### Class vars
-Attributes annotated with `typing.ClassVar` are properly treated by Pydantic as class variables, and will not
+### Class variables
+
+Attributes annotated with [`ClassVar`][typing.ClassVar] are properly treated by Pydantic as class variables, and will not
 become fields on model instances:
 
 ```python
@@ -1521,14 +1483,15 @@ from pydantic import BaseModel
 
 
 class Model(BaseModel):
-    x: int = 2
-    y: ClassVar[int] = 1
+    x: ClassVar[int] = 1
+
+    y: int = 2
 
 
 m = Model()
 print(m)
-#> x=2
-print(Model.y)
+#> y=2
+print(Model.x)
 #> 1
 ```
 
@@ -1541,15 +1504,12 @@ Attributes whose name has a leading underscore are not treated as fields by Pyda
 model schema. Instead, these are converted into a "private attribute" which is not validated or even set during
 calls to `__init__`, `model_validate`, etc.
 
-!!! note
-    As of Pydantic v2.1.0, you will receive a NameError if trying to use the [`Field` function](fields.md) with a private attribute.
-    Because private attributes are not treated as fields, the Field() function cannot be applied.
-
 Here is an example of usage:
 
 ```python
 from datetime import datetime
 from random import randint
+from typing import Any
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -1558,9 +1518,8 @@ class TimeAwareModel(BaseModel):
     _processed_at: datetime = PrivateAttr(default_factory=datetime.now)
     _secret_value: str
 
-    def __init__(self, **data):
-        super().__init__(**data)
-        # this could also be done with default_factory
+    def model_post_init(self, context: Any) -> None:
+        # this could also be done with `default_factory`:
         self._secret_value = randint(1, 5)
 
 
@@ -1572,32 +1531,7 @@ print(m._secret_value)
 ```
 
 Private attribute names must start with underscore to prevent conflicts with model fields. However, dunder names
-(such as `__attr__`) are not supported.
-
-## Data conversion
-
-Pydantic may cast input data to force it to conform to model field types,
-and in some cases this may result in a loss of information.
-For example:
-
-```python
-from pydantic import BaseModel
-
-
-class Model(BaseModel):
-    a: int
-    b: float
-    c: str
-
-
-print(Model(a=3.000, b='2.72', c=b'binary data').model_dump())
-#> {'a': 3, 'b': 2.72, 'c': 'binary data'}
-```
-
-This is a deliberate decision of Pydantic, and is frequently the most useful approach. See
-[here](https://github.com/pydantic/pydantic/issues/578) for a longer discussion on the subject.
-
-Nevertheless, [strict type checking](strict_mode.md) is also supported.
+(such as `__attr__`) are not supported, and will be completely ignored from the model definition.
 
 ## Model signature
 
@@ -1710,8 +1644,8 @@ arr_orig = [1, 9, 10, 3]
 
 c1 = C1(arr_orig)
 c2 = C2(arr=arr_orig)
-print('id(c1.arr) == id(c2.arr):', id(c1.arr) == id(c2.arr))
-#> id(c1.arr) == id(c2.arr): False
+print(f'{id(c1.arr) == id(c2.arr)=}')
+#> id(c1.arr) == id(c2.arr)=False
 ```
 
 !!! note

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -219,7 +219,7 @@ print(Model(items=(1, 2, 3)))
    in most cases this isn't necessary.
 
 Besides, using these abstract types can also lead to [poor validation performance](./performance.md#sequence-vs-list-or-tuple---mapping-vs-dict), and in general using concrete container types
-will avoid unecessary checks.
+will avoid unnecessary checks.
 
 ## Nested models
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -216,8 +216,10 @@ print(Model(items=(1, 2, 3)))
 
 1. In this case, you might be tempted to use the abstract [`Sequence`][collections.abc.Sequence] type
    to allow both lists and tuples. But Pydantic takes care of converting the tuple input to a list, so
-   in most cases this isn't necessary. Beside, using these abstract types can also lead to
-   [poor validation performance](./performance.md#sequence-vs-list-or-tuple---mapping-vs-dict).
+   in most cases this isn't necessary.
+
+Besides, using these abstract types can also lead to [poor validation performance](./performance.md#sequence-vs-list-or-tuple---mapping-vs-dict), and in general using concrete container types
+will avoid unecessary checks.
 
 ## Nested models
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -194,6 +194,9 @@ print(Model(a=3.000, b='2.72', c=b'binary data').model_dump())
 This is a deliberate decision of Pydantic, and is frequently the most useful approach. See
 [here](https://github.com/pydantic/pydantic/issues/578) for a longer discussion on the subject.
 
+Nevertheless, Pydantic provides a [strict mode](strict_mode.md), where no data conversion is performed.
+Values must be of the same type than the declared field type.
+
 This is also the case for collections. In most cases, you shouldn't make use of abstract container classes
 and just use a concrete type, such as [`list`][]:
 
@@ -213,10 +216,8 @@ print(Model(items=(1, 2, 3)))
 
 1. In this case, you might be tempted to use the abstract [`Sequence`][collections.abc.Sequence] type
    to allow both lists and tuples. But Pydantic takes care of converting the tuple input to a list, so
-   in most cases this isn't necessary.
-
-Nevertheless, Pydantic provides a [strict mode](strict_mode.md), where no data conversion is performed.
-Values must be of the same type than the declared field type.
+   in most cases this isn't necessary. Beside, using these abstract types can also lead to
+   [poor validation performance](./performance.md#sequence-vs-list-or-tuple---mapping-vs-dict).
 
 ## Nested models
 

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -66,15 +66,12 @@ Besides the above, you can also have a [`FiniteFloat`][pydantic.types.FiniteFloa
 
 You can also define your own custom data types. There are several ways to achieve it.
 
-### Composing types via `Annotated`
+### Using the annotated pattern
 
-[PEP 593] introduced `Annotated` as a way to attach runtime metadata to types without changing how type checkers interpret them.
-Pydantic takes advantage of this to allow you to create types that are identical to the original type as far as type checkers are concerned, but add validation, serialize differently, etc.
-
-For example, to create a type representing a positive int:
+The [annotated pattern](./fields.md#the-annotated-pattern) can be used to make types reusable across your code base.
+For example, to create a type representing a positive integer:
 
 ```python
-# or `from typing import Annotated` for Python 3.9+
 from typing_extensions import Annotated
 
 from pydantic import Field, TypeAdapter, ValidationError

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -174,11 +174,6 @@ print(user_03_uuid.int)
 #> 275603287559914445491632874575877060712
 ```
 
-!!! tip
-    The type `Optional[x]` is a shorthand for `Union[x, None]`.
-
-    See more details in [Required fields](../concepts/models.md#required-fields).
-
 ## Discriminated Unions
 
 **Discriminated unions are sometimes referred to as "Tagged Unions".**
@@ -382,19 +377,21 @@ except ValidationError as e:
    When `None` is returned, this `union_tag_not_found` error is raised.
 
 !!! note
-    Using the [[`typing.Annotated`][] fields syntax](../concepts/types.md#composing-types-via-annotated) can be handy to regroup
+    Using the [annotated pattern](./fields.md#the-annotated-pattern) can be handy to regroup
     the `Union` and `discriminator` information. See the next example for more details.
 
     There are a few ways to set a discriminator for a field, all varying slightly in syntax.
 
     For `str` discriminators:
-    ```
-    some_field: Union[...] = Field(discriminator='my_discriminator'
+
+    ```python {lint="skip" test="skip"}
+    some_field: Union[...] = Field(discriminator='my_discriminator')
     some_field: Annotated[Union[...], Field(discriminator='my_discriminator')]
     ```
 
     For callable `Discriminator`s:
-    ```
+
+    ```python {lint="skip" test="skip"}
     some_field: Union[...] = Field(discriminator=Discriminator(...))
     some_field: Annotated[Union[...], Discriminator(...)]
     some_field: Annotated[Union[...], Field(discriminator=Discriminator(...))]

--- a/docs/concepts/validation_decorator.md
+++ b/docs/concepts/validation_decorator.md
@@ -191,7 +191,7 @@ using all possible [parameter configurations][parameter] and all possible combin
 ## Using the [`Field()`][pydantic.Field] function to describe function parameters
 
 The [`Field()` function](fields.md) can also be used with the decorator to provide extra information about
-the field and validations. In general it should be used in a type hint with [Annotated](types.md#composing-types-via-annotated),
+the field and validations. In general it should be used in a type hint with [Annotated](types.md#using-the-annotated-pattern),
 unless `default_factory` is specified, in which case it should be used as the default value of the field:
 
 ```python

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -368,7 +368,7 @@ See the [`ConfigDict` API reference][pydantic.config.ConfigDict] for more detail
     and improvements.
     * The new `@field_validator` decorator does not have the `each_item` keyword argument; validators you want to
         apply to items within a generic container should be added by annotating the type argument. See
-        [validators in Annotated metadata](concepts/types.md#composing-types-via-annotated) for details.
+        [validators in Annotated metadata](concepts/types.md#using-the-annotated-pattern) for details.
         This looks like `List[Annotated[int, Field(ge=0)]]`
     * Even if you keep using the deprecated `@validator` decorator, you can no longer add the `field` or
         `config` arguments to the signature of validator functions. If you need access to these, you'll need
@@ -880,7 +880,7 @@ class Model(BaseModel):
     x: MyInt
 ```
 
-Read more about it in the [Composing types via `Annotated`](concepts/types.md#composing-types-via-annotated)
+Read more about it in the [Composing types via `Annotated`](concepts/types.md#using-the-annotated-pattern)
 docs.
 
 For `ConstrainedStr` you can use [`StringConstraints`][pydantic.types.StringConstraints] instead.


### PR DESCRIPTION
This is a continuation of https://github.com/pydantic/pydantic/pull/10231:

- Some parts of the `models.md` page related to fields where merged into the `fields.md` page.
- A new "annotated pattern" section was added. I will use it to improve the documentation of validators, and we should also reference it from other places of the documentation if possible. This is where we should document the annotation application logic, but postponing for later.
