### PR TITLE
Fix `PydanticRecursiveRef` returned by `mro` in multi-level generic model

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -427,6 +427,7 @@ def generic_recursion_self_type(
         else:
             previously_seen_type_refs.add(type_ref)
             yield None
+            previously_seen_type_refs.remove(type_ref)
     finally:
         if token:
             _generic_recursion_cache.reset(token)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -802,7 +802,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             )  # use dict as ordered set
 
             with _generics.generic_recursion_self_type(origin, args) as maybe_self_type:
-                # Check cached first otherwise `mro` may return `PydanticRecursiveRef`
                 cached = _generics.get_cached_generic_type_late(cls, typevar_values, origin, args)
                 if cached is not None:
                     return cached


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
During creation of generic models, we may parametrize and insert some base models into the MRO. This may let `generic_recursion_self_type` report false positive, i.e. mistaken non-recursive models for recursive ones, eventually the new MRO will contain `PydanticRecursiveRef` instead of the concrete model. This can be fixed by poping the model in `_generics.generic_recursion_self_type`. 

I also add some comments in `mro` to improve readability without altering the logic.

#### Side notes
Previous workaround rely on caches. However, this fails because in some cases two models may have different cache keys despite having same `ref`. For example:
```py
class A[T1, T2](BaseModel): ...
class B[T](BaseModel): ...
print(B[A[int, int]] == B[A][int, int])  # False
print(B[A[int, int]].__pydantic_core_schema__['ref'] == B[A][int, int].__pydantic_core_schema__['ref']) # True
```

## Related issue number
fix #11024 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
