### PR TITLE
Properly fetch PEP 695 type params for functions, do not fetch annotations from signature

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1197,7 +1197,9 @@ except PydanticUserError as exc_info:
 
 ## Unsupported type for `validate_call` {#validate-call-type}
 
-`validate_call` has some limitations on the callables it can validate. This error is raised when you try to use it with an unsupported callable. Currently the supported callables are functions (including lambdas) and methods and instances of [`partial`][functools.partial]. In the case of [`partial`][functools.partial], the function being partially applied must be one of the supported callables.
+`validate_call` has some limitations on the callables it can validate. This error is raised when you try to use it with an unsupported callable.
+Currently the supported callables are functions (including lambdas, but not built-ins) and methods and instances of [`partial`][functools.partial].
+In the case of [`partial`][functools.partial], the function being partially applied must be one of the supported callables.
 
 ### `@classmethod`, `@staticmethod`, and `@property`
 
@@ -1250,9 +1252,10 @@ class A2:
     def __new__(cls): ...
 ```
 
-### Custom callable
+### Callable instances
 
-Although you can create custom callable types in Python by implementing a `__call__` method, currently the instances of these types cannot be validated with `validate_call`. This may change in the future, but for now, you should use `validate_call` explicitly on `__call__` instead.
+Although instances can be callable by implementing a `__call__` method, currently the instances of these types cannot be validated with `validate_call`.
+This may change in the future, but for now, you should use `validate_call` explicitly on `__call__` instead.
 
 ```python
 from pydantic import PydanticUserError, validate_call

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import inspect
 from functools import partial
+from types import BuiltinFunctionType
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast, overload
 
 from ._internal import _generate_schema, _typing_extra, _validate_call
@@ -42,6 +43,8 @@ def _check_function_type(function: object) -> None:
 
         return
 
+    if isinstance(function, BuiltinFunctionType):
+        raise PydanticUserError(f'Input built-in function `{function}` is not supported', code=_INVALID_TYPE_ERROR_CODE)
     if isinstance(function, (classmethod, staticmethod, property)):
         name = type(function).__name__
         raise PydanticUserError(


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/11076, fixes https://github.com/pydantic/pydantic/issues/11073.

Turns out discussion in https://github.com/pydantic/pydantic/pull/10484#issuecomment-2390793894 was relevant, as not using `get_function_type_hints` would skip the `None -> NoneType` conversion, and other things might happen as well.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
