### PR TITLE
Unpack PEP 695 type aliases if using the `Annotated` form

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1967,12 +1967,25 @@ class GenerateSchema:
     def _annotated_schema(self, annotated_type: Any) -> core_schema.CoreSchema:
         """Generate schema for an Annotated type, e.g. `Annotated[int, Field(...)]` or `Annotated[int, Gt(0)]`."""
         FieldInfo = import_cached_field_info()
+        # Ideally, we should delegate all this to `_typing_extra.unpack_annotated`, e.g.:
+        # `typ, annotations = _typing_extra.unpack_annotated(annotated_type); schema = self.apply_annotations(...)`
+        # if it was able to use a `NsResolver`. But because `unpack_annotated` is also used
+        # when constructing `FieldInfo` instances (where we don't have access to a `NsResolver`),
+        # the implementation of the function does *not* resolve forward annotations. This could
+        # be solved by calling `unpack_annotated` directly inside `collect_model_fields`.
+        # For now, we at least resolve the annotated type if it is a forward ref, but note that
+        # unexpected results will happen if you have something like `Annotated[Alias, ...]` and
+        # `Alias` is a PEP 695 type alias containing forward references.
+        typ, *annotations = get_args(annotated_type)
+        if isinstance(typ, str):
+            typ = _typing_extra._make_forward_ref(typ)
+        if isinstance(typ, ForwardRef):
+            typ = self._resolve_forward_ref(typ)
 
-        source_type, *annotations = self._get_args_resolving_forward_refs(
-            annotated_type,
-            required=True,
-        )
-        schema = self._apply_annotations(source_type, annotations)
+        typ, sub_annotations = _typing_extra.unpack_annotated(typ)
+        annotations = sub_annotations + annotations
+
+        schema = self._apply_annotations(typ, annotations)
         # put the default validator last so that TypeAdapter.get_default_value() works
         # even if there are function validators involved
         for annotation in annotations:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -168,7 +168,17 @@ def unpack_annotated(annotation: Any, /) -> tuple[Any, list[Any]]:
         typ, sub_meta = unpack_annotated(typ)
         metadata = sub_meta + metadata
         return typ, metadata
-    elif is_type_alias_type(annotation):
+
+    if sys.version_info[:2] == (3, 10):
+        # Parametrized PEP 695 type aliases are instances of `types.GenericAlias` in typing_extensions>=4.13.0.
+        # On Python 3.10, with `Alias[int]` being a such an instance of `GenericAlias`,
+        # `isinstance(Alias[int], TypeAliasType)` returns `True`.
+        # See https://github.com/python/cpython/issues/89828.
+        ann_is_type_alias = type(annotation) is not types.GenericAlias and is_type_alias_type(annotation)
+    else:
+        ann_is_type_alias = is_type_alias_type(annotation)
+
+    if ann_is_type_alias:
         try:
             value = annotation.__value__
         except NameError:

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -128,6 +128,89 @@ def annotated_type(tp: Any, /) -> Any | None:
     return get_args(tp)[0] if is_annotated(tp) else None
 
 
+def unpack_annotated(annotation: Any, /) -> tuple[Any, list[Any]]:
+    """Unpack the annotation if it is wrapped with the `Annotated` type qualifier.
+
+    This function also unpacks PEP 695 type aliases if necessary (and also generic
+    aliases with a PEP 695 type alias origin). However, it does *not* try to evaluate
+    forward references, so users should make sure the type alias' `__value__` does not
+    contain unresolvable forward references.
+
+    Example:
+        ```python {test="skip" lint="skip"}
+        from typing import Annotated
+
+        type InnerList[T] = Annotated[list[T], 'meta_1']
+        type MyList[T] = Annotated[InnerList[T], 'meta_2']
+        type MyIntList = MyList[int]
+
+        _unpack_annotated(MyList)
+        #> (list[T], ['meta_1', 'meta_2'])
+        _unpack_annotated(MyList[int])
+        #> (list[int], ['meta_1', 'meta_2'])
+        _unpack_annotated(MyIntList)
+        #> (list[int], ['meta_1', 'meta_2'])
+        ```
+
+    Returns:
+        A two-tuple, the first element is the annotated type and the second element
+            is a list containing the annotated metadata. If the annotation wasn't
+            wrapped with `Annotated` in the first place, it is returned as is and the
+            metadata list is empty.
+    """
+    if is_annotated(annotation):
+        typ, *metadata = typing_extensions.get_args(annotation)
+        # The annotated type might be a PEP 695 type alias, so we need to recursively
+        # unpack it. Note that we could make an optimization here: the following next
+        # call to `_unpack_annotated` could omit the `is_annotated` check, because Python
+        # already flattens `Annotated[Annotated[<type>, ...], ...]` forms. However, we would
+        # need to "re-enable" the check for further recursive calls.
+        typ, sub_meta = unpack_annotated(typ)
+        metadata = sub_meta + metadata
+        return typ, metadata
+    elif is_type_alias_type(annotation):
+        try:
+            value = annotation.__value__
+        except NameError:
+            # The type alias value contains an unresolvable reference. Note that even if it
+            # resolves successfully, it might contain string annotations, and because of design
+            # limitations we don't evaluate the type (we don't have access to a `NsResolver` instance).
+            pass
+        else:
+            typ, metadata = unpack_annotated(value)
+            if metadata:
+                # Having metadata means the type alias' `__value__` was an `Annotated` form
+                # (or, recursively, a type alias to an `Annotated` form). It is important to
+                # check for this as we don't want to unpack "normal" type aliases (e.g. `type MyInt = int`).
+                return typ, metadata
+            return annotation, []
+    elif is_generic_alias(annotation):
+        # When parametrized, a PEP 695 type alias becomes a generic alias
+        # (e.g. with `type MyList[T] = Annotated[list[T], ...]`, `MyList[int]`
+        # is a generic alias).
+        origin = typing_extensions.get_origin(annotation)
+        if is_type_alias_type(origin):
+            try:
+                value = origin.__value__
+            except NameError:
+                pass
+            else:
+                # Circular import (note that these two functions should probably be defined in `_typing_extra`):
+                from ._generics import get_standard_typevars_map, replace_types
+
+                # While Python already handles type variable replacement for simple `Annotated` forms,
+                # we need to manually apply the same logic for PEP 695 type aliases:
+                # - With `MyList = Annotated[list[T], ...]`, `MyList[int] == Annotated[list[int], ...]`
+                # - With `type MyList = Annotated[list[T], ...]`, `MyList[int].__value__ == Annotated[list[T], ...]`.
+                value = replace_types(value, get_standard_typevars_map(annotation))
+                typ, metadata = unpack_annotated(value)
+                if metadata:
+                    return typ, metadata
+                return annotation, []
+
+    return annotation, []
+
+
 def is_unpack(tp: Any, /) -> bool:
     """Return whether the provided argument is a `Unpack` special form.
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -315,11 +315,11 @@ class FieldInfo(_repr.Representation):
         final = _typing_extra.is_finalvar(annotation)
         if final:
             if _typing_extra.is_generic_alias(annotation):
-                # The annotation is a parametrized `Final`, e.g. `Final[int]`.
-                # In this case, `annotation` will be `int`:
+                # 1.1. The annotation is a parametrized `Final`, e.g. `Final[int]`.
+                #      In this case, `annotation` will be `int`:
                 annotation = typing_extensions.get_args(annotation)[0]
             else:
-                # The annotation is a bare `Final`. Use `Any` as a type annotation:
+                # 1.2. The annotation is a bare `Final`. Use `Any` as a type annotation:
                 return FieldInfo(annotation=Any, frozen=True)  # pyright: ignore[reportArgumentType] (PEP 747)
 
         # 2. Check if the annotation is an `Annotated` form.
@@ -354,6 +354,7 @@ class FieldInfo(_repr.Representation):
                 new_field_info.metadata = field_metadata
                 return new_field_info
 
+        # 4. We don't have metadata:
         return FieldInfo(annotation=annotation, frozen=final or None)  # pyright: ignore[reportArgumentType] (PEP 747)
 
     @staticmethod

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -314,28 +314,14 @@ def test_recursive_generic_type_alias_annotated_defs() -> None:
     }
 
 
-@pytest.mark.xfail(reason='description is currently dropped')
-def test_field() -> None:
-    SomeAlias = TypeAliasType('SomeAlias', Annotated[int, Field(description='number')])
-
-    ta = TypeAdapter(Annotated[SomeAlias, Field(title='abc')])
-
-    # insert_assert(ta.json_schema())
-    assert ta.json_schema() == {
-        '$defs': {'SomeAlias': {'type': 'integer', 'description': 'number'}},
-        '$ref': '#/$defs/SomeAlias',
-        'title': 'abc',
-    }
-
-
 def test_nested_generic_type_alias_type() -> None:
     class MyModel(BaseModel):
         field_1: MyList[bool]
         field_2: MyList[str]
 
-    model = MyModel(field_1=[True], field_2=['abc'])
+    MyModel(field_1=[True], field_2=['abc'])
 
-    assert model.model_json_schema() == {
+    assert MyModel.model_json_schema() == {
         '$defs': {
             'MyList_bool_': {'items': {'type': 'boolean'}, 'type': 'array'},
             'MyList_str_': {'items': {'type': 'string'}, 'type': 'array'},
@@ -443,3 +429,44 @@ def test_circular_type_aliases() -> None:
 
     assert exc_info.value.code == 'circular-reference-schema'
     assert exc_info.value.message.startswith('tests.test_type_alias_type.C')
+
+
+## Tests related to (recursive) unpacking of annotated types, when PEP 695 type aliases are involved:
+
+
+def test_nested_annotated_with_type_aliases() -> None:
+    SomeAlias = TypeAliasType('SomeAlias', Annotated[int, Field(description='number')])
+
+    ta = TypeAdapter(Annotated[SomeAlias, Field(title='abc')])
+
+    assert ta.json_schema() == {'description': 'number', 'title': 'abc', 'type': 'integer'}
+
+
+@pytest.mark.xfail(
+    reason="When trying to recursively unpack the annotated form, we don't resolve "
+    'forward annotations in PEP 695 type aliases (due to current limitations).'
+)
+def test_nested_annotated_with_type_aliases_and_forward_ref() -> None:
+    SomeAlias = TypeAliasType('SomeAlias', "Annotated[int, Field(description='number')]")
+
+    ta = TypeAdapter(Annotated[SomeAlias, Field(title='abc')])
+
+    assert ta.json_schema() == {'description': 'number', 'title': 'abc', 'type': 'integer'}
+
+
+def test_nested_annotated_model_field() -> None:
+    T = TypeVar('T')
+
+    InnerList = TypeAliasType('InnerList', Annotated[List[T], Field(alias='alias')], type_params=(T,))
+    MyList = TypeAliasType('MyList', Annotated[InnerList[T], Field(deprecated=True)], type_params=(T,))
+    MyIntList = TypeAliasType('MyIntList', MyList[int])
+
+    class Model(BaseModel):
+        f1: Annotated[MyIntList, Field(json_schema_extra={'extra': 'test'})]
+
+    f1_info = Model.model_fields['f1']
+
+    assert f1_info.annotation == List[int]
+    assert f1_info.alias == 'alias'
+    assert f1_info.deprecated
+    assert f1_info.json_schema_extra == {'extra': 'test'}

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -444,7 +444,8 @@ def test_nested_annotated_with_type_aliases() -> None:
 
 @pytest.mark.xfail(
     reason="When trying to recursively unpack the annotated form, we don't resolve "
-    'forward annotations in PEP 695 type aliases (due to current limitations).'
+    'forward annotations in PEP 695 type aliases (due to current limitations) '
+    '(see https://github.com/pydantic/pydantic/issues/11122).',
 )
 def test_nested_annotated_with_type_aliases_and_forward_ref() -> None:
     SomeAlias = TypeAliasType('SomeAlias', "Annotated[int, Field(description='number')]")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/6352
Fixes https://github.com/pydantic/pydantic/issues/10219

This PR also makes a first step in refactoring the `FieldInfo` class (see https://github.com/pydantic/pydantic/issues/11122), at least for the `from_annotation` constructor method. The method logic is alsmost untouched, it was just adapted to use the new `_unpack_annotated` utility function (also some variables had to be renamed) and comments were added to better describe the logic.

The `from_annotated_attribute` should also be updated, but this is left for https://github.com/pydantic/pydantic/issues/11122.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
