### PR TITLE
Add `len` to `_BaseUrl` to avoid TypeError

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -239,6 +239,9 @@ class _BaseUrl:
     def __hash__(self) -> int:
         return hash(self._url)
 
+    def __len__(self) -> int:
+        return len(str(self._url))
+
     @classmethod
     def build(
         cls,

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -400,6 +400,9 @@ class _BaseMultiHostUrl:
     def __hash__(self) -> int:
         return hash(self._url)
 
+    def __len__(self) -> int:
+        return len(str(self._url))
+
     @classmethod
     def build(
         cls,

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1157,7 +1157,7 @@ def test_any_url_comparison() -> None:
     assert second_url >= first_url
 
 
-def test_max_length() -> None:
+def test_max_length_base_url() -> None:
     class Model(BaseModel):
         url: AnyUrl = Field(max_length=20)
 
@@ -1169,3 +1169,14 @@ def test_max_length() -> None:
 
     with pytest.raises(ValidationError, match=r'Value should have at most 20 items after validation'):
         Model(url='https://example.com/longer')
+
+
+def test_max_length_base_multi_host() -> None:
+    class Model(BaseModel):
+        postgres: PostgresDsn = Field(max_length=45)
+
+    expected = 'postgres://user:pass@localhost:5432/foobar'
+    assert len(Model(postgres=expected).postgres) == len(expected)
+
+    with pytest.raises(ValidationError, match=r'Value should have at most 45 items after validation'):
+        Model(postgres='postgres://user:pass@localhost:5432/foobarbazfoo')

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -13,6 +13,7 @@ from pydantic import (
     BaseModel,
     ClickHouseDsn,
     CockroachDsn,
+    Field,
     FileUrl,
     FtpUrl,
     HttpUrl,
@@ -1154,3 +1155,17 @@ def test_any_url_comparison() -> None:
     assert second_url > first_url
     assert first_url <= second_url
     assert second_url >= first_url
+
+
+def test_max_length() -> None:
+    class Model(BaseModel):
+        url: AnyUrl = Field(max_length=20)
+
+    # _BaseUrl/AnyUrl adds trailing slash: https://github.com/pydantic/pydantic/issues/7186
+    # once solved the second expected line can be removed
+    expected = 'https://example.com'
+    expected = f'{expected}/'
+    assert len(Model(url='https://example.com').url) == len(expected)
+
+    with pytest.raises(ValidationError, match=r'Value should have at most 20 items after validation'):
+        Model(url='https://example.com/longer')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add magic method to _BaseUrl class to support allowed usage of Field with max length with AnyUrl and simple length comparison and checks of AnyUrl types.

## Related issue number
fix #11092 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle