### PR TITLE
Improve discriminated union error message for invalid union variants

### DIFF
--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -286,10 +286,13 @@ class _ApplyInferredDiscriminator:
             'definition-ref',
         } and not _core_utils.is_function_with_inner_schema(choice):
             # We should eventually handle 'definition-ref' as well
-            raise TypeError(
-                f'{choice["type"]!r} is not a valid discriminated union variant;'
-                ' should be a `BaseModel` or `dataclass`'
-            )
+            err_str = f'The core schema type {choice["type"]!r} is not a valid discriminated union variant.'
+            if choice['type'] == 'list':
+                err_str += (
+                    ' If you are making use of a list of union types, make sure the discriminator is applied to the '
+                    'union type and not the list (e.g. `list[Annotated[<T> | <U>, Field(discriminator=...)]]`).'
+                )
+            raise TypeError(err_str)
         else:
             if choice['type'] == 'tagged-union' and self._is_discriminator_shared(choice):
                 # In this case, this inner tagged-union is compatible with the outer tagged-union,
@@ -323,13 +326,10 @@ class _ApplyInferredDiscriminator:
         """
         if choice['type'] == 'definitions':
             return self._infer_discriminator_values_for_choice(choice['schema'], source_name=source_name)
-        elif choice['type'] == 'function-plain':
-            raise TypeError(
-                f'{choice["type"]!r} is not a valid discriminated union variant;'
-                ' should be a `BaseModel` or `dataclass`'
-            )
+
         elif _core_utils.is_function_with_inner_schema(choice):
             return self._infer_discriminator_values_for_choice(choice['schema'], source_name=source_name)
+
         elif choice['type'] == 'lax-or-strict':
             return sorted(
                 set(
@@ -380,10 +380,13 @@ class _ApplyInferredDiscriminator:
                 raise MissingDefinitionForUnionRef(schema_ref)
             return self._infer_discriminator_values_for_choice(self.definitions[schema_ref], source_name=source_name)
         else:
-            raise TypeError(
-                f'{choice["type"]!r} is not a valid discriminated union variant;'
-                ' should be a `BaseModel` or `dataclass`'
-            )
+            err_str = f'The core schema type {choice["type"]!r} is not a valid discriminated union variant.'
+            if choice['type'] == 'list':
+                err_str += (
+                    ' If you are making use of a list of union types, make sure the discriminator is applied to the '
+                    'union type and not the list (e.g. `list[Annotated[<T> | <U>, Field(discriminator=...)]]`).'
+                )
+            raise TypeError(err_str)
 
     def _infer_discriminator_values_for_typed_dict_choice(
         self, choice: core_schema.TypedDictSchema, source_name: str | None = None


### PR DESCRIPTION
Remove duplicated test and improve `test_plain_function_schema_is_invalid`
to make use of a real model definition.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Closes https://github.com/pydantic/pydantic/pull/11158.

Note that more cleanups could be applied to the discriminator inference logic. I was able to remove one useless condition check, but we still raise the same error in two different places and with a bit of refactoring we can surely simplify it further.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
