### PR TITLE
Raise a deprecation warning when a field is annotated as final with a default value

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -51,6 +51,8 @@ if typing.TYPE_CHECKING:
         PydanticDeprecatedSince20,
         PydanticDeprecatedSince26,
         PydanticDeprecatedSince29,
+        PydanticDeprecatedSince210,
+        PydanticDeprecatedSince211,
         PydanticDeprecationWarning,
         PydanticExperimentalWarning,
     )
@@ -215,6 +217,8 @@ __all__ = (
     'PydanticDeprecatedSince20',
     'PydanticDeprecatedSince26',
     'PydanticDeprecatedSince29',
+    'PydanticDeprecatedSince210',
+    'PydanticDeprecatedSince211',
     'PydanticDeprecationWarning',
     'PydanticExperimentalWarning',
     # annotated handlers
@@ -370,6 +374,8 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'PydanticDeprecatedSince20': (__spec__.parent, '.warnings'),
     'PydanticDeprecatedSince26': (__spec__.parent, '.warnings'),
     'PydanticDeprecatedSince29': (__spec__.parent, '.warnings'),
+    'PydanticDeprecatedSince210': (__spec__.parent, '.warnings'),
+    'PydanticDeprecatedSince211': (__spec__.parent, '.warnings'),
     'PydanticDeprecationWarning': (__spec__.parent, '.warnings'),
     'PydanticExperimentalWarning': (__spec__.parent, '.warnings'),
     # annotated handlers

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -165,8 +165,8 @@ def collect_model_fields(  # noqa: C901
         if _is_finalvar_with_default_val(ann_type, assigned_value):
             warnings.warn(
                 f'Annotation {ann_name!r} is marked as final and has a default value. Pydantic treats {ann_name!r} as a '
-                f'class variable, but it will be considered as an normal field in V3. If you still want {ann_name!r} to be '
-                'considered as a class variable, annotate it as: `ClassVar[<type>] = <default>.`',
+                'class variable, but it will be considered as a normal field in V3 to be aligned with dataclasses. If you '
+                f'still want {ann_name!r} to be considered as a class variable, annotate it as: `ClassVar[<type>] = <default>.`',
                 category=PydanticDeprecatedSince211,
                 # Incorrect when `create_model` is used, but the chance that final with a default is used is low in that case:
                 stacklevel=4,

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -6,8 +6,11 @@ from .version import version_short
 
 __all__ = (
     'PydanticDeprecatedSince20',
-    'PydanticDeprecationWarning',
     'PydanticDeprecatedSince26',
+    'PydanticDeprecatedSince29',
+    'PydanticDeprecatedSince210',
+    'PydanticDeprecatedSince211',
+    'PydanticDeprecationWarning',
     'PydanticExperimentalWarning',
 )
 
@@ -72,6 +75,13 @@ class PydanticDeprecatedSince210(PydanticDeprecationWarning):
 
     def __init__(self, message: str, *args: object) -> None:
         super().__init__(message, *args, since=(2, 10), expected_removal=(3, 0))
+
+
+class PydanticDeprecatedSince211(PydanticDeprecationWarning):
+    """A specific `PydanticDeprecationWarning` subclass defining functionality deprecated since Pydantic 2.11."""
+
+    def __init__(self, message: str, *args: object) -> None:
+        super().__init__(message, *args, since=(2, 11), expected_removal=(3, 0))
 
 
 class GenericBeforeBaseModelWarning(Warning):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,6 +38,7 @@ from pydantic import (
     Field,
     GetCoreSchemaHandler,
     PrivateAttr,
+    PydanticDeprecatedSince211,
     PydanticUndefinedAnnotation,
     PydanticUserError,
     SecretStr,
@@ -2011,8 +2012,10 @@ def test_frozen_field_decl_without_default_val(ann, value):
     ids=['no-arg', 'with-arg'],
 )
 def test_final_field_decl_with_default_val(ann):
-    class Model(BaseModel):
-        a: ann = 10
+    with pytest.warns(PydanticDeprecatedSince211):
+
+        class Model(BaseModel):
+            a: ann = 10
 
     assert 'a' in Model.__class_vars__
     assert 'a' not in Model.model_fields

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2011,7 +2011,7 @@ def test_frozen_field_decl_without_default_val(ann, value):
     [Final, Final[int]],
     ids=['no-arg', 'with-arg'],
 )
-def test_final_field_decl_with_default_val(ann):
+def test_deprecated_final_field_decl_with_default_val(ann):
     with pytest.warns(PydanticDeprecatedSince211):
 
         class Model(BaseModel):


### PR DESCRIPTION

Also adapt the `collect_model_fields` logic a bit.

Part of https://github.com/pydantic/pydantic/issues/11119.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
