### PR TITLE
Deprecate accessing `model_fields` and `model_computed_fields` on instances

### DIFF
--- a/docs/api/base_model.md
+++ b/docs/api/base_model.md
@@ -9,11 +9,11 @@ Pydantic models are simply classes which inherit from `BaseModel` and define fie
         members:
           - __init__
           - model_config
-          - model_computed_fields
-          - model_extra
           - model_fields
-          - model_fields_set
+          - model_computed_fields
           - __pydantic_core_schema__
+          - model_extra
+          - model_fields_set
           - model_construct
           - model_copy
           - model_dump
@@ -25,7 +25,6 @@ Pydantic models are simply classes which inherit from `BaseModel` and define fie
           - model_validate
           - model_validate_json
           - model_validate_strings
-          - copy
 
 ::: pydantic.create_model
     options:

--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -1009,7 +1009,7 @@ class Model(BaseModel):
 m = Model.model_validate({'state': 2})
 print(repr(m))
 #> Model(state=2)
-print(m.model_fields)
+print(Model.model_fields)
 """
 {
     'state': FieldInfo(

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -39,8 +39,8 @@ from ._typing_extra import (
 from ._utils import LazyClassAttribute, SafeGetItemProxy
 
 if typing.TYPE_CHECKING:
-    from ..fields import ComputedFieldInfo, FieldInfo, ModelPrivateAttr
     from ..fields import Field as PydanticModelField
+    from ..fields import FieldInfo, ModelPrivateAttr
     from ..fields import PrivateAttr as PydanticModelPrivateAttr
     from ..main import BaseModel
 else:
@@ -361,25 +361,7 @@ class ModelMetaclass(ABCMeta):
             PydanticDeprecatedSince20,
             stacklevel=2,
         )
-        return self.model_fields
-
-    @property
-    def model_fields(self) -> dict[str, FieldInfo]:
-        """Get metadata about the fields defined on the model.
-
-        Returns:
-            A mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
-        """
         return getattr(self, '__pydantic_fields__', {})
-
-    @property
-    def model_computed_fields(self) -> dict[str, ComputedFieldInfo]:
-        """Get metadata about the computed fields defined on the model.
-
-        Returns:
-            A mapping of computed field names to [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects.
-        """
-        return getattr(self, '__pydantic_computed_fields__', {})
 
     def __dir__(self) -> list[str]:
         attributes = list(super().__dir__())

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Generic, Mapping, TypeVar, overload
 
 from typing_extensions import TypeAlias, TypeGuard, deprecated
 
-from pydantic.warnings import PydanticDeprecatedSince210
+from pydantic import PydanticDeprecatedSince211
 
 from . import _repr, _typing_extra
 from ._import_utils import import_cached_base_model
@@ -422,6 +422,6 @@ class deprecated_instance_property(Generic[_ModelT, _RT]):
             warnings.warn(
                 'Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3. '
                 'Instead, you should access this attribute from the model class.',
-                category=PydanticDeprecatedSince210,
+                category=PydanticDeprecatedSince211,
             )
         return self.fget.__get__(instance, objtype)()

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -393,10 +393,10 @@ class SafeGetItemProxy:
 
 
 _ModelT = TypeVar('_ModelT', bound='BaseModel')
-_R = TypeVar('_R')
+_RT = TypeVar('_RT')
 
 
-class deprecatedinstanceproperty(Generic[_ModelT, _R]):
+class deprecated_instance_property(Generic[_ModelT, _RT]):
     """A decorator exposing the decorated class method as a property, with a warning on instance access.
 
     This decorator takes a class method defined on the `BaseModel` class and transforms it into
@@ -404,21 +404,24 @@ class deprecatedinstanceproperty(Generic[_ModelT, _R]):
     via an instance, a deprecation warning is emitted stating that instance access will be removed in V3.
     """
 
-    def __init__(self, fget: Callable[[type[_ModelT]], _R], /) -> None:
+    def __init__(self, fget: Callable[[type[_ModelT]], _RT], /) -> None:
+        # Note: fget should be a classmethod:
         self.fget = fget
 
     @overload
-    def __get__(self, instance: None, objtype: type[_ModelT]) -> _R: ...
+    def __get__(self, instance: None, objtype: type[_ModelT]) -> _RT: ...
     @overload
     @deprecated(
-        'Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3.',
+        'Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3. '
+        'Instead, you should access this attribute from the model class.',
         category=None,
     )
-    def __get__(self, instance: _ModelT, objtype: type[_ModelT]) -> _R: ...
-    def __get__(self, instance: _ModelT | None, objtype: type[_ModelT]) -> _R:
+    def __get__(self, instance: _ModelT, objtype: type[_ModelT]) -> _RT: ...
+    def __get__(self, instance: _ModelT | None, objtype: type[_ModelT]) -> _RT:
         if instance is not None:
             warnings.warn(
-                'Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3.',
+                'Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3. '
+                'Instead, you should access this attribute from the model class.',
                 category=PydanticDeprecatedSince210,
             )
         return self.fget.__get__(instance, objtype)()

--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations as _annotations
 import dataclasses
 import keyword
 import typing
+import warnings
 import weakref
 from collections import OrderedDict, defaultdict, deque
 from copy import deepcopy
@@ -15,9 +16,11 @@ from functools import cached_property
 from inspect import Parameter
 from itertools import zip_longest
 from types import BuiltinFunctionType, CodeType, FunctionType, GeneratorType, LambdaType, ModuleType
-from typing import Any, Callable, Mapping, TypeVar
+from typing import Any, Callable, Generic, Mapping, TypeVar, overload
 
-from typing_extensions import TypeAlias, TypeGuard
+from typing_extensions import TypeAlias, TypeGuard, deprecated
+
+from pydantic.warnings import PydanticDeprecatedSince210
 
 from . import _repr, _typing_extra
 from ._import_utils import import_cached_base_model
@@ -387,3 +390,35 @@ class SafeGetItemProxy:
 
         def __contains__(self, key: str, /) -> bool:
             return self.wrapped.__contains__(key)
+
+
+_ModelT = TypeVar('_ModelT', bound='BaseModel')
+_R = TypeVar('_R')
+
+
+class deprecatedinstanceproperty(Generic[_ModelT, _R]):
+    """A decorator exposing the decorated class method as a property, with a warning on instance access.
+
+    This decorator takes a class method defined on the `BaseModel` class and transforms it into
+    an attribute. The attribute can be accessed on both the class and instances of the class. If accessed
+    via an instance, a deprecation warning is emitted stating that instance access will be removed in V3.
+    """
+
+    def __init__(self, fget: Callable[[type[_ModelT]], _R], /) -> None:
+        self.fget = fget
+
+    @overload
+    def __get__(self, instance: None, objtype: type[_ModelT]) -> _R: ...
+    @overload
+    @deprecated(
+        'Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3.',
+        category=None,
+    )
+    def __get__(self, instance: _ModelT, objtype: type[_ModelT]) -> _R: ...
+    def __get__(self, instance: _ModelT | None, objtype: type[_ModelT]) -> _R:
+        if instance is not None:
+            warnings.warn(
+                'Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3.',
+                category=PydanticDeprecatedSince210,
+            )
+        return self.fget.__get__(instance, objtype)()

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -240,39 +240,27 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     # The following line sets a flag that we use to determine when `__init__` gets overridden by the user
     __init__.__pydantic_base_init__ = True  # pyright: ignore[reportFunctionMemberAccess]
 
-    if TYPE_CHECKING:
-        model_fields: ClassVar[dict[str, FieldInfo]]
-        model_computed_fields: ClassVar[dict[str, ComputedFieldInfo]]
-    else:
-        # TODO: V3 - remove `model_fields` and `model_computed_fields` properties from the `BaseModel` class - they should only
-        # be accessible on the model class, not on instances. We have these purely for backwards compatibility with Pydantic <v2.10.
-        # This is similar to the fact that we have __fields__ defined here (on `BaseModel`) and on `ModelMetaClass`.
-        # Another problem here is that there's no great way to have class properties :(
-        @property
-        def model_fields(self) -> dict[str, FieldInfo]:
-            """Get metadata about the fields defined on the model.
+    @_utils.deprecatedinstanceproperty
+    @classmethod
+    def model_fields(cls) -> dict[str, FieldInfo]:
+        """A mapping of field names to their respective [`FieldInfo`][pydantic.fields.FieldInfo] instances.
 
-            Deprecation warning: you should be getting this information from the model class, not from an instance.
-            In V3, this property will be removed from the `BaseModel` class.
+        !!! warning
+            Accessing this attribute from a model instance is deprecated, and will not work in Pydantic V3.
+            Instead, you should access this attribute from the model class.
+        """
+        return getattr(cls, '__pydantic_fields__', {})
 
-            Returns:
-                A mapping of field names to [`FieldInfo`][pydantic.fields.FieldInfo] objects.
-            """
-            # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation, hence the default here.
-            return getattr(self, '__pydantic_fields__', {})
+    @_utils.deprecatedinstanceproperty
+    @classmethod
+    def model_computed_fields(cls) -> dict[str, ComputedFieldInfo]:
+        """A mapping of computed field names to their respective [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] instances.
 
-        @property
-        def model_computed_fields(self) -> dict[str, ComputedFieldInfo]:
-            """Get metadata about the computed fields defined on the model.
-
-            Deprecation warning: you should be getting this information from the model class, not from an instance.
-            In V3, this property will be removed from the `BaseModel` class.
-
-            Returns:
-                A mapping of computed field names to [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects.
-            """
-            # Must be set for `GenerateSchema.model_schema` to work for a plain `BaseModel` annotation, hence the default here.
-            return getattr(self, '__pydantic_computed_fields__', {})
+        !!! warning
+            Accessing this attribute from a model instance is deprecated, and will not work in Pydantic V3.
+            Instead, you should access this attribute from the model class.
+        """
+        return getattr(cls, '__pydantic_computed_fields__', {})
 
     @property
     def model_extra(self) -> dict[str, Any] | None:
@@ -1169,7 +1157,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             category=PydanticDeprecatedSince20,
             stacklevel=2,
         )
-        return self.model_fields
+        return getattr(type(self), '__pydantic_fields__', {})
 
     @property
     @typing_extensions.deprecated(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -240,7 +240,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     # The following line sets a flag that we use to determine when `__init__` gets overridden by the user
     __init__.__pydantic_base_init__ = True  # pyright: ignore[reportFunctionMemberAccess]
 
-    @_utils.deprecatedinstanceproperty
+    @_utils.deprecated_instance_property
     @classmethod
     def model_fields(cls) -> dict[str, FieldInfo]:
         """A mapping of field names to their respective [`FieldInfo`][pydantic.fields.FieldInfo] instances.
@@ -251,7 +251,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
         return getattr(cls, '__pydantic_fields__', {})
 
-    @_utils.deprecatedinstanceproperty
+    @_utils.deprecated_instance_property
     @classmethod
     def model_computed_fields(cls) -> dict[str, ComputedFieldInfo]:
         """A mapping of computed field names to their respective [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] instances.

--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -44,13 +44,13 @@ def test_computed_fields_get():
             return self.width * 2
 
     rect = Rectangle(width=10, length=5)
-    assert set(rect.model_fields) == {'width', 'length'}
-    assert set(rect.model_computed_fields) == {'area', 'area2'}
+    assert set(Rectangle.model_fields) == {'width', 'length'}
+    assert set(Rectangle.model_computed_fields) == {'area', 'area2'}
     assert rect.__dict__ == {'width': 10, 'length': 5}
 
-    assert rect.model_computed_fields['area'].description == 'An awesome area'
-    assert rect.model_computed_fields['area2'].title == 'Pikarea'
-    assert rect.model_computed_fields['area2'].description == 'Another area'
+    assert Rectangle.model_computed_fields['area'].description == 'An awesome area'
+    assert Rectangle.model_computed_fields['area2'].title == 'Pikarea'
+    assert Rectangle.model_computed_fields['area2'].description == 'Another area'
 
     assert rect.area == 50
     assert rect.double_width == 20
@@ -406,7 +406,7 @@ def test_free_function():
         double = computed_field(double_func)
 
     m = MyModel(x=2)
-    assert set(m.model_fields) == {'x'}
+    assert set(MyModel.model_fields) == {'x'}
     assert m.__private_attributes__ == {}
     assert m.double == 4
     assert repr(m) == 'MyModel(x=2, double=4)'
@@ -754,9 +754,9 @@ def test_generic_computed_field():
     assert A[int](x=1).model_dump() == {'x': 1, 'double_x': 2}
     assert A[str](x='abc').model_dump() == {'x': 'abc', 'double_x': 'abcabc'}
 
-    assert A(x='xxxxxx').model_computed_fields['double_x'].return_type == T
-    assert A[int](x=123).model_computed_fields['double_x'].return_type == int
-    assert A[str](x='x').model_computed_fields['double_x'].return_type == str
+    assert A.model_computed_fields['double_x'].return_type is T
+    assert A[int].model_computed_fields['double_x'].return_type is int
+    assert A[str].model_computed_fields['double_x'].return_type is str
 
     class B(BaseModel, Generic[T]):
         @computed_field
@@ -814,26 +814,3 @@ def test_computed_field_with_field_serializer():
             return f'{info.field_name} = {value}'
 
     assert MyModel().model_dump() == {'my_field': 'my_field = foo', 'other_field': 'other_field = 42'}
-
-
-def test_fields_on_instance_and_cls() -> None:
-    """For now, we support `model_fields` and `model_computed_fields` access on both instances and classes.
-
-    In V3, we should only support class access, though we need to preserve the current behavior for V2 compatibility."""
-
-    class Rectangle(BaseModel):
-        x: int
-        y: int
-
-        @computed_field
-        @property
-        def area(self) -> int:
-            return self.x * self.y
-
-    r = Rectangle(x=10, y=5)
-
-    for attr in {'model_fields', 'model_computed_fields'}:
-        assert getattr(r, attr) == getattr(Rectangle, attr)
-
-    assert set(r.model_fields) == {'x', 'y'}
-    assert set(r.model_computed_fields) == {'area'}

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -143,7 +143,6 @@ def test_simple_copy(copy_method):
     assert m.a == m2.a == 24
     assert m.b == m2.b == 10
     assert m == m2
-    assert m.model_fields == m2.model_fields
 
 
 @pytest.fixture(scope='session', name='ModelTwo')
@@ -169,7 +168,6 @@ def test_deep_copy(ModelTwo, copy_method):
     assert m.c == m2.c == 'foobar'
     assert m.d is not m2.d
     assert m == m2
-    assert m.model_fields == m2.model_fields
     assert m._foo_ == m2._foo_
     assert m._foo_ is not m2._foo_
 
@@ -329,7 +327,6 @@ def test_simple_pickle():
     assert m is not m2
     assert tuple(m) == (('a', 24.0), ('b', 10))
     assert tuple(m2) == (('a', 24.0), ('b', 10))
-    assert m.model_fields == m2.model_fields
 
 
 def test_recursive_pickle(create_module):
@@ -355,7 +352,6 @@ def test_recursive_pickle(create_module):
 
     assert m.d.a == 123.45
     assert m2.d.a == 123.45
-    assert m.model_fields == m2.model_fields
     assert m._foo_ == m2._foo_
 
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -18,6 +18,7 @@ from pydantic import (
     PydanticDeprecatedSince20,
     PydanticUserError,
     ValidationError,
+    computed_field,
     conlist,
     root_validator,
 )
@@ -29,6 +30,7 @@ from pydantic.deprecated.tools import parse_obj_as, schema_json_of, schema_of
 from pydantic.functional_serializers import model_serializer
 from pydantic.json_schema import JsonSchemaValue
 from pydantic.type_adapter import TypeAdapter
+from pydantic.warnings import PydanticDeprecatedSince210
 
 
 def deprecated_from_orm(model_type: Type[BaseModel], obj: Any) -> Any:
@@ -316,9 +318,20 @@ def test_fields():
         x: int
         y: int = 2
 
+        @computed_field
+        @property
+        def area(self) -> int:
+            return self.x * self.y
+
     m = Model(x=1)
     assert len(Model.model_fields) == 2
-    assert len(m.model_fields) == 2
+
+    with pytest.warns(PydanticDeprecatedSince210):
+        assert len(m.model_fields) == 2
+
+    with pytest.warns(PydanticDeprecatedSince210):
+        assert len(m.model_computed_fields) == 1
+
     match = '^The `__fields__` attribute is deprecated, use `model_fields` instead.'
     with pytest.warns(PydanticDeprecatedSince20, match=match):
         assert len(Model.__fields__) == 2

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -16,6 +16,7 @@ from pydantic import (
     GetCoreSchemaHandler,
     GetJsonSchemaHandler,
     PydanticDeprecatedSince20,
+    PydanticDeprecatedSince211,
     PydanticUserError,
     ValidationError,
     computed_field,
@@ -30,7 +31,6 @@ from pydantic.deprecated.tools import parse_obj_as, schema_json_of, schema_of
 from pydantic.functional_serializers import model_serializer
 from pydantic.json_schema import JsonSchemaValue
 from pydantic.type_adapter import TypeAdapter
-from pydantic.warnings import PydanticDeprecatedSince210
 
 
 def deprecated_from_orm(model_type: Type[BaseModel], obj: Any) -> Any:
@@ -326,10 +326,10 @@ def test_fields():
     m = Model(x=1)
     assert len(Model.model_fields) == 2
 
-    with pytest.warns(PydanticDeprecatedSince210):
+    with pytest.warns(PydanticDeprecatedSince211):
         assert len(m.model_fields) == 2
 
-    with pytest.warns(PydanticDeprecatedSince210):
+    with pytest.warns(PydanticDeprecatedSince211):
         assert len(m.model_computed_fields) == 1
 
     match = '^The `__fields__` attribute is deprecated, use `model_fields` instead.'

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -60,7 +60,7 @@ def test_str_bytes():
 
     m = Model(v='s')
     assert m.v == 's'
-    assert repr(m.model_fields['v']) == 'FieldInfo(annotation=Union[str, bytes], required=True)'
+    assert repr(Model.model_fields['v']) == 'FieldInfo(annotation=Union[str, bytes], required=True)'
 
     m = Model(v=b'b')
     assert m.v == b'b'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,8 +111,8 @@ def test_ultra_simple_repr(UltraSimpleModel):
     m = UltraSimpleModel(a=10.2)
     assert str(m) == 'a=10.2 b=10'
     assert repr(m) == 'UltraSimpleModel(a=10.2, b=10)'
-    assert repr(m.model_fields['a']) == 'FieldInfo(annotation=float, required=True)'
-    assert repr(m.model_fields['b']) == 'FieldInfo(annotation=int, required=False, default=10)'
+    assert repr(UltraSimpleModel.model_fields['a']) == 'FieldInfo(annotation=float, required=True)'
+    assert repr(UltraSimpleModel.model_fields['b']) == 'FieldInfo(annotation=int, required=False, default=10)'
     assert dict(m) == {'a': 10.2, 'b': 10}
     assert m.model_dump() == {'a': 10.2, 'b': 10}
     assert m.model_dump_json() == '{"a":10.2,"b":10}'
@@ -142,7 +142,7 @@ def test_default_factory_field():
 
     m = Model()
     assert str(m) == 'a=1'
-    assert repr(m.model_fields['a']) == 'FieldInfo(annotation=int, required=False, default_factory=myfunc)'
+    assert repr(Model.model_fields['a']) == 'FieldInfo(annotation=int, required=False, default_factory=myfunc)'
     assert dict(m) == {'a': 1}
     assert m.model_dump_json() == '{"a":1}'
 
@@ -1864,9 +1864,9 @@ def test_repr_field():
 
     m = Model(a=1, b=2.5, c=True)
     assert repr(m) == 'Model(a=1, b=2.5)'
-    assert repr(m.model_fields['a']) == 'FieldInfo(annotation=int, required=True)'
-    assert repr(m.model_fields['b']) == 'FieldInfo(annotation=float, required=True)'
-    assert repr(m.model_fields['c']) == 'FieldInfo(annotation=bool, required=True, repr=False)'
+    assert repr(Model.model_fields['a']) == 'FieldInfo(annotation=int, required=True)'
+    assert repr(Model.model_fields['b']) == 'FieldInfo(annotation=float, required=True)'
+    assert repr(Model.model_fields['c']) == 'FieldInfo(annotation=bool, required=True, repr=False)'
 
 
 def test_inherited_model_field_copy():

--- a/tests/typechecking/base_model.py
+++ b/tests/typechecking/base_model.py
@@ -34,5 +34,6 @@ k = Knight()  # type: ignore[call-arg]  # pyright: ignore[reportCallIssue]
 
 assert_type(Knight.model_fields, dict[str, FieldInfo])
 assert_type(Knight.model_computed_fields, dict[str, ComputedFieldInfo])
-assert_type(k.model_fields, dict[str, FieldInfo])
-assert_type(k.model_computed_fields, dict[str, ComputedFieldInfo])
+# Mypy does not report the deprecated access (https://github.com/python/mypy/issues/18323):
+assert_type(k.model_fields, dict[str, FieldInfo])  # pyright: ignore[reportDeprecated]
+assert_type(k.model_computed_fields, dict[str, ComputedFieldInfo])  # pyright: ignore[reportDeprecated]


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/10930.
Requires https://github.com/pydantic/pydantic/pull/11168, which defines the new deprecation class.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
