### PR TITLE
Include `openapi-python-client` check in issue creation for third-party failures, use `main` branch

### DIFF
--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -130,8 +130,7 @@ jobs:
     - name: Checkout openapi-python-client
       uses: actions/checkout@v4
       with:
-        repository: Viicos/openapi-python-client
-        ref: 'model-rebuild'
+        repository: openapi-generators/openapi-python-client
 
     - name: Checkout Pydantic
       uses: actions/checkout@v4

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -164,12 +164,14 @@ jobs:
     needs:
       - test-fastapi
       - test-sqlmodel
+      - test-openapi-python-client
     if: |
       github.repository == 'pydantic/pydantic' &&
       github.event_name == 'schedule' &&
       (
         needs.test-fastapi.result == 'failure' ||
-        needs.test-sqlmodel.result == 'failure'
+        needs.test-sqlmodel.result == 'failure' ||
+        needs.test-openapi-python-client.result == 'failure'
       )
     permissions:
       issues: write


### PR DESCRIPTION
Follow up to https://github.com/pydantic/pydantic/pull/11171

Update the issue creation to include case where openapi tests fail, and update branch pointer.