### PR TITLE
Consolidate schema definitions logic in the `_Definitions` class

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -824,10 +824,6 @@ class GenerateSchema:
         if ref:
             return self.defs.create_definition_reference_schema(schema)
 
-        # TODO
-        # if schema['type'] == 'definition-ref':
-        #     return core_schema.definition_reference_schema(schema_ref=schema['schema_ref'])
-
         return schema
 
     def _resolve_forward_ref(self, obj: Any) -> Any:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -30,6 +30,7 @@ from typing import (
     Dict,
     Final,
     ForwardRef,
+    Generator,
     Iterable,
     Iterator,
     Mapping,
@@ -589,24 +590,13 @@ class GenerateSchema:
         pass
 
     def clean_schema(self, schema: CoreSchema) -> CoreSchema:
-        schema = self.collect_definitions(schema)
+        schema = self.defs.as_definitions_schema(schema)
         schema = simplify_schema_references(schema)
         if collect_invalid_schemas(schema):
             raise self.CollectedInvalid()
         schema = _discriminated_union.apply_discriminators(schema)
         schema = validate_core_schema(schema)
         return schema
-
-    def collect_definitions(self, schema: CoreSchema) -> CoreSchema:
-        ref = cast('str | None', schema.get('ref', None))
-        if ref:
-            self.defs.definitions[ref] = schema
-        if 'ref' in schema:
-            schema = core_schema.definition_reference_schema(schema['ref'])
-        return core_schema.definitions_schema(
-            schema,
-            list(self.defs.definitions.values()),
-        )
 
     def _add_js_function(self, metadata_schema: CoreSchema, js_function: Callable[..., Any]) -> None:
         metadata = metadata_schema.get('metadata', {})
@@ -658,7 +648,7 @@ class GenerateSchema:
 
         metadata_js_function = _extract_get_pydantic_json_schema(obj)
         if metadata_js_function is not None:
-            metadata_schema = resolve_original_schema(schema, self.defs.definitions)
+            metadata_schema = resolve_original_schema(schema, self.defs)
             if metadata_schema:
                 self._add_js_function(metadata_schema, metadata_js_function)
 
@@ -762,19 +752,7 @@ class GenerateSchema:
 
                 schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
                 schema = apply_model_validators(schema, model_validators, 'outer')
-                self.defs.definitions[model_ref] = schema
-                return core_schema.definition_reference_schema(model_ref)
-
-    def _unpack_refs_defs(self, schema: CoreSchema) -> CoreSchema:
-        """Unpack all 'definitions' schemas into `GenerateSchema.defs.definitions`
-        and return the inner schema.
-        """
-        if schema['type'] == 'definitions':
-            definitions = self.defs.definitions
-            for s in schema['definitions']:
-                definitions[s['ref']] = s  # type: ignore
-            return schema['schema']
-        return schema
+                return self.defs.create_definition_reference_schema(schema)
 
     def _resolve_self_type(self, obj: Any) -> Any:
         obj = self.model_type_stack.get()
@@ -833,7 +811,8 @@ class GenerateSchema:
             # we have no existing schema information on the property, exit early so that we can go generate a schema
             return None
 
-        schema = self._unpack_refs_defs(schema)
+        if schema['type'] == 'definitions':
+            schema = self.defs.unpack_definitions(schema)
 
         if is_function_with_inner_schema(schema):
             ref = schema['schema'].pop('ref', None)  # pyright: ignore[reportCallIssue, reportArgumentType]
@@ -843,8 +822,11 @@ class GenerateSchema:
             ref = get_ref(schema)
 
         if ref:
-            self.defs.definitions[ref] = schema
-            return core_schema.definition_reference_schema(ref)
+            return self.defs.create_definition_reference_schema(schema)
+
+        # TODO
+        # if schema['type'] == 'definition-ref':
+        #     return core_schema.definition_reference_schema(schema_ref=schema['schema_ref'])
 
         return schema
 
@@ -1408,8 +1390,7 @@ class GenerateSchema:
                 schema = self.generate_schema(annotation)
                 assert schema['type'] != 'definitions'
                 schema['ref'] = ref  # type: ignore
-            self.defs.definitions[ref] = schema
-            return core_schema.definition_reference_schema(ref)
+            return self.defs.create_definition_reference_schema(schema)
 
     def _literal_schema(self, literal_type: Any) -> CoreSchema:
         """Generate schema for a Literal."""
@@ -1527,8 +1508,7 @@ class GenerateSchema:
 
                 schema = self._apply_model_serializers(td_schema, decorators.model_serializers.values())
                 schema = apply_model_validators(schema, decorators.model_validators.values(), 'all')
-                self.defs.definitions[typed_dict_ref] = schema
-                return core_schema.definition_reference_schema(typed_dict_ref)
+                return self.defs.create_definition_reference_schema(schema)
 
     def _namedtuple_schema(self, namedtuple_cls: Any, origin: Any) -> core_schema.CoreSchema:
         """Generate schema for a NamedTuple."""
@@ -1567,7 +1547,8 @@ class GenerateSchema:
                 ],
                 metadata={'pydantic_js_prefer_positional_arguments': True},
             )
-            return core_schema.call_schema(arguments_schema, namedtuple_cls, ref=namedtuple_ref)
+            schema = core_schema.call_schema(arguments_schema, namedtuple_cls, ref=namedtuple_ref)
+            return self.defs.create_definition_reference_schema(schema)
 
     def _generate_parameter_schema(
         self,
@@ -1861,8 +1842,7 @@ class GenerateSchema:
                 )
                 schema = self._apply_model_serializers(dc_schema, decorators.model_serializers.values())
                 schema = apply_model_validators(schema, model_validators, 'outer')
-                self.defs.definitions[dataclass_ref] = schema
-                return core_schema.definition_reference_schema(dataclass_ref)
+                return self.defs.create_definition_reference_schema(schema)
 
     def _call_schema(self, function: ValidateCallSupportedTypes) -> core_schema.CallSchema:
         """Generate schema for a Callable.
@@ -2098,7 +2078,7 @@ class GenerateSchema:
                 schema = from_property
             metadata_js_function = _extract_get_pydantic_json_schema(obj)
             if metadata_js_function is not None:
-                metadata_schema = resolve_original_schema(schema, self.defs.definitions)
+                metadata_schema = resolve_original_schema(schema, self.defs)
                 if metadata_schema is not None:
                     self._add_js_function(metadata_schema, metadata_js_function)
             return transform_inner_schema(schema)
@@ -2138,21 +2118,21 @@ class GenerateSchema:
             return schema
 
         original_schema = schema
-        ref = schema.get('ref', None)
+        ref = schema.get('ref')
         if ref is not None:
             schema = schema.copy()
             new_ref = ref + f'_{repr(metadata)}'
-            if new_ref in self.defs.definitions:
-                return self.defs.definitions[new_ref]
-            schema['ref'] = new_ref  # type: ignore
+            if (existing := self.defs.get_schema_from_ref(new_ref)) is not None:
+                return existing
+            schema['ref'] = new_ref  # pyright: ignore[reportGeneralTypeIssues]
         elif schema['type'] == 'definition-ref':
             ref = schema['schema_ref']
-            if ref in self.defs.definitions:
-                schema = self.defs.definitions[ref].copy()
+            if (referenced_schema := self.defs.get_schema_from_ref(ref)) is not None:
+                schema = referenced_schema.copy()
                 new_ref = ref + f'_{repr(metadata)}'
-                if new_ref in self.defs.definitions:
-                    return self.defs.definitions[new_ref]
-                schema['ref'] = new_ref  # type: ignore
+                if (existing := self.defs.get_schema_from_ref(new_ref)) is not None:
+                    return existing
+                schema['ref'] = new_ref  # pyright: ignore[reportGeneralTypeIssues]
 
         maybe_updated_schema = _known_annotated_metadata.apply_known_metadata(metadata, schema)
 
@@ -2211,11 +2191,8 @@ class GenerateSchema:
                 inner_schema = schema['schema']
                 schema['schema'] = self._apply_field_serializers(inner_schema, serializers)
                 return schema
-            else:
-                ref = typing.cast('str|None', schema.get('ref', None))
-                if ref is not None:
-                    self.defs.definitions[ref] = schema
-                    schema = core_schema.definition_reference_schema(ref)
+            elif 'ref' in schema:
+                schema = self.defs.create_definition_reference_schema(schema)
 
             # use the last serializer to make it easy to override a serializer set on a parent model
             serializer = serializers[-1]
@@ -2501,12 +2478,30 @@ def _common_field(
 class _Definitions:
     """Keeps track of references and definitions."""
 
+    _recursively_seen: set[str]
+    """A set of recursively seen references.
+
+    When a referenceable type is encountered, the `get_schema_or_ref` context manager is
+    entered to compute the reference. If the type references itself by some way (e.g. for
+    a dataclass a Pydantic model, the class can be referenced as a field annotation),
+    entering the context manager again will yield a `'definition-ref'` schema that should
+    short-circuit the normal generation process, as the reference was already in this set.
+    """
+
+    _definitions: dict[str, core_schema.CoreSchema]
+    """A mapping of references to their corresponding schema.
+
+    When a schema for a referenceable type is generated, it is stored in this mapping. If the
+    same type is encountered again, the reference is yielded by the `get_schema_or_ref` context
+    manager.
+    """
+
     def __init__(self) -> None:
-        self.seen: set[str] = set()
-        self.definitions: dict[str, core_schema.CoreSchema] = {}
+        self._recursively_seen = set()
+        self._definitions = {}
 
     @contextmanager
-    def get_schema_or_ref(self, tp: Any) -> Iterator[tuple[str, None] | tuple[str, CoreSchema]]:
+    def get_schema_or_ref(self, tp: Any, /) -> Generator[tuple[str, core_schema.DefinitionReferenceSchema | None]]:
         """Get a definition for `tp` if one exists.
 
         If a definition exists, a tuple of `(ref_string, CoreSchema)` is returned.
@@ -2520,26 +2515,61 @@ class _Definitions:
 
         At present the following types can be named/recursive:
 
-        - BaseModel
-        - Dataclasses
-        - TypedDict
-        - TypeAliasType
+        - Pydantic model
+        - Pydantic and stdlib dataclasses
+        - Typed dictionaries
+        - Named tuples
+        - `TypeAliasType` instances
+        - Enums
         """
         ref = get_type_ref(tp)
-        # return the reference if we're either (1) in a cycle or (2) it was already defined
-        if ref in self.seen or ref in self.definitions:
+        # return the reference if we're either (1) in a cycle or (2) it the reference was already encountered:
+        if ref in self._recursively_seen or ref in self._definitions:
             yield (ref, core_schema.definition_reference_schema(ref))
         else:
-            self.seen.add(ref)
+            self._recursively_seen.add(ref)
             try:
                 yield (ref, None)
             finally:
-                self.seen.discard(ref)
+                self._recursively_seen.discard(ref)
+
+    def get_schema_from_ref(self, ref: str) -> CoreSchema | None:
+        """Resolve the schema from the given reference."""
+        return self._definitions.get(ref)
+
+    def create_definition_reference_schema(self, schema: CoreSchema) -> core_schema.DefinitionReferenceSchema:
+        """Store the schema as a definition and return a `'definition-reference'` schema pointing to it.
+
+        The schema must have a reference attached to it.
+        """
+        ref = schema['ref']  # pyright: ignore
+        self._definitions[ref] = schema
+        return core_schema.definition_reference_schema(ref)
+
+    def unpack_definitions(self, schema: core_schema.DefinitionsSchema) -> CoreSchema:
+        """Store the definitions of the `'definitions` core schema and return the inner core schema."""
+        for def_schema in schema['definitions']:
+            self._definitions[def_schema['ref']] = def_schema  # pyright: ignore
+        return schema['schema']
+
+    def as_definitions_schema(self, schema: CoreSchema) -> CoreSchema:
+        """Create a `'definitions'` schema containing all the collected definitions.
+
+        If the passed schema contains a reference, it is also stored in the definitions list,
+        and substituted by a `'definition-reference'` schema.
+        """
+        if 'ref' in schema:
+            schema = self.create_definition_reference_schema(schema)
+
+        return core_schema.definitions_schema(
+            schema,
+            list(self._definitions.values()),
+        )
 
 
-def resolve_original_schema(schema: CoreSchema, definitions: dict[str, CoreSchema]) -> CoreSchema | None:
+def resolve_original_schema(schema: CoreSchema, definitions: _Definitions) -> CoreSchema | None:
     if schema['type'] == 'definition-ref':
-        return definitions.get(schema['schema_ref'], None)
+        return definitions.get_schema_from_ref(schema['schema_ref'])
     elif schema['type'] == 'definitions':
         return schema['schema']
     else:

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -82,13 +82,12 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
 
     def __call__(self, source_type: Any, /) -> core_schema.CoreSchema:
         schema = self._handler(source_type)
-        ref = schema.get('ref')
         if self._ref_mode == 'to-def':
+            ref = schema.get('ref')
             if ref is not None:
-                self._generate_schema.defs.definitions[ref] = schema
-                return core_schema.definition_reference_schema(ref)
+                return self._generate_schema.defs.create_definition_reference_schema(schema)
             return schema
-        else:  # ref_mode = 'unpack
+        else:  # ref_mode = 'unpack'
             return self.resolve_ref_schema(schema)
 
     def _get_types_namespace(self) -> NamespacesTuple:
@@ -115,12 +114,13 @@ class CallbackGetCoreSchemaHandler(GetCoreSchemaHandler):
         """
         if maybe_ref_schema['type'] == 'definition-ref':
             ref = maybe_ref_schema['schema_ref']
-            if ref not in self._generate_schema.defs.definitions:
+            definition = self._generate_schema.defs.get_schema_from_ref(ref)
+            if definition is None:
                 raise LookupError(
                     f'Could not find a ref for {ref}.'
                     ' Maybe you tried to call resolve_ref_schema from within a recursive model?'
                 )
-            return self._generate_schema.defs.definitions[ref]
+            return definition
         elif maybe_ref_schema['type'] == 'definitions':
             return self.resolve_ref_schema(maybe_ref_schema['schema'])
         return maybe_ref_schema


### PR DESCRIPTION
Some common patterns are defined as methods to avoid duplication (e.g. `create_reference_to_schema`, used to store a schema as a definition and returns a `'definition-reference'` schema). A couple existing methods on the `GenerateSchema` class are moved (and renamed to better describe what they do) to the `_Definitions` class.

Proper docstrings are added to attribute and methods.

Type hints are tweaked when necessary.

This is meant to be a simplified changeset of https://github.com/pydantic/pydantic/pull/10887, only with the necessary changes present.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
