### PR TITLE
Support initializing root model fields with values of the `root` type in the mypy plugin

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from configparser import ConfigParser
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, cast
 
 from mypy.errorcodes import ErrorCode
 from mypy.expandtype import expand_type, expand_type_by_instance
@@ -131,7 +131,7 @@ class PydanticPlugin(Plugin):
         sym = self.lookup_fully_qualified(fullname)
         if sym and isinstance(sym.node, TypeInfo):  # pragma: no branch
             # No branching may occur if the mypy cache has not been cleared
-            if any(base.fullname == BASEMODEL_FULLNAME for base in sym.node.mro):
+            if sym.node.has_base(BASEMODEL_FULLNAME):
                 return self._pydantic_model_class_maker_callback
         return None
 
@@ -235,7 +235,7 @@ def from_attributes_callback(ctx: MethodContext) -> Type:
     pydantic_metadata = model_type.type.metadata.get(METADATA_KEY)
     if pydantic_metadata is None:
         return ctx.default_return_type
-    if not any(base.fullname == BASEMODEL_FULLNAME for base in model_type.type.mro):
+    if not model_type.type.has_base(BASEMODEL_FULLNAME):
         # not a Pydantic v2 model
         return ctx.default_return_type
     from_attributes = pydantic_metadata.get('config', {}).get('from_attributes')
@@ -327,7 +327,15 @@ class PydanticModelField:
                     for arg in filled_with_typevars.args:
                         if isinstance(arg, TypeVarType):
                             arg.variance = INVARIANT
-                return expand_type(self.type, {self.info.self_type.id: filled_with_typevars})
+
+                expanded_type = expand_type(self.type, {self.info.self_type.id: filled_with_typevars})
+                if isinstance(expanded_type, Instance) and is_root_model(expanded_type.type):
+                    # When a root model is used as a field, Pydantic allows both an instance of the root model
+                    # as well as instances of the `root` field type:
+                    root_type = cast(Type, expanded_type.type['root'].type)
+                    expanded_root_type = expand_type_by_instance(root_type, expanded_type)
+                    expanded_type = UnionType([expanded_type, expanded_root_type])
+                return expanded_type
         return self.type
 
     def to_var(
@@ -441,9 +449,9 @@ class PydanticModelTransformer:
         * stores the fields, config, and if the class is settings in the mypy metadata for access by subclasses
         """
         info = self._cls.info
-        is_root_model = any(ROOT_MODEL_FULLNAME in base.fullname for base in info.mro[:-1])
+        is_a_root_model = is_root_model(info)
         config = self.collect_config()
-        fields, class_vars = self.collect_fields_and_class_vars(config, is_root_model)
+        fields, class_vars = self.collect_fields_and_class_vars(config, is_a_root_model)
         if fields is None or class_vars is None:
             # Some definitions are not ready. We need another pass.
             return False
@@ -451,9 +459,9 @@ class PydanticModelTransformer:
             if field.type is None:
                 return False
 
-        is_settings = any(base.fullname == BASESETTINGS_FULLNAME for base in info.mro[:-1])
-        self.add_initializer(fields, config, is_settings, is_root_model)
-        self.add_model_construct_method(fields, config, is_settings, is_root_model)
+        is_settings = info.has_base(BASESETTINGS_FULLNAME)
+        self.add_initializer(fields, config, is_settings, is_a_root_model)
+        self.add_model_construct_method(fields, config, is_settings, is_a_root_model)
         self.set_frozen(fields, self._api, frozen=config.frozen is True)
 
         self.adjust_decorator_signatures()
@@ -1163,6 +1171,11 @@ class ModelConfigData:
         """Set default value for Pydantic model config if config value is `None`."""
         if getattr(self, key) is None:
             setattr(self, key, value)
+
+
+def is_root_model(info: TypeInfo) -> bool:
+    """Return whether the type info is a root model subclass (or the `RootModel` class itself)."""
+    return info.has_base(ROOT_MODEL_FULLNAME)
 
 
 ERROR_ORM = ErrorCode('pydantic-orm', 'Invalid from_attributes call', 'Pydantic')

--- a/tests/mypy/modules/root_models.py
+++ b/tests/mypy/modules/root_models.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import Generic, List, TypeVar
 
-from pydantic import RootModel
+from pydantic import BaseModel, RootModel
 
 
 class Pets1(RootModel[List[str]]):
@@ -23,3 +23,22 @@ pets3 = Pets3(['dog', 'cat'])
 
 class Pets4(RootModel[List[str]]):
     pets: List[str]
+
+
+T = TypeVar('T')
+V = TypeVar('V')
+
+
+class Maybe(RootModel[T | None]):
+    pass
+
+
+class Model(BaseModel, Generic[V]):
+    m1: Maybe[int]
+    m2: Maybe[V]
+    m3: Maybe
+
+
+Model[str](m1=1, m2='dog', m3=[])
+Model[str](m1=Maybe(None), m2=Maybe('dog'), m3=Maybe([]))
+Model(m1=None, m2={}, m3=[])

--- a/tests/mypy/outputs/1.10.1/mypy-default_ini/root_models.py
+++ b/tests/mypy/outputs/1.10.1/mypy-default_ini/root_models.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import Generic, List, TypeVar
 
-from pydantic import RootModel
+from pydantic import BaseModel, RootModel
 
 
 class Pets1(RootModel[List[str]]):
@@ -24,3 +24,29 @@ pets3 = Pets3(['dog', 'cat'])
 
 class Pets4(RootModel[List[str]]):
     pets: List[str]
+
+
+T = TypeVar('T')
+V = TypeVar('V')
+
+
+class Maybe(RootModel[T | None]):
+    pass
+
+
+class Model(BaseModel, Generic[V]):
+    m1: Maybe[int]
+    m2: Maybe[V]
+    m3: Maybe
+# MYPY: error: Missing type parameters for generic type "Maybe"  [type-arg]
+
+
+Model[str](m1=1, m2='dog', m3=[])
+# MYPY: error: Argument "m1" to "Model" has incompatible type "int"; expected "Maybe[int]"  [arg-type]
+# MYPY: error: Argument "m2" to "Model" has incompatible type "str"; expected "Maybe[str]"  [arg-type]
+# MYPY: error: Argument "m3" to "Model" has incompatible type "List[Never]"; expected "Maybe[Any]"  [arg-type]
+Model[str](m1=Maybe(None), m2=Maybe('dog'), m3=Maybe([]))
+Model(m1=None, m2={}, m3=[])
+# MYPY: error: Argument "m1" to "Model" has incompatible type "None"; expected "Maybe[int]"  [arg-type]
+# MYPY: error: Argument "m2" to "Model" has incompatible type "Dict[Never, Never]"; expected "Maybe[Never]"  [arg-type]
+# MYPY: error: Argument "m3" to "Model" has incompatible type "List[Never]"; expected "Maybe[Any]"  [arg-type]

--- a/tests/mypy/outputs/1.10.1/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/1.10.1/mypy-plugin_ini/root_models.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import Generic, List, TypeVar
 
-from pydantic import RootModel
+from pydantic import BaseModel, RootModel
 
 
 class Pets1(RootModel[List[str]]):
@@ -25,3 +25,23 @@ pets3 = Pets3(['dog', 'cat'])
 class Pets4(RootModel[List[str]]):
     pets: List[str]
 # MYPY: error: Only `root` is allowed as a field of a `RootModel`  [pydantic-field]
+
+
+T = TypeVar('T')
+V = TypeVar('V')
+
+
+class Maybe(RootModel[T | None]):
+    pass
+
+
+class Model(BaseModel, Generic[V]):
+    m1: Maybe[int]
+    m2: Maybe[V]
+    m3: Maybe
+# MYPY: error: Missing type parameters for generic type "Maybe"  [type-arg]
+
+
+Model[str](m1=1, m2='dog', m3=[])
+Model[str](m1=Maybe(None), m2=Maybe('dog'), m3=Maybe([]))
+Model(m1=None, m2={}, m3=[])

--- a/tests/mypy/outputs/1.10.1/pyproject-default_toml/root_models.py
+++ b/tests/mypy/outputs/1.10.1/pyproject-default_toml/root_models.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import Generic, List, TypeVar
 
-from pydantic import RootModel
+from pydantic import BaseModel, RootModel
 
 
 class Pets1(RootModel[List[str]]):
@@ -24,3 +24,29 @@ pets3 = Pets3(['dog', 'cat'])
 
 class Pets4(RootModel[List[str]]):
     pets: List[str]
+
+
+T = TypeVar('T')
+V = TypeVar('V')
+
+
+class Maybe(RootModel[T | None]):
+    pass
+
+
+class Model(BaseModel, Generic[V]):
+    m1: Maybe[int]
+    m2: Maybe[V]
+    m3: Maybe
+# MYPY: error: Missing type parameters for generic type "Maybe"  [type-arg]
+
+
+Model[str](m1=1, m2='dog', m3=[])
+# MYPY: error: Argument "m1" to "Model" has incompatible type "int"; expected "Maybe[int]"  [arg-type]
+# MYPY: error: Argument "m2" to "Model" has incompatible type "str"; expected "Maybe[str]"  [arg-type]
+# MYPY: error: Argument "m3" to "Model" has incompatible type "List[Never]"; expected "Maybe[Any]"  [arg-type]
+Model[str](m1=Maybe(None), m2=Maybe('dog'), m3=Maybe([]))
+Model(m1=None, m2={}, m3=[])
+# MYPY: error: Argument "m1" to "Model" has incompatible type "None"; expected "Maybe[int]"  [arg-type]
+# MYPY: error: Argument "m2" to "Model" has incompatible type "Dict[Never, Never]"; expected "Maybe[Never]"  [arg-type]
+# MYPY: error: Argument "m3" to "Model" has incompatible type "List[Never]"; expected "Maybe[Any]"  [arg-type]


### PR DESCRIPTION
Also use the `TypeInfo.has_base` method instead of iterating over the MRO in various places.

Closes https://github.com/pydantic/pydantic/issues/11203.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
