### PR TITLE
Reorganize `extra` configuration documentation

### DIFF
--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -45,7 +45,7 @@ except ValidationError as e:
     """
 ```
 
-1. See the [Extra Attributes](models.md#extra-fields) section for more details.
+1. See the [Extra data](models.md#extra-data) section for more details.
 
 Similarly, if using the [`@dataclass`][pydantic.dataclasses] decorator from Pydantic:
 ```python
@@ -142,7 +142,7 @@ class Parent(BaseModel):
 
 
 class Model(Parent):
-    model_config = ConfigDict(str_to_lower=True)  # (1)!
+    model_config = ConfigDict(str_to_lower=True)
 
     x: str
 

--- a/docs/concepts/dataclasses.md
+++ b/docs/concepts/dataclasses.md
@@ -141,6 +141,7 @@ class MyDataclass2:
     While Pydantic dataclasses support the [`extra`][pydantic.config.ConfigDict.extra] configuration value, some default
     behavior of stdlib dataclasses may prevail. For example, any extra fields present on a Pydantic dataclass with
     [`extra`][pydantic.config.ConfigDict.extra] set to `'allow'` are omitted in the dataclass' string representation.
+    There is also no way to provide validation [using the `__pydantic_extra__` attribute](./models.md#extra-data).
 
 ## Rebuilding dataclass schema
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -253,6 +253,7 @@ class Model(BaseModel):
 
 
 m = Model(x=1, y='a')  # (1)!
+assert m.model_dump() == {'x': 1, 'y': 'a'}
 assert m.__pydantic_extra__ == {'y': 'a'}
 ```
 
@@ -267,8 +268,7 @@ The configuration can take three values:
 
 For more details, refer to the [`extra`][pydantic.ConfigDict.extra] API documentation.
 
-The same behavior applies to typed dictionaries and dataclasses (see how to
-[add configuration to these types](./config.md#configuration-with-dataclass-from-the-standard-library-or-typeddict)).
+Pydantic dataclasses also support extra data (see the [dataclass configuration](./dataclasses.md#dataclass-config) section).
 
 ## Nested models
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -59,69 +59,101 @@ class ConfigDict(TypedDict, total=False):
     """The maximum length for str types. Defaults to `None`."""
 
     extra: ExtraValues | None
-    """
-    Whether to ignore, allow, or forbid extra attributes during model initialization. Defaults to `'ignore'`.
+    '''
+    Whether to ignore, allow, or forbid extra data during model initialization. Defaults to `'ignore'`.
 
-    You can configure how pydantic handles the attributes that are not defined in the model:
+    Three configuration values are available:
 
-    * `allow` - Allow any extra attributes.
-    * `forbid` - Forbid any extra attributes.
-    * `ignore` - Ignore any extra attributes.
+    - `'ignore'`: Providing extra data is ignored (the default):
+      ```python
+      from pydantic import BaseModel, ConfigDict
 
-    ```python
-    from pydantic import BaseModel, ConfigDict
+      class User(BaseModel):
+          model_config = ConfigDict(extra='ignore')  # (1)!
 
-    class User(BaseModel):
-        model_config = ConfigDict(extra='ignore')  # (1)!
+          name: str
 
-        name: str
+      user = User(name='John Doe', age=20)  # (2)!
+      print(user)
+      #> name='John Doe'
+      ```
 
-    user = User(name='John Doe', age=20)  # (2)!
-    print(user)
-    #> name='John Doe'
-    ```
+        1. This is the default behaviour.
+        2. The `age` argument is ignored.
 
-    1. This is the default behaviour.
-    2. The `age` argument is ignored.
+    - `'forbid'`: Providing extra data is not permitted, and a [`ValidationError`][pydantic_core.ValidationError]
+      will be raised if this is the case:
+      ```python
+      from pydantic import BaseModel, ConfigDict, ValidationError
 
-    Instead, with `extra='allow'`, the `age` argument is included:
 
-    ```python
-    from pydantic import BaseModel, ConfigDict
+      class Model(BaseModel):
+          x: int
 
-    class User(BaseModel):
-        model_config = ConfigDict(extra='allow')
+          model_config = ConfigDict(extra='forbid')
 
-        name: str
 
-    user = User(name='John Doe', age=20)  # (1)!
-    print(user)
-    #> name='John Doe' age=20
-    ```
+      try:
+          Model(x=1, y='a')
+      except ValidationError as exc:
+          print(exc)
+          """
+          1 validation error for Model
+          y
+            Extra inputs are not permitted [type=extra_forbidden, input_value='a', input_type=str]
+          """
+      ```
 
-    1. The `age` argument is included.
+    - `'allow'`: Providing extra data is allowed and stored in the `__pydantic_extra__` dictionary attribute:
+      ```python
+      from pydantic import BaseModel, ConfigDict
 
-    With `extra='forbid'`, an error is raised:
 
-    ```python
-    from pydantic import BaseModel, ConfigDict, ValidationError
+      class Model(BaseModel):
+          x: int
 
-    class User(BaseModel):
-        model_config = ConfigDict(extra='forbid')
+          model_config = ConfigDict(extra='allow')
 
-        name: str
 
-    try:
-        User(name='John Doe', age=20)
-    except ValidationError as e:
-        print(e)
-        '''
-        1 validation error for User
-        age
-          Extra inputs are not permitted [type=extra_forbidden, input_value=20, input_type=int]
-        '''
-    ```
-    """
+      m = Model(x=1, y='a')
+      assert m.__pydantic_extra__ == {'y': 'a'}
+      ```
+      By default, no validation will be applied to these extra items, but you can set a type for the values by overriding
+      the type annotation for `__pydantic_extra__`:
+      ```python
+      from typing import Dict
+
+      from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+      class Model(BaseModel):
+          __pydantic_extra__: Dict[str, int] = Field(init=False)  # (1)!
+
+          x: int
+
+          model_config = ConfigDict(extra='allow')
+
+
+      try:
+          Model(x=1, y='a')
+      except ValidationError as exc:
+          print(exc)
+          """
+          1 validation error for Model
+          y
+            Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='a', input_type=str]
+          """
+
+      m = Model(x=1, y='2')
+      assert m.x == 1
+      assert m.y == 2
+      assert m.model_dump() == {'x': 1, 'y': 2}
+      assert m.__pydantic_extra__ == {'y': 2}
+      ```
+
+        1. The `= Field(init=False)` does not have any effect at runtime, but prevents the `__pydantic_extra__` field from
+           being included as a parameter to the model's `__init__` method by type checkers.
+    '''
 
     frozen: bool
     """


### PR DESCRIPTION
The section in the concepts page was moved to the top, as the default behavior is usually confusing for some users.

The section was also simplified to just give some insights, and we refer to the API docs to avoid duplication. The API documentation was updated to take examples from both the existing concepts section and API documentation.

Add more info about support for extra data with dataclasses

Remove unused annotation comment.

Closes https://github.com/pydantic/pydantic/issues/11201 and closes https://github.com/pydantic/pydantic/issues/10644 along the way.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
