### PR TITLE
Fix url serialization for unions

### DIFF
--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Union
 
 import pytest
-from pydantic_core import PydanticCustomError, Url
+from pydantic_core import PydanticCustomError, PydanticSerializationError, Url
 from typing_extensions import Annotated
 
 from pydantic import (
@@ -1180,3 +1180,12 @@ def test_max_length_base_multi_host() -> None:
 
     with pytest.raises(ValidationError, match=r'Value should have at most 45 items after validation'):
         Model(postgres='postgres://user:pass@localhost:5432/foobarbazfoo')
+
+
+def test_unexpected_ser() -> None:
+    ta = TypeAdapter(HttpUrl)
+    with pytest.raises(
+        PydanticSerializationError,
+        match="Expected `<class 'pydantic.networks.HttpUrl'>` but got `<class 'str'>` with value `'http://example.com'`",
+    ):
+        ta.dump_python('http://example.com', warnings='error')


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/11211

We want to make sure that non-url type data passed to url serialization logic raises a warning, just like we do for the custom ip types, see:

https://github.com/pydantic/pydantic/blob/a2eb22bd42d919eef82461a1a77ae6d23a191b48/pydantic/_internal/_generate_schema.py#L462

This makes it such that serialization of data having union types like `HttpUrl | str` prefers the `str` type when appropriate.