### PR TITLE
Fix compatibility with ForwardRef._evaluate and Python < 3.12.4

### DIFF
--- a/pydantic/typing.py
+++ b/pydantic/typing.py
@@ -58,7 +58,7 @@ if sys.version_info < (3, 9):
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         return type_._evaluate(globalns, localns)
 
-elif sys.version_info < (3, 12):
+elif sys.version_info < (3, 12, 4):
 
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fix unexpected argument 'type_params' (#11230) 

## Related issue number

fix #11230

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist - *we should probably add Python 3.12.0 and 3.12.4 checkpoints to CI, but not sure how, yet*
* [x] Tests pass on CI (*apart from combine-coverage which has been failing for a long time*)
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
