### PR TITLE
Move `deque` schema gen to `GenerateSchema` class

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -539,11 +539,11 @@ class GenerateSchema:
             python_schema=core_schema.is_instance_schema(collections.deque, cls_repr='Deque'),
         )
 
+        lax_schema = core_schema.no_info_wrap_validator_function(deque_validator, list_schema)
+
         return core_schema.lax_or_strict_schema(
-            lax_schema=core_schema.no_info_wrap_validator_function(deque_validator, list_schema),
-            strict_schema=core_schema.chain_schema(
-                [check_instance, core_schema.no_info_wrap_validator_function(deque_validator, list_schema)]
-            ),
+            lax_schema=lax_schema,
+            strict_schema=core_schema.chain_schema([check_instance, lax_schema]),
             serialization=core_schema.wrap_serializer_function_ser_schema(
                 serialize_sequence_via_list, schema=item_type_schema, info_arg=True
             ),

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -524,6 +524,31 @@ class GenerateSchema:
         )
         return schema
 
+    def _deque_schema(self, items_type: Any) -> CoreSchema:
+        from ._serializers import serialize_sequence_via_list
+        from ._validators import deque_validator
+
+        item_type_schema = self.generate_schema(items_type)
+
+        # we have to use a lax list schema here, because we need to validate the deque's
+        # items via a list schema, but it's ok if the deque itself is not a list
+        list_schema = core_schema.list_schema(item_type_schema, strict=False)
+
+        check_instance = core_schema.json_or_python_schema(
+            json_schema=core_schema.list_schema(),
+            python_schema=core_schema.is_instance_schema(collections.deque, cls_repr='Deque'),
+        )
+
+        return core_schema.lax_or_strict_schema(
+            lax_schema=core_schema.no_info_wrap_validator_function(deque_validator, list_schema),
+            strict_schema=core_schema.chain_schema(
+                [check_instance, core_schema.no_info_wrap_validator_function(deque_validator, list_schema)]
+            ),
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                serialize_sequence_via_list, schema=item_type_schema, info_arg=True
+            ),
+        )
+
     def _fraction_schema(self) -> CoreSchema:
         """Support for [`fractions.Fraction`][fractions.Fraction]."""
         from ._validators import fraction_validator
@@ -967,6 +992,8 @@ class GenerateSchema:
             return self._dict_schema(Any, Any)
         elif obj in PATH_TYPES:
             return self._path_schema(obj, Any)
+        elif obj in DEQUE_TYPES:
+            return self._deque_schema(Any)
         elif _typing_extra.is_type_alias_type(obj):
             return self._type_alias_type_schema(obj)
         elif obj is type:
@@ -1047,6 +1074,8 @@ class GenerateSchema:
             return self._dict_schema(*self._get_first_two_args_or_any(obj))
         elif origin in PATH_TYPES:
             return self._path_schema(origin, self._get_first_arg_or_any(obj))
+        elif origin in DEQUE_TYPES:
+            return self._deque_schema(self._get_first_arg_or_any(obj))
         elif is_typeddict(origin):
             return self._typed_dict_schema(obj, origin)
         elif origin in (typing.Type, type):
@@ -2019,10 +2048,7 @@ class GenerateSchema:
     def _get_prepare_pydantic_annotations_for_known_type(
         self, obj: Any, annotations: tuple[Any, ...]
     ) -> tuple[Any, list[Any]] | None:
-        from ._std_types_schema import (
-            deque_schema_prepare_pydantic_annotations,
-            mapping_like_prepare_pydantic_annotations,
-        )
+        from ._std_types_schema import mapping_like_prepare_pydantic_annotations
 
         # Check for hashability
         try:
@@ -2036,9 +2062,7 @@ class GenerateSchema:
         # not always called from match_type, but sometimes from _apply_annotations
         obj_origin = get_origin(obj) or obj
 
-        if obj_origin in DEQUE_TYPES:
-            return deque_schema_prepare_pydantic_annotations(obj, annotations)
-        elif obj_origin in MAPPING_TYPES:
+        if obj_origin in MAPPING_TYPES:
             return mapping_like_prepare_pydantic_annotations(obj, annotations)
         else:
             return None

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -5,6 +5,7 @@ Import of this module is deferred since it contains imports of many standard lib
 
 from __future__ import annotations as _annotations
 
+import collections.abc
 import math
 import re
 import typing
@@ -400,6 +401,14 @@ def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
         return x
     except TypeError:
         raise TypeError(f"Unable to apply constraint 'decimal_places' to supplied value {x}")
+
+
+def deque_validator(input_value: Any, handler: core_schema.ValidatorFunctionWrapHandler) -> collections.deque[Any]:
+    if isinstance(input_value, collections.deque):
+        maxlen = input_value.maxlen
+        return collections.deque(handler(input_value), maxlen=maxlen)
+    else:
+        return collections.deque(handler(input_value))
 
 
 NUMERIC_VALIDATOR_LOOKUP: dict[str, Callable] = {

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -5,10 +5,10 @@ Import of this module is deferred since it contains imports of many standard lib
 
 from __future__ import annotations as _annotations
 
-import collections.abc
 import math
 import re
 import typing
+from collections import deque
 from decimal import Decimal
 from fractions import Fraction
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
@@ -403,12 +403,8 @@ def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
         raise TypeError(f"Unable to apply constraint 'decimal_places' to supplied value {x}")
 
 
-def deque_validator(input_value: Any, handler: core_schema.ValidatorFunctionWrapHandler) -> collections.deque[Any]:
-    if isinstance(input_value, collections.deque):
-        maxlen = input_value.maxlen
-        return collections.deque(handler(input_value), maxlen=maxlen)
-    else:
-        return collections.deque(handler(input_value))
+def deque_validator(input_value: Any, handler: core_schema.ValidatorFunctionWrapHandler) -> deque[Any]:
+    return deque(handler(input_value), maxlen=getattr(input_value, 'maxlen', None))
 
 
 NUMERIC_VALIDATOR_LOOKUP: dict[str, Callable] = {

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5190,36 +5190,12 @@ def test_deque_typed_maxlen():
     assert DequeModel3(field=deque(maxlen=8)).field.maxlen == 8
 
 
-def test_deque_set_maxlen():
+def test_deque_enforces_maxlen():
     class DequeModel1(BaseModel):
-        field: Annotated[Deque[int], Field(max_length=10)]
+        field: Annotated[Deque[int], Field(max_length=3)]
 
-    assert DequeModel1(field=deque()).field.maxlen == 10
-    assert DequeModel1(field=deque(maxlen=8)).field.maxlen == 8
-    assert DequeModel1(field=deque(maxlen=15)).field.maxlen == 10
-
-    class DequeModel2(BaseModel):
-        field: Annotated[Deque[int], Field(max_length=10)] = deque()
-
-    assert DequeModel2().field.maxlen is None
-    assert DequeModel2(field=deque()).field.maxlen == 10
-    assert DequeModel2(field=deque(maxlen=8)).field.maxlen == 8
-    assert DequeModel2(field=deque(maxlen=15)).field.maxlen == 10
-
-    class DequeModel3(DequeModel2):
-        model_config = ConfigDict(validate_default=True)
-
-    assert DequeModel3().field.maxlen == 10
-
-    class DequeModel4(BaseModel):
-        field: Annotated[Deque[int], Field(max_length=10)] = deque(maxlen=5)
-
-    assert DequeModel4().field.maxlen == 5
-
-    class DequeModel5(DequeModel4):
-        model_config = ConfigDict(validate_default=True)
-
-    assert DequeModel4().field.maxlen == 5
+    with pytest.raises(ValidationError):
+        DequeModel1(field=deque([1, 2, 3, 4]))
 
 
 @pytest.mark.parametrize('value_type', (None, type(None), None.__class__))


### PR DESCRIPTION
Follow up to https://github.com/pydantic/pydantic/pull/10846

See the description of that PR for more detail.

One consequence here is slightly different behavior for `maxlen` being set for `deque` types, but I think this is worth the significant simplification in internal logic we see here.

`max_length` constraints are still enforced, but we no longer monkeypatch the `maxlen` from `max_length` on the deque. If users want this, they should write a custom validator.

I'll be writing an in depth explanation of changes in the changelog for v2.11 related to this PR sequence.