### PR TITLE
Properly wrap custom `model_post_init` implementation when private attributes are defined

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -9,7 +9,7 @@ import typing
 import warnings
 import weakref
 from abc import ABCMeta
-from functools import lru_cache, partial
+from functools import lru_cache, partial, wraps
 from types import FunctionType
 from typing import Any, Callable, Generic, Literal, NoReturn, cast
 
@@ -118,6 +118,7 @@ class ModelMetaclass(ABCMeta):
                 if original_model_post_init is not None:
                     # if there are private_attributes and a model_post_init function, we handle both
 
+                    @wraps(original_model_post_init)
                     def wrapped_model_post_init(self: BaseModel, context: Any, /) -> None:
                         """We need to both initialize private attributes and call the user-defined model_post_init
                         method.
@@ -125,7 +126,6 @@ class ModelMetaclass(ABCMeta):
                         init_private_attributes(self, context)
                         original_model_post_init(self, context)
 
-                    wrapped_model_post_init.__doc__ = original_model_post_init.__doc__
                     namespace['model_post_init'] = wrapped_model_post_init
                 else:
                     namespace['model_post_init'] = init_private_attributes

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -125,6 +125,7 @@ class ModelMetaclass(ABCMeta):
                         init_private_attributes(self, context)
                         original_model_post_init(self, context)
 
+                    wrapped_model_post_init.__doc__ = original_model_post_init.__doc__
                     namespace['model_post_init'] = wrapped_model_post_init
                 else:
                     namespace['model_post_init'] = init_private_attributes

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2059,9 +2059,6 @@ def test_annotated_final():
 
 def test_post_init():
     calls = []
-    inner_model_docstring = 'InnerModel Docstring'
-    sub_model_docstring = 'SubModel Docstring'
-    model_docstring = 'Model Docstring'
 
     class InnerModel(BaseModel):
         a: int
@@ -2072,8 +2069,6 @@ def test_post_init():
             assert self.model_dump() == {'a': 3, 'b': 4}
             calls.append('inner_model_post_init')
 
-        model_post_init.__doc__ = inner_model_docstring
-
     class Model(BaseModel):
         c: int
         d: int
@@ -2083,13 +2078,9 @@ def test_post_init():
             assert self.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
             calls.append('model_post_init')
 
-        model_post_init.__doc__ = model_docstring
-
     m = Model(c=1, d='2', sub={'a': 3, 'b': '4'})
     assert calls == ['inner_model_post_init', 'model_post_init']
     assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
-    assert InnerModel.model_post_init.__doc__ == inner_model_docstring
-    assert Model.model_post_init.__doc__ == model_docstring
 
     class SubModel(Model):
         def model_post_init(self, context, /) -> None:
@@ -2097,13 +2088,10 @@ def test_post_init():
             super().model_post_init(context)
             calls.append('submodel_post_init')
 
-        model_post_init.__doc__ = sub_model_docstring
-
     calls.clear()
     m = SubModel(c=1, d='2', sub={'a': 3, 'b': '4'})
     assert calls == ['inner_model_post_init', 'model_post_init', 'submodel_post_init']
     assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
-    assert SubModel.model_post_init.__doc__ == sub_model_docstring
 
 
 @pytest.mark.parametrize('include_private_attribute', [True, False])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2059,6 +2059,9 @@ def test_annotated_final():
 
 def test_post_init():
     calls = []
+    inner_model_docstring = 'InnerModel Docstring'
+    sub_model_docstring = 'SubModel Docstring'
+    model_docstring = 'Model Docstring'
 
     class InnerModel(BaseModel):
         a: int
@@ -2069,6 +2072,8 @@ def test_post_init():
             assert self.model_dump() == {'a': 3, 'b': 4}
             calls.append('inner_model_post_init')
 
+        model_post_init.__doc__ = inner_model_docstring
+
     class Model(BaseModel):
         c: int
         d: int
@@ -2078,9 +2083,13 @@ def test_post_init():
             assert self.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
             calls.append('model_post_init')
 
+        model_post_init.__doc__ = model_docstring
+
     m = Model(c=1, d='2', sub={'a': 3, 'b': '4'})
     assert calls == ['inner_model_post_init', 'model_post_init']
     assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
+    assert InnerModel.model_post_init.__doc__ == inner_model_docstring
+    assert Model.model_post_init.__doc__ == model_docstring
 
     class SubModel(Model):
         def model_post_init(self, context, /) -> None:
@@ -2088,10 +2097,13 @@ def test_post_init():
             super().model_post_init(context)
             calls.append('submodel_post_init')
 
+        model_post_init.__doc__ = sub_model_docstring
+
     calls.clear()
     m = SubModel(c=1, d='2', sub={'a': 3, 'b': '4'})
     assert calls == ['inner_model_post_init', 'model_post_init', 'submodel_post_init']
     assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
+    assert SubModel.model_post_init.__doc__ == sub_model_docstring
 
 
 @pytest.mark.parametrize('include_private_attribute', [True, False])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2094,6 +2094,16 @@ def test_post_init():
     assert m.model_dump() == {'c': 1, 'd': 2, 'sub': {'a': 3, 'b': 4}}
 
 
+def test_post_init_function_attrs_preserved() -> None:
+    class Model(BaseModel):
+        _a: int  # Necessary to have model_post_init wrapped
+
+        def model_post_init(self, context, /) -> None:
+            """Custom docstring"""
+
+    assert Model.model_post_init.__doc__ == 'Custom docstring'
+
+
 @pytest.mark.parametrize('include_private_attribute', [True, False])
 def test_post_init_call_signatures(include_private_attribute):
     calls = []


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
The docstring of `model_post_init` is overwritten with the docstring of `wrapped_model_post_init`.
In order to fix this, I just copy the docstring of model_post_init over to the new wrapped-object.
I also modified an existing test-case to test for this instead of creating a new one. 

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
I think the change is quite small - so I didn't create an issue. I don't mind creating one if it is necessary :-)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle