### PR TITLE
Do not transform model serializer functions as class methods in the mypy plugin

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -95,6 +95,7 @@ DECORATOR_FULLNAMES = {
     'pydantic.deprecated.class_validators.validator',
     'pydantic.deprecated.class_validators.root_validator',
 }
+IMPLICIT_CLASSMETHOD_DECORATOR_FULLNAMES = DECORATOR_FULLNAMES - {'pydantic.functional_serializers.model_serializer'}
 
 
 MYPY_VERSION_TUPLE = parse_mypy_version(mypy_version)
@@ -489,7 +490,7 @@ class PydanticModelTransformer:
                 if (
                     isinstance(first_dec, CallExpr)
                     and isinstance(first_dec.callee, NameExpr)
-                    and first_dec.callee.fullname in DECORATOR_FULLNAMES
+                    and first_dec.callee.fullname in IMPLICIT_CLASSMETHOD_DECORATOR_FULLNAMES
                     # @model_validator(mode="after") is an exception, it expects a regular method
                     and not (
                         first_dec.callee.fullname == MODEL_VALIDATOR_FULLNAME

--- a/tests/mypy/modules/decorator_implicit_classmethod.py
+++ b/tests/mypy/modules/decorator_implicit_classmethod.py
@@ -12,8 +12,8 @@ class Model(BaseModel):
         return value
 
     @model_validator(mode='before')
-    def m_val_before(self, values: dict[str, object]) -> dict[str, object]:
-        reveal_type(self)
+    def m_val_before(cls, values: dict[str, object]) -> dict[str, object]:
+        reveal_type(cls)
         return values
 
     @model_validator(mode='after')

--- a/tests/mypy/modules/decorator_implicit_classmethod.py
+++ b/tests/mypy/modules/decorator_implicit_classmethod.py
@@ -1,0 +1,27 @@
+"""Test that the mypy plugin implicitly transforms the right decorators into class methods."""
+
+from pydantic import BaseModel, field_validator, model_serializer, model_validator
+
+
+class Model(BaseModel):
+    a: int
+
+    @field_validator('a')
+    def f_val(cls, value: int) -> int:
+        reveal_type(cls)
+        return value
+
+    @model_validator(mode='before')
+    def m_val_before(self, values: dict[str, object]) -> dict[str, object]:
+        reveal_type(self)
+        return values
+
+    @model_validator(mode='after')
+    def m_val_after(self) -> 'Model':
+        reveal_type(self)
+        return self
+
+    @model_serializer
+    def m_ser(self) -> dict[str, object]:
+        reveal_type(self)
+        return self.model_dump()

--- a/tests/mypy/outputs/1.10.1/mypy-plugin_ini/decorator_implicit_classmethod.py
+++ b/tests/mypy/outputs/1.10.1/mypy-plugin_ini/decorator_implicit_classmethod.py
@@ -13,8 +13,8 @@ class Model(BaseModel):
         return value
 
     @model_validator(mode='before')
-    def m_val_before(self, values: dict[str, object]) -> dict[str, object]:
-        reveal_type(self)
+    def m_val_before(cls, values: dict[str, object]) -> dict[str, object]:
+        reveal_type(cls)
 # MYPY: note: Revealed type is "type[tests.mypy.modules.decorator_implicit_classmethod.Model]"
         return values
 

--- a/tests/mypy/outputs/1.10.1/mypy-plugin_ini/decorator_implicit_classmethod.py
+++ b/tests/mypy/outputs/1.10.1/mypy-plugin_ini/decorator_implicit_classmethod.py
@@ -1,0 +1,31 @@
+"""Test that the mypy plugin implicitly transforms the right decorators into class methods."""
+
+from pydantic import BaseModel, field_validator, model_serializer, model_validator
+
+
+class Model(BaseModel):
+    a: int
+
+    @field_validator('a')
+    def f_val(cls, value: int) -> int:
+        reveal_type(cls)
+# MYPY: note: Revealed type is "type[tests.mypy.modules.decorator_implicit_classmethod.Model]"
+        return value
+
+    @model_validator(mode='before')
+    def m_val_before(self, values: dict[str, object]) -> dict[str, object]:
+        reveal_type(self)
+# MYPY: note: Revealed type is "type[tests.mypy.modules.decorator_implicit_classmethod.Model]"
+        return values
+
+    @model_validator(mode='after')
+    def m_val_after(self) -> 'Model':
+        reveal_type(self)
+# MYPY: note: Revealed type is "tests.mypy.modules.decorator_implicit_classmethod.Model"
+        return self
+
+    @model_serializer
+    def m_ser(self) -> dict[str, object]:
+        reveal_type(self)
+# MYPY: note: Revealed type is "tests.mypy.modules.decorator_implicit_classmethod.Model"
+        return self.model_dump()

--- a/tests/mypy/outputs/1.10.1/pyproject-plugin_toml/decorator_implicit_classmethod.py
+++ b/tests/mypy/outputs/1.10.1/pyproject-plugin_toml/decorator_implicit_classmethod.py
@@ -13,8 +13,8 @@ class Model(BaseModel):
         return value
 
     @model_validator(mode='before')
-    def m_val_before(self, values: dict[str, object]) -> dict[str, object]:
-        reveal_type(self)
+    def m_val_before(cls, values: dict[str, object]) -> dict[str, object]:
+        reveal_type(cls)
 # MYPY: note: Revealed type is "type[tests.mypy.modules.decorator_implicit_classmethod.Model]"
         return values
 

--- a/tests/mypy/outputs/1.10.1/pyproject-plugin_toml/decorator_implicit_classmethod.py
+++ b/tests/mypy/outputs/1.10.1/pyproject-plugin_toml/decorator_implicit_classmethod.py
@@ -1,0 +1,31 @@
+"""Test that the mypy plugin implicitly transforms the right decorators into class methods."""
+
+from pydantic import BaseModel, field_validator, model_serializer, model_validator
+
+
+class Model(BaseModel):
+    a: int
+
+    @field_validator('a')
+    def f_val(cls, value: int) -> int:
+        reveal_type(cls)
+# MYPY: note: Revealed type is "type[tests.mypy.modules.decorator_implicit_classmethod.Model]"
+        return value
+
+    @model_validator(mode='before')
+    def m_val_before(self, values: dict[str, object]) -> dict[str, object]:
+        reveal_type(self)
+# MYPY: note: Revealed type is "type[tests.mypy.modules.decorator_implicit_classmethod.Model]"
+        return values
+
+    @model_validator(mode='after')
+    def m_val_after(self) -> 'Model':
+        reveal_type(self)
+# MYPY: note: Revealed type is "tests.mypy.modules.decorator_implicit_classmethod.Model"
+        return self
+
+    @model_serializer
+    def m_ser(self) -> dict[str, object]:
+        reveal_type(self)
+# MYPY: note: Revealed type is "tests.mypy.modules.decorator_implicit_classmethod.Model"
+        return self.model_dump()

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -88,6 +88,7 @@ cases: list[ParameterSet | tuple[str, str]] = [
             'plugin_success_baseConfig.py',
             'plugin_fail_baseConfig.py',
             'pydantic_settings.py',
+            'decorator_implicit_classmethod.py',
         ],
     ),
     # Strict plugin config
@@ -188,7 +189,7 @@ def test_mypy_results(config_filename: str, python_filename: str, request: pytes
         '--show-error-codes',
         '--show-traceback',
     ]
-    print(f"\nExecuting: mypy {' '.join(command)}")  # makes it easier to debug as necessary
+    print(f'\nExecuting: mypy {" ".join(command)}')  # makes it easier to debug as necessary
     mypy_out, mypy_err, mypy_returncode = mypy_api.run(command)
 
     # Need to strip filenames due to differences in formatting by OS
@@ -230,7 +231,7 @@ def test_bad_toml_config() -> None:
     full_filename = 'tests/mypy/modules/generics.py'  # File doesn't matter
 
     command = [full_filename, '--config-file', full_config_filename, '--show-error-codes']
-    print(f"\nExecuting: mypy {' '.join(command)}")  # makes it easier to debug as necessary
+    print(f'\nExecuting: mypy {" ".join(command)}')  # makes it easier to debug as necessary
     with pytest.raises(ValueError) as e:
         mypy_api.run(command)
 


### PR DESCRIPTION


Also format the mypy test code using latest Ruff.

Fixes https://github.com/pydantic/pydantic/issues/10707.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
