### PR TITLE
Fix JSON Schema reference collection with `"examples"` keys

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2552,8 +2552,13 @@ def _get_all_json_refs(item: Any) -> set[JsonRef]:
         current = stack.pop()
         if isinstance(current, dict):
             for key, value in current.items():
-                if key == 'examples':
-                    continue  # skip examples, allow arbitrary values / refs
+                if key == 'examples' and isinstance(value, list):
+                    # Skip examples that may contain arbitrary values and references
+                    # (e.g. `{"examples": [{"$ref": "..."}]}`). Note: checking for value
+                    # of type list is necessary to avoid skipping valid portions of the schema,
+                    # for instance when "examples" is used as a property key. A more robust solution
+                    # could be found, but would require more advanced JSON Schema parsing logic.
+                    continue
                 if key == '$ref' and isinstance(value, str):
                     refs.add(JsonRef(value))
                 elif isinstance(value, dict):

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6609,7 +6609,26 @@ def test_arbitrary_ref_in_json_schema() -> None:
         'type': 'object',
     }
 
-    # raises KeyError: '#/components/schemas/Pet'
+
+def test_examples_as_property_key() -> None:
+    """https://github.com/pydantic/pydantic/issues/11304.
+
+    A regression of https://github.com/pydantic/pydantic/issues/9981 (see `test_arbitrary_ref_in_json_schema`).
+    """
+
+    class Model1(BaseModel):
+        pass
+
+    class Model(BaseModel):
+        examples: Model1
+
+    assert Model.model_json_schema() == {
+        '$defs': {'Model1': {'properties': {}, 'title': 'Model1', 'type': 'object'}},
+        'properties': {'examples': {'$ref': '#/$defs/Model1'}},
+        'required': ['examples'],
+        'title': 'Model',
+        'type': 'object',
+    }
 
 
 def test_warn_on_mixed_compose() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11304.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
