### PR TITLE
Fix url python serialization

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -290,12 +290,14 @@ class _BaseUrl:
         )
 
     @classmethod
-    def serialize_url(cls, url: Any) -> str:
+    def serialize_url(cls, url: Any, info: core_schema.SerializationInfo) -> str | Self:
         if not isinstance(url, cls):
             raise PydanticSerializationUnexpectedValue(
                 f"Expected `{cls}` but got `{type(url)}` with value `'{url}'` - serialized value may not be as expected."
             )
-        return str(url)
+        if info.mode == 'json':
+            return str(url)
+        return url
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -314,7 +316,9 @@ class _BaseUrl:
         return core_schema.no_info_wrap_validator_function(
             wrap_val,
             schema=core_schema.url_schema(**cls._constraints.defined_constraints),
-            serialization=core_schema.plain_serializer_function_ser_schema(cls.serialize_url),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                cls.serialize_url, info_arg=True, when_used='always'
+            ),
         )
 
     @classmethod
@@ -465,12 +469,14 @@ class _BaseMultiHostUrl:
         )
 
     @classmethod
-    def serialize_url(cls, url: Any) -> str:
+    def serialize_url(cls, url: Any, info: core_schema.SerializationInfo) -> str | Self:
         if not isinstance(url, cls):
             raise PydanticSerializationUnexpectedValue(
                 f"Expected `{cls}` but got `{type(url)}` with value `'{url}'` - serialized value may not be as expected."
             )
-        return str(url)
+        if info.mode == 'json':
+            return str(url)
+        return url
 
     @classmethod
     def __get_pydantic_core_schema__(

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1187,3 +1187,15 @@ def test_unexpected_ser() -> None:
         match="Expected `<class 'pydantic.networks.HttpUrl'>` but got `<class 'str'>` with value `'http://example.com'`",
     ):
         ta.dump_python('http://example.com', warnings='error')
+
+
+def test_url_ser() -> None:
+    ta = TypeAdapter(HttpUrl)
+    assert ta.dump_python(HttpUrl('http://example.com')) == HttpUrl('http://example.com')
+    assert ta.dump_json(HttpUrl('http://example.com')) == b'"http://example.com/"'
+
+
+def test_url_ser_as_any() -> None:
+    ta = TypeAdapter(Any)
+    assert ta.dump_python(HttpUrl('http://example.com')) == HttpUrl('http://example.com')
+    assert ta.dump_json(HttpUrl('http://example.com')) == b'"http://example.com/"'

--- a/uv.lock
+++ b/uv.lock
@@ -285,7 +285,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -869,7 +869,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
@@ -1227,7 +1227,7 @@ email = [
     { name = "email-validator" },
 ]
 timezone = [
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -1257,7 +1257,7 @@ all = [
     { name = "pytest-benchmark" },
     { name = "pytest-codspeed" },
     { name = "pytest-examples" },
-    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and platform_system != 'Windows'" },
+    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },
     { name = "pytest-mock" },
     { name = "pytest-pretty" },
     { name = "pytz" },
@@ -1278,7 +1278,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-codspeed" },
     { name = "pytest-examples" },
-    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and platform_system != 'Windows'" },
+    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },
     { name = "pytest-mock" },
     { name = "pytest-pretty" },
     { name = "pytz" },
@@ -1321,7 +1321,7 @@ requires-dist = [
     { name = "email-validator", marker = "extra == 'email'", specifier = ">=2.0.0" },
     { name = "pydantic-core", specifier = "==2.27.2" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "tzdata", marker = "python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'" },
+    { name = "tzdata", marker = "python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'" },
 ]
 
 [package.metadata.requires-dev]
@@ -1351,7 +1351,7 @@ all = [
     { name = "pytest-benchmark" },
     { name = "pytest-codspeed" },
     { name = "pytest-examples" },
-    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and platform_system != 'Windows'" },
+    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },
     { name = "pytest-mock" },
     { name = "pytest-pretty" },
     { name = "pytz" },
@@ -1372,7 +1372,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-codspeed" },
     { name = "pytest-examples" },
-    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and platform_system != 'Windows'" },
+    { name = "pytest-memray", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },
     { name = "pytest-mock" },
     { name = "pytest-pretty" },
     { name = "pytz" },


### PR DESCRIPTION
Fix https://github.com/pydantic/pydantic/issues/11248

Ensure that urls dumped to python return the corresponding url type instead of being coerced to strings, a regression introduced in https://github.com/pydantic/pydantic/pull/11233.

We could probably do a better job of standardizing logic like this in types like ips, networks, and secrets in a different PR.