### PR TITLE
Coerce decimal constraints to `Decimal` instances

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from copy import copy
+from decimal import Decimal
 from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any
 
@@ -219,7 +220,10 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             if constraint == 'union_mode' and schema_type == 'union':
                 schema['mode'] = value  # type: ignore  # schema is UnionSchema
             else:
-                schema[constraint] = value
+                if schema_type == 'decimal' and constraint in {'multiple_of', 'le', 'ge', 'lt', 'gt'}:
+                    schema[constraint] = Decimal(value)
+                else:
+                    schema[constraint] = value
             continue
 
         #  else, apply a function after validator to the schema to enforce the corresponding constraint

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1058,6 +1058,13 @@ def test_decimal():
     assert m.model_dump() == {'v': Decimal('1.234')}
 
 
+def test_decimal_constraint_coerced() -> None:
+    ta = TypeAdapter(Annotated[Decimal, Field(gt=2)])
+
+    with pytest.raises(ValidationError):
+        ta.validate_python(Decimal(0))
+
+
 def test_decimal_allow_inf():
     class MyModel(BaseModel):
         value: Annotated[Decimal, AllowInfNan(True)]


### PR DESCRIPTION
Since core schema validation was disabled, constraints such as `gt` are not coerced to a `Decimal` instance if provided as e.g. an `int`.

Partially addresses https://github.com/pydantic/pydantic/issues/11341.
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
