### PR TITLE
Fix `AllowInfNan` code example formatting

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -395,6 +395,7 @@ class AllowInfNan(_fields.PydanticMetadata):
         from pydantic.types import AllowInfNan
 
         LaxFloat = Annotated[float, AllowInfNan()]
+        ```
     """
 
     allow_inf_nan: bool = True


### PR DESCRIPTION
## Change Summary

Fix doc formatting for `AllowInfNan` type found there: https://docs.pydantic.dev/latest/api/types/#pydantic.types.AllowInfNan

## Related issue number

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
