### PR TITLE
FutureRef.typing._eval_type: fix Python 3.13 DeprecationWarning

### DIFF
--- a/pydantic/v1/typing.py
+++ b/pydantic/v1/typing.py
@@ -65,7 +65,10 @@ else:
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
         # Python 3.13/3.12.4+ made `recursive_guard` a kwarg, so name it explicitly to avoid:
         # TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
-        return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set())
+        if sys.version_info >= (3, 13):
+            return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set(), type_params=())
+        else:
+            return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set())
 
 
 if sys.version_info < (3, 9):


### PR DESCRIPTION
## Change Summary

Fixes the following DeprecationWarning:
```
/../../opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/pydantic/v1/typing.py:68
../../../../../opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/pydantic/v1/typing.py:68
  /opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/pydantic/v1/typing.py:68: DeprecationWarning: Failing to pass a value to the 'type_params' parameter of 'typing.ForwardRef._evaluate' is deprecated, as it leads to incorrect behaviour when calling typing.ForwardRef._evaluate on a stringified annotation that references a PEP 695 type parameter. It will be disallowed in Python 3.15.
    return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set())
```

## Related issue number

Related to #9613

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

please review