### PR TITLE
Collect model fields when rebuilding a model

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -210,7 +210,7 @@ def collect_model_fields(  # noqa: C901
                     UserWarning,
                 )
 
-        if assigned_value is PydanticUndefined:
+        if assigned_value is PydanticUndefined:  # no assignment, just a plain annotation
             if ann_name in annotations:
                 # field is present in the current model's annotations (and *not* from parent classes)
                 field_info = FieldInfo_.from_annotation(ann_type)
@@ -229,7 +229,7 @@ def collect_model_fields(  # noqa: C901
                 # Store the original annotation that should be used to rebuild
                 # the field info later:
                 field_info._original_annotation = ann_type
-        else:
+        else:  # An assigned value is present (either the default value, or a `Field()` function)
             _warn_on_nested_alias_in_annotation(ann_type, ann_name)
             if isinstance(assigned_value, FieldInfo_) and ismethoddescriptor(assigned_value.default):
                 # `assigned_value` was fetched using `getattr`, which triggers a call to `__get__`

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -75,7 +75,6 @@ def _update_fields_from_docstrings(cls: type[Any], fields: dict[str, FieldInfo],
 
 def collect_model_fields(  # noqa: C901
     cls: type[BaseModel],
-    bases: tuple[type[Any], ...],
     config_wrapper: ConfigWrapper,
     ns_resolver: NsResolver | None,
     *,
@@ -89,7 +88,6 @@ def collect_model_fields(  # noqa: C901
 
     Args:
         cls: BaseModel or dataclass.
-        bases: Parents of the class, generally `cls.__bases__`.
         config_wrapper: The config wrapper instance.
         ns_resolver: Namespace resolver to use when getting model annotations.
         typevars_map: A dictionary mapping type variables to their concrete types.
@@ -106,6 +104,7 @@ def collect_model_fields(  # noqa: C901
     BaseModel = import_cached_base_model()
     FieldInfo_ = import_cached_field_info()
 
+    bases = cls.__bases__
     parent_fields_lookup: dict[str, FieldInfo] = {}
     for base in reversed(bases):
         if model_fields := getattr(base, '__pydantic_fields__', None):

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -311,8 +311,7 @@ def rebuild_model_fields(
     cls: type[BaseModel],
     *,
     ns_resolver: NsResolver,
-    typevars_map: dict[TypeVar, Any],
-    raise_errors: bool = True,
+    typevars_map: Mapping[TypeVar, Any],
 ) -> dict[str, FieldInfo]:
     """Rebuild the (already present) model fields by trying to reevaluate annotations.
 
@@ -330,17 +329,11 @@ def rebuild_model_fields(
             if field_info._complete:
                 rebuilt_fields[f_name] = field_info
             else:
-                try:
-                    ann = _typing_extra.eval_type(
-                        field_info._original_annotation,
-                        *ns_resolver.types_namespace,
-                    )
-                    ann = _generics.replace_types(ann, typevars_map)
-                except NameError:
-                    if raise_errors:
-                        raise
-                    else:
-                        return cls.__pydantic_fields__
+                ann = _typing_extra.eval_type(
+                    field_info._original_annotation,
+                    *ns_resolver.types_namespace,
+                )
+                ann = _generics.replace_types(ann, typevars_map)
 
                 if (assign := field_info._original_assignment) is PydanticUndefined:
                     rebuilt_fields[f_name] = FieldInfo_.from_annotation(ann)

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -84,9 +84,9 @@ from ._decorators import (
     inspect_validator,
 )
 from ._docs_extraction import extract_docstrings_from_cls
-from ._fields import collect_dataclass_fields, takes_validated_data_argument
+from ._fields import collect_dataclass_fields, collect_model_fields, takes_validated_data_argument
 from ._forward_ref import PydanticRecursiveRef
-from ._generics import get_standard_typevars_map, has_instance_in_type, replace_types
+from ._generics import get_standard_typevars_map, replace_types
 from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._mock_val_ser import MockCoreSchema
 from ._namespace_utils import NamespacesTuple, NsResolver
@@ -704,6 +704,8 @@ class GenerateSchema:
 
     def _model_schema(self, cls: type[BaseModel]) -> core_schema.CoreSchema:
         """Generate schema for a Pydantic model."""
+        BaseModel_ = import_cached_base_model()
+
         with self.defs.get_schema_or_ref(cls) as (model_ref, maybe_schema):
             if maybe_schema is not None:
                 return maybe_schema
@@ -725,22 +727,38 @@ class GenerateSchema:
                 else:
                     return schema
 
-            fields = getattr(cls, '__pydantic_fields__', {})
-            decorators = cls.__pydantic_decorators__
-            computed_fields = decorators.computed_fields
-            check_decorator_fields_exist(
-                chain(
-                    decorators.field_validators.values(),
-                    decorators.field_serializers.values(),
-                    decorators.validators.values(),
-                ),
-                {*fields.keys(), *computed_fields.keys()},
-            )
             config_wrapper = ConfigWrapper(cls.model_config, check=False)
-            core_config = config_wrapper.core_config(title=cls.__name__)
-            model_validators = decorators.model_validators.values()
 
             with self._config_wrapper_stack.push(config_wrapper), self._ns_resolver.push(cls):
+                core_config = self._config_wrapper.core_config(title=cls.__name__)
+
+                if cls.__pydantic_fields_complete__ or cls is BaseModel_:
+                    fields = getattr(cls, '__pydantic_fields__', {})
+                else:
+                    fields, _, evaluation_succeeded = collect_model_fields(
+                        cls,
+                        config_wrapper=self._config_wrapper,
+                        ns_resolver=self._ns_resolver,
+                        typevars_map=self._typevars_map,
+                    )
+                    if not evaluation_succeeded:
+                        raise PydanticUndefinedAnnotation(
+                            name='<unknown>', message=f'An annotation is not defined in model {cls}'
+                        )
+
+                decorators = cls.__pydantic_decorators__
+                computed_fields = decorators.computed_fields
+                check_decorator_fields_exist(
+                    chain(
+                        decorators.field_validators.values(),
+                        decorators.field_serializers.values(),
+                        decorators.validators.values(),
+                    ),
+                    {*fields.keys(), *computed_fields.keys()},
+                )
+
+                model_validators = decorators.model_validators.values()
+
                 extras_schema = None
                 if core_config.get('extra_fields_behavior') == 'allow':
                     assert cls.__mro__[0] is cls
@@ -1305,32 +1323,6 @@ class GenerateSchema:
     def _common_field_schema(  # C901
         self, name: str, field_info: FieldInfo, decorators: DecoratorInfos
     ) -> _CommonField:
-        # Update FieldInfo annotation if appropriate:
-        FieldInfo = import_cached_field_info()
-        if not field_info.evaluated:
-            # TODO Can we use field_info.apply_typevars_map here?
-            try:
-                evaluated_type = _typing_extra.eval_type(field_info.annotation, *self._types_namespace)
-            except NameError as e:
-                raise PydanticUndefinedAnnotation.from_name_error(e) from e
-            evaluated_type = replace_types(evaluated_type, self._typevars_map)
-            field_info.evaluated = True
-            if not has_instance_in_type(evaluated_type, PydanticRecursiveRef):
-                new_field_info = FieldInfo.from_annotation(evaluated_type)
-                field_info.annotation = new_field_info.annotation
-
-                # Handle any field info attributes that may have been obtained from now-resolved annotations
-                for k, v in new_field_info._attributes_set.items():
-                    # If an attribute is already set, it means it was set by assigning to a call to Field (or just a
-                    # default value), and that should take the highest priority. So don't overwrite existing attributes.
-                    # We skip over "attributes" that are present in the metadata_lookup dict because these won't
-                    # actually end up as attributes of the `FieldInfo` instance.
-                    if k not in field_info._attributes_set and k not in field_info.metadata_lookup:
-                        setattr(field_info, k, v)
-
-                # Finally, ensure the field info also reflects all the `_attributes_set` that are actually metadata.
-                field_info.metadata = [*new_field_info.metadata, *field_info.metadata]
-
         source_type, annotations = field_info.annotation, field_info.metadata
 
         def set_discriminator(schema: CoreSchema) -> CoreSchema:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -740,7 +740,6 @@ class GenerateSchema:
                             cls,
                             ns_resolver=self._ns_resolver,
                             typevars_map=self._typevars_map or {},
-                            raise_errors=True,
                         )
                     except NameError as e:
                         raise PydanticUndefinedAnnotation.from_name_error(e) from e

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -340,39 +340,6 @@ def replace_types(type_: Any, type_map: Mapping[TypeVar, Any] | None) -> Any:
     return type_map.get(type_, type_)
 
 
-def has_instance_in_type(type_: Any, isinstance_target: Any) -> bool:
-    """Checks if the type, or any of its arbitrary nested args, satisfy
-    `isinstance(<type>, isinstance_target)`.
-    """
-    if isinstance(type_, isinstance_target):
-        return True
-    if _typing_extra.is_annotated(type_):
-        return has_instance_in_type(type_.__origin__, isinstance_target)
-    if _typing_extra.is_literal(type_):
-        return False
-
-    type_args = get_args(type_)
-
-    # Having type args is a good indicator that this is a typing module
-    # class instantiation or a generic alias of some sort.
-    for arg in type_args:
-        if has_instance_in_type(arg, isinstance_target):
-            return True
-
-    # Handle special case for typehints that can have lists as arguments.
-    # `typing.Callable[[int, str], int]` is an example for this.
-    if (
-        isinstance(type_, list)
-        # On Python < 3.10, typing_extensions implements `ParamSpec` as a subclass of `list`:
-        and not isinstance(type_, typing_extensions.ParamSpec)
-    ):
-        for element in type_:
-            if has_instance_in_type(element, isinstance_target):
-                return True
-
-    return False
-
-
 def map_generic_model_arguments(cls: type[BaseModel], args: tuple[Any, ...]) -> dict[TypeVar, Any]:
     """Return a mapping between the arguments of a generic model and the provided arguments during parametrization.
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -312,7 +312,7 @@ class ModelMetaclass(ABCMeta):
 
     @property
     def __pydantic_fields_complete__(self) -> bool:
-        """Whether the fields where successfully collected.
+        """Whether the fields where successfully collected (i.e. type hints were successfully resolves).
 
         This is a private attribute, not meant to be used outside Pydantic.
         """

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -226,7 +226,10 @@ class ModelMetaclass(ABCMeta):
                 k: v.info for k, v in cls.__pydantic_decorators__.computed_fields.items()
             }
 
-            if config_wrapper.defer_build or not cls.__pydantic_fields_complete__:
+            if config_wrapper.defer_build:
+                # TODO we can also stop there if `__pydantic_fields_complete__` is False.
+                # However, `set_model_fields()` is currently lenient and we don't have access to the `NameError`.
+                # (which is useful as we can provide the name in the error message: `set_model_mock(cls, e.name)`)
                 set_model_mocks(cls)
             else:
                 # Any operation that requires accessing the field infos instances should be put inside

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -156,7 +156,6 @@ class FieldInfo(_repr.Representation):
 
     __slots__ = (
         'annotation',
-        'evaluated',
         'default',
         'default_factory',
         'alias',
@@ -210,7 +209,6 @@ class FieldInfo(_repr.Representation):
         self._attributes_set = {k: v for k, v in kwargs.items() if v is not _Unset}
         kwargs = {k: _DefaultValues.get(k) if v is _Unset else v for k, v in kwargs.items()}  # type: ignore
         self.annotation = kwargs.get('annotation')
-        self.evaluated = False
 
         default = kwargs.pop('default', PydanticUndefined)
         if default is Ellipsis:
@@ -681,7 +679,7 @@ class FieldInfo(_repr.Representation):
         for s in self.__slots__:
             # TODO: properly make use of the protocol (https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol)
             # By yielding a three-tuple:
-            if s in ('_attributes_set', 'annotation', 'evaluated'):
+            if s in ('_attributes_set', 'annotation'):
                 continue
             elif s == 'metadata' and not self.metadata:
                 continue

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -177,6 +177,10 @@ class FieldInfo(_repr.Representation):
         'init_var',
         'kw_only',
         'metadata',
+        '_attributes_set',
+        '_complete',
+        '_original_assignment',
+        '_original_annotation',
     )
 
     # used to convert kwargs to metadata/constraints,
@@ -205,12 +209,14 @@ class FieldInfo(_repr.Representation):
 
         See the signature of `pydantic.fields.Field` for more details about the expected arguments.
         """
+        self._attributes_set = {k: v for k, v in kwargs.items() if v is not _Unset}
         kwargs = {k: _DefaultValues.get(k) if v is _Unset else v for k, v in kwargs.items()}  # type: ignore
         self.annotation = kwargs.get('annotation')
 
         default = kwargs.pop('default', PydanticUndefined)
         if default is Ellipsis:
             self.default = PydanticUndefined
+            self._attributes_set.pop('default', None)
         else:
             self.default = default
 
@@ -242,6 +248,11 @@ class FieldInfo(_repr.Representation):
         self.kw_only = kwargs.pop('kw_only', None)
 
         self.metadata = self._collect_metadata(kwargs)  # type: ignore
+
+        # Private attributes, used to rebuild FieldInfo instances:
+        self._complete = True
+        self._original_annotation: Any = PydanticUndefined
+        self._original_assignment: Any = PydanticUndefined
 
     @staticmethod
     def from_field(default: Any = PydanticUndefined, **kwargs: Unpack[_FromFieldInfoInputs]) -> FieldInfo:
@@ -450,6 +461,7 @@ class FieldInfo(_repr.Representation):
         if len(field_infos) == 1:
             # No merging necessary, but we still need to make a copy and apply the overrides
             field_info = copy(field_infos[0])
+            field_info._attributes_set.update(overrides)
 
             default_override = overrides.pop('default', PydanticUndefined)
             if default_override is Ellipsis:
@@ -464,8 +476,10 @@ class FieldInfo(_repr.Representation):
         merged_field_info_kwargs: dict[str, Any] = {}
         metadata = {}
         for field_info in field_infos:
-            json_schema_extra = field_info.json_schema_extra
-            if json_schema_extra is not None:
+            attributes_set = field_info._attributes_set.copy()
+
+            try:
+                json_schema_extra = attributes_set.pop('json_schema_extra')
                 existing_json_schema_extra = merged_field_info_kwargs.get('json_schema_extra')
 
                 if existing_json_schema_extra is None:
@@ -486,6 +500,11 @@ class FieldInfo(_repr.Representation):
                 elif callable(json_schema_extra):
                     # if ever there's a case of a callable, we'll just keep the last json schema extra spec
                     merged_field_info_kwargs['json_schema_extra'] = json_schema_extra
+            except KeyError:
+                pass
+
+            # later FieldInfo instances override everything except json_schema_extra from earlier FieldInfo instances
+            merged_field_info_kwargs.update(attributes_set)
 
             for x in field_info.metadata:
                 if not isinstance(x, FieldInfo):
@@ -665,7 +684,7 @@ class FieldInfo(_repr.Representation):
         for s in self.__slots__:
             # TODO: properly make use of the protocol (https://rich.readthedocs.io/en/stable/pretty.html#rich-repr-protocol)
             # By yielding a three-tuple:
-            if s == 'annotation':
+            if s in ('annotation', '_attributes_set', '_complete', '_original_assignment', '_original_annotation'):
                 continue
             elif s == 'metadata' and not self.metadata:
                 continue

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -616,11 +616,12 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                     cls,
                     ns_resolver=ns_resolver,
                     typevars_map=typevars_map,
-                    raise_errors=raise_errors,
                 )
             except NameError as e:
+                exc = PydanticUndefinedAnnotation.from_name_error(e)
+                _mock_val_ser.set_model_mocks(cls, f'`{exc.name}`')
                 if raise_errors:
-                    raise PydanticUndefinedAnnotation.from_name_error(e) from e
+                    raise exc from e
 
             if not raise_errors and not cls.__pydantic_fields_complete__:
                 # No need to continue with schema gen, it is guaranteed to fail

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -147,6 +147,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     __pydantic_complete__: ClassVar[bool] = False
     """Whether model building is completed, or if there are still undefined fields."""
 
+    __pydantic_fields_complete__: ClassVar[bool] = False
+    """Whether the fields where successfully collected. This is a private attribute, not meant
+    to be used outside Pydantic.
+    """
+
     __pydantic_core_schema__: ClassVar[CoreSchema]
     """The core schema of the model."""
 

--- a/tests/test_deprecated_fields.py
+++ b/tests/test_deprecated_fields.py
@@ -251,3 +251,19 @@ def test_computed_field_deprecated_subclass() -> None:
 
     class Sub(Base):
         pass
+
+
+def test_deprecated_field_forward_annotation() -> None:
+    """https://github.com/pydantic/pydantic/issues/11390"""
+
+    class Model(BaseModel):
+        a: "Annotated[Test, deprecated('test')]" = 2
+
+    Test = int
+
+    Model.model_rebuild()
+    assert Model.model_fields['a'].deprecated == 'test'
+
+    m = Model()
+
+    pytest.warns(DeprecationWarning, lambda: m.a, match='test')

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -58,16 +58,14 @@ def test_forward_ref_auto_update_no_model(create_module):
             b: 'Foo'
 
     assert module.Bar.__pydantic_complete__ is True
-    assert repr(module.Bar.model_fields['b']) == 'FieldInfo(annotation=Foo, required=True)'
+    assert module.Bar.model_fields['b']._complete
 
     # Bar should be complete and ready to use
     b = module.Bar(b={'a': {'b': {}}})
     assert b.model_dump() == {'b': {'a': {'b': {'a': None}}}}
 
-    # model_fields is complete on Foo
-    assert repr(module.Foo.model_fields['a']) == (
-        'FieldInfo(annotation=Union[Bar, NoneType], required=False, default=None)'
-    )
+    # model_fields is *not* complete on Foo
+    assert not module.Foo.model_fields['a']._complete
 
     assert module.Foo.__pydantic_complete__ is False
     # Foo gets auto-rebuilt during the first attempt at validation

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1640,6 +1640,23 @@ def test_generic_recursive_models_parametrized() -> None:
     Model2[str].model_rebuild()
 
 
+@pytest.mark.xfail(reason='Core schema generation is missing the M1 definition')
+def test_generic_recursive_models_inheritance() -> None:
+    """https://github.com/pydantic/pydantic/issues/9969"""
+
+    T = TypeVar('T')
+
+    class M1(BaseModel, Generic[T]):
+        bar: 'M1[T]'
+
+    class M2(M1[str]):
+        pass
+
+    M2.model_rebuild()
+
+    assert M2.__pydantic_complete__
+
+
 def test_generic_recursive_models_separate_parameters(create_module):
     @create_module
     def module():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

Fixes https://github.com/pydantic/pydantic/issues/11390, fixes https://github.com/pydantic/pydantic/issues/10695, works towards https://github.com/pydantic/pydantic/issues/9969 (we don't get the `KeyError` anymore, but we still get a clean schema error because of a missing definition).

## Change Summary

https://github.com/pydantic/pydantic/pull/5305 made it so that unknown forward annotations would not stop field collection. The PR is huge and doesn't explain why this was done, but this introduced subtle bugs and code smells that this PR tries removing.

The first issue arising from this is that the model fields can be inaccurate when a model is not fully built yet:

```python
from typing import Annotated

from pydantic import BaseModel

class Model(BaseModel):
    a: 'Annotated[Forward, Field(alias="b")]'

Model.model_fields['a'].alias
#> None, should be 'b'
```

and I won't be surprised if some users currently make use of `model_fields` on an incomplete model (especially as we implicitly rebuild on instance creation — meaning most users don't explicitly call `model_rebuild()`). A relatively big concern I also have is FastAPI relying on `FieldInfo` instances to validate data. They do manual stuff before calling the Pydantic validate methods, such as checking for `FieldInfo.is_required()`, `alias`.

When a model is being rebuilt, we reevaluate the annotation and recreate a `FieldInfo` instance during the core schema gen process (and we used to even to this in a less performant way; see https://github.com/pydantic/pydantic/pull/10769):

https://github.com/pydantic/pydantic/blob/929e8f47ede2f895290714a6de96e6fb7b4c926c/pydantic/_internal/_generate_schema.py#L1301-L1320

Doing so introduced a code smell where we track explicitly set attributes using `_attributes_set`. This is known to be a source of bugs as we need to keep track of such explicitly set attrs when you alter the `FieldInfo` instance:
- We forgot to update it when using `...` as the default value in some cases. See this added test case:
  https://github.com/pydantic/pydantic/blob/929e8f47ede2f895290714a6de96e6fb7b4c926c/tests/test_edge_cases.py#L1919-L1927
- We currently forget to update `deprecated` (first bug of https://github.com/pydantic/pydantic/issues/11390).

And more generally:
- On `_generate_schema.py#L1311`, we **directly mutate** the original field info instance to take the newly evaluated annotation. This is the reason we get the `KeyError` on generics (https://github.com/pydantic/pydantic/issues/9969).
- We make use of the model fields (even though they might be incorrect) inside `ModelMetaclass.__new__ `, at model creation (i.e. stuff that _isn't_ reprocessed on `model_rebuild()`), such as setting deprecated descriptors (second bug of [#11390](https://github.com/pydantic/pydantic/issues/11390): we set these descriptors based on `FieldInfo.deprecated`).

---

Instead, this PR does three things:

- Add a new `__pydantic_fields_complete__` class property on models (for private use). It is true if at least one field annotation failed to evaluate during `collect_model_fields()`. On a related note: we still set `__pydantic_fields__` for backwards compatibility, but a follow up PR can now easily add a user/deprecation warning when accessing `model_fields` _if_ `__pydantic_fields_complete__ == False`. In V3, we could remove this backward compatibility logic (TBD).
  Also note that now we _don't_ enter `GenerateSchema` if the fields collection failed, as it is guaranteed to fail anyway (if an annotation failed to evaluate during fields collection, it will also immediately fail to be evaluated in `GenerateSchema`). 
- Calling `model_rebuild()` _will_ redo the fields collection if it wasn't successful the first time. Note that this aligns with Pydantic dataclasses.
- When an incomplete Pydantic model is encountered as an annotation (inside `GenerateSchema`), we first call `rebuild_model_fields()`; a new function that iterates over the existing (but potentially not complete) field infos, and recreate instances if the annotation needs to be evaluated again. This way, we avoid generating a schema for each field just to realize that one field still has a forward annotation:
  ```python
  class Sub(BaseModel):
      f1: int
      ...  # Many fields...
      f100: 'Forward'

  class Model(BaseModel):
      sub: Sub
      # Note that Sub is incomplete, so in the process of generating the schema for
      # `Model`, we don't use the cached schema attribute
      # Thus previously, we would generate a schema for f1, f2, ..., f99. f100 would fail,
      # meaning we generated 99 fields core schemas for nothing.
      # In this PR, we first (re)collect fields for `Sub`, and immediately raise if fields collection did not suceed.
  ```
  On important thing to acknowledge: when encountering `sub: Sub`, we don't call `Sub.model_rebuild()`. Doing so might be the right thing to do, but is unfortunately not backwards compatible. The reason is that the NS Resolver used for `Model` might contain annotations (e.g. provided through the [`parent_namespace`](https://github.com/pydantic/pydantic/blob/929e8f47ede2f895290714a6de96e6fb7b4c926c/pydantic/_internal/_namespace_utils.py#L226)) that should be available for `Sub`. This means that even if `sub: Sub` successfully builds, `Sub` isn't complete yet — each model should be rebuilt independently, through `model_rebuild()`).

TODO:

- Performance issues: I believe this is a tradeoff to have, as the couple affected benchmarks are models with one field defined, and the new `rebuild_model_fields()` might add a bit of overhead. However, it will be beneficial if many fields are defined (see the example with `f1..100` above and the `test_failed_rebuild` benchmark).

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
