### PR TITLE
use locally-built rust with symbols & pgo

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   codspeed-profiling:
     name: CodSpeed profiling
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -24,12 +24,57 @@ jobs:
       # Using this action is still necessary for CodSpeed to work:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
+
+      - id: core-version
+        name: resolve pydantic-core tag
+        run: |
+          set -uex -o pipefail
+          echo core-ref=$(python -c "
+          import re
+          import tomllib
+          pyproject_toml = tomllib.loads(open('pyproject.toml').read())
+          core = next(d for d in pyproject_toml['project']['dependencies'] if d.startswith('pydantic-core'))
+          if (result := re.search(r'==(.+)', core)) is not None:
+            print(f'v{result.group(1)}')
+          elif (result := re.search(r'@ git\+https://github\.com/pydantic/pydantic-core\.git@(.+)', core)) is not None:
+            print(result.group(1))
+          else:
+            raise RuntimeError('Could not resolve pydantic-core ref')
+          ") >> $GITHUB_OUTPUT
 
       - name: install deps
         run: uv sync --python 3.12 --group testing-extra --extra email --frozen
 
+      - name: checkout pydantic-core
+        uses: actions/checkout@v4
+        with:
+          repository: pydantic/pydantic-core
+          ref: ${{ steps.core-version.outputs.core-ref }}
+          path: pydantic-core
+
+      - name: install rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+
+      - name: cache rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: pydantic-core
+
+      - name: install pydantic-core with profiling symbols
+        run: |
+          cd pydantic-core
+          ln -s ../.venv .venv
+          uv sync --group all --inexact
+          uv pip uninstall pytest-speed
+          uv run make build-pgo
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
+          CARGO_PROFILE_RELEASE_STRIP: "false"
+
       - name: Run CodSpeed benchmarks
         uses: CodSpeedHQ/action@v3
         with:
-          run: uv run pytest ./tests/benchmarks --codspeed
+          run: uv run --no-sync pytest ./tests/benchmarks --codspeed


### PR DESCRIPTION
## Change Summary

Should make benchmarks easier to read:
- git-based stuff like #11374 will now use PGO
- all benchmarks will have rust symbols in the codspeed flamegraphs

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
