### PR TITLE
Add regex patterns reflecting Decimal Constraints to the Decimal type's string schema

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -277,10 +277,7 @@ print(Model.model_json_schema(mode='validation'))
 {
     'properties': {
         'a': {
-            'anyOf': [
-                {'type': 'number'},
-                {'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$', 'type': 'string'},
-            ],
+            'anyOf': [{'type': 'number'}, {'type': 'string'}],
             'default': '12.34',
             'title': 'A',
         }
@@ -293,14 +290,7 @@ print(Model.model_json_schema(mode='validation'))
 print(Model.model_json_schema(mode='serialization'))
 """
 {
-    'properties': {
-        'a': {
-            'default': '12.34',
-            'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$',
-            'title': 'A',
-            'type': 'string',
-        }
-    },
+    'properties': {'a': {'default': '12.34', 'title': 'A', 'type': 'string'}},
     'title': 'Model',
     'type': 'object',
 }

--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -277,7 +277,10 @@ print(Model.model_json_schema(mode='validation'))
 {
     'properties': {
         'a': {
-            'anyOf': [{'type': 'number'}, {'type': 'string'}],
+            'anyOf': [
+                {'type': 'number'},
+                {'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$', 'type': 'string'},
+            ],
             'default': '12.34',
             'title': 'A',
         }
@@ -290,7 +293,14 @@ print(Model.model_json_schema(mode='validation'))
 print(Model.model_json_schema(mode='serialization'))
 """
 {
-    'properties': {'a': {'default': '12.34', 'title': 'A', 'type': 'string'}},
+    'properties': {
+        'a': {
+            'default': '12.34',
+            'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$',
+            'title': 'A',
+            'type': 'string',
+        }
+    },
     'title': 'Model',
     'type': 'object',
 }

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -674,7 +674,17 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        json_schema = self.str_schema(core_schema.str_schema())
+        max_digits = schema.get('max_digits')
+        decimal_places = schema.get('decimal_places')
+        str_schema = core_schema.str_schema()
+
+        if max_digits is not None and decimal_places is not None:
+            integer_places = max_digits - decimal_places
+            pattern = f'^-?(?:0|[1-9]\\d{{0,{integer_places-1}}})(\\.\\d{{0,{decimal_places}}})?$'
+            str_schema['pattern'] = pattern
+
+        json_schema = self.str_schema(str_schema)
+
         if self.mode == 'validation':
             multiple_of = schema.get('multiple_of')
             le = schema.get('le')

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -129,7 +129,7 @@ JsonSchemaKeyT = TypeVar('JsonSchemaKeyT', bound=Hashable)
 
 _DECIMAL_JSON_MAX_DIGIT_LOOKAHEAD_PATTERN = (
     r'(?=\d{{0,{max_digits}}}$'  # Positive lookahead for max_digits
-    r'|[\d\.]{{0,{max_digits_plus_dp}}}$)'  # or max_digits +1 if there is a decimal point
+    r'|(?=.*\..*)[\d\.]{{0,{max_digits_plus_dp}}}$)'  # or max_digits +1 if there is a decimal point
 )
 
 _DECIMAL_JSON_VALIDATION_PATTERN = (

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -128,34 +128,23 @@ JsonSchemaKeyT = TypeVar('JsonSchemaKeyT', bound=Hashable)
 # ##### Regex for Decimal JSON Schema Generation #####
 
 _DECIMAL_JSON_MAX_DIGIT_LOOKAHEAD_PATTERN = (
-    r'(?='
-    r'\d{{0,{max_digits}}}$'  # Positive lookahead for max_digits
-    r'|'
-    r'[\d\.]{{0,{max_digits_plus_dp}}}$'  # or max_digits +1 if there is a decimal point
-    r')'
+    r'(?=\d{{0,{max_digits}}}$'  # Positive lookahead for max_digits
+    r'|[\d\.]{{0,{max_digits_plus_dp}}}$)'  # or max_digits +1 if there is a decimal point
 )
 
 _DECIMAL_JSON_VALIDATION_PATTERN = (
     r'^-?'  # Minus sign (optional)
     r'0*'  # Allow leading zeroes
     r'{max_digit_lookahead}'  # Substitution for max digit lookahead if required
-    r'\d{{0,{integer_places}}}'  # One or more digits for the integer part
-    r'(?:'  # Optional non-capturing decimal group
-    r'\.'  # Decimal point
-    r'\d{{0,{decimal_places}}}'  # Up to {decimal_places} decimal digits
-    r')?$'
+    r'\d{{1,{integer_places}}}'  # One or more integer digits
+    r'(?:\.\d{{0,{decimal_places}}})?$'  # Optional non-capturing group: decimal digits
 )
 
 _DECIMAL_JSON_SERIALIZATION_PATTERN = (
     r'^-?'  # Minus sign (optional)
     r'{max_digit_lookahead}'  # Substitution for max digit lookahead if required
-    r'(?:'  # Non-capturing group integer digits
-    r'0|[1-9]\d{{0,{integer_places}}}'  # Single zero OR non-zero digit followed by additional digits
-    r')'
-    r'(?:'  # Optional non-capturing decimal group
-    r'\.'  # Decimal point
-    r'\d{{0,{decimal_places}}}'  # Up to {decimal_places} decimal digits
-    r')?$'
+    r'(?:0|[1-9]\d{{0,{integer_places}}})'  # Non-capturing group: Single zero OR non-zero digit and integer digits
+    r'(?:\.\d{{0,{decimal_places}}})?$'  # Optional non-capturing group: decimal digits
 )
 
 
@@ -727,6 +716,7 @@ class GenerateJsonSchema:
                     integer_places='' if max_digits is None or decimal_places is None else max_digits - decimal_places,
                     decimal_places='' if decimal_places is None else decimal_places,
                 )
+                str_schema['pattern'] = re.compile(decimal_regex_pattern).pattern
             elif self.mode == 'serialization':
                 # The _DECIMAL_JSON_SERIALIZATION_PATTERN matches the first integer digit separate from the rest, to
                 # account for this we want our integer_places argument to be one less than max_digits - decimal_places
@@ -737,9 +727,7 @@ class GenerateJsonSchema:
                     else max_digits - decimal_places - 1,
                     decimal_places='' if decimal_places is None else decimal_places,
                 )
-            else:
-                decimal_regex_pattern = ''
-            str_schema['pattern'] = re.compile(decimal_regex_pattern).pattern
+                str_schema['pattern'] = re.compile(decimal_regex_pattern).pattern
         json_schema = self.str_schema(str_schema)
 
         if self.mode == 'validation':

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -933,11 +933,41 @@ def test_str_constrained_types(field_type, expected_schema):
 
 def test_decimal_constraints():
     constraints = {'max_digits': 5, 'decimal_places': 2, 'ge': 0.0, 'le': 10.0}
-    schema = TypeAdapter(Annotated[Decimal, Field(**constraints)]).json_schema()
+    ta = TypeAdapter(Annotated[Decimal, Field(**constraints)])
 
-    assert 'pattern' in schema['anyOf'][1]
-    assert schema['anyOf'][0]['maximum'] == 10.0
-    assert schema['anyOf'][0]['minimum'] == 0.0
+    validation_cases = [
+        ('0', Decimal('0')),  # Single zero
+        ('00.12', Decimal('0.12')),  # Leading zeros
+        ('000.12', Decimal('0.12')),  # Multiple leading zeros
+        ('1.23', Decimal('1.23')),  # Regular decimal
+        ('10.00', Decimal('10.00')),  # Maximum value with trailing zeros
+        ('0.12', Decimal('0.12')),  # Decimal less than 1
+    ]
+
+    for input_value, expected in validation_cases:
+        result = ta.validate_json(f'"{input_value}"')
+        assert result == expected
+
+    invalid_cases = [
+        '123.455',  # Exceeds max_digits (5 digits total)
+        '12.345',  # Too many decimal places (3 vs allowed 2)
+        '12.34',  # 11.00 exceeds le=10.0
+        '-1.23',  # Below ge=0.0
+    ]
+
+    for value in invalid_cases:
+        with pytest.raises(ValidationError):
+            ta.validate_json(f'"{value}"')
+
+    serialization_cases = {
+        Decimal('0'): '0',  # Zero case
+        Decimal('00.12'): '0.12',  # Leading zeros removed
+        Decimal('1.20'): '1.20',  # Trailing zeros preserved
+        Decimal('10.00'): '10.00',  # Maximum value
+    }
+
+    for input_value, expected in serialization_cases.items():
+        assert ta.dump_json(input_value).decode().strip('"') == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2019,7 +2019,7 @@ def test_docstring(docstring, description):
                 'anyOf': [
                     {'type': 'number'},
                     {
-                        'pattern': '^-?0*(?=\\d{0,4}0*$|(?=.*\\..*)[\\d\\.]{0,5}0*$)\\d{1,}(?:\\.\\d{0,})?0*$',
+                        'pattern': '^-?0*(?=(?:\\d(\\.)?){1,4}(?(1)0*)$)\\d{1,}(?:\\.\\d{0,}0*)?$',
                         'type': 'string',
                     },
                 ]
@@ -2028,7 +2028,7 @@ def test_docstring(docstring, description):
         (
             {'decimal_places': 2},
             Decimal,
-            {'anyOf': [{'type': 'number'}, {'pattern': '^-?0*\\d{1,}(?:\\.\\d{0,2})?0*$', 'type': 'string'}]},
+            {'anyOf': [{'type': 'number'}, {'pattern': '^-?0*\\d{1,}(?:\\.\\d{0,2}0*)?$', 'type': 'string'}]},
         ),
         (
             {'max_digits': 4, 'decimal_places': 2},
@@ -2037,7 +2037,7 @@ def test_docstring(docstring, description):
                 'anyOf': [
                     {'type': 'number'},
                     {
-                        'pattern': '^-?0*\\d{1,2}(?:\\.\\d{0,2})?0*$',
+                        'pattern': '^-?0*(?=(?:\\d(\\.)?){1,4}(?(1)0*)$)\\d{1,2}(?:\\.\\d{0,2}0*)?$',
                         'type': 'string',
                     },
                 ]
@@ -2090,7 +2090,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             {'max_digits': 4},
             Decimal,
             {
-                'pattern': '^-?(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$',
+                'pattern': '^-?(?=(?:\\d\\.?){1,4}$)(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$',
                 'type': 'string',
             },
         ),
@@ -2099,7 +2099,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             {'max_digits': 4, 'decimal_places': 2},
             Decimal,
             {
-                'pattern': '^-?(?:0|[1-9]\\d{0,1})(?:\\.\\d{0,2})?$',
+                'pattern': '^-?(?=(?:\\d\\.?){1,4}$)(?:0|[1-9]\\d{0,1})(?:\\.\\d{0,2})?$',
                 'type': 'string',
             },
         ),

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -526,11 +526,7 @@ def test_decimal_json_schema():
     assert model_json_schema_validation == {
         'properties': {
             'a': {'default': 'foobar', 'format': 'binary', 'title': 'A', 'type': 'string'},
-            'b': {
-                'anyOf': [{'type': 'number'}, {'type': 'string', 'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$'}],
-                'default': '12.34',
-                'title': 'B',
-            },
+            'b': {'anyOf': [{'type': 'number'}, {'type': 'string'}], 'default': '12.34', 'title': 'B'},
         },
         'title': 'Model',
         'type': 'object',
@@ -538,12 +534,7 @@ def test_decimal_json_schema():
     assert model_json_schema_serialization == {
         'properties': {
             'a': {'default': 'foobar', 'format': 'binary', 'title': 'A', 'type': 'string'},
-            'b': {
-                'default': '12.34',
-                'title': 'B',
-                'type': 'string',
-                'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$',
-            },
+            'b': {'default': '12.34', 'title': 'B', 'type': 'string'},
         },
         'title': 'Model',
         'type': 'object',
@@ -940,6 +931,45 @@ def test_str_constrained_types(field_type, expected_schema):
     assert model_schema == base_schema
 
 
+def test_decimal_constraints():
+    constraints = {'max_digits': 5, 'decimal_places': 2, 'ge': 0.0, 'le': 10.0}
+    ta = TypeAdapter(Annotated[Decimal, Field(**constraints)])
+
+    validation_cases = [
+        ('0', Decimal('0')),  # Single zero
+        ('00.12', Decimal('0.12')),  # Leading zeros
+        ('000.12', Decimal('0.12')),  # Multiple leading zeros
+        ('1.23', Decimal('1.23')),  # Regular decimal
+        ('10.00', Decimal('10.00')),  # Maximum value with trailing zeros
+        ('0.12', Decimal('0.12')),  # Decimal less than 1
+    ]
+
+    for input_value, expected in validation_cases:
+        result = ta.validate_json(f'"{input_value}"')
+        assert result == expected
+
+    invalid_cases = [
+        '123.455',  # Exceeds max_digits (5 digits total)
+        '12.345',  # Too many decimal places (3 vs allowed 2)
+        '12.34',  # 11.00 exceeds le=10.0
+        '-1.23',  # Below ge=0.0
+    ]
+
+    for value in invalid_cases:
+        with pytest.raises(ValidationError):
+            ta.validate_json(f'"{value}"')
+
+    serialization_cases = {
+        Decimal('0'): '0',  # Zero case
+        Decimal('00.12'): '0.12',  # Leading zeros removed
+        Decimal('1.20'): '1.20',  # Trailing zeros preserved
+        Decimal('10.00'): '10.00',  # Maximum value
+    }
+
+    for input_value, expected in serialization_cases.items():
+        assert ta.dump_json(input_value).decode().strip('"') == expected
+
+
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -1063,12 +1093,7 @@ def test_special_decimal_types(field_type, expected_schema):
     base_schema = {
         'title': 'Model',
         'type': 'object',
-        'properties': {
-            'a': {
-                'anyOf': [{'type': 'number'}, {'type': 'string', 'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$'}],
-                'title': 'A',
-            }
-        },
+        'properties': {'a': {'anyOf': [{'type': 'number'}, {'type': 'string'}], 'title': 'A'}},
         'required': ['a'],
     }
     base_schema['properties']['a']['anyOf'][0].update(expected_schema)
@@ -2021,56 +2046,11 @@ def test_docstring(docstring, description):
         ({'ge': -math.inf}, float, {'type': 'number'}),
         ({'le': math.inf}, float, {'type': 'number'}),
         ({'multiple_of': 5}, float, {'type': 'number', 'multipleOf': 5}),
-        (
-            {'gt': 2},
-            Decimal,
-            {
-                'anyOf': [
-                    {'exclusiveMinimum': 2.0, 'type': 'number'},
-                    {'type': 'string', 'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$'},
-                ]
-            },
-        ),
-        (
-            {'lt': 5},
-            Decimal,
-            {
-                'anyOf': [
-                    {'type': 'number', 'exclusiveMaximum': 5},
-                    {'type': 'string', 'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$'},
-                ]
-            },
-        ),
-        (
-            {'ge': 2},
-            Decimal,
-            {
-                'anyOf': [
-                    {'type': 'number', 'minimum': 2},
-                    {'type': 'string', 'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$'},
-                ]
-            },
-        ),
-        (
-            {'le': 5},
-            Decimal,
-            {
-                'anyOf': [
-                    {'type': 'number', 'maximum': 5},
-                    {'type': 'string', 'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$'},
-                ]
-            },
-        ),
-        (
-            {'multiple_of': 5},
-            Decimal,
-            {
-                'anyOf': [
-                    {'type': 'number', 'multipleOf': 5},
-                    {'type': 'string', 'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$'},
-                ]
-            },
-        ),
+        ({'gt': 2}, Decimal, {'anyOf': [{'exclusiveMinimum': 2.0, 'type': 'number'}, {'type': 'string'}]}),
+        ({'lt': 5}, Decimal, {'anyOf': [{'type': 'number', 'exclusiveMaximum': 5}, {'type': 'string'}]}),
+        ({'ge': 2}, Decimal, {'anyOf': [{'type': 'number', 'minimum': 2}, {'type': 'string'}]}),
+        ({'le': 5}, Decimal, {'anyOf': [{'type': 'number', 'maximum': 5}, {'type': 'string'}]}),
+        ({'multiple_of': 5}, Decimal, {'anyOf': [{'type': 'number', 'multipleOf': 5}, {'type': 'string'}]}),
     ],
 )
 def test_constraints_schema_validation(kwargs, type_, expected_extra):
@@ -2109,11 +2089,11 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
         ({'ge': -math.inf}, float, {'type': 'number'}),
         ({'le': math.inf}, float, {'type': 'number'}),
         ({'multiple_of': 5}, float, {'type': 'number', 'multipleOf': 5}),
-        ({'gt': 2}, Decimal, {'type': 'string', 'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$'}),
-        ({'lt': 5}, Decimal, {'type': 'string', 'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$'}),
-        ({'ge': 2}, Decimal, {'type': 'string', 'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$'}),
-        ({'le': 5}, Decimal, {'type': 'string', 'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$'}),
-        ({'multiple_of': 5}, Decimal, {'type': 'string', 'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$'}),
+        ({'gt': 2}, Decimal, {'type': 'string'}),
+        ({'lt': 5}, Decimal, {'type': 'string'}),
+        ({'ge': 2}, Decimal, {'type': 'string'}),
+        ({'le': 5}, Decimal, {'type': 'string'}),
+        ({'multiple_of': 5}, Decimal, {'type': 'string'}),
     ],
 )
 def test_constraints_schema_serialization(kwargs, type_, expected_extra):
@@ -5745,10 +5725,8 @@ def test_generate_definitions_for_no_ref_schemas():
     )
     assert result == (
         {
-            ('Decimal', 'serialization'): {'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$', 'type': 'string'},
-            ('Decimal', 'validation'): {
-                'anyOf': [{'type': 'number'}, {'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,})?$', 'type': 'string'}]
-            },
+            ('Decimal', 'serialization'): {'type': 'string'},
+            ('Decimal', 'validation'): {'anyOf': [{'type': 'number'}, {'type': 'string'}]},
             ('Model', 'validation'): {'$ref': '#/$defs/Model'},
         },
         {'Model': {'properties': {}, 'title': 'Model', 'type': 'object'}},

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -931,6 +931,15 @@ def test_str_constrained_types(field_type, expected_schema):
     assert model_schema == base_schema
 
 
+def test_decimal_constraints():
+    constraints = {'max_digits': 5, 'decimal_places': 2, 'ge': 0.0, 'le': 10.0}
+    schema = TypeAdapter(Annotated[Decimal, Field(**constraints)]).json_schema()
+
+    assert 'pattern' in schema['anyOf'][1]
+    assert schema['anyOf'][0]['maximum'] == 10.0
+    assert schema['anyOf'][0]['minimum'] == 0.0
+
+
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2019,7 +2019,7 @@ def test_docstring(docstring, description):
                 'anyOf': [
                     {'type': 'number'},
                     {
-                        'pattern': '^-?0*(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)\\d{1,}(?:\\.\\d{0,})?$',
+                        'pattern': '^-?0*(?=\\d{0,4}0*$|(?=.*\\..*)[\\d\\.]{0,5}0*$)\\d{1,}(?:\\.\\d{0,})?0*$',
                         'type': 'string',
                     },
                 ]
@@ -2028,7 +2028,7 @@ def test_docstring(docstring, description):
         (
             {'decimal_places': 2},
             Decimal,
-            {'anyOf': [{'type': 'number'}, {'pattern': '^-?0*\\d{1,}(?:\\.\\d{0,2})?$', 'type': 'string'}]},
+            {'anyOf': [{'type': 'number'}, {'pattern': '^-?0*\\d{1,}(?:\\.\\d{0,2})?0*$', 'type': 'string'}]},
         ),
         (
             {'max_digits': 4, 'decimal_places': 2},
@@ -2037,7 +2037,7 @@ def test_docstring(docstring, description):
                 'anyOf': [
                     {'type': 'number'},
                     {
-                        'pattern': '^-?0*(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)\\d{1,2}(?:\\.\\d{0,2})?$',
+                        'pattern': '^-?0*\\d{1,2}(?:\\.\\d{0,2})?0*$',
                         'type': 'string',
                     },
                 ]
@@ -2099,7 +2099,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             {'max_digits': 4, 'decimal_places': 2},
             Decimal,
             {
-                'pattern': '^-?(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)(?:0|[1-9]\\d{0,1})(?:\\.\\d{0,2})?$',
+                'pattern': '^-?(?:0|[1-9]\\d{0,1})(?:\\.\\d{0,2})?$',
                 'type': 'string',
             },
         ),

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2018,7 +2018,10 @@ def test_docstring(docstring, description):
             {
                 'anyOf': [
                     {'type': 'number'},
-                    {'pattern': '^-?0*(?=\\d{0,4}$|[\\d\\.]{0,5}$)\\d{1,}(?:\\.\\d{0,})?$', 'type': 'string'},
+                    {
+                        'pattern': '^-?0*(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)\\d{1,}(?:\\.\\d{0,})?$',
+                        'type': 'string',
+                    },
                 ]
             },
         ),
@@ -2033,7 +2036,10 @@ def test_docstring(docstring, description):
             {
                 'anyOf': [
                     {'type': 'number'},
-                    {'pattern': '^-?0*(?=\\d{0,4}$|[\\d\\.]{0,5}$)\\d{1,2}(?:\\.\\d{0,2})?$', 'type': 'string'},
+                    {
+                        'pattern': '^-?0*(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)\\d{1,2}(?:\\.\\d{0,2})?$',
+                        'type': 'string',
+                    },
                 ]
             },
         ),
@@ -2083,13 +2089,19 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
         (
             {'max_digits': 4},
             Decimal,
-            {'pattern': '^-?(?=\\d{0,4}$|[\\d\\.]{0,5}$)(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$', 'type': 'string'},
+            {
+                'pattern': '^-?(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)(?:0|[1-9]\\d{0,})(?:\\.\\d{0,})?$',
+                'type': 'string',
+            },
         ),
         ({'decimal_places': 2}, Decimal, {'pattern': '^-?(?:0|[1-9]\\d{0,})(?:\\.\\d{0,2})?$', 'type': 'string'}),
         (
             {'max_digits': 4, 'decimal_places': 2},
             Decimal,
-            {'pattern': '^-?(?=\\d{0,4}$|[\\d\\.]{0,5}$)(?:0|[1-9]\\d{0,1})(?:\\.\\d{0,2})?$', 'type': 'string'},
+            {
+                'pattern': '^-?(?=\\d{0,4}$|(?=.*\\..*)[\\d\\.]{0,5}$)(?:0|[1-9]\\d{0,1})(?:\\.\\d{0,2})?$',
+                'type': 'string',
+            },
         ),
     ],
 )

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2018,14 +2018,14 @@ def test_docstring(docstring, description):
             {
                 'anyOf': [
                     {'type': 'number'},
-                    {'pattern': '^-?0*(?=\\d{0,4}$|[\\d\\.]{0,5}$)\\d{0,}(?:\\.\\d{0,})?$', 'type': 'string'},
+                    {'pattern': '^-?0*(?=\\d{0,4}$|[\\d\\.]{0,5}$)\\d{1,}(?:\\.\\d{0,})?$', 'type': 'string'},
                 ]
             },
         ),
         (
             {'decimal_places': 2},
             Decimal,
-            {'anyOf': [{'type': 'number'}, {'pattern': '^-?0*\\d{0,}(?:\\.\\d{0,2})?$', 'type': 'string'}]},
+            {'anyOf': [{'type': 'number'}, {'pattern': '^-?0*\\d{1,}(?:\\.\\d{0,2})?$', 'type': 'string'}]},
         ),
         (
             {'max_digits': 4, 'decimal_places': 2},
@@ -2033,7 +2033,7 @@ def test_docstring(docstring, description):
             {
                 'anyOf': [
                     {'type': 'number'},
-                    {'pattern': '^-?0*(?=\\d{0,4}$|[\\d\\.]{0,5}$)\\d{0,2}(?:\\.\\d{0,2})?$', 'type': 'string'},
+                    {'pattern': '^-?0*(?=\\d{0,4}$|[\\d\\.]{0,5}$)\\d{1,2}(?:\\.\\d{0,2})?$', 'type': 'string'},
                 ]
             },
         ),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR builds on and addresses remaining requirements from #11016

Based on the remaining requirements from the previous PR I have:

1. Updated the patterns and corresponding logic in json_schema.py. These should now handle the following cases for both validation and serialization:
	- **decimal_places and max_digits set:**  both decimal_places and integer_places enforced via a repetition quantifier, the total of the maximum of integer_places and decimal_places enforces max_digits
	- **decimal_places set and max_digits not set:** decimal_places enforced via a repetition quantifier, excludes the lookahead and leaves the upper bound of integer_places repetition quantifier blank
	- **decimal_places not set and max_digits set:** max_digits enforced via positive lookahead, integer_places and decimal_places repetition quantifier upper bound left blank
	
2. Removed the test that was added in the previous PR, and added a few more parametrize test cases for `test_constraints_schema_validation()` and `test_constraints_schema_serialization()` tests - ruff format split these out over quite a few lines due to their length

I've been able to reuse the patterns for all cases by using bracketed repetition quantifiers where we just leave the upper bound empty if it doesn't need to be enforced by `max_digits` or `decimal_places`. This does have a downside in that the output of json_schema() for the user will be slightly less succinct, using `{0,}` or `{1,}` in some places where `*` or `+` feels more natural. What this looks like can be seen in the new test cases, [example here](https://github.com/pydantic/pydantic/pull/11420/files#diff-cbcfeba88238560f75e880d530f4cd82ab6bf90247012e8f664281941f8da1f7R2022)

I also have a couple of questions:
- ~~Do we want to allow for trailing zeroes in validation and/or serialization?~~ Implemented for validation
- We currently match against something like `1.` as a valid Decimal, but wouldn't match against `.1` due to the pattern requiring at minimum one integer place.
    - Do we want to match against entries like `.1`? We can drop the requirement for a minimum of one integer place but then we'd match against `.` and empty entries - the best way to handle it might be a minimum digit requirement in the positive lookahead, where we don't care if its an integer or decimal, and then always include the lookahead.
    - Instead if we shouldn't be matching against entries like `1.` this should be an easy fix by requiring a minimum of one digit in the optional decimal place capture group

## Related issue number
fix #10867 

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [X] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle