### PR TITLE
Fix cached property not cleared on model copy

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1445,9 +1445,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         if exclude:
             fields_set -= set(exclude)
 
-        for attr in dir(self):
-            if isinstance(getattr(type(self), attr, None), cached_property):
-                values.pop(attr, None)
+        for attr in self._get_cached_properties():
+            values.pop(attr, None)
 
         return copy_internals._copy_and_set_values(self, values, fields_set, extra, private, deep=deep)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -388,6 +388,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             else:
                 copied.__dict__.update(update)
             copied.__pydantic_fields_set__.update(update.keys())
+
+        for attr in dir(copied):
+            if isinstance(getattr(type(copied), attr, None), cached_property):
+                copied.__dict__.pop(attr, None)
+
         return copied
 
     def model_dump(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1388,7 +1388,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         exclude: AbstractSetIntStr | MappingIntStrAny | None = None,
         update: Dict[str, Any] | None = None,  # noqa UP006
         deep: bool = False,
-        unset_cached_properties: bool = False,
     ) -> Self:  # pragma: no cover
         """Returns a copy of the model.
 
@@ -1408,7 +1407,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             exclude: Optional set or mapping specifying which fields to exclude in the copied model.
             update: Optional dictionary of field-value pairs to override field values in the copied model.
             deep: If True, the values of fields that are Pydantic models will be deep-copied.
-            unset_cached_properties: Set to `True` to unset cached properties.
 
         Returns:
             A copy of the model with included, excluded and updated fields as specified.
@@ -1452,10 +1450,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # removing excluded fields from `__pydantic_fields_set__`
         if exclude:
             fields_set -= set(exclude)
-
-        if unset_cached_properties:
-            for attr in self._get_cached_properties():
-                values.pop(attr, None)
 
         return copy_internals._copy_and_set_values(self, values, fields_set, extra, private, deep=deep)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2483,7 +2483,7 @@ def test_model_copy_cached_property():
             return self.x + 1
 
     m = Model(x=5)
-    updated_m = m.model_copy(update={'x': 123})
+    updated_m = m.model_copy(update={'x': 123}, unset_cached_properties=True)
     assert updated_m.bar == 124
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
-from functools import cache, partial
+from functools import cache, cached_property, partial
 from typing import (
     Annotated,
     Any,
@@ -2472,6 +2472,19 @@ def test_model_copy_extra():
     m5 = m.model_copy(update={'x': 4, 'b': 3})
     assert m5.model_dump() == {'x': 4, 'b': 3}
     assert m5.model_extra == {'b': 3}
+
+
+def test_model_copy_cached_property():
+    class Model(BaseModel):
+        x: int
+
+        @cached_property
+        def bar(self):
+            return self.x + 1
+
+    m = Model(x=5)
+    updated_m = m.model_copy(update={'x': 123})
+    assert updated_m.bar == 124
 
 
 def test_model_parametrized_name_not_generic():


### PR DESCRIPTION
## Change Summary

Now when you do `model_copy` on a `BaseModel`, if you have cached properties, they are unset and therefor will return the correct value

## Related issue number

fix #11428 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle