### PR TITLE
Allow cached properties to be altered on frozen models

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
-from functools import cache, partial
+from functools import cache, cached_property, partial
 from typing import (
     Annotated,
     Any,
@@ -544,6 +544,25 @@ def test_frozen_model():
     ]
 
     assert m.a == 10
+
+
+def test_frozen_model_cached_property():
+    class FrozenModel(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        a: int
+
+        @cached_property
+        def test(self) -> int:
+            return self.a + 1
+
+    m = FrozenModel(a=1)
+
+    assert m.test == 2
+    # This shouldn't raise:
+    del m.test
+    m.test = 3
+    assert m.test == 3
 
 
 def test_frozen_field():


### PR DESCRIPTION
Also clarify documentation of `model_copy()`.

Fixes https://github.com/pydantic/pydantic/issues/11428, closes https://github.com/pydantic/pydantic/pull/11431.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
