### PR TITLE
Reuse cached core schemas for parametrized generic Pydantic models

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -711,14 +711,7 @@ class GenerateSchema:
                 return maybe_schema
 
             schema = cls.__dict__.get('__pydantic_core_schema__')
-            if (
-                schema is not None
-                and not isinstance(schema, MockCoreSchema)
-                # Due to the way generic classes are built, it's possible that an invalid schema may be temporarily
-                # set on generic classes. Probably we could resolve this to ensure that we get proper schema caching
-                # for generics, but for simplicity for now, we just always rebuild if the class has a generic origin:
-                and not cls.__pydantic_generic_metadata__['origin']
-            ):
+            if schema is not None and not isinstance(schema, MockCoreSchema):
                 if schema['type'] == 'definitions':
                     schema = self.defs.unpack_definitions(schema)
                 ref = get_ref(schema)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -731,8 +731,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         # Logic copied over from `GenerateSchema._model_schema`:
         schema = cls.__dict__.get('__pydantic_core_schema__')
         if schema is not None and not isinstance(schema, _mock_val_ser.MockCoreSchema):
-            if not cls.__pydantic_generic_metadata__['origin']:
-                return cls.__pydantic_core_schema__
+            return cls.__pydantic_core_schema__
 
         return handler(source)
 


### PR DESCRIPTION
## Change Summary

Speeds up generics initialization significantly in the codspeed benchmark (+67.4%).

## Related issue number

Many of the model init slowness related issues eg.  https://github.com/pydantic/pydantic/issues/6768

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**