### PR TITLE
fix: Fix conditional check for validators in schema generation

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -873,7 +873,7 @@ class GenerateSchema:
             # safety measure (because these are inlined in place -- i.e. mutated directly)
             return schema
 
-        if (validators := getattr(obj, '__get_validators__', None)) is not None:
+        if get_schema is None and (validators := getattr(obj, '__get_validators__', None)) is not None:
             from pydantic.v1 import BaseModel as BaseModelV1
 
             if issubclass(obj, BaseModelV1):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->


## Related issue number

fixes #11443 by not checking for the existence of `__get_validators__` on classes where `__get_pydantic_core_schema__` is also defined

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
