### PR TITLE
Run Beanie third-party tests on a single Python version

### DIFF
--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -128,7 +128,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13' ]
+        # Testing on a single version to avoid reaching Docker API limits:
+        python-version: ['3.13']
     steps:
     - name: Checkout Beanie
       uses: actions/checkout@v4


### PR DESCRIPTION
Otherwise we reach Docker API limits when pulling MongoDB.

Fixes https://github.com/pydantic/pydantic/issues/11501.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
