### PR TITLE
Implicitly set `validate_by_name` to `True` when `validate_by_alias` is `False`

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -182,6 +182,11 @@ class ConfigWrapper:
                 config['validate_by_alias'] = True
                 config['validate_by_name'] = populate_by_name
 
+        # We dynamically patch validate_by_name to be True if validate_by_alias is set to False
+        # and validate_by_name is not explicitly set.
+        if config.get('validate_by_alias') is False and config.get('validate_by_name') is None:
+            config['validate_by_name'] = True
+
         if (not config.get('validate_by_alias', True)) and (not config.get('validate_by_name', False)):
             raise PydanticUserError(
                 'At least one of `validate_by_alias` or `validate_by_name` must be set to True.',

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1042,7 +1042,8 @@ class ConfigDict(TypedDict, total=False):
         to empower users with more fine grained validation control. In <v2.11, disabling validation by alias was not possible.
 
     !!! tip
-        If you set `validate_by_alias` to `False`, you should set `validate_by_name` to `True` to ensure that the field can still be populated.
+        If you set `validate_by_alias` to `False`, under the hood, Pydantic dynamically sets
+        `validate_by_name` to `True` to ensure that validation can still occur.
 
     Here's an example of disabling validation by alias:
 
@@ -1105,9 +1106,6 @@ class ConfigDict(TypedDict, total=False):
     !!! warning
         You cannot set both `validate_by_alias` and `validate_by_name` to `False`.
         This would make it impossible to populate an attribute.
-
-        This also means you can't set `validate_by_alias` to `False` and leave `validate_by_name` unset,
-        as `validate_by_name` defaults to `False`.
 
         See [usage errors](../errors/usage_errors.md#validate-by-alias-and-name-false) for an example.
     """

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1041,10 +1041,6 @@ class ConfigDict(TypedDict, total=False):
         In v2.11, `validate_by_alias` was introduced in conjunction with [`validate_by_name`][pydantic.ConfigDict.validate_by_name]
         to empower users with more fine grained validation control. In <v2.11, disabling validation by alias was not possible.
 
-    !!! tip
-        If you set `validate_by_alias` to `False`, under the hood, Pydantic dynamically sets
-        `validate_by_name` to `True` to ensure that validation can still occur.
-
     Here's an example of disabling validation by alias:
 
     ```py
@@ -1068,6 +1064,9 @@ class ConfigDict(TypedDict, total=False):
         This would make it impossible to populate an attribute.
 
         See [usage errors](../errors/usage_errors.md#validate-by-alias-and-name-false) for an example.
+
+        If you set `validate_by_alias` to `False`, under the hood, Pydantic dynamically sets
+        `validate_by_name` to `True` to ensure that validation can still occur.
     """
 
     validate_by_name: bool

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -963,3 +963,10 @@ def test_user_error_on_alias_settings() -> None:
 
         class Model(BaseModel):
             model_config = ConfigDict(validate_by_alias=False, validate_by_name=False)
+
+
+def test_dynamic_default() -> None:
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_by_alias=False)
+
+    assert Model.model_config == {'validate_by_alias': False, 'validate_by_name': True}


### PR DESCRIPTION
If `validate_by_alias` is manually set to `False` and `validate_by_name` is unset, we set `validate_by_name` to `True`.