### PR TITLE
New API for date-like types unit/format configuration

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -69,6 +69,8 @@ class ConfigWrapper:
     # whether instances of models and dataclasses (including subclass instances) should re-validate, default 'never'
     revalidate_instances: Literal['always', 'never', 'subclass-instances']
     ser_json_timedelta: Literal['iso8601', 'float']
+    ser_json_temporal: Literal['iso8601', 'seconds', 'milliseconds']
+    val_temporal_unit: Literal['seconds', 'milliseconds', 'infer']
     ser_json_bytes: Literal['utf8', 'base64', 'hex']
     val_json_bytes: Literal['utf8', 'base64', 'hex']
     ser_json_inf_nan: Literal['null', 'constants', 'strings']
@@ -90,10 +92,6 @@ class ConfigWrapper:
     validate_by_alias: bool
     validate_by_name: bool
     serialize_by_alias: bool
-    val_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
-    ser_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
-    val_json_datetime: tuple[Literal['iso8601', 'float', 'int'], ...]
-    ser_json_datetime: Literal['iso8601', 'float', 'int']
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -197,10 +195,6 @@ class ConfigWrapper:
                 code='validate-by-alias-and-name-false',
             )
 
-        # ser_json_timedelta will be deprecated in V3, so we patch the value to ser_json_datetime if set.
-        if (ser_json_timedelta := config.get('ser_json_timedelta')) is not None:
-            config['ser_json_datetime'] = ser_json_timedelta
-
         return core_schema.CoreConfig(
             **{  # pyright: ignore[reportArgumentType]
                 k: v
@@ -212,13 +206,12 @@ class ConfigWrapper:
                     ('str_to_lower', config.get('str_to_lower')),
                     ('str_to_upper', config.get('str_to_upper')),
                     ('strict', config.get('strict')),
+                    ('ser_json_timedelta', config.get('ser_json_timedelta')),
+                    ('ser_json_temporal', config.get('ser_json_temporal')),
+                    ('val_temporal_unit', config.get('val_temporal_unit')),
                     ('ser_json_bytes', config.get('ser_json_bytes')),
                     ('val_json_bytes', config.get('val_json_bytes')),
                     ('ser_json_inf_nan', config.get('ser_json_inf_nan')),
-                    ('val_datetime_unit', config.get('val_datetime_unit')),
-                    ('ser_datetime_unit', config.get('ser_datetime_unit')),
-                    ('val_json_datetime', config.get('val_json_datetime')),
-                    ('ser_json_datetime', config.get('ser_json_datetime')),
                     ('from_attributes', config.get('from_attributes')),
                     ('loc_by_alias', config.get('loc_by_alias')),
                     ('revalidate_instances', config.get('revalidate_instances')),
@@ -293,12 +286,11 @@ config_defaults = ConfigDict(
     json_schema_extra=None,
     strict=False,
     revalidate_instances='never',
+    ser_json_timedelta='iso8601',
+    ser_json_temporal='iso8601',
+    val_temporal_unit='infer',
     ser_json_bytes='utf8',
     val_json_bytes='utf8',
-    val_datetime_unit='infer',
-    ser_datetime_unit='infer',
-    val_json_datetime=('iso8601', 'float', 'int'),
-    ser_json_datetime='iso8601',
     ser_json_inf_nan='null',
     validate_default=False,
     validate_return=False,

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -90,6 +90,10 @@ class ConfigWrapper:
     validate_by_alias: bool
     validate_by_name: bool
     serialize_by_alias: bool
+    val_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
+    ser_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
+    val_json_datetime: tuple[Literal['iso8601', 'float', 'int'], ...]
+    ser_json_datetime: Literal['iso8601', 'float', 'int']
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -193,6 +197,10 @@ class ConfigWrapper:
                 code='validate-by-alias-and-name-false',
             )
 
+        # ser_json_timedelta will be deprecated in V3, so we patch the value to ser_json_datetime if set.
+        if (ser_json_timedelta := config.get('ser_json_timedelta')) is not None:
+            config['ser_json_datetime'] = ser_json_timedelta
+
         return core_schema.CoreConfig(
             **{  # pyright: ignore[reportArgumentType]
                 k: v
@@ -204,10 +212,13 @@ class ConfigWrapper:
                     ('str_to_lower', config.get('str_to_lower')),
                     ('str_to_upper', config.get('str_to_upper')),
                     ('strict', config.get('strict')),
-                    ('ser_json_timedelta', config.get('ser_json_timedelta')),
                     ('ser_json_bytes', config.get('ser_json_bytes')),
                     ('val_json_bytes', config.get('val_json_bytes')),
                     ('ser_json_inf_nan', config.get('ser_json_inf_nan')),
+                    ('val_datetime_unit', config.get('val_datetime_unit')),
+                    ('ser_datetime_unit', config.get('ser_datetime_unit')),
+                    ('val_json_datetime', config.get('val_json_datetime')),
+                    ('ser_json_datetime', config.get('ser_json_datetime')),
                     ('from_attributes', config.get('from_attributes')),
                     ('loc_by_alias', config.get('loc_by_alias')),
                     ('revalidate_instances', config.get('revalidate_instances')),
@@ -282,9 +293,12 @@ config_defaults = ConfigDict(
     json_schema_extra=None,
     strict=False,
     revalidate_instances='never',
-    ser_json_timedelta='iso8601',
     ser_json_bytes='utf8',
     val_json_bytes='utf8',
+    val_datetime_unit='infer',
+    ser_datetime_unit='infer',
+    val_json_datetime=('iso8601', 'float', 'int'),
+    ser_json_datetime='iso8601',
     ser_json_inf_nan='null',
     validate_default=False,
     validate_return=False,

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -596,11 +596,32 @@ class ConfigDict(TypedDict, total=False):
         In v2.11+ it is recommended to use the [`ser_json_datetime`][pydantic.config.ConfigDict.ser_json_datetime]
         setting instead of `ser_json_timedelta`. This setting will be deprecated in v3.
 
-    - `'iso8601'` will serialize timedeltas to [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+    - `'iso8601'` will serialize timedeltas to [ISO 8601 text format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
     - `'float'` will serialize timedeltas to the total number of seconds.
     """
 
-    val_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
+    ser_json_temporal: Literal['iso8601', 'milliseconds', 'seconds']
+    """
+    The format of JSON serialized temporal types from the `datetime` library. This includes:
+
+    - [`datetime.datetime`][]
+    - [`datetime.date`][]
+    - [`datetime.time`][]
+    - [`datetime.timedelta`][]
+
+    !!! note
+        This setting was introduced in v2.11. It overlaps with the `ser_json_timedelta`
+        setting which will likely be deprecated in v3. It also adds more configurability for
+        the other temporal types.
+
+    Accepts the string values of `'iso8601'`, `'milliseconds'`, and `'seconds'`. Defaults to `'iso8601'`.
+
+    - `'iso8601'` will serialize date-like types to [ISO 8601 text format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+    - `'milliseconds'` will serialize date-like types to a floating point number of milliseconds since the epoch.
+    - `'seconds'` will serialize date-like types to a floating point number of seconds since the epoch.
+    """
+
+    val_temporal_unit: Literal['seconds', 'milliseconds', 'infer']
     """
     The unit to assume for validating numeric input for datetime-like types. This includes:
 
@@ -610,70 +631,12 @@ class ConfigDict(TypedDict, total=False):
     - [`datetime.timedelta`][]
 
     Defaults to `'infer'`.
-    The "epoch" reference below refers to the Unix epoch, which is 1970-01-01 00:00:00 UTC.
+    The "epoch" references below refer to the Unix epoch, which is 1970-01-01 00:00:00 UTC.
 
     - `'seconds'` will validate date or time numeric inputs as seconds since the epoch.
     - `'milliseconds'` will validate date or time numeric inputs as milliseconds since the epoch.
     - `'infer'` will infer the unit from the string numeric input on unix time:
-        i.e. seconds (if >= -2e10 and <= 2e10) or milliseconds (if < -2e10or > 2e10) since the epoch.
-    """
-
-    ser_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
-    """
-    The unit to use for serializing datetime-like types. This includes:
-
-    - [`datetime.datetime`][]
-    - [`datetime.date`][]
-    - [`datetime.time`][]
-    - [`datetime.timedelta`][]
-
-    This only applies when serializing to `'float'`. ISO8601 durations use a predefined format.
-    Defaults to `'infer'`.
-    The "epoch" reference below refers to the Unix epoch, which is 1970-01-01 00:00:00 UTC.
-
-    - `'seconds'` will validate date or time numeric inputs as seconds since the epoch.
-    - `'milliseconds'` will validate date or time numeric inputs as milliseconds since the epoch.
-    - `'infer'` will infer the unit from the string numeric input on unix time:
-        i.e. seconds (if >= -2e10 and <= 2e10) or milliseconds (if < -2e10or > 2e10) since the epoch.
-    """
-
-    val_json_datetime: tuple[Literal['iso8601', 'float', 'int'], ...]
-    """
-    The formats to accept when validating datetime-like types from JSON. This includes:
-
-    - [`datetime.datetime`][]
-    - [`datetime.date`][]
-    - [`datetime.time`][]
-    - [`datetime.timedelta`][]
-
-    Defaults to ('iso8601', 'float', 'int').
-    If `'float'` or `'int'` is included, `val_datetime_unit` can be used to specify the unit (s vs ms) of the float.
-
-    - `'iso8601'` will accept date-like types in [ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
-    - `'float'` will accept date-like types as a floating point number of seconds or milliseconds since the epoch.
-    - `'int'` will accept date-like types as an integer number of seconds or milliseconds since the epoch.
-    """
-
-    ser_json_datetime: Literal['iso8601', 'float', 'int']
-    """
-    The format of JSON serialized datetime-like types. This includes:
-
-    - [`datetime.datetime`][]
-    - [`datetime.date`][]
-    - [`datetime.time`][]
-    - [`datetime.timedelta`][]
-
-    !!! note
-        This setting was introduced in v2.11. It effectively replaces the `ser_json_timedelta`
-        setting which will be deprecated in v3. It also adds more configurability for
-        the other datetime-like types.
-
-    Accepts the string values of `'iso8601'` and `'float'`. Defaults to `'iso8601'`.
-    When `'float'` or `'int'` is used, `ser_datetime_unit` can be used to determine the unit (s vs ms) of the float.
-
-    - `'iso8601'` will serialize date-like types to [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).
-    - `'float'` will serialize date-like types to a floating point number of seconds or milliseconds since the epoch.
-    - `'int'` will serialize date-like types to an integer number of seconds or milliseconds since the epoch.
+        i.e. seconds (if >= -2^10 and <= 2^10) or milliseconds (if < -2^10or > 2^10) since the epoch.
     """
 
     ser_json_bytes: Literal['utf8', 'base64', 'hex']

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -592,8 +592,88 @@ class ConfigDict(TypedDict, total=False):
     The format of JSON serialized timedeltas. Accepts the string values of `'iso8601'` and
     `'float'`. Defaults to `'iso8601'`.
 
-    - `'iso8601'` will serialize timedeltas to ISO 8601 durations.
+    !!! warning
+        In v2.11+ it is recommended to use the [`ser_json_datetime`][pydantic.config.ConfigDict.ser_json_datetime]
+        setting instead of `ser_json_timedelta`. This setting will be deprecated in v3.
+
+    - `'iso8601'` will serialize timedeltas to [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).
     - `'float'` will serialize timedeltas to the total number of seconds.
+    """
+
+    val_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
+    """
+    The unit to assume for validating numeric input for datetime-like types. This includes:
+
+    - [`datetime.datetime`][]
+    - [`datetime.date`][]
+    - [`datetime.time`][]
+    - [`datetime.timedelta`][]
+
+    Defaults to `'infer'`.
+    The "epoch" reference below refers to the Unix epoch, which is 1970-01-01 00:00:00 UTC.
+
+    - `'seconds'` will validate date or time numeric inputs as seconds since the epoch.
+    - `'milliseconds'` will validate date or time numeric inputs as milliseconds since the epoch.
+    - `'infer'` will infer the unit from the string numeric input on unix time:
+        i.e. seconds (if >= -2e10 and <= 2e10) or milliseconds (if < -2e10or > 2e10) since the epoch.
+    """
+
+    ser_datetime_unit: Literal['seconds', 'milliseconds', 'infer']
+    """
+    The unit to use for serializing datetime-like types. This includes:
+
+    - [`datetime.datetime`][]
+    - [`datetime.date`][]
+    - [`datetime.time`][]
+    - [`datetime.timedelta`][]
+
+    This only applies when serializing to `'float'`. ISO8601 durations use a predefined format.
+    Defaults to `'infer'`.
+    The "epoch" reference below refers to the Unix epoch, which is 1970-01-01 00:00:00 UTC.
+
+    - `'seconds'` will validate date or time numeric inputs as seconds since the epoch.
+    - `'milliseconds'` will validate date or time numeric inputs as milliseconds since the epoch.
+    - `'infer'` will infer the unit from the string numeric input on unix time:
+        i.e. seconds (if >= -2e10 and <= 2e10) or milliseconds (if < -2e10or > 2e10) since the epoch.
+    """
+
+    val_json_datetime: tuple[Literal['iso8601', 'float', 'int'], ...]
+    """
+    The formats to accept when validating datetime-like types from JSON. This includes:
+
+    - [`datetime.datetime`][]
+    - [`datetime.date`][]
+    - [`datetime.time`][]
+    - [`datetime.timedelta`][]
+
+    Defaults to ('iso8601', 'float', 'int').
+    If `'float'` or `'int'` is included, `val_datetime_unit` can be used to specify the unit (s vs ms) of the float.
+
+    - `'iso8601'` will accept date-like types in [ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+    - `'float'` will accept date-like types as a floating point number of seconds or milliseconds since the epoch.
+    - `'int'` will accept date-like types as an integer number of seconds or milliseconds since the epoch.
+    """
+
+    ser_json_datetime: Literal['iso8601', 'float', 'int']
+    """
+    The format of JSON serialized datetime-like types. This includes:
+
+    - [`datetime.datetime`][]
+    - [`datetime.date`][]
+    - [`datetime.time`][]
+    - [`datetime.timedelta`][]
+
+    !!! note
+        This setting was introduced in v2.11. It effectively replaces the `ser_json_timedelta`
+        setting which will be deprecated in v3. It also adds more configurability for
+        the other datetime-like types.
+
+    Accepts the string values of `'iso8601'` and `'float'`. Defaults to `'iso8601'`.
+    When `'float'` or `'int'` is used, `ser_datetime_unit` can be used to determine the unit (s vs ms) of the float.
+
+    - `'iso8601'` will serialize date-like types to [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+    - `'float'` will serialize date-like types to a floating point number of seconds or milliseconds since the epoch.
+    - `'int'` will serialize date-like types to an integer number of seconds or milliseconds since the epoch.
     """
 
     ser_json_bytes: Literal['utf8', 'base64', 'hex']


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/10454
Fixes https://github.com/pydantic/pydantic/issues/7940

Previously outlined this API in https://github.com/pydantic/pydantic/pull/10949, but continuing here with a clean history.