### PR TITLE
include user's call stack in warnings

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -320,7 +320,11 @@ def prepare_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> Co
         return ConfigDict()
 
     if not isinstance(config, dict):
-        warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
+        warnings.warn(
+            DEPRECATION_MESSAGE,
+            DeprecationWarning,
+            stacklevel=2,
+        )
         config = {k: getattr(config, k) for k in dir(config) if not k.startswith('__')}
 
     config_dict = cast(ConfigDict, config)
@@ -370,4 +374,8 @@ def check_deprecated(config_dict: ConfigDict) -> None:
         renamed_bullets = [f'* {k!r} has been renamed to {v!r}' for k, v in renamings.items()]
         removed_bullets = [f'* {k!r} has been removed' for k in sorted(deprecated_removed_keys)]
         message = '\n'.join(['Valid config keys have changed in V2:'] + renamed_bullets + removed_bullets)
-        warnings.warn(message, UserWarning)
+        warnings.warn(
+            message,
+            UserWarning,
+            stacklevel=2,
+        )

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -514,6 +514,7 @@ class FieldInfo(_repr.Representation):
                             'The `callable` type is being ignored.'
                             "If you'd like support for this behavior, please open an issue on pydantic.",
                             PydanticJsonSchemaWarning,
+                            stacklevel=2,
                         )
                 elif callable(json_schema_extra):
                     # if ever there's a case of a callable, we'll just keep the last json schema extra spec
@@ -1042,13 +1043,17 @@ def Field(  # noqa: C901
 
     min_items = extra.pop('min_items', None)  # type: ignore
     if min_items is not None:
-        warn('`min_items` is deprecated and will be removed, use `min_length` instead', DeprecationWarning)
+        warn(
+            '`min_items` is deprecated and will be removed, use `min_length` instead', DeprecationWarning, stacklevel=2
+        )
         if min_length in (None, _Unset):
             min_length = min_items  # type: ignore
 
     max_items = extra.pop('max_items', None)  # type: ignore
     if max_items is not None:
-        warn('`max_items` is deprecated and will be removed, use `max_length` instead', DeprecationWarning)
+        warn(
+            '`max_items` is deprecated and will be removed, use `max_length` instead', DeprecationWarning, stacklevel=2
+        )
         if max_length in (None, _Unset):
             max_length = max_items  # type: ignore
 
@@ -1064,7 +1069,9 @@ def Field(  # noqa: C901
 
     allow_mutation = extra.pop('allow_mutation', None)  # type: ignore
     if allow_mutation is not None:
-        warn('`allow_mutation` is deprecated and will be removed. use `frozen` instead', DeprecationWarning)
+        warn(
+            '`allow_mutation` is deprecated and will be removed. use `frozen` instead', DeprecationWarning, stacklevel=2
+        )
         if allow_mutation is False:
             frozen = True
 
@@ -1078,6 +1085,7 @@ def Field(  # noqa: C901
             ' Use `json_schema_extra` instead.'
             f' (Extra keys: {", ".join(k.__repr__() for k in extra.keys())})',
             DeprecationWarning,
+            stacklevel=2,
         )
         if not json_schema_extra or json_schema_extra is _Unset:
             json_schema_extra = extra  # type: ignore
@@ -1097,7 +1105,11 @@ def Field(  # noqa: C901
 
     include = extra.pop('include', None)  # type: ignore
     if include is not None:
-        warn('`include` is deprecated and does nothing. It will be removed, use `exclude` instead', DeprecationWarning)
+        warn(
+            '`include` is deprecated and does nothing. It will be removed, use `exclude` instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     return FieldInfo.from_field(
         default,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add stack trace to fields.py and _internal/_config.py warnings so that users know which part of the code are actually generating that warning.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle