### PR TITLE
Add `generate_arguments_schema()` function

### DIFF
--- a/docs/api/experimental.md
+++ b/docs/api/experimental.md
@@ -1,4 +1,14 @@
+# Pipeline API
+
 ::: pydantic.experimental.pipeline
     options:
         members:
             - _Pipeline
+
+# Arguments schema API
+
+::: pydantic.experimental.arguments_schema
+    options:
+        members:
+            - SKIP
+            - generate_arguments_schema

--- a/docs/api/experimental.md
+++ b/docs/api/experimental.md
@@ -10,5 +10,4 @@
 ::: pydantic.experimental.arguments_schema
     options:
         members:
-            - SKIP
             - generate_arguments_schema

--- a/docs/concepts/experimental.md
+++ b/docs/concepts/experimental.md
@@ -473,10 +473,7 @@ from typing import Any
 
 from pydantic_core import SchemaValidator
 
-from pydantic.experimental.arguments_schema import (
-    SKIP,
-    generate_arguments_schema,
-)
+from pydantic.experimental.arguments_schema import generate_arguments_schema
 
 
 def func(p: bool, *args: str, **kwargs: int) -> None: ...
@@ -484,7 +481,7 @@ def func(p: bool, *args: str, **kwargs: int) -> None: ...
 
 def skip_first_parameter(index: int, name: str, annotation: Any) -> Any:
     if index == 0:
-        return SKIP
+        return 'skip'
 
 
 arguments_schema = generate_arguments_schema(

--- a/pydantic/_internal/_schema_gather.py
+++ b/pydantic/_internal/_schema_gather.py
@@ -152,6 +152,9 @@ def traverse_schema(schema: AllSchemas, context: GatherContext) -> None:
             traverse_schema(schema['var_args_schema'], context)
         if 'var_kwargs_schema' in schema:
             traverse_schema(schema['var_kwargs_schema'], context)
+    elif schema_type == 'arguments-v3':
+        for s in schema['arguments_schema']:
+            traverse_schema(s['schema'], context)
     elif schema_type == 'call':
         traverse_schema(schema['arguments_schema'], context)
         if 'return_schema' in schema:

--- a/pydantic/experimental/arguments_schema.py
+++ b/pydantic/experimental/arguments_schema.py
@@ -10,9 +10,6 @@ from pydantic_core import CoreSchema
 from pydantic import ConfigDict
 from pydantic._internal import _config, _generate_schema, _namespace_utils
 
-SKIP = object()
-"""A sentinel object to skip a parameter in the schema generation."""
-
 
 def generate_arguments_schema(
     func: Callable[..., Any],
@@ -28,8 +25,8 @@ def generate_arguments_schema(
         parameters_callback: A callable that will be invoked for each parameter. The callback
             should take three required arguments: the index, the name and the type annotation
             (or [`Parameter.empty`][inspect.Parameter.empty] if not annotated) of the parameter.
-            The callback can optionally return the [`SKIP`][pydantic.experimental.arguments_schema.SKIP]
-            sentinel, so that the parameter gets excluded from the resulting schema.
+            The callback can optionally return `'skip'`, so that the parameter gets excluded
+            from the resulting schema.
         config: The configuration to use.
 
     Returns:

--- a/pydantic/experimental/arguments_schema.py
+++ b/pydantic/experimental/arguments_schema.py
@@ -1,0 +1,47 @@
+"""Experimental module exposing a function to generate a core schema that validates callable arguments."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal
+
+from pydantic_core import CoreSchema
+
+from pydantic import ConfigDict
+from pydantic._internal import _config, _generate_schema, _namespace_utils
+
+SKIP = object()
+"""A sentinel object to skip a parameter in the schema generation."""
+
+
+def generate_arguments_schema(
+    func: Callable[..., Any],
+    schema_type: Literal['arguments', 'arguments-v3'] = 'arguments-v3',
+    parameters_callback: Callable[[int, str, Any], Any] | None = None,
+    config: ConfigDict | None = None,
+) -> CoreSchema:
+    """Generate the schema for the arguments of a function.
+
+    Args:
+        func: The function to generate the schema for.
+        schema_type: The type of schema to generate.
+        parameters_callback: A callable that will be invoked for each parameter. The callback
+            should take three required arguments: the index, the name and the type annotation
+            (or [`Parameter.empty`][inspect.Parameter.empty] if not annotated) of the parameter.
+            The callback can optionally return the [`SKIP`][pydantic.experimental.arguments_schema.SKIP]
+            sentinel, so that the parameter gets excluded from the resulting schema.
+        config: The configuration to use.
+
+    Returns:
+        The generated schema.
+    """
+    generate_schema = _generate_schema.GenerateSchema(
+        _config.ConfigWrapper(config),
+        ns_resolver=_namespace_utils.NsResolver(namespaces_tuple=_namespace_utils.ns_for_function(func)),
+    )
+
+    if schema_type == 'arguments':
+        schema = generate_schema._arguments_schema(func, parameters_callback)  # pyright: ignore[reportArgumentType]
+    else:
+        schema = generate_schema._arguments_v3_schema(func, parameters_callback)  # pyright: ignore[reportArgumentType]
+    return generate_schema.clean_schema(schema)

--- a/pydantic/experimental/arguments_schema.py
+++ b/pydantic/experimental/arguments_schema.py
@@ -14,7 +14,7 @@ from pydantic._internal import _config, _generate_schema, _namespace_utils
 def generate_arguments_schema(
     func: Callable[..., Any],
     schema_type: Literal['arguments', 'arguments-v3'] = 'arguments-v3',
-    parameters_callback: Callable[[int, str, Any], Any] | None = None,
+    parameters_callback: Callable[[int, str, Any], Literal['skip'] | None] | None = None,
     config: ConfigDict | None = None,
 ) -> CoreSchema:
     """Generate the schema for the arguments of a function.

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -5,11 +5,9 @@ from __future__ import annotations as _annotations
 import inspect
 from functools import partial
 from types import BuiltinFunctionType
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast, overload
 
-from pydantic_core.core_schema import ArgumentsSchema, ArgumentsV3Schema
-
-from ._internal import _config, _generate_schema, _typing_extra, _validate_call
+from ._internal import _generate_schema, _typing_extra, _validate_call
 from .errors import PydanticUserError
 
 __all__ = ('validate_call',)
@@ -116,52 +114,3 @@ def validate_call(
         return validate(func)
     else:
         return validate
-
-
-
-SKIP = object()
-"""A sentinel object to skip a parameter in the schema generation."""
-
-
-@overload
-def generate_arguments_schema(
-    func: Callable[..., Any],
-    schema_type: Literal['arguments-v3'],
-    parameters_callback: Callable[[int, str, Any], Any] | None = None,
-    config: ConfigDict | None = None,
-) -> ArgumentsV3Schema: ...
-
-
-@overload
-def generate_arguments_schema(
-    func: Callable[..., Any],
-    schema_type: Literal['arguments'] = 'arguments',
-    parameters_callback: Callable[[int, str, Any], Any] | None = None,
-    config: ConfigDict | None = None,
-) -> ArgumentsSchema: ...
-
-
-def generate_arguments_schema(
-    func: Callable[..., Any],
-    schema_type: Literal['arguments', 'arguments-v3'] = 'arguments',
-    parameters_callback: Callable[[int, str, Any], Any] | None = None,
-    config: ConfigDict | None = None,
-) -> ArgumentsSchema | ArgumentsV3Schema:
-    """Generate the schema for the arguments of a function.
-
-    Args:
-        func: The function to generate the schema for.
-        schema_type: The type of schema to generate.
-        parameters_callback: A callable that will be invoked for each parameter.
-            If the return value is SKIP, the parameter will be skipped.
-        config: The configuration to use.
-
-    Returns:
-        The generated schema.
-    """
-    generate_schema = _generate_schema.GenerateSchema(_config.ConfigWrapper(config))
-
-    if schema_type == 'arguments':
-        return generate_schema._arguments_schema(func, parameters_callback)  # pyright: ignore[reportArgumentType]
-    else:
-        return generate_schema._arguments_v3_schema(func, parameters_callback)  # pyright: ignore[reportArgumentType]

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -5,9 +5,11 @@ from __future__ import annotations as _annotations
 import inspect
 from functools import partial
 from types import BuiltinFunctionType
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar, cast, overload
 
-from ._internal import _generate_schema, _typing_extra, _validate_call
+from pydantic_core.core_schema import ArgumentsSchema, ArgumentsV3Schema
+
+from ._internal import _config, _generate_schema, _typing_extra, _validate_call
 from .errors import PydanticUserError
 
 __all__ = ('validate_call',)
@@ -114,3 +116,52 @@ def validate_call(
         return validate(func)
     else:
         return validate
+
+
+
+SKIP = object()
+"""A sentinel object to skip a parameter in the schema generation."""
+
+
+@overload
+def generate_arguments_schema(
+    func: Callable[..., Any],
+    schema_type: Literal['arguments-v3'],
+    parameters_callback: Callable[[int, str, Any], Any] | None = None,
+    config: ConfigDict | None = None,
+) -> ArgumentsV3Schema: ...
+
+
+@overload
+def generate_arguments_schema(
+    func: Callable[..., Any],
+    schema_type: Literal['arguments'] = 'arguments',
+    parameters_callback: Callable[[int, str, Any], Any] | None = None,
+    config: ConfigDict | None = None,
+) -> ArgumentsSchema: ...
+
+
+def generate_arguments_schema(
+    func: Callable[..., Any],
+    schema_type: Literal['arguments', 'arguments-v3'] = 'arguments',
+    parameters_callback: Callable[[int, str, Any], Any] | None = None,
+    config: ConfigDict | None = None,
+) -> ArgumentsSchema | ArgumentsV3Schema:
+    """Generate the schema for the arguments of a function.
+
+    Args:
+        func: The function to generate the schema for.
+        schema_type: The type of schema to generate.
+        parameters_callback: A callable that will be invoked for each parameter.
+            If the return value is SKIP, the parameter will be skipped.
+        config: The configuration to use.
+
+    Returns:
+        The generated schema.
+    """
+    generate_schema = _generate_schema.GenerateSchema(_config.ConfigWrapper(config))
+
+    if schema_type == 'arguments':
+        return generate_schema._arguments_schema(func, parameters_callback)  # pyright: ignore[reportArgumentType]
+    else:
+        return generate_schema._arguments_v3_schema(func, parameters_callback)  # pyright: ignore[reportArgumentType]

--- a/tests/test_experimental_arguments_schema.py
+++ b/tests/test_experimental_arguments_schema.py
@@ -15,7 +15,7 @@ with warnings.catch_warnings():
 def func(p: bool, *args: str, **kwargs: int) -> None: ...
 
 
-def skip_first_parameter(index: int, name: str, annotation: Any) -> Literal['skip'] | None:
+def skip_first_parameter(index: int, name: str, annotation: Any) -> Literal['skip', None]:
     if index == 0:
         return 'skip'
 

--- a/tests/test_experimental_arguments_schema.py
+++ b/tests/test_experimental_arguments_schema.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Annotated, Any, Generic, TypeVar
+from typing import Annotated, Any, Generic, Literal, TypeVar
 
 import pytest
 from pydantic_core import ArgsKwargs, SchemaValidator
@@ -9,15 +9,15 @@ from pydantic import AliasGenerator, Field, PydanticExperimentalWarning, Pydanti
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', category=PydanticExperimentalWarning)
-    from pydantic.experimental.arguments_schema import SKIP, generate_arguments_schema
+    from pydantic.experimental.arguments_schema import generate_arguments_schema
 
 
 def func(p: bool, *args: str, **kwargs: int) -> None: ...
 
 
-def skip_first_parameter(index: int, name: str, annotation: Any) -> Any:
+def skip_first_parameter(index: int, name: str, annotation: Any) -> Literal['skip'] | None:
     if index == 0:
-        return SKIP
+        return 'skip'
 
 
 def test_generate_arguments_v3_schema() -> None:

--- a/tests/test_experimental_arguments_schema.py
+++ b/tests/test_experimental_arguments_schema.py
@@ -1,0 +1,191 @@
+import warnings
+from typing import Annotated, Any, Generic, TypeVar
+
+import pytest
+from pydantic_core import ArgsKwargs, SchemaValidator
+from typing_extensions import TypedDict, Unpack
+
+from pydantic import AliasGenerator, Field, PydanticExperimentalWarning, PydanticUserError, ValidationError
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', category=PydanticExperimentalWarning)
+    from pydantic.experimental.arguments_schema import SKIP, generate_arguments_schema
+
+
+def func(p: bool, *args: str, **kwargs: int) -> None: ...
+
+
+def skip_first_parameter(index: int, name: str, annotation: Any) -> Any:
+    if index == 0:
+        return SKIP
+
+
+def test_generate_arguments_v3_schema() -> None:
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        parameters_callback=skip_first_parameter,
+    )
+
+    val = SchemaValidator(arguments_schema, config={'coerce_numbers_to_str': True})
+
+    args, kwargs = val.validate_json('{"args": ["arg1", 1], "kwargs": {"extra": 1}}')
+    assert args == ('arg1', '1')
+    assert kwargs == {'extra': 1}
+
+    args, kwargs = val.validate_python({'args': ['arg1', 1], 'kwargs': {'extra': 1}})
+    assert args == ('arg1', '1')
+    assert kwargs == {'extra': 1}
+
+
+def test_generate_arguments_schema() -> None:
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        schema_type='arguments',
+        parameters_callback=skip_first_parameter,
+    )
+
+    val = SchemaValidator(arguments_schema, config={'coerce_numbers_to_str': True})
+
+    args, kwargs = val.validate_python(ArgsKwargs(('arg1', 1), {'extra': 1}))
+    assert args == ('arg1', '1')
+    assert kwargs == {'extra': 1}
+
+
+# The following tests should be removed in V3, as `@validate_call` will make use of the
+# `'arguments-v3'` schema and as such the `@validate_call` tests will cover these cases
+# (most of these tests are actually copied over from there):
+
+
+def test_arguments_v3() -> None:
+    def func(a, /, b: Annotated[int, Field(alias='b_alias')], *args: int, c: int = 6) -> None: ...
+
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        schema_type='arguments-v3',
+    )
+    val = SchemaValidator(arguments_schema)
+    args, kwargs = val.validate_python({'a': 1, 'b_alias': 2, 'args': [3, 4], 'c': 5})
+
+    assert args == (1, 2, 3, 4)
+    assert kwargs == {'c': 5}
+
+
+def test_arguments_v3_alias_generator() -> None:
+    def func(*, a: int) -> None: ...
+
+    arguments_schema = generate_arguments_schema(
+        func=func, schema_type='arguments-v3', config={'alias_generator': lambda f: 'b'}
+    )
+    val = SchemaValidator(arguments_schema)
+    _, kwargs = val.validate_python({'b': 1})
+    assert kwargs == {'a': 1}
+
+    arguments_schema = generate_arguments_schema(
+        func=func, schema_type='arguments-v3', config={'alias_generator': AliasGenerator(alias=lambda f: 'b')}
+    )
+    val = SchemaValidator(arguments_schema)
+    _, kwargs = val.validate_python({'b': 1})
+    assert kwargs == {'a': 1}
+
+
+def test_arguments_v3_kwargs_uniform() -> None:
+    def func(**kwargs: int) -> None: ...
+
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        schema_type='arguments-v3',
+    )
+    val = SchemaValidator(arguments_schema)
+    _, kwargs = val.validate_python({'kwargs': {'extra': 1}})
+
+    assert kwargs == {'extra': 1}
+
+
+def test_unpacked_typed_dict_kwargs_invalid_type() -> None:
+    def func(**kwargs: Unpack[int]): ...
+
+    with pytest.raises(PydanticUserError) as exc:
+        generate_arguments_schema(
+            func=func,
+            schema_type='arguments-v3',
+        )
+
+    assert exc.value.code == 'unpack-typed-dict'
+
+
+def test_unpacked_typed_dict_kwargs_overlaps() -> None:
+    class TD(TypedDict, total=False):
+        a: int
+        b: int
+        c: int
+
+    def func(a: int, b: int, **kwargs: Unpack[TD]): ...
+
+    with pytest.raises(PydanticUserError) as exc:
+        generate_arguments_schema(
+            func=func,
+            schema_type='arguments-v3',
+        )
+
+    assert exc.value.code == 'overlapping-unpack-typed-dict'
+    assert exc.value.message == "Typed dictionary 'TD' overlaps with parameters 'a', 'b'"
+
+    # Works for a pos-only argument
+    def func(a: int, /, **kwargs: Unpack[TD]): ...
+
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        schema_type='arguments-v3',
+    )
+    val = SchemaValidator(arguments_schema)
+    args, kwargs = val.validate_python({'a': 1, 'kwargs': {'a': 2, 'b': 3, 'c': 4}})
+
+    assert args == (1,)
+    assert kwargs == {'a': 2, 'b': 3, 'c': 4}
+
+
+def test_arguments_v3_kwargs_unpacked_typed_dict() -> None:
+    def func(**kwargs: int) -> None: ...
+
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        schema_type='arguments-v3',
+    )
+    val = SchemaValidator(arguments_schema)
+    _, kwargs = val.validate_python({'kwargs': {'extra': 1}})
+
+    assert kwargs == {'extra': 1}
+
+
+def test_unpacked_generic_typed_dict_kwargs() -> None:
+    T = TypeVar('T')
+
+    class TD(TypedDict, Generic[T]):
+        t: T
+
+    def func(**kwargs: Unpack[TD[int]]): ...
+
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        schema_type='arguments-v3',
+    )
+    val = SchemaValidator(arguments_schema)
+
+    with pytest.raises(ValidationError):
+        val.validate_python({'kwargs': {'t': 'not_an_int'}})
+
+
+def test_multiple_references() -> None:
+    class TD(TypedDict):
+        pass
+
+    def func(a: TD, b: TD) -> None: ...
+
+    arguments_schema = generate_arguments_schema(
+        func=func,
+        schema_type='arguments-v3',
+    )
+    val = SchemaValidator(arguments_schema)
+    args, kwargs = val.validate_python({'a': {}, 'b': {}})
+    assert args == ({}, {})
+    assert kwargs == {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Example usage:

```python
from pydantic.validate_call_decorator import SKIP, generate_arguments_schema

def func(context: RunContext[str], a: int):
    pass

def callback(index: int, name: str, hint: Any):
    if index == 0 and hint is RunContext or get_origin(hint) is RunContext:
        return SKIP
    # Do other checks as well, e.g. RunContext in another position, etc.

generate_arguments_schema(
    func,
    schema_type='arguments-v3',
    parameters_callback=callback 
)
"""
{
│   'type': 'arguments-v3',
│   'arguments_schema': [{'name': 'a', 'schema': {'type': 'int', 'metadata': {}}, 'mode': 'positional_or_keyword'}],
│   'validate_by_name': False
}
"""
```

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
