### PR TITLE
Add `encoded_string()` method to the URL types

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -217,6 +217,14 @@ class _BaseUrl:
         """
         return self._url.unicode_string()
 
+    @property
+    def encoded(self) -> str:
+        """The URL's encoded string representation via __str__().
+
+        This returns the punycode-encoded host version of the URL as a string.
+        """
+        return str(self)
+
     def __str__(self) -> str:
         """The URL as a string, this will punycode encode the host if required."""
         return str(self._url)

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -217,8 +217,7 @@ class _BaseUrl:
         """
         return self._url.unicode_string()
 
-    @property
-    def encoded(self) -> str:
+    def encoded_string(self) -> str:
         """The URL's encoded string representation via __str__().
 
         This returns the punycode-encoded host version of the URL as a string.
@@ -405,6 +404,13 @@ class _BaseMultiHostUrl:
             A list of dicts, each representing a host.
         '''
         return self._url.hosts()
+
+    def encoded_string(self) -> str:
+        """The URL's encoded string representation via __str__().
+
+        This returns the punycode-encoded host version of the URL as a string.
+        """
+        return str(self)
 
     def unicode_string(self) -> str:
         """The URL as a unicode string, unlike `__str__()` this will not punycode encode the hosts."""

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -330,7 +330,6 @@ def test_http_url_invalid(value, err_type, err_msg):
         # https://www.xudongz.com/blog/2017/idn-phishing/ accepted but converted
         ('https://www.аррӏе.com/', 'https://www.xn--80ak6aa92e.com/'),
         ('https://exampl£e.org', 'https://xn--example-gia.org/'),
-        ('http://puny£code.com', 'http://xn--punycode-eja.com/'),
         ('https://example.珠宝', 'https://example.xn--pbt977c/'),
         ('https://example.vermögensberatung', 'https://example.xn--vermgensberatung-pwb/'),
         ('https://example.рф', 'https://example.xn--p1ai/'),
@@ -1063,8 +1062,8 @@ def test_specialized_urls() -> None:
     assert http_url2.path == '/something'
     assert http_url2.username is None
     assert http_url2.password is None
-    assert http_url.encoded == 'http://example.com/something'
-    assert http_url2.encoded == 'http://example.com/something'
+    assert http_url.encoded_string() == 'http://example.com/something'
+    assert http_url2.encoded_string() == 'http://example.com/something'
 
 
 def test_url_equality() -> None:

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1072,11 +1072,14 @@ def test_url_equality() -> None:
     assert PostgresDsn('postgres://user:pass@localhost:5432/app') == PostgresDsn(
         'postgres://user:pass@localhost:5432/app'
     )
-    assert (
-        PostgresDsn('postgres://user:pass@localhost:5432/app').encoded_string()
-        == 'postgres://user:pass@localhost:5432/app'
-    )
-    assert HttpUrl('http://example.com/something').encoded_string() == 'http://example.com/something'
+
+
+def test_encode_multi_host_url() -> None:
+    multi_host_url_postgres = PostgresDsn('postgres://user:pass@host1:543')
+    multi_host_url_http_url = HttpUrl('http://example.com/something')
+
+    assert multi_host_url_postgres.encoded_string() == 'postgres://user:pass@localhost:5432/app'
+    assert multi_host_url_http_url.encoded_string() == 'http://example.com/something'
 
 
 def test_equality_independent_of_init() -> None:

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -330,6 +330,7 @@ def test_http_url_invalid(value, err_type, err_msg):
         # https://www.xudongz.com/blog/2017/idn-phishing/ accepted but converted
         ('https://www.аррӏе.com/', 'https://www.xn--80ak6aa92e.com/'),
         ('https://exampl£e.org', 'https://xn--example-gia.org/'),
+        ('http://puny£code.com', 'http://xn--punycode-eja.com/'),
         ('https://example.珠宝', 'https://example.xn--pbt977c/'),
         ('https://example.vermögensberatung', 'https://example.xn--vermgensberatung-pwb/'),
         ('https://example.рф', 'https://example.xn--p1ai/'),
@@ -1062,6 +1063,8 @@ def test_specialized_urls() -> None:
     assert http_url2.path == '/something'
     assert http_url2.username is None
     assert http_url2.password is None
+    assert http_url.encoded == 'http://example.com/something'
+    assert http_url2.encoded == 'http://example.com/something'
 
 
 def test_url_equality() -> None:

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1072,6 +1072,11 @@ def test_url_equality() -> None:
     assert PostgresDsn('postgres://user:pass@localhost:5432/app') == PostgresDsn(
         'postgres://user:pass@localhost:5432/app'
     )
+    assert (
+        PostgresDsn('postgres://user:pass@localhost:5432/app').encoded_string()
+        == 'postgres://user:pass@localhost:5432/app'
+    )
+    assert HttpUrl('http://example.com/something').encoded_string() == 'http://example.com/something'
 
 
 def test_equality_independent_of_init() -> None:

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1075,7 +1075,7 @@ def test_url_equality() -> None:
 
 
 def test_encode_multi_host_url() -> None:
-    multi_host_url_postgres = PostgresDsn('postgres://user:pass@host1:543')
+    multi_host_url_postgres = PostgresDsn('postgres://user:pass@localhost:5432/app')
     multi_host_url_http_url = HttpUrl('http://example.com/something')
 
     assert multi_host_url_postgres.encoded_string() == 'postgres://user:pass@localhost:5432/app'


### PR DESCRIPTION
## Change Summary

This PR introduces a new `encoded` property to the `Url` class in `pydantic/networks.py`. The `encoded` property returns the punycode-encoded host version of the URL as a string. Additionally, a new test case has been added to `tests/test_networks.py` to verify the functionality of the `encoded` property.

## Related issue number

#11551 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog

* [x] Unit tests for the changes exist

* [x] Tests pass on CI

* [x] Documentation reflects the changes where applicable

* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**