### PR TITLE
Add support for `defer_build` with `@validate_call` decorator

### DIFF
--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -49,7 +49,18 @@ def update_wrapper_attributes(wrapped: ValidateCallSupportedTypes, wrapper: Call
 class ValidateCallWrapper:
     """This is a wrapper around a function that validates the arguments passed to it, and optionally the return value."""
 
-    __slots__ = ('__pydantic_validator__', '__return_pydantic_validator__')
+    __slots__ = (
+        'function',
+        'validate_return',
+        'schema_type',
+        'module',
+        'qualname',
+        'ns_resolver',
+        'config_wrapper',
+        '__pydantic_complete__',
+        '__pydantic_validator__',
+        '__return_pydantic_validator__',
+    )
 
     def __init__(
         self,
@@ -58,46 +69,54 @@ class ValidateCallWrapper:
         validate_return: bool,
         parent_namespace: MappingNamespace | None,
     ) -> None:
+        self.function = function
+        self.validate_return = validate_return
         if isinstance(function, partial):
-            schema_type = function.func
-            module = function.func.__module__
+            self.schema_type = function.func
+            self.module = function.func.__module__
         else:
-            schema_type = function
-            module = function.__module__
-        qualname = extract_function_qualname(function)
+            self.schema_type = function
+            self.module = function.__module__
+        self.qualname = extract_function_qualname(function)
 
-        ns_resolver = NsResolver(namespaces_tuple=ns_for_function(schema_type, parent_namespace=parent_namespace))
+        self.ns_resolver = NsResolver(
+            namespaces_tuple=ns_for_function(self.schema_type, parent_namespace=parent_namespace)
+        )
+        self.config_wrapper = ConfigWrapper(config)
+        if not self.config_wrapper.defer_build:
+            self._create_validators()
+        else:
+            self.__pydantic_complete__ = False
 
-        config_wrapper = ConfigWrapper(config)
-        gen_schema = GenerateSchema(config_wrapper, ns_resolver)
-        schema = gen_schema.clean_schema(gen_schema.generate_schema(function))
-        core_config = config_wrapper.core_config(title=qualname)
+    def _create_validators(self) -> None:
+        gen_schema = GenerateSchema(self.config_wrapper, self.ns_resolver)
+        schema = gen_schema.clean_schema(gen_schema.generate_schema(self.function))
+        core_config = self.config_wrapper.core_config(title=self.qualname)
 
         self.__pydantic_validator__ = create_schema_validator(
             schema,
-            schema_type,
-            module,
-            qualname,
+            self.schema_type,
+            self.module,
+            self.qualname,
             'validate_call',
             core_config,
-            config_wrapper.plugin_settings,
+            self.config_wrapper.plugin_settings,
         )
-
-        if validate_return:
-            signature = inspect.signature(function)
+        if self.validate_return:
+            signature = inspect.signature(self.function)
             return_type = signature.return_annotation if signature.return_annotation is not signature.empty else Any
-            gen_schema = GenerateSchema(config_wrapper, ns_resolver)
+            gen_schema = GenerateSchema(self.config_wrapper, self.ns_resolver)
             schema = gen_schema.clean_schema(gen_schema.generate_schema(return_type))
             validator = create_schema_validator(
                 schema,
-                schema_type,
-                module,
-                qualname,
+                self.schema_type,
+                self.module,
+                self.qualname,
                 'validate_call',
                 core_config,
-                config_wrapper.plugin_settings,
+                self.config_wrapper.plugin_settings,
             )
-            if inspect.iscoroutinefunction(function):
+            if inspect.iscoroutinefunction(self.function):
 
                 async def return_val_wrapper(aw: Awaitable[Any]) -> None:
                     return validator.validate_python(await aw)
@@ -108,7 +127,12 @@ class ValidateCallWrapper:
         else:
             self.__return_pydantic_validator__ = None
 
+        self.__pydantic_complete__ = True
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if not self.__pydantic_complete__:
+            self._create_validators()
+
         res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
         if self.__return_pydantic_validator__:
             return self.__return_pydantic_validator__(res)

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -1258,3 +1258,19 @@ def test_uses_local_ns():
         assert bar({'z': 1}) == M2(z=1)
 
     foo()
+
+
+# The class needs to be defined at the module level
+# For 'DeferBuildClass' to resolve:
+class DeferBuildClass(BaseModel):
+    @classmethod
+    @validate_call(config={'defer_build': True})
+    def cls_meth(cls, x: int) -> 'DeferBuildClass':
+        return DeferBuildClass()
+
+
+def test_validate_call_defer_build() -> None:
+    DeferBuildClass.cls_meth(x=1)
+
+    with pytest.raises(ValidationError):
+        DeferBuildClass.cls_meth(x='not_an_int')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11582.

All the schema generation logic is moved into a `_create_validators()` function, logic is identical.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
