### PR TITLE
Allow `@with_config` decorator to be used with keyword arguments

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any, NamedTuple, Optional, Union
 import pytest
 from dirty_equals import HasRepr, IsPartialDict
 from pydantic_core import SchemaError, SchemaSerializer, SchemaValidator
+from typing_extensions import TypedDict
 
 from pydantic import (
     BaseConfig,
@@ -35,7 +36,7 @@ from pydantic.dataclasses import rebuild_dataclass
 from pydantic.errors import PydanticUserError
 from pydantic.fields import ComputedFieldInfo, FieldInfo
 from pydantic.type_adapter import TypeAdapter
-from pydantic.warnings import PydanticDeprecatedSince210, PydanticDeprecationWarning
+from pydantic.warnings import PydanticDeprecatedSince210, PydanticDeprecatedSince211, PydanticDeprecationWarning
 
 from .conftest import CallCounter
 
@@ -934,6 +935,32 @@ def test_with_config_disallowed_with_model():
 
         @with_config({'coerce_numbers_to_str': True})
         class Model(BaseModel):
+            pass
+
+
+def test_with_config_kwargs() -> None:
+    @with_config(coerce_numbers_to_str=True)
+    class TD(TypedDict):
+        a: str
+
+    assert TypeAdapter(TD).validate_python({'a': 1}) == {'a': '1'}
+
+
+def test_with_config_keyword_argument_deprecated() -> None:
+    with pytest.warns(PydanticDeprecatedSince211):
+
+        @with_config(config={'coerce_numbers_to_str': True})
+        class TD(TypedDict):
+            a: str
+
+    assert TypeAdapter(TD).validate_python({'a': 1}) == {'a': '1'}
+
+
+def test_with_config_positional_and_keyword_error() -> None:
+    with pytest.raises(ValueError):
+
+        @with_config({'coerce_numbers_to_str': True}, coerce_numbers_to_str=True)
+        class TD(TypedDict):
             pass
 
 

--- a/tests/typechecking/with_config_decorator.py
+++ b/tests/typechecking/with_config_decorator.py
@@ -6,12 +6,22 @@ from pydantic import ConfigDict, with_config
 
 
 @with_config(ConfigDict(str_to_lower=True))
-class Model(TypedDict):
+class Model1(TypedDict):
     a: str
 
 
-assert_type(Model, type[Model])
+@with_config(str_to_lower=True)
+class Model2(TypedDict):
+    pass
 
-model = Model(a='ABC')
 
-assert_type(model, Model)
+@with_config(config=ConfigDict(str_to_lower=True))  # pyright: ignore[reportDeprecated]
+class Model3(TypedDict):
+    pass
+
+
+assert_type(Model1, type[Model1])
+
+model = Model1(a='ABC')
+
+assert_type(model, Model1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

Fixes #11606, closes #11607

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
