### PR TITLE
Fix inaccurate docstring example in `_BaseMultiHostUrl.query_params()`

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -374,7 +374,7 @@ class _BaseMultiHostUrl:
     def query_params(self) -> list[tuple[str, str]]:
         """The query part of the URL as a list of key-value pairs.
 
-        e.g. `[('baz', 'qux')]` in `https://foo.com,bar.com/path?baz=qux#fragment`
+        e.g. `[('foo', 'bar')]` in `https://foo.com,bar.com/path?foo=bar#fragment`
         """
         return self._url.query_params()
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -374,7 +374,7 @@ class _BaseMultiHostUrl:
     def query_params(self) -> list[tuple[str, str]]:
         """The query part of the URL as a list of key-value pairs.
 
-        e.g. `[('foo', 'bar')]` in `https://foo.com,bar.com/path?query#fragment`
+        e.g. `[('baz', 'qux')]` in `https://foo.com,bar.com/path?baz=qux#fragment`
         """
         return self._url.query_params()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The previous docstring included a mismatched query example, which could cause confusion.
The updated docstring uses a corresponding return value to clearly demonstrate expected behavior.

## Related issue number

N/A

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle