### PR TITLE
Add default factory with validated data to PrivateAttr

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -9,7 +9,7 @@ from copy import copy
 from functools import cache
 from inspect import Parameter, ismethoddescriptor, signature
 from re import Pattern
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 from pydantic_core import PydanticUndefined
 from typing_extensions import TypeIs, get_origin
@@ -456,3 +456,27 @@ def takes_validated_data_argument(
     parameters = list(sig.parameters.values())
 
     return len(parameters) == 1 and can_be_positional(parameters[0]) and parameters[0].default is Parameter.empty
+
+
+def resolve_default_value(
+    default: Any,
+    default_factory: Callable[[], Any] | Callable[[dict[str, Any]], Any] | None,
+    *,
+    validated_data: dict[str, Any] | None = None,
+    call_default_factory: bool = False,
+) -> Any:
+    """Resolve the default value using either a static default or a default_factory."""
+    from ._utils import smart_deepcopy
+
+    if default_factory is None:
+        return smart_deepcopy(default)
+    if call_default_factory:
+        if takes_validated_data_argument(default_factory=default_factory):
+            fac = cast('Callable[[dict[str, Any]], Any]', default_factory)
+            if validated_data is None:
+                raise ValueError("The default_factory requires 'validated_data' but none was provided.")
+            return fac(validated_data)
+        else:
+            fac = cast('Callable[[], Any]', default_factory)
+            return fac()
+    return None

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -345,7 +345,9 @@ def init_private_attributes(self: BaseModel, context: Any, /) -> None:
     if getattr(self, '__pydantic_private__', None) is None:
         pydantic_private = {}
         for name, private_attr in self.__private_attributes__.items():
-            default = private_attr.get_default()
+            default = private_attr.get_default(
+                call_default_factory=True, validated_data={**self.__dict__, **pydantic_private}
+            )
             if default is not PydanticUndefined:
                 pydantic_private[name] = default
         object_setattr(self, '__pydantic_private__', pydantic_private)

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from copy import copy
 from dataclasses import Field as DataclassField
 from functools import cached_property
-from typing import Annotated, Any, Callable, ClassVar, Literal, TypeVar, cast, overload
+from typing import Annotated, Any, Callable, ClassVar, Literal, TypeVar, overload
 from warnings import warn
 
 import annotated_types
@@ -21,7 +21,7 @@ from typing_inspection import typing_objects
 from typing_inspection.introspection import UNKNOWN, AnnotationSource, ForbiddenQualifier, Qualifier, inspect_annotation
 
 from . import types
-from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra, _utils
+from ._internal import _decorators, _fields, _generics, _internal_dataclass, _repr, _typing_extra
 from ._internal._namespace_utils import GlobalsNamespace, MappingNamespace
 from .aliases import AliasChoices, AliasPath
 from .config import JsonDict
@@ -597,15 +597,6 @@ class FieldInfo(_repr.Representation):
             return 'deprecated' if self.deprecated else None
         return self.deprecated if isinstance(self.deprecated, str) else self.deprecated.message
 
-    @property
-    def default_factory_takes_validated_data(self) -> bool | None:
-        """Whether the provided default factory callable has a validated data parameter.
-
-        Returns `None` if no default factory is set.
-        """
-        if self.default_factory is not None:
-            return _fields.takes_validated_data_argument(self.default_factory)
-
     @overload
     def get_default(
         self, *, call_default_factory: Literal[True], validated_data: dict[str, Any] | None = None
@@ -628,21 +619,12 @@ class FieldInfo(_repr.Representation):
         Returns:
             The default value, calling the default factory if requested or `None` if not set.
         """
-        if self.default_factory is None:
-            return _utils.smart_deepcopy(self.default)
-        elif call_default_factory:
-            if self.default_factory_takes_validated_data:
-                fac = cast('Callable[[dict[str, Any]], Any]', self.default_factory)
-                if validated_data is None:
-                    raise ValueError(
-                        "The default factory requires the 'validated_data' argument, which was not provided when calling 'get_default'."
-                    )
-                return fac(validated_data)
-            else:
-                fac = cast('Callable[[], Any]', self.default_factory)
-                return fac()
-        else:
-            return None
+        return _fields.resolve_default_value(
+            default=self.default,
+            default_factory=self.default_factory,
+            validated_data=validated_data,
+            call_default_factory=call_default_factory,
+        )
 
     def is_required(self) -> bool:
         """Check if the field is required (i.e., does not have a default value or factory).
@@ -1158,7 +1140,10 @@ class ModelPrivateAttr(_repr.Representation):
     __slots__ = ('default', 'default_factory')
 
     def __init__(
-        self, default: Any = PydanticUndefined, *, default_factory: typing.Callable[[], Any] | None = None
+        self,
+        default: Any = PydanticUndefined,
+        *,
+        default_factory: Callable[[], _T] | Callable[[dict[str, Any]], _T] | None = None,
     ) -> None:
         if default is Ellipsis:
             self.default = PydanticUndefined
@@ -1187,17 +1172,34 @@ class ModelPrivateAttr(_repr.Representation):
         if callable(set_name):
             set_name(cls, name)
 
-    def get_default(self) -> Any:
-        """Retrieve the default value of the object.
+    @overload
+    def get_default(
+        self, *, call_default_factory: Literal[True], validated_data: dict[str, Any] | None = None
+    ) -> Any: ...
 
-        If `self.default_factory` is `None`, the method will return a deep copy of the `self.default` object.
+    @overload
+    def get_default(self, *, call_default_factory: Literal[False] = ...) -> Any: ...
 
-        If `self.default_factory` is not `None`, it will call `self.default_factory` and return the value returned.
+    def get_default(self, *, call_default_factory: bool = False, validated_data: dict[str, Any] | None = None) -> Any:
+        """Get the default value.
+
+        We expose an option for whether to call the default_factory (if present), as calling it may
+        result in side effects that we want to avoid. However, there are times when it really should
+        be called (namely, when instantiating a model via `model_construct`).
+
+        Args:
+            call_default_factory: Whether to call the default factory or not.
+            validated_data: The already validated data to be passed to the default factory.
 
         Returns:
-            The default value of the object.
+            The default value, calling the default factory if requested or `None` if not set.
         """
-        return _utils.smart_deepcopy(self.default) if self.default_factory is None else self.default_factory()
+        return _fields.resolve_default_value(
+            default=self.default,
+            default_factory=self.default_factory,
+            validated_data=validated_data,
+            call_default_factory=call_default_factory,
+        )
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, self.__class__) and (self.default, self.default_factory) == (
@@ -1217,7 +1219,7 @@ def PrivateAttr(
 @overload  # `default_factory` argument set
 def PrivateAttr(
     *,
-    default_factory: Callable[[], _T],
+    default_factory: Callable[[], _T] | Callable[[dict[str, Any]], _T],
     init: Literal[False] = False,
 ) -> _T: ...
 @overload  # No default set
@@ -1228,7 +1230,7 @@ def PrivateAttr(
 def PrivateAttr(
     default: Any = PydanticUndefined,
     *,
-    default_factory: Callable[[], Any] | None = None,
+    default_factory: Callable[[], _T] | Callable[[dict[str, Any]], _T] | None = None,
     init: Literal[False] = False,
 ) -> Any:
     """!!! abstract "Usage Documentation"
@@ -1243,7 +1245,9 @@ def PrivateAttr(
     Args:
         default: The attribute's default value. Defaults to Undefined.
         default_factory: Callable that will be
-            called when a default value is needed for this attribute.
+            called when a default value is needed for this attribute. The callable can either take 0 arguments
+            (in which case it is called as is) or a single argument containing the already validated data, in this
+            case for private attributes will correspond to the entire model fields gotten from __dict__.
             If both `default` and `default_factory` are set, an error will be raised.
         init: Whether the attribute should be included in the constructor of the dataclass. Always `False`.
 

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -67,7 +67,7 @@ def test_private_attribute_nested():
 def test_private_attribute_factory():
     default = {'a': {}}
 
-    def factory():
+    def factory() -> dict[str, dict]:
         return default
 
     class Model(BaseModel):
@@ -85,6 +85,55 @@ def test_private_attribute_factory():
 
     assert m.model_dump() == {}
     assert m.__dict__ == {}
+
+
+def test_private_attribute_factory_uses_validated_data():
+    def factory(data: dict[str, str]) -> str:
+        return data['foo'] + data['bar']
+
+    class Model(BaseModel):
+        foo: str
+        bar: str
+        _foobaz = PrivateAttr(default_factory=factory)
+
+    assert Model.__private_attributes__ == {'_foobaz': PrivateAttr(default_factory=factory)}
+
+    m = Model(foo='foo', bar='bar')
+    assert m._foobaz == 'foobar'
+
+
+def test_private_attribute_factory_uses_other_private_attribute():
+    def factory(data: dict[str, str]) -> str:
+        return data['foo'] + data['bar'] + data['_foobaz']
+
+    class Model(BaseModel):
+        foo: str
+        bar: str
+        _foobaz = PrivateAttr(default='foobaz')
+        _foobazfoo = PrivateAttr(default_factory=factory)
+
+    assert Model.__private_attributes__ == {
+        '_foobaz': PrivateAttr(default='foobaz'),
+        '_foobazfoo': PrivateAttr(default_factory=factory),
+    }
+
+    m = Model(foo='foo', bar='bar')
+    assert m._foobaz == 'foobaz'
+    assert m._foobazfoo == 'foobarfoobaz'
+
+
+def test_private_attribute_factory_unset_private():
+    def factory(data: dict[str, str]) -> str:
+        return data['foo'] + data['bar'] + data['_foobazfoo']
+
+    class Model(BaseModel):
+        foo: str
+        bar: str
+        _foobaz = PrivateAttr(default_factory=factory)
+        _foobazfoo = PrivateAttr(default='foobazfoo')
+
+    with pytest.raises(KeyError, match='_foobazfoo'):
+        _ = Model(foo='foo', bar='bar')
 
 
 def test_private_attribute_annotation():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

This PR adds default_factory to `PrivateAttr` working in a similar way that it works with `Field`. Due that private attributes happen before init, the `default_factory` callable has available the entire `__dict__` attribute. Also, private attributes defined **before** the current private are available (similar as this callable work with field)

```python
class Model(BaseModel):
    x: str
    _y: str = PrivateAttr(default = 'y')
    _z: str = PrivateAttr(default_factory = lambda data: data['x'] + data['_y'] + 'z')
    
m =  Model(x = 'x')
>>> m._z
'xyz'

# Fails with KeyError

class Model(BaseModel):
    x: str
    _y: str = PrivateAttr(default_factory= lambda data: data['x'] + data['_z'] + 'y')
    _z: str = PrivateAttr(default = 'z')

Model(x = 'x')
>>> KeyError

```


## Related issue number

Related issue is #10992 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
