### PR TITLE
📝 Add a code snippet to generate cached TypeAdapter instances.

### DIFF
--- a/docs/concepts/type_adapter.md
+++ b/docs/concepts/type_adapter.md
@@ -91,6 +91,24 @@ handle as fields of a [`BaseModel`][pydantic.main.BaseModel].
     schema. This comes with some non-trivial overhead, so it is recommended to create a `TypeAdapter` for a given type
     just once and reuse it in loops or other performance-critical code.
 
+    If you don't want to create all the [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] instances up front, you might want to consider using the following code snippet:
+
+    ??? note "Show code"
+        ```python
+        from functools import cache
+        from typing import TypeVar
+
+        from pydantic import TypeAdapter
+
+        T = TypeVar('T')
+
+        @cache
+        def _get_type_adapter(type_: T) -> TypeAdapter[T]:
+            """Create a cached TypeAdapter instance for a type. The caching is the only reason for this function to exist."""
+            print(f"Creating cached TypeAdapter for {type_}")
+            return TypeAdapter(type_)
+        ```
+
 
 ## Rebuilding a `TypeAdapter`'s schema
 


### PR DESCRIPTION
## Change Summary

> When creating an instance of `TypeAdapter`, the provided type must be analyzed and converted into a pydantic-core schema. This comes with some non-trivial overhead, so it is recommended to create a `TypeAdapter` for a given type just once and reuse it in loops or other performance-critical code.

Added a code snippet to the TypeAdapter documentation showing how to create cached TypeAdapter instances. This provides users with an efficient pattern for handling TypeAdapter instantiation in performance-critical code.

I tested this snippet locally with comprehensive tests that verify:

- The function correctly creates working TypeAdapter instances
- The caching mechanism properly reuses instances for the same types
- Different types receive different adapter instances
- The caching behavior works as expected (only creating new instances when needed)

<details>
<summary>Test code</summary>
python
import pytest
from pydantic import TypeAdapter
from functools import cache
from typing import TypeVar
# Paste the code snippet in here so that everything is in one file and I don't have to bother with importing business...
T = TypeVar('T')
@cache
def *get*type_adapter(type_: T) -> TypeAdapter[T]:
    """Create a cached TypeAdapter instance for a type. The caching is the only reason for this function to exist."""
    print(f"Creating cached TypeAdapter for {type_}")
    return TypeAdapter(type_)
def test_type_adapter_creation():
    adapter = *get*type_adapter(int)
    assert isinstance(adapter, TypeAdapter)
    assert adapter.validate_python(42) == 42
    assert adapter.dump_python(42) == 42
def test_type_adapter_caching():
    adapter1 = *get*type_adapter(int)
    adapter2 = *get*type_adapter(int)
    adapter3 = *get*type_adapter(str)
    assert adapter1 is adapter2  # Cached instance should be the same
    assert adapter1 is not adapter3  # Different types should have different instances
def test_print_logging(capfd):
    *get*type_adapter(float)  # First call should print
    *get*type_adapter(float)  # Cached call should not print again
    captured = capfd.readouterr()
    assert "Creating cached TypeAdapter for <class 'float'>" in captured.out  # Should print once
    *get*type_adapter(float)  # Call again to check caching
    captured = capfd.readouterr()
    assert captured.out == ""  # No new print output (cached)

</details>

## Related issue number

There is no issue for this change, as it is just a documentation improvement to help users with a common performance concern when using TypeAdapter.

## Checklist
* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, please add a comment including the phrase "please review" to assign reviewers

Selected Reviewer: @sydney-runkle