### PR TITLE
Fix allow 'computed_fields' with 'create_model'

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1745,9 +1745,10 @@ def create_model(  # noqa: C901
                     'being the type and the second element the assigned value (either a default or the `Field()` function).',
                     code='create-model-field-definitions',
                 )
-
             annotations[f_name] = f_def[0]
             fields[f_name] = f_def[1]
+        elif isinstance(f_def, _decorators.PydanticDescriptorProxy):
+            fields[f_name] = f_def
         else:
             annotations[f_name] = f_def
 

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -11,6 +11,7 @@ from pydantic import (
     PydanticDeprecatedSince20,
     PydanticUserError,
     ValidationError,
+    computed_field,
     create_model,
     errors,
     field_validator,
@@ -398,3 +399,12 @@ def test_type_field_in_the_same_module():
     B = create_model('B', a_cls=(type, A))
     b = B()
     assert b.a_cls == A
+
+
+def test_computed_field():
+    def bar(self) -> float:
+        return 1
+
+    A = create_model('A', bar=computed_field(bar))
+    a = A()
+    assert a.bar == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Allow `computed_fields` with `create_model`

## Related issue number
Fixes https://github.com/pydantic/pydantic/issues/11709

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle