### PR TITLE
Remove unecessary note in errors documentation

### DIFF
--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -430,9 +430,6 @@ This error is also raised for strict fields when the input value is not an insta
 
 ## `datetime_from_date_parsing`
 
-!!! note
-    Support for this error, along with support for parsing datetimes from `yyyy-MM-DD` dates was added in `v2.6.0`
-
 This error is raised when the input value is a string that cannot be parsed for a `datetime` field:
 
 ```python

--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -431,7 +431,7 @@ This error is also raised for strict fields when the input value is not an insta
 ## `datetime_from_date_parsing`
 
 !!! note
-    Support for this error, along with support for parsing datetimes from `yyyy-MM-DD` dates will be added in `v2.6.0`
+    Support for this error, along with support for parsing datetimes from `yyyy-MM-DD` dates was added in `v2.6.0`
 
 This error is raised when the input value is a string that cannot be parsed for a `datetime` field:
 


### PR DESCRIPTION
Hello! I assume this is trivial enough to not require an issue/discussion, but happy to raise an issue if desired.

## Change Summary

Update the note on `datetime_from_date_parsing` which was referencing an old version of pydantic as if it is yet to be released.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
