### PR TITLE
Fix: validate_assignment not disabled when set post-init and using se…

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1039,10 +1039,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # This can be changed if it ever gets requested.
             if isinstance(attr, property):
                 return lambda model, _name, val: attr.__set__(model, val)
-            elif cls.model_config.get('validate_assignment'):
+            elif self.model_config.get('validate_assignment'):
                 return _SIMPLE_SETATTR_HANDLERS['validate_assignment']
             elif name not in cls.__pydantic_fields__:
-                if cls.model_config.get('extra') != 'allow':
+                if self.model_config.get('extra') != 'allow':
                     # TODO - matching error
                     raise ValueError(f'"{cls.__name__}" object has no field "{name}"')
                 elif attr is None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3574,3 +3574,29 @@ def test_replace() -> None:
 
     m = Model(x=1, y=2)
     assert replace(m, x=3) == Model(x=3, y=2)
+
+
+def test_validate_assignment_with_model_config() -> None:
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_assignment=True)
+        x: list[int]
+
+    m = Model(x=[1, 2, 3])
+    with pytest.raises(ValidationError):
+        m.x = ['a', 'b', 'c']
+
+    m.model_config['validate_assignment'] = False
+    m.x = ['a', 'b', 'c']  # this should not raise a ValidationError
+
+
+def test_validate_extra_with_model_config() -> None:
+    class Model(BaseModel):
+        model_config = ConfigDict(extra='forbid')
+        x: int
+
+    m = Model(x=1)
+    with pytest.raises(ValueError):
+        m.y = 2
+
+    m.model_config['extra'] = 'allow'
+    m.y = 2  # this should not raise a ValueError


### PR DESCRIPTION
…tter

Setting `validate_assignment=False` after model initialization did not disable validation on assignment via setters. This commit ensures that toggling `validate_assignment` post-init behaves as expected.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number
https://github.com/pydantic/pydantic/issues/11729

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
