### PR TITLE
feat: add DefaultFactory.

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
     from .annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
     from .config import ConfigDict, with_config
     from .errors import *
-    from .fields import Field, PrivateAttr, computed_field
+    from .fields import Field, PrivateAttr, computed_field, DefaultFactory
     from .functional_serializers import (
         PlainSerializer,
         SerializeAsAny,
@@ -109,6 +109,7 @@ __all__ = (
     'Field',
     'computed_field',
     'PrivateAttr',
+    'DefaultFactory',
     # alias
     'AliasChoices',
     'AliasGenerator',
@@ -276,6 +277,7 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'Field': (__spec__.parent, '.fields'),
     'computed_field': (__spec__.parent, '.fields'),
     'PrivateAttr': (__spec__.parent, '.fields'),
+    'DefaultFactory': (__spec__.parent, '.fields'),
     # alias
     'AliasChoices': (__spec__.parent, '.aliases'),
     'AliasGenerator': (__spec__.parent, '.aliases'),

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1540,3 +1540,7 @@ def computed_field(
         return dec
     else:
         return dec(func)
+
+
+def DefaultFactory(default_factory: Callable[[], _T]) -> _T:
+    return Field(default_factory=default_factory)

--- a/tests/typechecking/fields.py
+++ b/tests/typechecking/fields.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, Field, PrivateAttr
+from typing import Annotated
+
+from pydantic import BaseModel, DefaultFactory, Field, PrivateAttr
 
 
 # private attributes should be excluded from
@@ -38,3 +40,5 @@ class Model(BaseModel):
 
     # Do not error on the ellipsis:
     f13: int = Field(...)
+
+    f14: Annotated[list[int], Field(...)] = DefaultFactory(lambda: [123])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Previously, I created an [Issue](#9769) proposing a DefaultFactory to be combined with Annotated.
During our conversation in the Issue, it became clear that my request could be accomplished by creating a simple function.
Since then, I have created DefaultFactory in many of my products.

I was inclined to provide a DefaultFactory on the pydantic side to obtain type safety in combination with Annotated.
    
 As discussed in the issue, `DefaultFactory` and `Default` need to be assigned to fields to avoid unspecified argument errors in the constructor.
 In the case of using default, a literal value can already be assigned, but in the case of using `Field(default_factory=...)` we need to provide a DefaultFactory.

See the following example:

![image](https://github.com/user-attachments/assets/df00b8fc-6301-4020-a7f4-34ef927d9e47)

```python
from typing import Annotated, Callable, TypeVar

from pydantic import BaseModel, Field


_T = TypeVar("_T")

######################## Current implementation ########################
class Model(BaseModel):
    f1: Annotated[list[int], Field(default_factory=lambda: [123])]


# f1 is not specified, so it is an error
assert Model().f1 == [123]


###################### Proposal: DefaultFactory #######################
def DefaultFactory(default_factory: Callable[[], _T]) -> _T:
    return Field(default_factory=default_factory)


class UseDefaultFactory(BaseModel):
    f1: Annotated[list[int], Field(...)] = DefaultFactory(lambda: [123])


# The field is assigned, so it is not an error
assert UseDefaultFactory().f1 == [123]


######### DefaultFactory detection with wrong factory function #########
class UseDefaultFactoryWrongInitialization(BaseModel):
    # The default factory returns a list[str], but the field is annotated as list[int]
    f1: Annotated[list[int], Field(...)] = DefaultFactory(lambda: ["123"])

```

## Related issue number
#9769

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

