### PR TITLE
Remove generics cache workaround

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -908,12 +908,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
                 submodel = _generics.create_generic_submodel(model_name, origin, args, params)
 
-                # Cache the generated model *only* if not in the process of parametrizing
-                # another model. In some valid scenarios, we miss the opportunity to cache
-                # it but in some cases this results in `PydanticRecursiveRef` instances left
-                # on `FieldInfo` annotations:
-                if len(_generics.recursively_defined_type_refs()) == 1:
-                    _generics.set_cached_generic_type(cls, typevar_values, submodel, origin, args)
+                _generics.set_cached_generic_type(cls, typevar_values, submodel, origin, args)
 
         return submodel
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -525,10 +525,10 @@ def test_generics_reused() -> None:
 
     To fix an issue with recursive generics, we introduced a change in 2.11 that would
     skip caching the parameterized model under specific circumstances. The following setup
-    is an example of where this happens. As a result, we end up with two different `A[float]`
-    classes, although they are the same in practice.
-    When serializing, we check that the value instances are matching the type, but we end up
-    with warnings as `isinstance(value, A[float])` fails.
+    is an example of where this would happen. As a result, we ended up with two different `A[int]`
+    classes, although they were the same in practice.
+    When serializing, we check that the value instances are matching the type, but we ended up
+    with warnings as `isinstance(value, A[int])` fails.
     The fix was reverted as a refactor (https://github.com/pydantic/pydantic/pull/11388) fixed
     the underlying issue.
     """

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -27,6 +27,7 @@ from typing_extensions import (
     Never,
     NotRequired,
     ParamSpec,
+    TypeAliasType,
     TypedDict,
     TypeVarTuple,
     Unpack,
@@ -517,6 +518,37 @@ def test_generics_work_with_many_parametrized_base_models():
     assert len(cache) < target_size + _LIMITED_DICT_SIZE
     del models
     del generics
+
+
+def test_generics_reused() -> None:
+    """https://github.com/pydantic/pydantic/issues/11747
+
+    To fix an issue with recursive generics, we introduced a change in 2.11 that would
+    skip caching the parameterized model under specific circumstances. The following setup
+    is an example of where this happens. As a result, we end up with two different `A[float]`
+    classes, although they are the same in practice.
+    When serializing, we check that the value instances are matching the type, but we end up
+    with warnings as `isinstance(value, A[float])` fails.
+    The fix was reverted as a refactor (https://github.com/pydantic/pydantic/pull/11388) fixed
+    the underlying issue.
+    """
+
+    T = TypeVar('T')
+
+    class A(BaseModel, Generic[T]):
+        pass
+
+    class B(BaseModel, Generic[T]):
+        pass
+
+    AorB = TypeAliasType('AorB', Union[A[T], B[T]], type_params=(T,))
+
+    class Main(BaseModel, Generic[T]):
+        ls: list[AorB[T]] = []
+
+    m = Main[int]()
+    m.ls.append(A[int]())
+    m.model_dump_json(warnings='error')
 
 
 def test_generic_config():
@@ -1445,7 +1477,9 @@ def test_deep_generic_with_referenced_inner_generic():
 
     with pytest.raises(ValidationError):
         InnerModel[int](a=['s', {'a': 'wrong'}])
+
     assert InnerModel[int](a=['s', {'a': 1}]).a[1].a == 1
+    assert InnerModel[int].model_fields['a'].annotation == Optional[list[Union[ReferencedModel[int], str]]]
 
 
 def test_deep_generic_with_multiple_typevars():


### PR DESCRIPTION

This results in parameterized classes being different type objects, although they represent the same type.

A new refactor (https://github.com/pydantic/pydantic/pull/11388) was introduced since then and fixes the root issue.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

Fixes https://github.com/pydantic/pydantic/issues/11747.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
