### PR TITLE
Only mark model as complete once all fields are complete

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -234,8 +234,8 @@ class ModelMetaclass(ABCMeta):
                 complete_model_class(
                     cls,
                     config_wrapper,
+                    ns_resolver,
                     raise_errors=False,
-                    ns_resolver=ns_resolver,
                     create_model_module=_create_model_module,
                 )
 
@@ -572,8 +572,8 @@ def complete_model_class(
     Args:
         cls: BaseModel or dataclass.
         config_wrapper: The config wrapper instance.
-        raise_errors: Whether to raise errors.
         ns_resolver: The namespace resolver instance to use during schema building.
+        raise_errors: Whether to raise errors.
         create_model_module: The module of the class to be created, if created by `create_model`.
 
     Returns:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -640,8 +640,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         return _model_construction.complete_model_class(
             cls,
             _config.ConfigWrapper(cls.model_config, check=False),
+            ns_resolver,
             raise_errors=raise_errors,
-            ns_resolver=ns_resolver,
         )
 
     @classmethod

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -637,26 +637,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             parent_namespace={**rebuild_ns, **parent_ns},
         )
 
-        if not cls.__pydantic_fields_complete__:
-            typevars_map = _generics.get_model_typevars_map(cls)
-            try:
-                cls.__pydantic_fields__ = _fields.rebuild_model_fields(
-                    cls,
-                    ns_resolver=ns_resolver,
-                    typevars_map=typevars_map,
-                )
-            except NameError as e:
-                exc = PydanticUndefinedAnnotation.from_name_error(e)
-                _mock_val_ser.set_model_mocks(cls, f'`{exc.name}`')
-                if raise_errors:
-                    raise exc from e
-
-            if not raise_errors and not cls.__pydantic_fields_complete__:
-                # No need to continue with schema gen, it is guaranteed to fail
-                return False
-
-            assert cls.__pydantic_fields_complete__
-
         return _model_construction.complete_model_class(
             cls,
             _config.ConfigWrapper(cls.model_config, check=False),

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2640,7 +2640,7 @@ def test_invalid_forward_ref_model():
 
 def test_incomplete_superclass() -> None:
     class MyModel(BaseModel):
-        sub_models: list['SubModel']
+        sub_model: 'SubModel'
 
     assert not MyModel.__pydantic_fields_complete__
     assert not MyModel.__pydantic_complete__
@@ -2661,8 +2661,8 @@ def test_incomplete_superclass() -> None:
 
     MyModel.model_rebuild()
 
-    assert MyModel.__pydantic_complete__
     assert MyModel.__pydantic_fields_complete__
+    assert MyModel.__pydantic_complete__
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

`BaseModel.model_rebuild` already ensured that `__pydantic_fields_complete__` was `True` before marking the model as complete, including rebuilding model fields to 1) see if any unknown annotations could not be resolved, and 2) if not, to make sure that the mock error message includes the name of the unknown annotation.

We now do the same on `ModelMetaclass.__new__`, to make sure that subclasses of incomplete superclasses don't incorrectly get marked as complete.

Here is such an example:

```python
class MyModel(BaseModel):
    sub_models: list['SubModel']

class SubModel(MyModel):
    pass
```

## Related issue number

Preparation for https://github.com/pydantic/pydantic/issues/11453

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @sydney-runkle