### PR TITLE
Make sure Pydantic dataclasses with slots and `validate_assignment` can be unpickled

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -5,7 +5,7 @@ from __future__ import annotations as _annotations
 import dataclasses
 import typing
 import warnings
-from functools import partial, wraps
+from functools import partial
 from typing import Any, ClassVar
 
 from pydantic_core import (
@@ -178,22 +178,12 @@ def complete_dataclass(
     # We are about to set all the remaining required properties expected for this cast;
     # __pydantic_decorators__ and __pydantic_fields__ should already be set
     cls = typing.cast('type[PydanticDataclass]', cls)
-    # debug(schema)
 
     cls.__pydantic_core_schema__ = schema
-    cls.__pydantic_validator__ = validator = create_schema_validator(
+    cls.__pydantic_validator__ = create_schema_validator(
         schema, cls, cls.__module__, cls.__qualname__, 'dataclass', core_config, config_wrapper.plugin_settings
     )
     cls.__pydantic_serializer__ = SchemaSerializer(schema, core_config)
-
-    if config_wrapper.validate_assignment:
-
-        @wraps(cls.__setattr__)
-        def validated_setattr(instance: Any, field: str, value: str, /) -> None:
-            validator.validate_assignment(instance, field, value)
-
-        cls.__setattr__ = validated_setattr.__get__(None, cls)  # type: ignore
-
     cls.__pydantic_complete__ = True
     return True
 

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -277,7 +277,7 @@ def dataclass(
                 # If slots is set, `pickle` (relied on by `copy.copy()`) will use
                 # `__setattr__()` to reconstruct the dataclass. However, the custom
                 # `__setattr__()` set above relies on `validate_assignment()`, which
-                # in turn excepts all the field values to be already present on the
+                # in turn expects all the field values to be already present on the
                 # instance, resulting in attribute errors.
                 # As such, we make use of `object.__setattr__()` instead.
                 # Note that we do so only if `__setstate__()` isn't already set (this is the

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2430,6 +2430,23 @@ def test_dataclass_slots(dataclass_decorator):
     assert dc.b == 'bar'
 
 
+# Must be defined at the module level to be pickable:
+@pydantic.dataclasses.dataclass(slots=True, config={'validate_assignment': True})
+class DataclassSlotsValidateAssignment:
+    a: int
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason='slots are only supported for dataclasses in Python >= 3.10')
+def test_dataclass_slots_validate_assignment():
+    """https://github.com/pydantic/pydantic/issues/11768"""
+
+    m = DataclassSlotsValidateAssignment(1)
+    m_pickle = pickle.loads(pickle.dumps(m))
+    assert m_pickle.a == 1
+    with pytest.raises(ValidationError):
+        m.a = 'not_an_int'
+
+
 @pytest.mark.parametrize(
     'dataclass_decorator',
     [

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2430,7 +2430,7 @@ def test_dataclass_slots(dataclass_decorator):
     assert dc.b == 'bar'
 
 
-# Must be defined at the module level to be pickable:
+# Must be defined at the module level to be picklable:
 @pydantic.dataclasses.dataclass(slots=True, config={'validate_assignment': True})
 class DataclassSlotsValidateAssignment:
     a: int


### PR DESCRIPTION


Fixes https://github.com/pydantic/pydantic/issues/11768.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
