### PR TITLE
Remove coercion of decimal constraints

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from copy import copy
-from decimal import Decimal
 from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any
 
@@ -220,10 +219,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             if constraint == 'union_mode' and schema_type == 'union':
                 schema['mode'] = value  # type: ignore  # schema is UnionSchema
             else:
-                if schema_type == 'decimal' and constraint in {'multiple_of', 'le', 'ge', 'lt', 'gt'}:
-                    schema[constraint] = Decimal(value)
-                else:
-                    schema[constraint] = value
+                schema[constraint] = value
             continue
 
         #  else, apply a function after validator to the schema to enforce the corresponding constraint


### PR DESCRIPTION
This is now done in `pydantic-core`, and wasn't done right as it resulted in some floating point precision errors.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11763.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
