### PR TITLE
Fix qualified name comparison of private attributes during namespace inspection

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -406,7 +406,7 @@ def inspect_namespace(  # noqa C901
             isinstance(value, type)
             and value.__module__ == namespace['__module__']
             and '__qualname__' in namespace
-            and value.__qualname__.startswith(namespace['__qualname__'])
+            and value.__qualname__.startswith(f'{namespace["__qualname__"]}.')
         ):
             # `value` is a nested type defined in this namespace; don't error
             continue

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -580,7 +580,7 @@ def test_private_attr_set_name_do_not_crash_if_not_callable():
     assert Model()._private_attr == 2
 
 
-def test_private_attribute_not_skipped_during_ns_inspection():
+def test_private_attribute_not_skipped_during_ns_inspection() -> None:
     # It is important for the enum name to start with the class name
     # (it previously caused issues as we were comparing qualnames without
     # taking this into account):

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -1,4 +1,5 @@
 import functools
+from enum import Enum
 from typing import ClassVar, Generic, Optional, TypeVar
 
 import pytest
@@ -577,3 +578,16 @@ def test_private_attr_set_name_do_not_crash_if_not_callable():
     # Checks below are just to ensure that everything is the same as in `test_private_attr_set_name`
     # The main check is that model class definition above doesn't crash
     assert Model()._private_attr == 2
+
+
+def test_private_attribute_not_skipped_during_ns_inspection():
+    # It is important for the enum name to start with the class name
+    # (it previously caused issues as we were comparing qualnames without
+    # taking this into account):
+    class Fullname(str, Enum):
+        pass
+
+    class Full(BaseModel):
+        _priv: object = Fullname
+
+    assert isinstance(Full._priv, ModelPrivateAttr)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Check if __qualname__ startswith `namespace["__qualname__"]` with `.` at the end.

## Related issue number
Fixes https://github.com/pydantic/pydantic/issues/11797

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @DouweM