### PR TITLE
Fix Pydantic's dataclass overrides defaults

### DIFF
--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -3103,3 +3103,16 @@ def test_deferred_dataclass_fields_available() -> None:
         a: int
 
     assert 'a' in A.__pydantic_fields__  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_override_defaults_when_using_dataclass() -> None:
+    @dataclasses.dataclass
+    class A:
+        a: int = 1
+
+    @pydantic.dataclasses.dataclass
+    class B(A):
+        a: int = 100
+
+    assert B().a == 100
+    assert TypeAdapter(B).validate_python({}).a == 100


### PR DESCRIPTION
## Change Summary


## Related issue number
https://github.com/pydantic/pydantic/issues/11816

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
