### PR TITLE
Always make use of `inspect.getsourcelines()` for docstring extraction on Python 3.13 and greater

### DIFF
--- a/pydantic/_internal/_docs_extraction.py
+++ b/pydantic/_internal/_docs_extraction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import sys
 import textwrap
 from typing import Any
 
@@ -89,13 +90,17 @@ def extract_docstrings_from_cls(cls: type[Any], use_inspect: bool = False) -> di
     Returns:
         A mapping containing attribute names and their corresponding docstring.
     """
-    if use_inspect:
-        # Might not work as expected if two classes have the same name in the same source file.
+    if use_inspect or sys.version_info >= (3, 13):
+        # On Python < 3.13, `inspect.getsourcelines()` might not work as expected
+        # if two classes have the same name in the same source file.
+        # On Python 3.13+, it will use the new `__firstlineno__` class attribute,
+        # making it way more robust.
         try:
             source, _ = inspect.getsourcelines(cls)
         except OSError:  # pragma: no cover
             return {}
     else:
+        # TODO remove this implementation when we drop support for Python 3.12:
         source = _extract_source_from_frame(cls)
 
     if not source:

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1013,7 +1013,7 @@ class ConfigDict(TypedDict, total=False):
         [`TypedDict`][typing.TypedDict] and stdlib dataclasses, in particular when:
 
         - inheritance is being used.
-        - multiple classes have the same name in the same source file.
+        - multiple classes have the same name in the same source file (unless Python 3.13 or greater is used).
     '''
 
     cache_strings: bool | Literal['all', 'keys', 'none']

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -298,10 +298,16 @@ def dataclass(
         # This is an undocumented attribute to distinguish stdlib/Pydantic dataclasses.
         # It should be set as early as possible:
         cls.__is_pydantic_dataclass__ = True
-
         cls.__pydantic_decorators__ = decorators  # type: ignore
         cls.__doc__ = original_doc
+        # Can be non-existent for dynamically created classes:
+        firstlineno = getattr(original_cls, '__firstlineno__', None)
         cls.__module__ = original_cls.__module__
+        if sys.version_info >= (3, 13) and firstlineno is not None:
+            # As per https://docs.python.org/3/reference/datamodel.html#type.__firstlineno__:
+            # Setting the `__module__` attribute removes the `__firstlineno__` item from the type’s dictionary.
+            original_cls.__firstlineno__ = firstlineno
+            cls.__firstlineno__ = firstlineno
         cls.__qualname__ = original_cls.__qualname__
         cls.__pydantic_complete__ = False  # `complete_dataclass` will set it to `True` if successful.
         # TODO `parent_namespace` is currently None, but we could do the same thing as Pydantic models:


### PR DESCRIPTION

Fixes https://github.com/pydantic/pydantic/issues/11805.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
