### PR TITLE
Use `typing.Dict` for `BaseModel` annotations

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -211,13 +211,17 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     __pydantic_computed_fields__: ClassVar[Dict[str, ComputedFieldInfo]]  # noqa: UP006
     """A dictionary of computed field names and their corresponding [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects."""
 
-    __pydantic_extra__: dict[str, Any] | None = _model_construction.NoInitField(init=False)
+    __pydantic_extra__: Dict[str, Any] | None = _model_construction.NoInitField(
+        init=False
+    )
     """A dictionary containing extra values, if [`extra`][pydantic.config.ConfigDict.extra] is set to `'allow'`."""
 
     __pydantic_fields_set__: set[str] = _model_construction.NoInitField(init=False)
     """The names of fields explicitly set during instantiation."""
 
-    __pydantic_private__: dict[str, Any] | None = _model_construction.NoInitField(init=False)
+    __pydantic_private__: Dict[str, Any] | None = _model_construction.NoInitField(
+        init=False
+    )
     """Values of private attributes set on the model instance."""
 
     if not TYPE_CHECKING:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -211,17 +211,13 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     __pydantic_computed_fields__: ClassVar[Dict[str, ComputedFieldInfo]]  # noqa: UP006
     """A dictionary of computed field names and their corresponding [`ComputedFieldInfo`][pydantic.fields.ComputedFieldInfo] objects."""
 
-    __pydantic_extra__: Dict[str, Any] | None = _model_construction.NoInitField(
-        init=False
-    )
+    __pydantic_extra__: Dict[str, Any] | None = _model_construction.NoInitField(init=False)  # noqa: UP006
     """A dictionary containing extra values, if [`extra`][pydantic.config.ConfigDict.extra] is set to `'allow'`."""
 
     __pydantic_fields_set__: set[str] = _model_construction.NoInitField(init=False)
     """The names of fields explicitly set during instantiation."""
 
-    __pydantic_private__: Dict[str, Any] | None = _model_construction.NoInitField(
-        init=False
-    )
+    __pydantic_private__: Dict[str, Any] | None = _model_construction.NoInitField(init=False)  # noqa: UP006
     """Values of private attributes set on the model instance."""
 
     if not TYPE_CHECKING:


### PR DESCRIPTION
## Change Summary

There is a disclaimer at top of file that mentions using `typing.Dict` for annotations rather than `dict` itself due to `dict` being part of the `BaseModel` namespace (in the form of the deprecated `dict()` method). We correct two violations of this disclaimer in this PR, which currently cause downstream issues in packages that rely heavily on parsing of type-annotations, e.g. mitmproxy/pdoc#792.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos