### PR TITLE
Install uv while running `family integration` tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,8 +9,15 @@ jobs:
   test-pydantic-settings:
     name: Test pydantic settings
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
+
+    - uses: astral-sh/setup-uv@v6
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Run tests
       run: make test-pydantic-settings
@@ -18,8 +25,15 @@ jobs:
   test-pydantic-extra-types:
     name: Test pydantic extra types
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
+
+    - uses: astral-sh/setup-uv@v6
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Run tests
       run: make test-pydantic-extra-types


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Hi, I noticed that this workflow was failing. Initially, the error was caused by a missing uv installation. Later, I found a bug in [pydantic-extra-types](https://github.com/pydantic/pydantic-extra-types/pull/315), but I’ve already fixed it.
The workflow now completes [successfully](https://github.com/karta9821/pydantic/actions/runs/14819231123)

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos