### PR TITLE
Fix SecretStr if None 

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1863,6 +1863,9 @@ class SecretStr(_SecretField[str]):
     _inner_schema: ClassVar[CoreSchema] = core_schema.str_schema()
     _error_kind: ClassVar[str] = 'string_type'
 
+    def __bool__(self) -> bool:
+        return bool(self._secret_value)
+
     def __len__(self) -> int:
         return len(self._secret_value)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Fixes
```py
from pydantic import SecretStr
test = SecretStr(None)
print(bool(test))
```

---
```
Traceback (most recent call last):
  File "c:\Users\smart\Desktop\GD\Kevin\tempCodeRunnerFile.python", line 5, in <module>
    print(bool(test))
          ^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\pydantic\types.py", line 1826, in __len__
    return len(self._secret_value)
           ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```
## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
