### PR TITLE
Improve documentation regarding `json_schema_input_type`

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -94,8 +94,8 @@ class BeforeValidator:
 
     Attributes:
         func: The validator function.
-        json_schema_input_type: The input type of the function. This is only used to generate the appropriate
-            JSON Schema (in validation mode).
+        json_schema_input_type: The input type used to generate the appropriate
+            JSON Schema (in validation mode). The actual input type is `Any`.
 
     Example:
         ```python
@@ -166,8 +166,8 @@ class PlainValidator:
 
     Attributes:
         func: The validator function.
-        json_schema_input_type: The input type of the function. This is only used to generate the appropriate
-            JSON Schema (in validation mode). If not provided, will default to `Any`.
+        json_schema_input_type: The input type used to generate the appropriate
+            JSON Schema (in validation mode). The actual input type is `Any`.
 
     Example:
         ```python
@@ -257,8 +257,8 @@ class WrapValidator:
 
     Attributes:
         func: The validator function.
-        json_schema_input_type: The input type of the function. This is only used to generate the appropriate
-            JSON Schema (in validation mode).
+        json_schema_input_type: The input type used to generate the appropriate
+            JSON Schema (in validation mode). The actual input type is `Any`.
 
     ```python
     from datetime import datetime


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Improve documentation regarding the `json_schema_input_type` attribute in `BeforeValidator`, `PlainValidator`, and `WrapValidator` by limiting the wording to state that its only purpose is for generating JSON schema. The deleted sentence, "the input type of the function", is incorrect because the input type of the validator function is always `Any` since the validator function handles raw inputs.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @DouweM