### PR TITLE
Respect custom title in functions JSON Schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1748,7 +1748,8 @@ class GenerateJsonSchema:
         for argument in arguments:
             name = self.get_argument_name(argument)
             argument_schema = self.generate_inner(argument['schema']).copy()
-            argument_schema['title'] = self.get_title_from_name(name)
+            if 'title' not in argument_schema:
+                argument_schema['title'] = self.get_title_from_name(name)
             properties[name] = argument_schema
 
             if argument['schema']['type'] != 'default':
@@ -1787,7 +1788,8 @@ class GenerateJsonSchema:
             name = self.get_argument_name(argument)
 
             argument_schema = self.generate_inner(argument['schema']).copy()
-            argument_schema['title'] = self.get_title_from_name(name)
+            if 'title' not in argument_schema:
+                argument_schema['title'] = self.get_title_from_name(name)
             prefix_items.append(argument_schema)
 
             if argument['schema']['type'] != 'default':

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -671,6 +671,15 @@ def test_json_schema():
     }
 
 
+def test_json_schema_custom_title() -> None:
+    def func(a: int):
+        pass
+
+    ta = TypeAdapter(func, config={'field_title_generator': lambda f_name, _: f_name + 'test'})
+
+    assert ta.json_schema()['properties']['a']['title'] == 'atest'
+
+
 def test_alias_generator():
     @validate_call(config=dict(alias_generator=lambda x: x * 2))
     def foo(a: int, b: int):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11728.

I think we should also check if the title needs to be set, as it is done currently for model fields with (`field_title_should_be_set()` L1395):

https://github.com/pydantic/pydantic/blob/944674a5c0e89f34a91f0bbefd524c89a4196403/pydantic/json_schema.py#L1383-L1396

```python
from pydantic import BaseModel

class Model(BaseModel): ...

class Main(BaseModel):
    m: Model

Main.model_json_schema()
{
│   '$defs': {'Model': {'properties': {}, 'title': 'Model', 'type': 'object'}},
│   'properties': {'m': {'$ref': '#/$defs/Model'}},  # no title
│   'required': ['m'],
│   'title': 'Main',
│   'type': 'object'
}

def func(m: Model): pass

TypeAdapter(func).json_schema()
{
│   '$defs': {'Model': {'properties': {}, 'title': 'Model', 'type': 'object'}},
│   'additionalProperties': False,
│   'properties': {'m': {'$ref': '#/$defs/Model', 'title': 'M'}},  # duplicate title
│   'required': ['m'],
│   'type': 'object'
}
```

thoughts @dmontagu?

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
