### PR TITLE
Refactor `FieldInfo` creation implementation

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -330,16 +330,11 @@ def collect_model_fields(  # noqa: C901
                 assigned_value.default = default
                 assigned_value._attributes_set['default'] = default
 
-            # The `from_annotated_attribute()` call below mutates the assigned `Field()`, so make a copy:
-            original_assignment = (
-                copy(assigned_value) if not evaluated and isinstance(assigned_value, FieldInfo_) else assigned_value
-            )
-
             field_info = FieldInfo_.from_annotated_attribute(ann_type, assigned_value, _source=AnnotationSource.CLASS)
             # Store the original annotation and assignment value that should be used to rebuild the field info later.
             # Note that the assignment is always stored as the annotation might contain a type var that is later
             #  parameterized with an unknown forward reference (and we'll need it to rebuild the field info):
-            field_info._original_assignment = original_assignment
+            field_info._original_assignment = assigned_value
             if not evaluated:
                 field_info._complete = False
                 field_info._original_annotation = ann_type

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -326,7 +326,9 @@ def collect_model_fields(  # noqa: C901
                 # Note that we only do this for method descriptors for now, we might want to
                 # extend this to any descriptor in the future (by simply checking for
                 # `hasattr(assigned_value.default, '__get__')`).
-                assigned_value.default = assigned_value.default.__get__(None, cls)
+                default = assigned_value.default.__get__(None, cls)
+                assigned_value.default = default
+                assigned_value._attributes_set['default'] = default
 
             # The `from_annotated_attribute()` call below mutates the assigned `Field()`, so make a copy:
             original_assignment = (

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Mapping
 from copy import copy
 from dataclasses import Field as DataclassField
 from functools import cached_property
-from typing import Annotated, Any, ClassVar, Literal, TypeVar, cast, overload
+from typing import Annotated, Any, ClassVar, Literal, TypeVar, cast, final, overload
 from warnings import warn
 
 import annotated_types
@@ -97,6 +97,7 @@ class _FieldInfoInputs(_FromFieldInfoInputs, total=False):
     default: Any
 
 
+@final
 class FieldInfo(_repr.Representation):
     """This class holds information about a field.
 
@@ -518,6 +519,11 @@ class FieldInfo(_repr.Representation):
         return merged_field_info
 
     @staticmethod
+    @typing_extensions.deprecated(
+        "The 'merge_field_infos()' method is deprecated and will be removed in a future version. "
+        'If you relied on this method, please open an issue in the Pydantic issue tracker.',
+        category=None,
+    )
     def merge_field_infos(*field_infos: FieldInfo, **overrides: Any) -> FieldInfo:
         """Merge `FieldInfo` instances keeping only explicitly set attributes.
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -438,10 +438,10 @@ class FieldInfo(_repr.Representation):
             # `default` is the actual default value
             attr_overrides['default'] = default
 
-        field_info = FieldInfo._construct(metadata, **attr_overrides)
+        field_info = FieldInfo._construct(
+            prepend_metadata + metadata if prepend_metadata is not None else metadata, **attr_overrides
+        )
         field_info._qualifiers = inspected_ann.qualifiers
-        if prepend_metadata is not None:
-            field_info.metadata = prepend_metadata + field_info.metadata
         return field_info
 
     @classmethod

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -58,7 +58,7 @@ NO_VALUE = object()
         (
             lambda: Annotated[int, Lt(2)],
             Field(5, gt=0),
-            'FieldInfo(annotation=int, required=False, default=5, metadata=[Lt(lt=2), Gt(gt=0)])',
+            'FieldInfo(annotation=int, required=False, default=5, metadata=[Gt(gt=0), Lt(lt=2)])',
         ),
         (
             lambda: Annotated[int, Gt(0)],
@@ -501,28 +501,6 @@ def test_min_length_field_info_not_lost():
             'input': '00',
             'ctx': {'min_length': 3},
             'msg': 'String should have at least 3 characters',
-            'type': 'string_too_short',
-        }
-    ]
-
-    # Ensure that the inner annotation does not override the outer, even for metadata:
-    class AnnotatedFieldModel2(BaseModel):
-        foo: 'Annotated[String, Field(min_length=3)]' = Field(description='hello', min_length=2)
-
-    AnnotatedFieldModel2(foo='00')
-
-    class AnnotatedFieldModel4(BaseModel):
-        foo: 'Annotated[String, Field(min_length=3)]' = Field(description='hello', min_length=4)
-
-    with pytest.raises(ValidationError) as exc_info:
-        AnnotatedFieldModel4(foo='00')
-
-    assert exc_info.value.errors(include_url=False) == [
-        {
-            'loc': ('foo',),
-            'input': '00',
-            'ctx': {'min_length': 4},
-            'msg': 'String should have at least 4 characters',
             'type': 'string_too_short',
         }
     ]

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -58,7 +58,7 @@ NO_VALUE = object()
         (
             lambda: Annotated[int, Lt(2)],
             Field(5, gt=0),
-            'FieldInfo(annotation=int, required=False, default=5, metadata=[Gt(gt=0), Lt(lt=2)])',
+            'FieldInfo(annotation=int, required=False, default=5, metadata=[Lt(lt=2), Gt(gt=0)])',
         ),
         (
             lambda: Annotated[int, Gt(0)],

--- a/tests/test_deprecated_fields.py
+++ b/tests/test_deprecated_fields.py
@@ -252,7 +252,8 @@ def test_deprecated_field_forward_annotation() -> None:
     Test = int
 
     Model.model_rebuild()
-    assert Model.model_fields['a'].deprecated == 'test'
+    assert isinstance(Model.model_fields['a'].deprecated, deprecated)
+    assert Model.model_fields['a'].deprecated.message == 'test'
 
     m = Model()
 

--- a/tests/test_deprecated_fields.py
+++ b/tests/test_deprecated_fields.py
@@ -258,3 +258,13 @@ def test_deprecated_field_forward_annotation() -> None:
     m = Model()
 
     pytest.warns(DeprecationWarning, lambda: m.a, match='test')
+
+
+def test_deprecated_field_with_assignment() -> None:
+    class Model(BaseModel):
+        # A buggy implementation made it so that deprecated wouldn't
+        # appear on the `FieldInfo`:
+        a: Annotated[int, deprecated('test')] = Field(default=1)
+
+    assert isinstance(Model.model_fields['a'].deprecated, deprecated)
+    assert Model.model_fields['a'].deprecated.message == 'test'

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6680,11 +6680,18 @@ def test_examples_as_property_key() -> None:
 
 def test_warn_on_mixed_compose() -> None:
     with pytest.warns(
-        PydanticJsonSchemaWarning, match='Composing `dict` and `callable` type `json_schema_extra` is not supported.'
+        UserWarning, match='Composing `dict` and `callable` type `json_schema_extra` is not supported.'
     ):
 
-        class Model(BaseModel):
+        class Model1(BaseModel):
             field: Annotated[int, Field(json_schema_extra={'a': 'dict'}), Field(json_schema_extra=lambda x: x.pop('a'))]  # type: ignore
+
+
+    with pytest.warns(
+        UserWarning, match='Composing `dict` and `callable` type `json_schema_extra` is not supported.'
+    ):
+        class Model2(BaseModel):
+            field: Annotated[int, Field(json_schema_extra=lambda x: x.pop('a')), Field(json_schema_extra={'a': 'dict'})]  # type: ignore
 
 
 def test_blank_title_is_respected() -> None:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6679,17 +6679,13 @@ def test_examples_as_property_key() -> None:
 
 
 def test_warn_on_mixed_compose() -> None:
-    with pytest.warns(
-        UserWarning, match='Composing `dict` and `callable` type `json_schema_extra` is not supported.'
-    ):
+    with pytest.warns(UserWarning, match='Composing `dict` and `callable` type `json_schema_extra` is not supported.'):
 
         class Model1(BaseModel):
             field: Annotated[int, Field(json_schema_extra={'a': 'dict'}), Field(json_schema_extra=lambda x: x.pop('a'))]  # type: ignore
 
+    with pytest.warns(UserWarning, match='Composing `dict` and `callable` type `json_schema_extra` is not supported.'):
 
-    with pytest.warns(
-        UserWarning, match='Composing `dict` and `callable` type `json_schema_extra` is not supported.'
-    ):
         class Model2(BaseModel):
             field: Annotated[int, Field(json_schema_extra=lambda x: x.pop('a')), Field(json_schema_extra={'a': 'dict'})]  # type: ignore
 

--- a/uv.lock
+++ b/uv.lock
@@ -2721,14 +2721,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222, upload-time = "2025-02-25T17:27:59.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125, upload-time = "2025-02-25T17:27:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

(best reviewed commit per commit).

Fixes https://github.com/pydantic/pydantic/issues/11870, fixes https://github.com/pydantic/pydantic/issues/11876, fixes https://github.com/pydantic/pydantic/issues/11978.

Fixes https://github.com/pydantic/pydantic/issues/11122 (the three bugs described in the issue).

Issue https://github.com/pydantic/pydantic/issues/10507 _isn't_ fixed with this, but at least now properly documented as a workaround in the implementation.

Most of the context of this PR is described in https://github.com/pydantic/pydantic/issues/11122.

The main thing being done here is the added `_construct()` classmethod, that centralizes most of the merging logic and avoids repetition (which actually wasn't mirrored in every code path, that's why many inconsistencies existed depending on whether you assigned a `Field()` to an attribute). We avoid copying `FieldInfo` instances everywhere, and doing buggy metadata handling.

As a result, the `merge_field_infos()` method is unused (you can compare both this method and `_construct()` to see what changed — the latter is much simpler). We need to deprecate it as third-party projects rely on it (unfortunately..). I propose marking it as deprecated _only_ for type checkers for now, and have a runtime deprecation emitted in V3?

openapi-python-client third party failure is unrelated, their CI is currently failing.