### PR TITLE
Do not duplicate metadata on model rebuild

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -16,7 +16,7 @@ from warnings import warn
 import annotated_types
 import typing_extensions
 from pydantic_core import PydanticUndefined
-from typing_extensions import TypeAlias, Unpack, deprecated
+from typing_extensions import Self, TypeAlias, Unpack, deprecated
 from typing_inspection import typing_objects
 from typing_inspection.introspection import UNKNOWN, AnnotationSource, ForbiddenQualifier, Qualifier, inspect_annotation
 
@@ -698,6 +698,18 @@ class FieldInfo(_repr.Representation):
         if not evaluated:
             self._complete = False
             self._original_annotation = self.annotation
+
+    def __copy__(self) -> Self:
+        cls = type(self)
+        copied = cls()
+        for attr_name in cls.__slots__:
+            value = getattr(self, attr_name)
+            if attr_name in ('metadata', '_attributes_set', '_qualifiers'):
+                # Apply "deep-copy" behavior on collections attributes:
+                value = value.copy()
+            setattr(copied, attr_name, value)
+
+        return copied
 
     def __repr_args__(self) -> ReprArgs:
         yield 'annotation', _repr.PlainRepr(_repr.display_as_type(self.annotation))

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,7 @@
-from typing import Union
+from typing import Annotated, Union
 
 import pytest
+from annotated_types import Gt
 
 import pydantic.dataclasses
 from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, RootModel, ValidationError, computed_field, fields
@@ -188,3 +189,16 @@ def test_rebuild_model_fields_preserves_description() -> None:
     Model.model_rebuild()
 
     assert Model.model_fields['f'].description == 'test doc'
+
+
+def test_no_duplicate_metadata_with_assignment_and_rebuild() -> None:
+    """https://github.com/pydantic/pydantic/issues/11870"""
+
+    class Model(BaseModel):
+        f: Annotated['Int', Gt(1)] = Field()
+
+    Int = int
+
+    Model.model_rebuild()
+
+    assert len(Model.model_fields['f'].metadata) == 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This is a stripped down version of https://github.com/pydantic/pydantic/pull/11898, as a backport to 2.11. In 2.11, a change in the model rebuild logic surfaced an issue with `FieldInfo` being wrongly mutated and copied properly, resulting in a regression.

https://github.com/pydantic/pydantic/pull/11898 is a proper refactor, but can't be fully backported as it would be too risky as a patch release.

Fixes (for 2.11) https://github.com/pydantic/pydantic/issues/11870.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
