### PR TITLE
Force `model_validator('after')` to decorate instance method

### DIFF
--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -521,7 +521,7 @@ class DecoratorInfos:
             computed_field_dec.info._update_from_config(config_wrapper, name)
 
 
-def inspect_validator(validator: Callable[..., Any], mode: FieldValidatorModes) -> bool:
+def inspect_validator(validator: Callable[..., Any], mode: FieldValidatorModes, *, model: bool = False) -> bool:
     """Look at a field or model validator function and determine whether it takes an info argument.
 
     An error is raised if the function has an invalid signature.
@@ -529,6 +529,7 @@ def inspect_validator(validator: Callable[..., Any], mode: FieldValidatorModes) 
     Args:
         validator: The validator function to inspect.
         mode: The proposed validator mode.
+        model: Whether the validator is a model validator.
 
     Returns:
         Whether the validator takes an info argument.
@@ -552,8 +553,9 @@ def inspect_validator(validator: Callable[..., Any], mode: FieldValidatorModes) 
         elif n_positional == 1:
             return False
 
+    validator_type = 'model_validator' if model else 'field_validator'
     raise PydanticUserError(
-        f'Unrecognized field_validator function signature for {validator} with `mode={mode}`:{sig}',
+        f'Unrecognized {validator_type} function signature for {validator} with `mode={mode}`:{sig}',
         code='validator-signature',
     )
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2415,7 +2415,11 @@ def apply_model_validators(
             continue
         if mode == 'outer' and validator.info.mode == 'before':
             continue
-        info_arg = inspect_validator(validator.func, validator.info.mode)
+        info_arg = inspect_validator(
+            validator.func,
+            validator.info.mode,
+            model=isinstance(validator.info, ModelValidatorDecoratorInfo),
+        )
         if validator.info.mode == 'wrap':
             if info_arg:
                 schema = core_schema.with_info_wrap_validator_function(function=validator.func, schema=schema)

--- a/tests/typechecking/decorators.py
+++ b/tests/typechecking/decorators.py
@@ -54,8 +54,7 @@ class WrapModelValidator(BaseModel):
     @classmethod
     def no_handler(cls, value: Any) -> Self: ...
 
-    # Mypy somehow reports "Cannot infer function type argument" here:
-    @model_validator(mode='wrap')  # type:ignore[misc]  # pyright: ignore[reportArgumentType]
+    @model_validator(mode='wrap')
     @classmethod
     def incompatible_type_var(cls, value: Any, handler: ModelWrapValidatorHandler[int]) -> int:
         """
@@ -83,8 +82,7 @@ class WrapModelValidator(BaseModel):
 
 
 class AfterModelValidator(BaseModel):
-    # Mypy somehow reports "Cannot infer function type argument" here:
-    @model_validator(mode='after')  # type:ignore[misc]  # pyright: ignore[reportArgumentType]
+    @model_validator(mode='after')
     def missing_return_value(self) -> None: ...
 
     @model_validator(mode='after')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

It addresses https://github.com/pydantic/pydantic/issues/11905

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos