### PR TITLE
Add `ValidateAs` annotation helper

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -802,6 +802,33 @@ Pydantic provides a few special utilities that can be used to customize validati
     1. Note that the validation of the second item is skipped. If it has the wrong type it will emit a
        warning during serialization.
 
+* [`ValidateFrom`][pydantic.functional_validators.ValidateFrom] can be used to validate an custom type from a
+  type natively supported by Pydantic.
+
+    ```python {lint="skip"}
+    from typing import Annotated
+
+    from pydantic import BaseModel, TypeAdapter, ValidateFrom
+
+    class MyCls:
+        def __init__(self, a: int) -> None:
+            self.a = a
+
+        def __repr__(self) -> str:
+            return f"MyCls(a={self.a})"
+
+    class ValModel(BaseModel):
+        a: int
+
+
+    ta = TypeAdapter(
+        Annotated[MyCls, ValidateFrom(ValModel, instantiation_hook=lambda v: MyCls(a=v.a))]
+    )
+
+    print(ta.validate_python({'a': 1}))
+    #> MyCls(a=1)
+    ```
+
 * [`PydanticUseDefault`][pydantic_core.PydanticUseDefault] can be used to notify Pydantic that the default value
   should be used.
 

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -822,7 +822,7 @@ Pydantic provides a few special utilities that can be used to customize validati
 
 
     ta = TypeAdapter(
-        Annotated[MyCls, ValidateAs(ValModel, instantiation_hook=lambda v: MyCls(a=v.a))]
+        Annotated[MyCls, ValidateAs(ValModel, lambda v: MyCls(a=v.a))]
     )
 
     print(ta.validate_python({'a': 1}))

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -803,7 +803,7 @@ Pydantic provides a few special utilities that can be used to customize validati
        warning during serialization.
 
 * [`ValidateFrom`][pydantic.functional_validators.ValidateFrom] can be used to validate an custom type from a
-  type natively supported by Pydantic.
+  type natively supported by Pydantic. This is particularly useful when using custom types with multiple fields.
 
     ```python {lint="skip"}
     from typing import Annotated

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -802,13 +802,13 @@ Pydantic provides a few special utilities that can be used to customize validati
     1. Note that the validation of the second item is skipped. If it has the wrong type it will emit a
        warning during serialization.
 
-* [`ValidateFrom`][pydantic.functional_validators.ValidateFrom] can be used to validate an custom type from a
+* [`ValidateAs`][pydantic.functional_validators.ValidateAs] can be used to validate an custom type from a
   type natively supported by Pydantic. This is particularly useful when using custom types with multiple fields.
 
     ```python {lint="skip"}
     from typing import Annotated
 
-    from pydantic import BaseModel, TypeAdapter, ValidateFrom
+    from pydantic import BaseModel, TypeAdapter, ValidateAs
 
     class MyCls:
         def __init__(self, a: int) -> None:
@@ -822,7 +822,7 @@ Pydantic provides a few special utilities that can be used to customize validati
 
 
     ta = TypeAdapter(
-        Annotated[MyCls, ValidateFrom(ValModel, instantiation_hook=lambda v: MyCls(a=v.a))]
+        Annotated[MyCls, ValidateAs(ValModel, instantiation_hook=lambda v: MyCls(a=v.a))]
     )
 
     print(ta.validate_python({'a': 1}))

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -37,6 +37,7 @@ if typing.TYPE_CHECKING:
         ModelWrapValidatorHandler,
         PlainValidator,
         SkipValidation,
+        ValidateFrom,
         WrapValidator,
         field_validator,
         model_validator,
@@ -76,6 +77,7 @@ __all__ = (
     'PlainValidator',
     'WrapValidator',
     'SkipValidation',
+    'ValidateFrom',
     'InstanceOf',
     'ModelWrapValidatorHandler',
     # JSON Schema
@@ -250,6 +252,7 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'WrapValidator': (__spec__.parent, '.functional_validators'),
     'SkipValidation': (__spec__.parent, '.functional_validators'),
     'InstanceOf': (__spec__.parent, '.functional_validators'),
+    'ValidateFrom': (__spec__.parent, '.functional_validators'),
     'ModelWrapValidatorHandler': (__spec__.parent, '.functional_validators'),
     # JSON Schema
     'WithJsonSchema': (__spec__.parent, '.json_schema'),

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -37,7 +37,7 @@ if typing.TYPE_CHECKING:
         ModelWrapValidatorHandler,
         PlainValidator,
         SkipValidation,
-        ValidateFrom,
+        ValidateAs,
         WrapValidator,
         field_validator,
         model_validator,
@@ -77,7 +77,7 @@ __all__ = (
     'PlainValidator',
     'WrapValidator',
     'SkipValidation',
-    'ValidateFrom',
+    'ValidateAs',
     'InstanceOf',
     'ModelWrapValidatorHandler',
     # JSON Schema
@@ -252,7 +252,7 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'WrapValidator': (__spec__.parent, '.functional_validators'),
     'SkipValidation': (__spec__.parent, '.functional_validators'),
     'InstanceOf': (__spec__.parent, '.functional_validators'),
-    'ValidateFrom': (__spec__.parent, '.functional_validators'),
+    'ValidateAs': (__spec__.parent, '.functional_validators'),
     'ModelWrapValidatorHandler': (__spec__.parent, '.functional_validators'),
     # JSON Schema
     'WithJsonSchema': (__spec__.parent, '.json_schema'),

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -870,6 +870,7 @@ class ValidateFrom:
         ```
     """
 
+    # TODO: make use of PEP 747
     def __init__(self, from_type: type[_FromTypeT], /, *, instantiation_hook: Callable[[_FromTypeT], Any]) -> None:
         self.from_type = from_type
         self.instantiation_hook = instantiation_hook

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -831,3 +831,52 @@ else:
             )
 
         __hash__ = object.__hash__
+
+
+_FromTypeT = TypeVar('_FromTypeT')
+
+
+class ValidateFrom:
+    """A helper class to validate a custom type from a type natively supported by Pydantic.
+
+    Args:
+        from_type: The type natively supported by Pydantic to use to perform validation.
+        instantiation_hook: A callable taking the validated type as an argument, and returning
+            the populated custom type.
+
+    Example:
+        ```python {lint="skip"}
+        from typing import Annotated
+
+        from pydantic import BaseModel, TypeAdapter, ValidateFrom
+
+        class MyCls:
+            def __init__(self, a: int) -> None:
+                self.a = a
+
+            def __repr__(self) -> str:
+                return f"MyCls(a={self.a})"
+
+        class Model(BaseModel):
+            a: int
+
+
+        ta = TypeAdapter(
+            Annotated[MyCls, ValidateFrom(Model, instantiation_hook=lambda v: MyCls(a=v.a))]
+        )
+
+        print(ta.validate_python({'a': 1}))
+        #> MyCls(a=1)
+        ```
+    """
+
+    def __init__(self, from_type: type[_FromTypeT], /, *, instantiation_hook: Callable[[_FromTypeT], Any]) -> None:
+        self.from_type = from_type
+        self.instantiation_hook = instantiation_hook
+
+    def __get_pydantic_core_schema__(self, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        schema = handler(self.from_type)
+        return core_schema.no_info_after_validator_function(
+            lambda value: self.instantiation_hook(value),
+            schema=schema,
+        )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -106,7 +106,7 @@ from pydantic import (
     StringConstraints,
     Tag,
     TypeAdapter,
-    ValidateFrom,
+    ValidateAs,
     ValidationError,
     conbytes,
     condate,
@@ -6029,7 +6029,7 @@ def test_validate_from() -> None:
     class ArbitraryModel(BaseModel):
         a: int
 
-    ta = TypeAdapter(Annotated[Arbitrary, ValidateFrom(ArbitraryModel, instantiation_hook=lambda v: Arbitrary(a=v.a))])
+    ta = TypeAdapter(Annotated[Arbitrary, ValidateAs(ArbitraryModel, instantiation_hook=lambda v: Arbitrary(a=v.a))])
 
     assert ta.validate_python({'a': 1}) == Arbitrary(1)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -106,6 +106,7 @@ from pydantic import (
     StringConstraints,
     Tag,
     TypeAdapter,
+    ValidateFrom,
     ValidationError,
     conbytes,
     condate,
@@ -6015,6 +6016,22 @@ def test_skip_validation_json_schema():
         'title': 'A',
         'type': 'object',
     }
+
+
+def test_validate_from() -> None:
+    class Arbitrary:
+        def __init__(self, a: int) -> None:
+            self.a = a
+
+        def __eq__(self, other) -> bool:
+            return self.a == other.a
+
+    class ArbitraryModel(BaseModel):
+        a: int
+
+    ta = TypeAdapter(Annotated[Arbitrary, ValidateFrom(ArbitraryModel, instantiation_hook=lambda v: Arbitrary(a=v.a))])
+
+    assert ta.validate_python({'a': 1}) == Arbitrary(1)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="`Annotated` doesn't allow instances in <3.12")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11682.

Currently, the `instantiation_hook` is required. We could also make it optional and by default populate the arbitrary class by e.g. calling `__new__()`. However, by doing so, we need to make some assumptions on the `from_type`. It can currently be anything (supported by Pydantic: models, dataclasses, typeddicts, etc), but we will have to constrain it to some specific types (perhaps only supporting Pydantic models?) as we will most likely have to assume `__dict__` is present to fetch the instance attributes and pass them to `__new__()`.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
