### PR TITLE
Add `flake8-pie` Ruff rules

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -761,7 +761,7 @@ may need to explicitly specify the generic parameter:
 from pydantic import TypeAdapter
 
 adapter = TypeAdapter[str | int](str | int)
-...  # noqa: PIE790
+...
 ```
 
 See [Type Adapter](concepts/type_adapter.md) for more information.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -761,7 +761,7 @@ may need to explicitly specify the generic parameter:
 from pydantic import TypeAdapter
 
 adapter = TypeAdapter[str | int](str | int)
-...
+...  # noqa: PIE790
 ```
 
 See [Type Adapter](concepts/type_adapter.md) for more information.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -591,7 +591,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """Override this method to perform additional initialization after `__init__` and `model_construct`.
         This is useful if you want to do some validation that requires the entire model to be initialized.
         """
-        pass
 
     @classmethod
     def model_rebuild(
@@ -837,7 +836,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             You may want to override [`__pydantic_on_complete__()`][pydantic.main.BaseModel.__pydantic_on_complete__]
             instead, which is called once the class and its fields are fully initialized and ready for validation.
         """
-        pass
 
     @classmethod
     def __pydantic_on_complete__(cls) -> None:
@@ -849,7 +847,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         In that case, it will be called later, when the model is rebuilt automatically or explicitly using
         [`model_rebuild()`][pydantic.main.BaseModel.model_rebuild].
         """
-        pass
 
     def __class_getitem__(
         cls, typevar_values: type[Any] | tuple[type[Any], ...]

--- a/pydantic/plugin/__init__.py
+++ b/pydantic/plugin/__init__.py
@@ -131,7 +131,6 @@ class ValidatePythonHandlerProtocol(BaseValidateHandlerProtocol, Protocol):
             by_alias: Whether to use the field's alias to match the input data to an attribute.
             by_name: Whether to use the field's name to match the input data to an attribute.
         """
-        pass
 
 
 class ValidateJsonHandlerProtocol(BaseValidateHandlerProtocol, Protocol):
@@ -158,7 +157,6 @@ class ValidateJsonHandlerProtocol(BaseValidateHandlerProtocol, Protocol):
             by_alias: Whether to use the field's alias to match the input data to an attribute.
             by_name: Whether to use the field's name to match the input data to an attribute.
         """
-        pass
 
 
 StringInput: TypeAlias = 'dict[str, StringInput]'
@@ -185,4 +183,3 @@ class ValidateStringsHandlerProtocol(BaseValidateHandlerProtocol, Protocol):
             by_alias: Whether to use the field's alias to match the input data to an attribute.
             by_name: Whether to use the field's name to match the input data to an attribute.
         """
-        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,12 +207,13 @@ select = [
     'T10',    # flake8-debugger
     'T20',    # flake8-print
     'C4',     # flake8-comprehensions
+    'PIE',    # flake8-pie
     'PYI006', # flake8-pyi
     'PYI062', # flake8-pyi
     'PYI063', # flake8-pyi
     'PYI066', # flake8-pyi
 ]
-ignore = ['D105', 'D107', 'D205', 'D415', 'E501', 'B011', 'B028', 'B904']
+ignore = ['D105', 'D107', 'D205', 'D415', 'E501', 'B011', 'B028', 'B904', 'PIE804']
 flake8-quotes = {inline-quotes = 'single', multiline-quotes = 'double'}
 isort = { known-first-party = ['pydantic', 'tests'] }
 mccabe = { max-complexity = 14 }
@@ -222,7 +223,9 @@ pydocstyle = { convention = 'google' }
 'docs/*' = ['D']
 'pydantic/__init__.py' = ['F405', 'F403', 'D']
 'tests/test_forward_ref.py' = ['F821']
+'tests/test_main.py' = ['PIE807']
 'tests/*' = ['D', 'B', 'C4']
+'pydantic/_internal/_known_annotated_metadata.py' = ['PIE800']
 'pydantic/deprecated/*' = ['D', 'PYI']
 'pydantic/color.py' = ['PYI']
 'pydantic/_internal/_decorators_v1.py' = ['PYI']

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -95,7 +95,7 @@ def run_example(example: CodeExample, eval_example: EvalExample, mocker: Any) ->
 
     group_name = prefix_settings.get('group')
 
-    eval_example.set_config(ruff_ignore=['D', 'T', 'B', 'C4', 'E721', 'Q001'], line_length=LINE_LENGTH)
+    eval_example.set_config(ruff_ignore=['D', 'T', 'B', 'C4', 'E721', 'Q001', 'PIE790'], line_length=LINE_LENGTH)
     if '# ignore-above' in example.source:
         eval_example.set_config(ruff_ignore=eval_example.config.ruff_ignore + ['E402'], line_length=LINE_LENGTH)
     if group_name:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -263,8 +263,6 @@ def test_fastapi_compatibility_hack() -> None:
     class Body(FieldInfo):
         """A reproduction of the FastAPI's `Body` param."""
 
-        pass
-
     field = Body()
     # Assigning after doesn't update `_attributes_set`, which is currently
     # relied on to merge `FieldInfo` instances during field creation.

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -321,7 +321,7 @@ def test_parameter_count():
 
     # This error message, which comes from `typing`, changed 'parameters' to 'arguments' in 3.11
     error_message = str(exc_info.value)
-    assert error_message.startswith('Too many parameters') or error_message.startswith('Too many arguments')
+    assert error_message.startswith(('Too many parameters', 'Too many arguments'))
     assert error_message.endswith(
         " for <class 'tests.test_generics.test_parameter_count.<locals>.Model'>; actual 3, expected 2"
     )

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -778,7 +778,7 @@ def test_serializer_allow_reuse_different_field_3():
             y: int
 
             ser_x = field_serializer('x')(ser1)
-            ser_x = field_serializer('y')(ser2)
+            ser_x = field_serializer('y')(ser2)  # noqa: PIE794
 
     assert Model(x=1, y=2).model_dump() == {'x': 1, 'y': 'ser2'}
 

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -207,7 +207,6 @@ def test_dataclass_config_field_title_generator(field_title_generator):
 def test_typeddict_model_title_generator(model_title_generator, TypedDict):
     class MyTypedDict(TypedDict):
         __pydantic_config__ = ConfigDict(model_title_generator=model_title_generator)
-        pass
 
     assert TypeAdapter(MyTypedDict).json_schema() == {
         'properties': {},
@@ -429,7 +428,6 @@ def test_model_title_generator_returns_invalid_type(invalid_return_value, TypedD
 
         class MyTypedDict(TypedDict):
             __pydantic_config__ = ConfigDict(model_title_generator=lambda m: invalid_return_value)
-            pass
 
         TypeAdapter(MyTypedDict).json_schema()
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2545,7 +2545,7 @@ def test_validator_allow_reuse_different_field_3():
             y: int
 
             val_x = field_validator('x')(val1)
-            val_x = field_validator('y')(val2)
+            val_x = field_validator('y')(val2)  # noqa: PIE794
 
     assert Model(x=1, y=2).model_dump() == {'x': 1, 'y': 4}
 

--- a/tests/typechecking/decorators.py
+++ b/tests/typechecking/decorators.py
@@ -77,7 +77,7 @@ class WrapModelValidator(BaseModel):
         the `_ModelType` type var will thus bind to `Self`. It is then expected to have
         `handler: ModelWrapValidatorHandler[_ModelType]` and the return type as `-> _ModelType`.
         """
-        ...
+        ...  # noqa: PIE790
 
     @model_validator(mode='wrap')
     @classmethod


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#flake8-pie-pie

% `ruff rule PIE810`
> The startswith and endswith methods accept tuples of prefixes or suffixes respectively.
Passing a tuple of prefixes or suffixes is more efficient and readable than calling the method multiple times.

> References
* [Python documentation: `str.startswith`](https://docs.python.org/3/library/stdtypes.html#str.startswith)

This transformation to reduce unnecessary repetitive function calls has been recommended since 2006 when [it was introduced](https://docs.python.org/2/whatsnew/2.5.html#other-language-changes) in Python 2.5

Please review.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
