### PR TITLE
Add regex patterns to JSON schema for `Decimal` type

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -279,7 +279,7 @@ print(Model.model_json_schema(mode='validation'))
             'anyOf': [
                 {'type': 'number'},
                 {
-                    'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     'type': 'string',
                 },
             ],
@@ -298,7 +298,7 @@ print(Model.model_json_schema(mode='serialization'))
     'properties': {
         'a': {
             'default': '12.34',
-            'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             'title': 'A',
             'type': 'string',
         }

--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -279,7 +279,7 @@ print(Model.model_json_schema(mode='validation'))
             'anyOf': [
                 {'type': 'number'},
                 {
-                    'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     'type': 'string',
                 },
             ],
@@ -298,7 +298,7 @@ print(Model.model_json_schema(mode='serialization'))
     'properties': {
         'a': {
             'default': '12.34',
-            'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             'title': 'A',
             'type': 'string',
         }

--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -276,7 +276,13 @@ print(Model.model_json_schema(mode='validation'))
 {
     'properties': {
         'a': {
-            'anyOf': [{'type': 'number'}, {'type': 'string'}],
+            'anyOf': [
+                {'type': 'number'},
+                {
+                    'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    'type': 'string',
+                },
+            ],
             'default': '12.34',
             'title': 'A',
         }
@@ -289,7 +295,14 @@ print(Model.model_json_schema(mode='validation'))
 print(Model.model_json_schema(mode='serialization'))
 """
 {
-    'properties': {'a': {'default': '12.34', 'title': 'A', 'type': 'string'}},
+    'properties': {
+        'a': {
+            'default': '12.34',
+            'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            'title': 'A',
+            'type': 'string',
+        }
+    },
     'title': 'Model',
     'type': 'object',
 }

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -676,26 +676,44 @@ class GenerateJsonSchema:
         """
 
         def get_decimal_pattern(schema: core_schema.DecimalSchema) -> str:
-            max_digits = schema.get('max_digits', '')
-            decimal_places = schema.get('decimal_places', '')
-            integer_places = max_digits
-
-            if isinstance(max_digits, int) and isinstance(decimal_places, int):
-                if (diff := max_digits - decimal_places) > 0:
-                    integer_places = diff
-                else:
-                    integer_places = 0
+            max_digits = schema.get('max_digits')
+            decimal_places = schema.get('decimal_places')
 
             pattern = (
-                r'^(?!^[-+.]*$)'  # check string is not empty and not single or sequence of ".+-" characters.
-                r'[+-]?0*'  # check "+-" optional characters in the very start and optional zeros.
-                r'(?:'  # open non-capturing group
-                rf'\d{{0,{integer_places}}}$'  # integer case
-                r'|'  # or decimal case
-                rf'(?=[\d\.]{{1,{max_digits + 1 if isinstance(max_digits, int) else ""}}}0*$)'  # decimal case, check max digits in decimal with lookahead
-                rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'  # if pass previous lookahead match decimal pattern
-                r')'  # close non-capturing group
+                r'^(?!^[-+.]*$)[+-]?0*'  # check it is not empty string and not one or sequence of ".+-" characters.
             )
+
+            # Case 1: Both max_digits and decimal_places are set
+            if max_digits is not None and decimal_places is not None:
+                integer_places = max(0, max_digits - decimal_places)
+                pattern += (
+                    rf'(?:'
+                    rf'\d{{0,{integer_places}}}'
+                    rf'|'
+                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
+                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}'
+                    rf')0*$'
+                )
+
+            # Case 2: Only max_digits is set
+            elif max_digits is not None and decimal_places is None:
+                pattern += (
+                    rf'(?:'
+                    rf'\d{{0,{max_digits}}}'
+                    rf'|'
+                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
+                    rf'\d*\.\d*0*$'
+                    rf')'
+                )
+
+            # Case 3: Only decimal_places is set
+            elif max_digits is None and decimal_places is not None:
+                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*$'
+
+            # Case 4: Both are None (no restrictions)
+            else:
+                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
+
             return pattern
 
         json_schema = self.str_schema(core_schema.str_schema(pattern=get_decimal_pattern(schema)))

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -691,8 +691,8 @@ class GenerateJsonSchema:
                     rf'\d{{0,{integer_places}}}'
                     rf'|'
                     rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}'
-                    rf')0*$'
+                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
+                    rf')'
                 )
 
             # Case 2: Only max_digits is set

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -687,7 +687,7 @@ class GenerateJsonSchema:
                     integer_places = 0
 
             pattern = (
-                r'^(?!^[+-\.]*$)'  # check string is not empty and not single or sequence of ".+-" characters.
+                r'^(?!^[-+.]*$)'  # check string is not empty and not single or sequence of ".+-" characters.
                 r'[+-]?0*'  # check "+-" optional characters in the very start and optional zeros.
                 r'(?:'  # open non-capturing group
                 rf'\d{{0,{integer_places}}}$'  # integer case

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7020,7 +7020,7 @@ def test_decimal_pattern_with_decimal_places_max_digits_set(valid_decimal, get_d
 
 @pytest.mark.parametrize(
     'invalid_decimal',
-    ['10.001', '111', '0100.0010', '011.0110', '111.1', '1111', '001.11100', '.111', '.111000', '000111.'],
+    ['10.001', '111', '0100.0010', '011.0110', '111.1', '1111', '001.11100', '.111', '.111000', '000111.', '1100'],
 )
 def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_set(invalid_decimal, get_decimal_pattern):
     pattern = get_decimal_pattern(max_digits=4, decimal_places=2)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -525,7 +525,17 @@ def test_decimal_json_schema():
     assert model_json_schema_validation == {
         'properties': {
             'a': {'default': 'foobar', 'format': 'binary', 'title': 'A', 'type': 'string'},
-            'b': {'anyOf': [{'type': 'number'}, {'type': 'string'}], 'default': '12.34', 'title': 'B'},
+            'b': {
+                'anyOf': [
+                    {'type': 'number'},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ],
+                'default': '12.34',
+                'title': 'B',
+            },
         },
         'title': 'Model',
         'type': 'object',
@@ -533,7 +543,12 @@ def test_decimal_json_schema():
     assert model_json_schema_serialization == {
         'properties': {
             'a': {'default': 'foobar', 'format': 'binary', 'title': 'A', 'type': 'string'},
-            'b': {'default': '12.34', 'title': 'B', 'type': 'string'},
+            'b': {
+                'default': '12.34',
+                'title': 'B',
+                'type': 'string',
+                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            },
         },
         'title': 'Model',
         'type': 'object',
@@ -1053,7 +1068,18 @@ def test_special_decimal_types(field_type, expected_schema):
     base_schema = {
         'title': 'Model',
         'type': 'object',
-        'properties': {'a': {'anyOf': [{'type': 'number'}, {'type': 'string'}], 'title': 'A'}},
+        'properties': {
+            'a': {
+                'anyOf': [
+                    {'type': 'number'},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ],
+                'title': 'A',
+            }
+        },
         'required': ['a'],
     }
     base_schema['properties']['a']['anyOf'][0].update(expected_schema)
@@ -2006,11 +2032,71 @@ def test_docstring(docstring, description):
         ({'ge': -math.inf}, float, {'type': 'number'}),
         ({'le': math.inf}, float, {'type': 'number'}),
         ({'multiple_of': 5}, float, {'type': 'number', 'multipleOf': 5}),
-        ({'gt': 2}, Decimal, {'anyOf': [{'exclusiveMinimum': 2.0, 'type': 'number'}, {'type': 'string'}]}),
-        ({'lt': 5}, Decimal, {'anyOf': [{'type': 'number', 'exclusiveMaximum': 5}, {'type': 'string'}]}),
-        ({'ge': 2}, Decimal, {'anyOf': [{'type': 'number', 'minimum': 2}, {'type': 'string'}]}),
-        ({'le': 5}, Decimal, {'anyOf': [{'type': 'number', 'maximum': 5}, {'type': 'string'}]}),
-        ({'multiple_of': 5}, Decimal, {'anyOf': [{'type': 'number', 'multipleOf': 5}, {'type': 'string'}]}),
+        (
+            {'gt': 2},
+            Decimal,
+            {
+                'anyOf': [
+                    {'exclusiveMinimum': 2.0, 'type': 'number'},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ]
+            },
+        ),
+        (
+            {'lt': 5},
+            Decimal,
+            {
+                'anyOf': [
+                    {'type': 'number', 'exclusiveMaximum': 5},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ]
+            },
+        ),
+        (
+            {'ge': 2},
+            Decimal,
+            {
+                'anyOf': [
+                    {'type': 'number', 'minimum': 2},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ]
+            },
+        ),
+        (
+            {'le': 5},
+            Decimal,
+            {
+                'anyOf': [
+                    {'type': 'number', 'maximum': 5},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ]
+            },
+        ),
+        (
+            {'multiple_of': 5},
+            Decimal,
+            {
+                'anyOf': [
+                    {'type': 'number', 'multipleOf': 5},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ]
+            },
+        ),
     ],
 )
 def test_constraints_schema_validation(kwargs, type_, expected_extra):
@@ -2049,11 +2135,46 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
         ({'ge': -math.inf}, float, {'type': 'number'}),
         ({'le': math.inf}, float, {'type': 'number'}),
         ({'multiple_of': 5}, float, {'type': 'number', 'multipleOf': 5}),
-        ({'gt': 2}, Decimal, {'type': 'string'}),
-        ({'lt': 5}, Decimal, {'type': 'string'}),
-        ({'ge': 2}, Decimal, {'type': 'string'}),
-        ({'le': 5}, Decimal, {'type': 'string'}),
-        ({'multiple_of': 5}, Decimal, {'type': 'string'}),
+        (
+            {'gt': 2},
+            Decimal,
+            {
+                'type': 'string',
+                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            },
+        ),
+        (
+            {'lt': 5},
+            Decimal,
+            {
+                'type': 'string',
+                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            },
+        ),
+        (
+            {'ge': 2},
+            Decimal,
+            {
+                'type': 'string',
+                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            },
+        ),
+        (
+            {'le': 5},
+            Decimal,
+            {
+                'type': 'string',
+                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            },
+        ),
+        (
+            {'multiple_of': 5},
+            Decimal,
+            {
+                'type': 'string',
+                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            },
+        ),
     ],
 )
 def test_constraints_schema_serialization(kwargs, type_, expected_extra):
@@ -5734,8 +5855,19 @@ def test_generate_definitions_for_no_ref_schemas():
     )
     assert result == (
         {
-            ('Decimal', 'serialization'): {'type': 'string'},
-            ('Decimal', 'validation'): {'anyOf': [{'type': 'number'}, {'type': 'string'}]},
+            ('Decimal', 'serialization'): {
+                'type': 'string',
+                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+            },
+            ('Decimal', 'validation'): {
+                'anyOf': [
+                    {'type': 'number'},
+                    {
+                        'type': 'string',
+                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                    },
+                ]
+            },
             ('Model', 'validation'): {'$ref': '#/$defs/Model'},
         },
         {'Model': {'properties': {}, 'title': 'Model', 'type': 'object'}},

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -530,7 +530,7 @@ def test_decimal_json_schema():
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ],
                 'default': '12.34',
@@ -547,7 +547,7 @@ def test_decimal_json_schema():
                 'default': '12.34',
                 'title': 'B',
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             },
         },
         'title': 'Model',
@@ -1075,7 +1075,7 @@ def test_special_decimal_types(field_type, expected_schema):
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ],
                 'title': 'A',
@@ -2042,7 +2042,7 @@ def test_docstring(docstring, description):
                     {'exclusiveMinimum': 2.0, 'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ]
             },
@@ -2055,7 +2055,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'exclusiveMaximum': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ]
             },
@@ -2068,7 +2068,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'minimum': 2},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ]
             },
@@ -2081,7 +2081,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'maximum': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ]
             },
@@ -2094,7 +2094,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'multipleOf': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ]
             },
@@ -2143,7 +2143,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             },
         ),
         (
@@ -2151,7 +2151,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             },
         ),
         (
@@ -2159,7 +2159,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             },
         ),
         (
@@ -2167,7 +2167,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             },
         ),
         (
@@ -2175,7 +2175,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             },
         ),
     ],
@@ -5860,14 +5860,14 @@ def test_generate_definitions_for_no_ref_schemas():
         {
             ('Decimal', 'serialization'): {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             },
             ('Decimal', 'validation'): {
                 'anyOf': [
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
                     },
                 ]
             },
@@ -6957,146 +6957,94 @@ def get_decimal_pattern():
     return pattern
 
 
-def test_invalid_base_cases(get_decimal_pattern):
-    invalid_cases = ['', ' ', '   ', '.', '..', '...', '+', '-', '++', '--']
-    pattern = get_decimal_pattern()
+@pytest.mark.parametrize('valid_decimal', ['0.1', '0000.1', '11.1', '001.1', '11111111.1', '0.100000', '0.01', '0.11'])
+def test_decimal_pattern_with_only_decimal_places_set(valid_decimal, get_decimal_pattern):
+    decimal_places = 2
+    pattern = get_decimal_pattern(decimal_places=decimal_places)
 
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
-
-
-def test_zeros_before_decimal_point(get_decimal_pattern):
-    invalid_cases = ['0+', '0-', '0++', '0--', '++0', '--0']
-    valid_cases = ['+0', '-0', '+00', '-00', '+0000', '-0000', '0', '0000']
-    pattern = get_decimal_pattern()
-
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
-
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, valid_decimal) is not None
 
 
-def test_integer_value_without_max_digits(get_decimal_pattern):
-    valid_cases = ['1', '0001', '12', '123456', '1000000']
-    pattern = get_decimal_pattern()
+@pytest.mark.parametrize(
+    'invalid_decimal', ['0.001', '0000.001', '11.001', '001.001', '11111111.001', '0.00100000', '0.011', '0.111']
+)
+def test_decimal_pattern_reject_invalid_values_with_only_decimal_places_set(invalid_decimal, get_decimal_pattern):
+    decimal_places = 2
+    pattern = get_decimal_pattern(decimal_places=decimal_places)
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
+    assert re.fullmatch(pattern, invalid_decimal) is None
 
 
-def test_integer_value_with_max_digits(get_decimal_pattern):
+@pytest.mark.parametrize('valid_decimal', ['0.1', '000.1', '0.001000', '0000.001000', '111', '100', '00100', '011.10'])
+def test_decimal_pattern_with_only_max_digit_set(valid_decimal, get_decimal_pattern):
     max_digits = 3
-    valid_cases = ['1', '12', '123', '0001', '00001', '0000100']
-    invalid_cases = ['1111', '1000', '1010', '00001000']
     pattern = get_decimal_pattern(max_digits=max_digits)
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
-
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, valid_decimal) is not None
 
 
-def test_integer_value_with_zero_max_digits(get_decimal_pattern):
-    max_digits = 0
-    valid_cases = ['0', '00', '000', '000000', '+000000', '-000000']
-    invalid_cases = ['1', '+1', '01', '-01', '+01', '001', '12', '0010', '1000']
+@pytest.mark.parametrize(
+    'valid_decimal', ['0.0001', '111.1', '0.0001000', '0001.001000', '1111', '1000', '001000', '011.110']
+)
+def test_decimal_pattern_reject_invalid_values_with_only_max_digit_set(valid_decimal, get_decimal_pattern):
+    max_digits = 3
     pattern = get_decimal_pattern(max_digits=max_digits)
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
-
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, valid_decimal) is None
 
 
-def test_decimal_value_without_max_digits_and_decimal_places(get_decimal_pattern):
-    valid_cases = [
-        '0.1',
-        '+0.1',
-        '.1',
-        '1.',
-        '111.000',
-        '+.1',
-        '-.1',
-        '+1.',
-        '-1.',
-        '1234.1234',
-        '0000.1000',
-        '1000.0001',
-    ]
-    invalid_cases = ['..1', '0..1', '1.1.', '1.1.1']
+@pytest.mark.parametrize(
+    'valid_decimal', ['11111111', '1111.11111', '0.00000001', '11.', '.11', '000', '0', '-.0', '-.1', '-1.', '-0.']
+)
+def test_decimal_pattern_with_decimal_places_max_digits_unset(valid_decimal, get_decimal_pattern):
     pattern = get_decimal_pattern()
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
-
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, valid_decimal) is not None
 
 
-def test_decimal_value_only_with_max_digits(get_decimal_pattern):
-    max_digits = 4
-    valid_cases = ['0.123', '1.234', '12.34', '00012.34', '00012.34000', '00010.0100', '+00010.0100', '-00010.0100']
-    invalid_cases = ['1.2345', '12.345', '123.45', '1234.5', '12345.0', '0012345.0', '0012345.000']
-    pattern = get_decimal_pattern(max_digits=max_digits)
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
+@pytest.mark.parametrize('invalid_decimal', ['.', '-.', '..', '1.1.1', '0.0.0', '1..1', '-', '--'])
+def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_unset(invalid_decimal, get_decimal_pattern):
+    pattern = get_decimal_pattern()
 
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, invalid_decimal) is None
 
 
-def test_decimal_value_only_with_decimal_places(get_decimal_pattern):
-    decimal_places = 2
-    pattern = get_decimal_pattern(decimal_places=decimal_places)
-    valid_cases = ['0.12', '123456.12', '123456.1200', '123456.10', '123456.100', '1234.01', '001234.0100']
-    invalid_cases = ['0.123', '123456.123', '123456.001', '123456.012', '123456.00200', '1234.011', '001234.001']
+@pytest.mark.parametrize(
+    'valid_decimal', ['10.01', '11.11', '010.010', '011.110', '11', '0011', '001.100', '.1', '.11000', '00011.']
+)
+def test_decimal_pattern_with_decimal_places_max_digits_set(valid_decimal, get_decimal_pattern):
+    pattern = get_decimal_pattern(max_digits=4, decimal_places=2)
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
-
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, valid_decimal) is not None
 
 
-def test_decimal_value_with_max_digits_and_decimal_places(get_decimal_pattern):
-    max_digits = 4
-    decimal_places = 2
-    pattern = get_decimal_pattern(max_digits=max_digits, decimal_places=decimal_places)
-    valid_cases = ['12.34', '1.2', '12.3', '0012.3200', '0010.0100', '0.1']
-    invalid_cases = ['120.34', '1.222', '120.333', '0012.3230', '0010.00100', '00123.', '00123.01', '.001']
+@pytest.mark.parametrize(
+    'invalid_decimal',
+    ['10.001', '111', '0100.0010', '011.0110', '111.1', '1111', '001.11100', '.111', '.111000', '000111.'],
+)
+def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_set(invalid_decimal, get_decimal_pattern):
+    pattern = get_decimal_pattern(max_digits=4, decimal_places=2)
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
-
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, invalid_decimal) is None
 
 
-def test_decimal_value_with_max_digits_and_decimal_places_eaqual(get_decimal_pattern):
-    max_digits = 4
-    decimal_places = max_digits
-    pattern = get_decimal_pattern(max_digits=max_digits, decimal_places=decimal_places)
-    valid_cases = ['0.34', '0000.2', '0.3333', '000.3333000', '+000.000100', '0.1']
-    invalid_cases = ['120.34', '1.222', '0.33333', '0001.1', '0010.00100', '1.']
+@pytest.mark.parametrize('valid_value', ['0.34', '0000.2', '0.3333', '000.3333000', '+000.000100', '0.1'])
+def test_decimal_pattern_with_max_digits_and_decimal_places_equal(valid_value, get_decimal_pattern):
+    pattern = get_decimal_pattern(max_digits=4, decimal_places=4)
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
-
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+    assert re.fullmatch(pattern, valid_value) is not None
 
 
-def test_decimal_value_with_zero_decimal_places(get_decimal_pattern):
-    decimal_places = 0
-    pattern = get_decimal_pattern(decimal_places=decimal_places)
-    valid_cases = ['1.0', '1.', '123.0', '123.', '.000']
-    invalid_cases = ['0.1', '123.1', '1.100', '1.01']
+@pytest.mark.parametrize('invalid_value', ['120.34', '1.222', '0.33333', '0001.1', '0010.00100', '1.'])
+def test_decimal_pattern_reject_invalid_with_max_digits_and_decimal_places_equal(invalid_value, get_decimal_pattern):
+    pattern = get_decimal_pattern(max_digits=4, decimal_places=4)
 
-    for case in valid_cases:
-        assert re.fullmatch(pattern, case) is not None
+    assert re.fullmatch(pattern, invalid_value) is None
 
-    for case in invalid_cases:
-        assert re.fullmatch(pattern, case) is None
+
+@pytest.mark.parametrize('invalid_decimal', ['', ' ', '   ', '.', '..', '...', '+', '-', '++', '--', 'a', 'a.1', '1.a'])
+def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places_max_digits_set(
+    invalid_decimal, get_decimal_pattern
+):
+    pattern = get_decimal_pattern()
+    assert re.fullmatch(pattern, invalid_decimal) is None

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1053,6 +1053,7 @@ def test_special_float_types(field_type, expected_schema):
     assert Model.model_json_schema() == base_schema
 
 
+# ADDTESTS: add test cases to check max_digits and decimal_places
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
@@ -2010,6 +2011,7 @@ def test_docstring(docstring, description):
     assert A.model_json_schema()['description'] == description
 
 
+# ADDTESTS: add test cases to check max_digits and decimal_places constrains
 @pytest.mark.parametrize(
     'kwargs,type_,expected_extra',
     [
@@ -2113,6 +2115,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
     assert Foo.model_json_schema(mode='validation') == expected_schema
 
 
+# ADDTESTS: add test cases to check max_digits and decimal_places constrains
 @pytest.mark.parametrize(
     'kwargs,type_,expected_extra',
     [

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -530,7 +530,7 @@ def test_decimal_json_schema():
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ],
                 'default': '12.34',
@@ -547,7 +547,7 @@ def test_decimal_json_schema():
                 'default': '12.34',
                 'title': 'B',
                 'type': 'string',
-                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             },
         },
         'title': 'Model',
@@ -1075,7 +1075,7 @@ def test_special_decimal_types(field_type, expected_schema):
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ],
                 'title': 'A',
@@ -2042,7 +2042,7 @@ def test_docstring(docstring, description):
                     {'exclusiveMinimum': 2.0, 'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ]
             },
@@ -2055,7 +2055,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'exclusiveMaximum': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ]
             },
@@ -2068,7 +2068,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'minimum': 2},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ]
             },
@@ -2081,7 +2081,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'maximum': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ]
             },
@@ -2094,7 +2094,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'multipleOf': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ]
             },
@@ -2143,7 +2143,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             },
         ),
         (
@@ -2151,7 +2151,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             },
         ),
         (
@@ -2159,7 +2159,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             },
         ),
         (
@@ -2167,7 +2167,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             },
         ),
         (
@@ -2175,7 +2175,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             },
         ),
     ],
@@ -5860,14 +5860,14 @@ def test_generate_definitions_for_no_ref_schemas():
         {
             ('Decimal', 'serialization'): {
                 'type': 'string',
-                'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
             },
             ('Decimal', 'validation'): {
                 'anyOf': [
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[+-\\.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
+                        'pattern': '^(?!^[-+.]*$)[+-]?0*(?:\\d{0,}$|(?=[\\d\\.]{1,}0*$)\\d{0,}\\.\\d{0,}0*$)',
                     },
                 ]
             },

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6958,7 +6958,7 @@ def get_decimal_pattern():
 
 
 @pytest.mark.parametrize('valid_decimal', ['0.1', '0000.1', '11.1', '001.1', '11111111.1', '0.100000', '0.01', '0.11'])
-def test_decimal_pattern_with_only_decimal_places_set(valid_decimal, get_decimal_pattern):
+def test_decimal_pattern_with_only_decimal_places_set(valid_decimal, get_decimal_pattern) -> None:
     decimal_places = 2
     pattern = get_decimal_pattern(decimal_places=decimal_places)
 
@@ -6968,7 +6968,9 @@ def test_decimal_pattern_with_only_decimal_places_set(valid_decimal, get_decimal
 @pytest.mark.parametrize(
     'invalid_decimal', ['0.001', '0000.001', '11.001', '001.001', '11111111.001', '0.00100000', '0.011', '0.111']
 )
-def test_decimal_pattern_reject_invalid_values_with_only_decimal_places_set(invalid_decimal, get_decimal_pattern):
+def test_decimal_pattern_reject_invalid_values_with_only_decimal_places_set(
+    invalid_decimal, get_decimal_pattern
+) -> None:
     decimal_places = 2
     pattern = get_decimal_pattern(decimal_places=decimal_places)
 
@@ -6976,7 +6978,7 @@ def test_decimal_pattern_reject_invalid_values_with_only_decimal_places_set(inva
 
 
 @pytest.mark.parametrize('valid_decimal', ['0.1', '000.1', '0.001000', '0000.001000', '111', '100', '00100', '011.10'])
-def test_decimal_pattern_with_only_max_digit_set(valid_decimal, get_decimal_pattern):
+def test_decimal_pattern_with_only_max_digit_set(valid_decimal, get_decimal_pattern) -> None:
     max_digits = 3
     pattern = get_decimal_pattern(max_digits=max_digits)
 
@@ -6986,7 +6988,7 @@ def test_decimal_pattern_with_only_max_digit_set(valid_decimal, get_decimal_patt
 @pytest.mark.parametrize(
     'valid_decimal', ['0.0001', '111.1', '0.0001000', '0001.001000', '1111', '1000', '001000', '011.110']
 )
-def test_decimal_pattern_reject_invalid_values_with_only_max_digit_set(valid_decimal, get_decimal_pattern):
+def test_decimal_pattern_reject_invalid_values_with_only_max_digit_set(valid_decimal, get_decimal_pattern) -> None:
     max_digits = 3
     pattern = get_decimal_pattern(max_digits=max_digits)
 
@@ -6996,14 +6998,16 @@ def test_decimal_pattern_reject_invalid_values_with_only_max_digit_set(valid_dec
 @pytest.mark.parametrize(
     'valid_decimal', ['11111111', '1111.11111', '0.00000001', '11.', '.11', '000', '0', '-.0', '-.1', '-1.', '-0.']
 )
-def test_decimal_pattern_with_decimal_places_max_digits_unset(valid_decimal, get_decimal_pattern):
+def test_decimal_pattern_with_decimal_places_max_digits_unset(valid_decimal, get_decimal_pattern) -> None:
     pattern = get_decimal_pattern()
 
     assert re.fullmatch(pattern, valid_decimal) is not None
 
 
 @pytest.mark.parametrize('invalid_decimal', ['.', '-.', '..', '1.1.1', '0.0.0', '1..1', '-', '--'])
-def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_unset(invalid_decimal, get_decimal_pattern):
+def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_unset(
+    invalid_decimal, get_decimal_pattern
+) -> None:
     pattern = get_decimal_pattern()
 
     assert re.fullmatch(pattern, invalid_decimal) is None
@@ -7012,7 +7016,7 @@ def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_unset(inv
 @pytest.mark.parametrize(
     'valid_decimal', ['10.01', '11.11', '010.010', '011.110', '11', '0011', '001.100', '.1', '.11000', '00011.']
 )
-def test_decimal_pattern_with_decimal_places_max_digits_set(valid_decimal, get_decimal_pattern):
+def test_decimal_pattern_with_decimal_places_max_digits_set(valid_decimal, get_decimal_pattern) -> None:
     pattern = get_decimal_pattern(max_digits=4, decimal_places=2)
 
     assert re.fullmatch(pattern, valid_decimal) is not None
@@ -7022,21 +7026,25 @@ def test_decimal_pattern_with_decimal_places_max_digits_set(valid_decimal, get_d
     'invalid_decimal',
     ['10.001', '111', '0100.0010', '011.0110', '111.1', '1111', '001.11100', '.111', '.111000', '000111.', '1100'],
 )
-def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_set(invalid_decimal, get_decimal_pattern):
+def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_set(
+    invalid_decimal, get_decimal_pattern
+) -> None:
     pattern = get_decimal_pattern(max_digits=4, decimal_places=2)
 
     assert re.fullmatch(pattern, invalid_decimal) is None
 
 
 @pytest.mark.parametrize('valid_value', ['0.34', '0000.2', '0.3333', '000.3333000', '+000.000100', '0.1'])
-def test_decimal_pattern_with_max_digits_and_decimal_places_equal(valid_value, get_decimal_pattern):
+def test_decimal_pattern_with_max_digits_and_decimal_places_equal(valid_value, get_decimal_pattern) -> None:
     pattern = get_decimal_pattern(max_digits=4, decimal_places=4)
 
     assert re.fullmatch(pattern, valid_value) is not None
 
 
 @pytest.mark.parametrize('invalid_value', ['120.34', '1.222', '0.33333', '0001.1', '0010.00100', '1.'])
-def test_decimal_pattern_reject_invalid_with_max_digits_and_decimal_places_equal(invalid_value, get_decimal_pattern):
+def test_decimal_pattern_reject_invalid_with_max_digits_and_decimal_places_equal(
+    invalid_value, get_decimal_pattern
+) -> None:
     pattern = get_decimal_pattern(max_digits=4, decimal_places=4)
 
     assert re.fullmatch(pattern, invalid_value) is None
@@ -7045,6 +7053,6 @@ def test_decimal_pattern_reject_invalid_with_max_digits_and_decimal_places_equal
 @pytest.mark.parametrize('invalid_decimal', ['', ' ', '   ', '.', '..', '...', '+', '-', '++', '--', 'a', 'a.1', '1.a'])
 def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places_max_digits_set(
     invalid_decimal, get_decimal_pattern
-):
+) -> None:
     pattern = get_decimal_pattern()
     assert re.fullmatch(pattern, invalid_decimal) is None

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6946,3 +6946,149 @@ def test_json_schema_arguments_v3_aliases() -> None:
         },
         'required': ['b'],
     }
+
+
+class TestDecimalPattern:
+    @pytest.fixture
+    def get_pattern(self):
+        def pattern(max_digits: int | None = None, decimal_places: int | None = None) -> str:
+            filed = TypeAdapter[Decimal](
+                Annotated[Decimal, Field(max_digits=max_digits, decimal_places=decimal_places)]
+            )
+            return filed.json_schema()['anyOf'][1]['pattern']
+
+        return pattern
+
+    def test_invalid_base_cases(self, get_pattern):
+        invalid_cases = ['', ' ', '   ', '.', '..', '...', '+', '-', '++', '--']
+        pattern = get_pattern()
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_zeros_before_decimal_point(self, get_pattern):
+        invalid_cases = ['0+', '0-', '0++', '0--', '++0', '--0']
+        valid_cases = ['+0', '-0', '+00', '-00', '+0000', '-0000', '0', '0000']
+        pattern = get_pattern()
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_integer_value_without_max_digits(self, get_pattern):
+        valid_cases = ['1', '0001', '12', '123456', '1000000']
+        pattern = get_pattern()
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+    def test_integer_value_with_max_digits(self, get_pattern):
+        max_digits = 3
+        valid_cases = ['1', '12', '123', '0001', '00001', '0000100']
+        invalid_cases = ['1111', '1000', '1010', '00001000']
+        pattern = get_pattern(max_digits=max_digits)
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_integer_value_with_zero_max_digits(self, get_pattern):
+        max_digits = 0
+        valid_cases = ['0', '00', '000', '000000', '+000000', '-000000']
+        invalid_cases = ['1', '+1', '01', '-01', '+01', '001', '12', '0010', '1000']
+        pattern = get_pattern(max_digits=max_digits)
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_decimal_value_without_max_digits_and_decimal_places(self, get_pattern):
+        valid_cases = [
+            '0.1',
+            '+0.1',
+            '.1',
+            '1.',
+            '111.000',
+            '+.1',
+            '-.1',
+            '+1.',
+            '-1.',
+            '1234.1234',
+            '0000.1000',
+            '1000.0001',
+        ]
+        invalid_cases = ['..1', '0..1', '1.1.', '1.1.1']
+        pattern = get_pattern()
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_decimal_value_only_with_max_digits(self, get_pattern):
+        max_digits = 4
+        valid_cases = ['0.123', '1.234', '12.34', '00012.34', '00012.34000', '00010.0100', '+00010.0100', '-00010.0100']
+        invalid_cases = ['1.2345', '12.345', '123.45', '1234.5', '12345.0', '0012345.0', '0012345.000']
+        pattern = get_pattern(max_digits=max_digits)
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_decimal_value_only_with_decimal_places(self, get_pattern):
+        decimal_places = 2
+        pattern = get_pattern(decimal_places=decimal_places)
+        valid_cases = ['0.12', '123456.12', '123456.1200', '123456.10', '123456.100', '1234.01', '001234.0100']
+        invalid_cases = ['0.123', '123456.123', '123456.001', '123456.012', '123456.00200', '1234.011', '001234.001']
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_decimal_value_with_max_digits_and_decimal_places(self, get_pattern):
+        max_digits = 4
+        decimal_places = 2
+        pattern = get_pattern(max_digits=max_digits, decimal_places=decimal_places)
+        valid_cases = ['12.34', '1.2', '12.3', '0012.3200', '0010.0100', '0.1']
+        invalid_cases = ['120.34', '1.222', '120.333', '0012.3230', '0010.00100', '00123.', '00123.01', '.001']
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_decimal_value_with_max_digits_and_decimal_places_eaqual(self, get_pattern):
+        max_digits = 4
+        decimal_places = max_digits
+        pattern = get_pattern(max_digits=max_digits, decimal_places=decimal_places)
+        valid_cases = ['0.34', '0000.2', '0.3333', '000.3333000', '+000.000100', '0.1']
+        invalid_cases = ['120.34', '1.222', '0.33333', '0001.1', '0010.00100', '1.']
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None
+
+    def test_decimal_value_with_zero_decimal_places(self, get_pattern):
+        decimal_places = 0
+        pattern = get_pattern(decimal_places=decimal_places)
+        valid_cases = ['1.0', '1.', '123.0', '123.', '.000']
+        invalid_cases = ['0.1', '123.1', '1.100', '1.01']
+
+        for case in valid_cases:
+            assert re.fullmatch(pattern, case) is not None
+
+        for case in invalid_cases:
+            assert re.fullmatch(pattern, case) is None

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6951,10 +6951,8 @@ def test_json_schema_arguments_v3_aliases() -> None:
 class TestDecimalPattern:
     @pytest.fixture
     def get_pattern(self):
-        def pattern(max_digits: int | None = None, decimal_places: int | None = None) -> str:
-            filed = TypeAdapter[Decimal](
-                Annotated[Decimal, Field(max_digits=max_digits, decimal_places=decimal_places)]
-            )
+        def pattern(max_digits=None, decimal_places=None) -> str:
+            filed = TypeAdapter(Annotated[Decimal, Field(max_digits=max_digits, decimal_places=decimal_places)])
             return filed.json_schema()['anyOf'][1]['pattern']
 
         return pattern


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR adds a regular expression pattern to the JSON schema of `Decimal` fields to validate their string representation according to the `max_digits` and `decimal_places` parameters of the `Field` class.

- Updated existing tests for `Decimal` fields to align with the new validation pattern.
- Added new tests to validate the pattern across different combinations of `max_digits` and `decimal_places`.

You can run the new tests with the following command:  
```bash
uv run pytest tests/test_json_schema.py::TestDecimalPattern
```

## Related issue number
fixes #11016
fixes #11420
fixes #10867
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos