### PR TITLE
fix(SkipValidation): Properly suppress PydanticSkipValidationWarning

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -62,7 +62,7 @@ from ..errors import PydanticSchemaGenerationError, PydanticUndefinedAnnotation,
 from ..functional_validators import AfterValidator, BeforeValidator, FieldValidatorModes, PlainValidator, WrapValidator
 from ..json_schema import JsonSchemaValue
 from ..version import version_short
-from ..warnings import PydanticDeprecatedSince20
+from ..warnings import PydanticDeprecatedSince20, PydanticSkipValidationWarning
 from . import _decorators, _discriminated_union, _known_annotated_metadata, _repr, _typing_extra
 from ._config import ConfigWrapper, ConfigWrapperStack
 from ._core_metadata import CoreMetadata, update_core_metadata
@@ -619,7 +619,7 @@ class GenerateSchema:
                 ' Pydantic will allow any object with no validation since we cannot even'
                 ' enforce that the input is an instance of the given type.'
                 ' To get rid of this error wrap the type with `pydantic.SkipValidation`.',
-                UserWarning,
+                PydanticSkipValidationWarning,  # Updated warning type,
             )
             return core_schema.any_schema()
         return core_schema.is_instance_schema(tp)

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import dataclasses
 import sys
+import warnings
 from functools import partialmethod
 from types import FunctionType
 from typing import TYPE_CHECKING, Annotated, Any, Callable, Literal, TypeVar, Union, cast, overload
@@ -14,6 +15,7 @@ from typing_extensions import Self, TypeAlias
 from ._internal import _decorators, _generics, _internal_dataclass
 from .annotated_handlers import GetCoreSchemaHandler
 from .errors import PydanticUserError
+from .warnings import PydanticSkipValidationWarning
 
 if sys.version_info < (3, 11):
     from typing_extensions import Protocol
@@ -817,13 +819,15 @@ else:
 
         @classmethod
         def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
-            original_schema = handler(source)
-            metadata = {'pydantic_js_annotation_functions': [lambda _c, h: h(original_schema)]}
-            return core_schema.any_schema(
-                metadata=metadata,
-                serialization=core_schema.wrap_serializer_function_ser_schema(
-                    function=lambda v, h: h(v), schema=original_schema
-                ),
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', PydanticSkipValidationWarning)
+                original_schema = handler(source)
+                metadata = {'pydantic_js_annotation_functions': [lambda _c, h: h(original_schema)]}
+                return core_schema.any_schema(
+                    metadata=metadata,
+                    serialization=core_schema.wrap_serializer_function_ser_schema(
+                        function=lambda v, h: h(v), schema=original_schema
+                    ),
+                )
 
         __hash__ = object.__hash__

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -94,3 +94,7 @@ class PydanticExperimentalWarning(Warning):
     This warning is raised when using experimental functionality in Pydantic.
     It is raised to warn users that the functionality may change or be removed in future versions of Pydantic.
     """
+
+
+class PydanticSkipValidationWarning(UserWarning):
+    """Warning raised when SkipValidation is used for unsupported types."""

--- a/tests/test_skipvalidation.py
+++ b/tests/test_skipvalidation.py
@@ -1,0 +1,27 @@
+import warnings
+from typing import Annotated
+
+from pydantic import BaseModel, SkipValidation
+from pydantic.warnings import PydanticSkipValidationWarning
+
+
+def test_skip_validation_warning():
+    class MyModel(BaseModel):
+        field: Annotated[int, SkipValidation]
+
+    # Ensure no warning is raised when SkipValidation is applied
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        MyModel(field='not_an_int')  # SkipValidation should bypass validation
+
+        # Assert no warnings of type PydanticSkipValidationWarning were raised
+        assert not any(issubclass(warning.category, PydanticSkipValidationWarning) for warning in w)
+
+
+def test_skip_validation_behavior():
+    class MyModel(BaseModel):
+        field: Annotated[int, SkipValidation]
+
+    # Ensure the field accepts any value without validation
+    instance = MyModel(field='not_an_int')
+    assert instance.field == 'not_an_int'  # Validation is skipped


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
1. **Added PydanticSkipValidationWarning**: Introduced a new warning subclass in warnings.py to categorise warnings related to unsupported types when using SkipValidation.

2. **Updated _generate_schema.py**: Modified the warning logic to use PydanticSkipValidationWarning instead of the generic UserWarning.

3. **Enhanced functional_validators.py**: Wrapped the handler call in SkipValidation with a mechanism to catch and suppress PydanticSkipValidationWarning.

4. **Test Coverage**: Added tests to ensure SkipValidation properly suppresses warnings and bypasses validation as expected.

## Related issue number
#11997 
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
