### PR TITLE
Fix: default target of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# .DEFAULT_GOAL := all
+.DEFAULT_GOAL := all
 sources = pydantic tests docs/plugins
 NUM_THREADS?=1
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Uncomment `Makefile` first line to be compliant with the `docs/contributing.md`

## Related issue number

#11996 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
