### PR TITLE
Emit warning when field-specific metadata is used in invalid contexts

### DIFF
--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -288,7 +288,7 @@ By leveraging the new [`type` statement](https://typing.readthedocs.io/en/latest
 
     === "Python 3.9 and above"
 
-        ```python
+        ```python {test="skip"}
         from typing import Annotated
 
         from typing_extensions import TypeAliasType
@@ -304,7 +304,7 @@ By leveraging the new [`type` statement](https://typing.readthedocs.io/en/latest
 
     === "Python 3.12 and above (new syntax)"
 
-        ```python {requires="3.12" upgrade="skip" lint="skip"}
+        ```python {requires="3.12" upgrade="skip" lint="skip" test="skip"}
         from typing import Annotated
 
         from pydantic import BaseModel, Field

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -12,8 +12,7 @@ from re import Pattern
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from pydantic_core import PydanticUndefined
-from typing_extensions import TypeIs, get_origin
-from typing_inspection import typing_objects
+from typing_extensions import TypeIs
 from typing_inspection.introspection import AnnotationSource
 
 from pydantic import PydanticDeprecatedSince211
@@ -350,7 +349,6 @@ def collect_model_fields(  # noqa: C901
                 field_info = copy(parent_fields_lookup[ann_name])
 
         else:  # An assigned value is present (either the default value, or a `Field()` function)
-            _warn_on_nested_alias_in_annotation(ann_type, ann_name)
             if isinstance(assigned_value, FieldInfo_) and ismethoddescriptor(assigned_value.default):
                 # `assigned_value` was fetched using `getattr`, which triggers a call to `__get__`
                 # for descriptors, so we do the same if the `= field(default=...)` form is used.
@@ -411,22 +409,6 @@ def collect_model_fields(  # noqa: C901
     if config_wrapper.use_attribute_docstrings:
         _update_fields_from_docstrings(cls, fields)
     return fields, class_vars
-
-
-def _warn_on_nested_alias_in_annotation(ann_type: type[Any], ann_name: str) -> None:
-    FieldInfo = import_cached_field_info()
-
-    args = getattr(ann_type, '__args__', None)
-    if args:
-        for anno_arg in args:
-            if typing_objects.is_annotated(get_origin(anno_arg)):
-                for anno_type_arg in _typing_extra.get_args(anno_arg):
-                    if isinstance(anno_type_arg, FieldInfo) and anno_type_arg.alias is not None:
-                        warnings.warn(
-                            f'`alias` specification on field "{ann_name}" must be set on outermost annotation to take effect.',
-                            UserWarning,
-                        )
-                        return
 
 
 def rebuild_model_fields(

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2218,13 +2218,12 @@ class GenerateSchema:
                 and type(metadata) is FieldInfo
                 and (unsupported_attributes := self._get_unsupported_field_info_attributes(metadata))
             ):
-                for unsupported_attr in unsupported_attributes:
+                for attr, value in unsupported_attributes:
                     warnings.warn(
-                        f'The {unsupported_attr[0]!r} attribute with value {unsupported_attr[1]!r} was provided '
-                        'to the `Field()` function, which is unsupported in the context it was used. '
-                        f'{unsupported_attr[0]!r} is field-specific metadata, and can only be attached to a model field '
-                        'using `Annotated` metadata or by assignment (note that using `Annotated` type aliases using '
-                        "the `type` statement isn't supported).",
+                        f'The {attr!r} attribute with value {value!r} was provided to the `Field()` function, '
+                        f'which has no effect in the context it was used. {attr!r} is field-specific metadata, '
+                        'and can only be attached to a model field using `Annotated` metadata or by assignment '
+                        "(note that using `Annotated` type aliases using the `type` statement isn't supported).",
                         category=UnsupportedFieldAttributeWarning,
                     )
             for field_metadata in metadata.metadata:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -37,7 +37,6 @@ from typing import (
     overload,
 )
 from uuid import UUID
-from warnings import warn
 from zoneinfo import ZoneInfo
 
 import typing_extensions
@@ -614,12 +613,12 @@ class GenerateSchema:
 
     def _arbitrary_type_schema(self, tp: Any) -> CoreSchema:
         if not isinstance(tp, type):
-            warn(
+            warnings.warn(
                 f'{tp!r} is not a Python type (it may be an instance of an object),'
                 ' Pydantic will allow any object with no validation since we cannot even'
                 ' enforce that the input is an instance of the given type.'
                 ' To get rid of this error wrap the type with `pydantic.SkipValidation`.',
-                PydanticArbitraryTypeWarning,
+                ArbitraryTypeWarning,
             )
             return core_schema.any_schema()
         return core_schema.is_instance_schema(tp)
@@ -903,12 +902,12 @@ class GenerateSchema:
             from pydantic.v1 import BaseModel as BaseModelV1
 
             if issubclass(obj, BaseModelV1):
-                warn(
+                warnings.warn(
                     f'Mixing V1 models and V2 models (or constructs, like `TypeAdapter`) is not supported. Please upgrade `{obj.__name__}` to V2.',
                     UserWarning,
                 )
             else:
-                warn(
+                warnings.warn(
                     '`__get_validators__` is deprecated and will be removed, use `__get_pydantic_core_schema__` instead.',
                     PydanticDeprecatedSince20,
                 )

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -584,7 +584,7 @@ class GenerateSchema:
             # the `defaultdict`'s `default_factory`. As a consequence, we get warnings
             # as normally `FieldInfo.default_factory` is unsupported in the context where
             # `Field()` is used and our only solution is to ignore them (note that this might
-            # wrongfully ignore valid warnings, e.g. if the `value_type` to a PEP 695 type alias
+            # wrongfully ignore valid warnings, e.g. if the `value_type` is a PEP 695 type alias
             # with unsupported metadata).
             warnings.simplefilter('ignore', category=UnsupportedFieldAttributeWarning)
             values_schema = self.generate_schema(values_type)
@@ -2222,8 +2222,9 @@ class GenerateSchema:
                     warnings.warn(
                         f'The {attr!r} attribute with value {value!r} was provided to the `Field()` function, '
                         f'which has no effect in the context it was used. {attr!r} is field-specific metadata, '
-                        'and can only be attached to a model field using `Annotated` metadata or by assignment '
-                        "(note that using `Annotated` type aliases using the `type` statement isn't supported).",
+                        'and can only be attached to a model field using `Annotated` metadata or by assignment. '
+                        'This may have happened because an `Annotated` type alias using the `type` statement was '
+                        'used, or if the `Field()` function was attached to a single member of a union type.',
                         category=UnsupportedFieldAttributeWarning,
                     )
             for field_metadata in metadata.metadata:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2211,8 +2211,12 @@ class GenerateSchema:
         FieldInfo = import_cached_field_info()
 
         if isinstance(metadata, FieldInfo):
-            if check_unsupported_field_info_attributes and (
-                unsupported_attributes := self._get_unsupported_field_info_attributes(metadata)
+            if (
+                check_unsupported_field_info_attributes
+                # HACK: we don't want to emit the warning for `FieldInfo` subclasses, because FastAPI does weird manipulations
+                # with its subclasses and their annotations:
+                and type(metadata) is FieldInfo
+                and (unsupported_attributes := self._get_unsupported_field_info_attributes(metadata))
             ):
                 for unsupported_attr in unsupported_attributes:
                     warnings.warn(

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -15,7 +15,7 @@ from typing_extensions import Self, TypeAlias
 from ._internal import _decorators, _generics, _internal_dataclass
 from .annotated_handlers import GetCoreSchemaHandler
 from .errors import PydanticUserError
-from .warnings import PydanticArbitraryTypeWarning
+from .warnings import ArbitraryTypeWarning
 
 if sys.version_info < (3, 11):
     from typing_extensions import Protocol
@@ -820,7 +820,7 @@ else:
         @classmethod
         def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore', PydanticArbitraryTypeWarning)
+                warnings.simplefilter('ignore', ArbitraryTypeWarning)
                 original_schema = handler(source)
             metadata = {'pydantic_js_annotation_functions': [lambda _c, h: h(original_schema)]}
             return core_schema.any_schema(

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -12,6 +12,7 @@ __all__ = (
     'PydanticDeprecatedSince211',
     'PydanticDeprecationWarning',
     'PydanticExperimentalWarning',
+    'ArbitraryTypeWarning',
 )
 
 
@@ -96,5 +97,9 @@ class PydanticExperimentalWarning(Warning):
     """
 
 
-class PydanticArbitraryTypeWarning(UserWarning):
-    """Warning raised when Pydantic fails to generate a core schema for an arbitrary type."""
+class CoreSchemaGenerationWarning(UserWarning):
+    """A warning raised during core schema generation."""
+
+
+class ArbitraryTypeWarning(CoreSchemaGenerationWarning):
+    """A warning raised when Pydantic fails to generate a core schema for an arbitrary type."""

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -13,6 +13,7 @@ __all__ = (
     'PydanticDeprecationWarning',
     'PydanticExperimentalWarning',
     'ArbitraryTypeWarning',
+    'UnsupportedFieldAttributeWarning',
 )
 
 
@@ -103,3 +104,7 @@ class CoreSchemaGenerationWarning(UserWarning):
 
 class ArbitraryTypeWarning(CoreSchemaGenerationWarning):
     """A warning raised when Pydantic fails to generate a core schema for an arbitrary type."""
+
+
+class UnsupportedFieldAttributeWarning(CoreSchemaGenerationWarning):
+    """A warning raised when a `Field()` attribute isn't supported in the context it is used."""

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -251,18 +251,6 @@ def test_modify_get_schema_annotated() -> None:
     calls.clear()
 
 
-def test_annotated_alias_at_low_level() -> None:
-    with pytest.warns(
-        UserWarning,
-        match=r'`alias` specification on field "low_level_alias_field" must be set on outermost annotation to take effect.',
-    ):
-
-        class Model(BaseModel):
-            low_level_alias_field: Optional[Annotated[int, Field(alias='field_alias')]] = None
-
-    assert Model(field_alias=1).low_level_alias_field is None
-
-
 def test_get_pydantic_core_schema_source_type() -> None:
     types: set[Any] = set()
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,8 +1,9 @@
-from typing import Annotated, Final, Union
+from typing import Annotated, Any, Final, Union
 
 import pytest
 from annotated_types import Gt
 from pydantic_core import PydanticUndefined
+from typing_extensions import TypeAliasType
 
 import pydantic.dataclasses
 from pydantic import (
@@ -15,9 +16,10 @@ from pydantic import (
     ValidationError,
     computed_field,
     create_model,
-    fields,
+    validate_call,
 )
 from pydantic.fields import FieldInfo
+from pydantic.warnings import UnsupportedFieldAttributeWarning
 
 
 def test_field_info_annotation_keyword_argument():
@@ -28,7 +30,7 @@ def test_field_info_annotation_keyword_argument():
     third-party tools.
     """
     with pytest.raises(TypeError) as e:
-        fields.FieldInfo.from_field(annotation=())
+        FieldInfo.from_field(annotation=())
 
     assert e.value.args == ('"annotation" is not permitted as a Field keyword argument',)
 
@@ -275,3 +277,64 @@ def test_fastapi_compatibility_hack() -> None:
 
     assert isinstance(model_field, Body)
     assert not model_field.is_required()
+
+
+_unsupported_standalone_fieldinfo_attributes = (
+    ('alias', 'alias'),
+    ('validation_alias', 'alias'),
+    ('serialization_alias', 'alias'),
+    ('default', 1),
+    ('default_factory', lambda: 1),
+    ('exclude', True),
+    ('deprecated', True),
+    ('repr', True),
+    ('validate_default', True),
+    ('frozen', True),
+    ('init', True),
+    ('init_var', True),
+    ('kw_only', True),
+)
+
+
+@pytest.mark.parametrize(
+    ['attribute', 'value'],
+    _unsupported_standalone_fieldinfo_attributes,
+)
+def test_unsupported_field_attribute_type_alias(attribute: str, value: Any) -> None:
+    TestType = TypeAliasType('TestType', Annotated[int, Field(**{attribute: value})])
+
+    with pytest.warns(UnsupportedFieldAttributeWarning):
+
+        class Model(BaseModel):
+            f: TestType
+
+
+@pytest.mark.parametrize(
+    ['attribute', 'value'],
+    _unsupported_standalone_fieldinfo_attributes,
+)
+def test_unsupported_field_attribute_nested(attribute: str, value: Any) -> None:
+    TestType = TypeAliasType('TestType', Annotated[int, Field(**{attribute: value})])
+
+    with pytest.warns(UnsupportedFieldAttributeWarning):
+
+        class Model(BaseModel):
+            f: list[TestType]
+
+
+@pytest.mark.parametrize(
+    ['attribute', 'value'],
+    [
+        (attr, value)
+        for attr, value in _unsupported_standalone_fieldinfo_attributes
+        if attr not in ('default', 'default_factory')
+    ],
+)
+def test_unsupported_field_attribute_nested_with_function(attribute: str, value: Any) -> None:
+    TestType = TypeAliasType('TestType', Annotated[int, Field(**{attribute: value})])
+
+    with pytest.warns(UnsupportedFieldAttributeWarning):
+
+        @validate_call
+        def func(a: list[TestType]) -> None:
+            return None

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -287,7 +287,7 @@ _unsupported_standalone_fieldinfo_attributes = (
     ('default_factory', lambda: 1),
     ('exclude', True),
     ('deprecated', True),
-    ('repr', True),
+    ('repr', False),
     ('validate_default', True),
     ('frozen', True),
     ('init', True),


### PR DESCRIPTION
Best reviewed commit per commit.

In a nutshell, this now raises a warning:

```python
from typing import Annotated

from pydantic import BaseModel, Field

type MyInt = Annotated[int, Field(alias='my_alias')]

class Model(BaseModel):
    # see the warning in https://docs.pydantic.dev/latest/concepts/types/#named-type-aliases for more info:
    a: MyInt
"""
>>> UnsupportedFieldAttributeWarning: The 'alias' attribute with value 'my_alias' was provided to the `Field()` function, which 
>>> is unsupported in the context it was used. 'alias' is field-specific metadata, and can only be attached to a model field 
>>> using `Annotated` metadata or by assignment (note that using `Annotated` type aliases using the `type` statement 
>>> isn't supported).
"""

# Other use case:
class Model(BaseModel):
    a: list[Annotated[int, Field(default=1)]]
"""
>>> UnsupportedFieldAttributeWarning: The 'default' attribute with value 1 was provided to the `Field()` function, which 
>>> is unsupported in the context it was used. 'alias' is field-specific metadata, and can only be attached to a model field 
>>> using `Annotated` metadata or by assignment (note that using `Annotated` type aliases using the `type` statement 
>>> isn't supported).
"""
```

We still need to figure out if we want the warning to be raised for `default` and `default_factory`. Currently, the following works:

```python
type MyInt = Annotated[int, Field(default=1)]

class Model(BaseModel):
    a: MyInt

Model()
#> Model(a=1)
```

This is explained by the fact that we need to support defaults in type adapters:

```python
TypeAdapter(Annotated[int, Field(default=1)]).get_default_vaue()
#> Some(1)
```

And as a consequence it accidentally worked for models as well. However, things are inconsistent:

```python
type MyInt = Annotated[int, Field(default=1)]

class Model(BaseModel):
    a: MyInt

Model.model_fields['a'].is_required()  # True
```

and JSON Schema generation is also acting weirdly: https://github.com/pydantic/pydantic/issues/12024.

Imo, I think we should keep the warning for `default` and `default_factory`. Sure, validation behavior still works, but it is a footgun for the reasons mentioned above. Users can still ignore the warning if they feel like it.

---

I've reached out to the FastAPI team regarding the failing tests. They will need to address them in some way.