### PR TITLE
Turn on validation for base64 decoding of Base64Bytes.

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2403,7 +2403,7 @@ class Base64Encoder(EncoderProtocol):
             The decoded data.
         """
         try:
-            return base64.b64decode(data)
+            return base64.b64decode(data, validate=True)
         except ValueError as e:
             raise PydanticCustomError('base64_decode', "Base64 decoding error: '{error}'", {'error': str(e)})
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5629,6 +5629,30 @@ def test_base64_invalid(field_type, input_data):
 
 
 @pytest.mark.parametrize(
+    ('field_type', 'input_data'),
+    [
+        pytest.param(Base64Bytes, b'abcd\xc8', id='Base64Bytes-invalid-base64-bytes'),
+    ],
+)
+def test_base64_out_of_range(field_type, input_data):
+    class Model(BaseModel):
+        base64_value: field_type
+
+    with pytest.raises(ValidationError) as e:
+        Model(base64_value=input_data)
+
+    assert e.value.errors(include_url=False) == [
+        {
+            'ctx': {'error': 'Only base64 data is allowed'},
+            'input': input_data,
+            'loc': ('base64_value',),
+            'msg': "Base64 decoding error: 'Only base64 data is allowed'",
+            'type': 'base64_decode',
+        },
+    ]
+
+
+@pytest.mark.parametrize(
     ('field_type', 'input_data', 'expected_value', 'serialized_data'),
     [
         pytest.param(Base64UrlBytes, b'Zm9vIGJhcg==\n', b'foo bar', b'Zm9vIGJhcg==', id='Base64UrlBytes-reversible'),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5641,15 +5641,19 @@ def test_base64_out_of_range(field_type, input_data):
     with pytest.raises(ValidationError) as e:
         Model(base64_value=input_data)
 
-    assert e.value.errors(include_url=False) == [
-        {
-            'ctx': {'error': 'Only base64 data is allowed'},
-            'input': input_data,
-            'loc': ('base64_value',),
-            'msg': "Base64 decoding error: 'Only base64 data is allowed'",
-            'type': 'base64_decode',
-        },
-    ]
+    errors = e.value.errors(include_url=False)
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["ctx"]["error"] in (
+        "Only base64 data is allowed",
+        "Non-base64 digit found",
+    )
+    assert error["loc"] == ("base64_value",)
+    assert error["type"] == "base64_decode"
+    assert error["msg"] in (
+        "Base64 decoding error: 'Only base64 data is allowed'",
+        "Base64 decoding error: 'Non-base64 digit found'",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5644,13 +5644,13 @@ def test_base64_out_of_range(field_type, input_data):
     errors = e.value.errors(include_url=False)
     assert len(errors) == 1
     error = errors[0]
-    assert error["ctx"]["error"] in (
-        "Only base64 data is allowed",
-        "Non-base64 digit found",
+    assert error['ctx']['error'] in (
+        'Only base64 data is allowed',
+        'Non-base64 digit found',
     )
-    assert error["loc"] == ("base64_value",)
-    assert error["type"] == "base64_decode"
-    assert error["msg"] in (
+    assert error['loc'] == ('base64_value',)
+    assert error['type'] == 'base64_decode'
+    assert error['msg'] in (
         "Base64 decoding error: 'Only base64 data is allowed'",
         "Base64 decoding error: 'Non-base64 digit found'",
     )


### PR DESCRIPTION
## Change Summary

Turn on base64 validation for the Base64Bytes type.

Without this, passing a raw byte array to a Base64Bytes field results in all bytes out of the base64 set being _silently_ dropped by base64.b64encode. This doesn't seem like what we want in general and always makes me nervous about whether I'm setting the fields correctly: setting a Base64Bytes field directly doesn't trigger this behavior.

This is technically breaking if someone was relying on the silent omission, but that seems dangerous at best.

fix #12047

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
