### PR TITLE
Add new postgres protocol according to sqlalchemy docs

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -759,6 +759,7 @@ class PostgresDsn(_BaseMultiHostUrl):
             'postgresql+psycopg2cffi',
             'postgresql+py-postgresql',
             'postgresql+pygresql',
+            'postgresql+psycopg_async',
         ],
     )
 

--- a/pydantic/v1/networks.py
+++ b/pydantic/v1/networks.py
@@ -495,6 +495,7 @@ class PostgresDsn(MultiHostDsn):
         'postgresql+psycopg2cffi',
         'postgresql+py-postgresql',
         'postgresql+pygresql',
+        'postgresql+psycopg_async',
     }
     user_required = True
 

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -55,6 +55,7 @@ except ImportError:
         'postgresql+psycopg2cffi://user:pass@localhost:5432/app',
         'postgresql+py-postgresql://user:pass@localhost:5432/app',
         'postgresql+pygresql://user:pass@localhost:5432/app',
+        'postgresql+psycopg_async://user:pass@localhost:5432/app',
         'mysql://user:pass@localhost:3306/app',
         'mysql+mysqlconnector://user:pass@localhost:3306/app',
         'mysql+aiomysql://user:pass@localhost:3306/app',
@@ -607,7 +608,7 @@ def test_snowflake_dsns(dsn):
                 'msg': (
                     "URL scheme should be 'postgres', 'postgresql', 'postgresql+asyncpg', 'postgresql+pg8000', "
                     "'postgresql+psycopg', 'postgresql+psycopg2', 'postgresql+psycopg2cffi', "
-                    "'postgresql+py-postgresql' or 'postgresql+pygresql'"
+                    "'postgresql+py-postgresql', 'postgresql+pygresql' or 'postgresql+psycopg_async'"
                 ),
                 'input': 'http://example.org',
             },


### PR DESCRIPTION
Add new postgres protocol according to sqlalchemy docs: https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#dialect-postgresql-psycopg-connect it has:
from sqlalchemy.ext.asyncio import create_async_engine

asyncio_engine = create_async_engine(
    "postgresql+psycopg_async://scott:tiger@localhost/test"
)
so it'd be nice to support it. It's optional since it can use async automatically, but better for explicit scheme

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add new postgres protocol according to sqlalchemy docs

## Related issue number

I decided to create PR directly instead of issue, pls ping me if it's required using my email: muslimbeibytuly@gmail.com or in this PR

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
