### PR TITLE
Fix: replace deprecated allow_population_by_field_name with populated…

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -350,7 +350,7 @@ V2_REMOVED_KEYS = {
     'post_init_call',
 }
 V2_RENAMED_KEYS = {
-    'allow_population_by_field_name': 'validate_by_name',
+    'allow_population_by_field_name': 'populate_by_name',
     'anystr_lower': 'str_to_lower',
     'anystr_strip_whitespace': 'str_strip_whitespace',
     'anystr_upper': 'str_to_upper',


### PR DESCRIPTION
## Change Summary

Fixed the issue where the replacement parameter for allow_population_by_field_name was incorrectly specified. Updated the configuration parameter to populated_by_name as required by Pydantic v2.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review