### PR TITLE
Add proper `stacklevel` for class-based config deprecation warning

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -326,7 +326,7 @@ def prepare_config(config: ConfigDict | dict[str, Any] | type[Any] | None) -> Co
         return ConfigDict()
 
     if not isinstance(config, dict):
-        warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
+        warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=4)
         config = {k: getattr(config, k) for k in dir(config) if not k.startswith('__')}
 
     config_dict = cast(ConfigDict, config)


### PR DESCRIPTION
## Change Summary

Previously it showed up as originating here, but with stacklevel=4 we get it at the site of the issue e.g:

```
  .venv/lib/python3.13/site-packages/ninja/schema.py:181: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    result = super().__new__(cls, name, bases, namespace, **kwargs)

.venv/lib/python3.13/site-packages/ninja/conf.py:8
.venv/lib/python3.13/site-packages/ninja_extra/conf/package_settings.py:63
...
```

Part of https://github.com/pydantic/pydantic/issues/7908.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
