### PR TITLE
Fix `__getattr__()` behavior on Pydantic models when a property raised an `AttributeError` and extra values are present

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -979,11 +979,8 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 except AttributeError:
                     pydantic_extra = None
 
-                if pydantic_extra:
-                    try:
-                        return pydantic_extra[item]
-                    except KeyError as exc:
-                        raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}') from exc
+                if pydantic_extra and item in pydantic_extra:
+                    return pydantic_extra[item]
                 else:
                     if hasattr(self.__class__, item):
                         return super().__getattribute__(item)  # Raises AttributeError if appropriate

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -158,6 +158,9 @@ def test_computed_field_raises_correct_attribute_error():
     with pytest.raises(AttributeError, match='Property attribute error'):
         Model().prop_field
 
+    with pytest.raises(AttributeError, match='Property attribute error'):
+        Model(some_extra_field='some value').prop_field
+
     with pytest.raises(AttributeError, match=f"'{Model.__name__}' object has no attribute 'invalid_field'"):
         Model().invalid_field
 


### PR DESCRIPTION
## Change Summary

Change the `BaseModel.__getattr__` to point check if the item exists in `pydantic_extra`, if not it will continue regular flow execution.

## Related issue number

fix #12105

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @DouweM