### PR TITLE
Fix: Properly update private attrs with `model_copy`, `update=` and `extra=allow`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -405,20 +405,18 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
         copied = self.__deepcopy__() if deep else self.__copy__()
         if update:
-            if self.model_config.get('extra') == 'allow':
-                for k, v in update.items():
-                    if k in self.__pydantic_fields__:
-                        copied.__dict__[k] = v
-                    elif k in self.__private_attributes__:
-                        if copied.__pydantic_private__ is None:
-                            copied.__pydantic_private__ = {}
-                        copied.__pydantic_private__[k] = v
-                    else:
+            for k, v in update.items():
+                if k in self.__pydantic_fields__:
+                    copied.__dict__[k] = v
+                elif k in self.__private_attributes__:
+                    if copied.__pydantic_private__ is None:
+                        copied.__pydantic_private__ = {}
+                    copied.__pydantic_private__[k] = v
+                else:
+                    if self.model_config.get('extra') == 'allow':
                         if copied.__pydantic_extra__ is None:
                             copied.__pydantic_extra__ = {}
                         copied.__pydantic_extra__[k] = v
-            else:
-                copied.__dict__.update(update)
             copied.__pydantic_fields_set__.update(update.keys())
         return copied
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -409,6 +409,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 for k, v in update.items():
                     if k in self.__pydantic_fields__:
                         copied.__dict__[k] = v
+                    elif k in self.__private_attributes__:
+                        if copied.__pydantic_private__ is None:
+                            copied.__pydantic_private__ = {}
+                        copied.__pydantic_private__[k] = v
                     else:
                         if copied.__pydantic_extra__ is None:
                             copied.__pydantic_extra__ = {}

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -296,17 +296,108 @@ def test_copy_update(ModelTwo, copy_method):
     assert m != m2
 
 
-def test_copy_update_private_attr(copy_method):
-    class Model(BaseModel):
+def test_copy_with_update_allow_extra_with_private_attr(copy_method):
+    """Tests that when extra is allow, private attr is copied and added to __pydantic_private__"""
+
+    class AllowExtraModel(BaseModel):
         model_config = ConfigDict(extra='allow')
 
         _foo: str = PrivateAttr()
 
-    m: Model = Model()
-    m2: Model = copy_method(m, update={'_foo': 'different'})
+    mae_original_private_unset = AllowExtraModel()
+    mae_copied_private_unset = copy_method(mae_original_private_unset, update={'_foo': 'different', '_extra': 'extra'})
 
-    assert m2._foo == 'different'
-    assert m2.__pydantic_extra__ == {}
+    assert mae_copied_private_unset._foo == 'different'
+
+    # Deprecated copy does not properly update private or extra attributes
+    if copy_method == deprecated_copy:
+        assert mae_copied_private_unset.__pydantic_extra__ == {}
+        assert mae_copied_private_unset.__pydantic_private__ == {}
+    else:
+        assert mae_copied_private_unset.__pydantic_extra__ == {'_extra': 'extra'}
+        assert mae_copied_private_unset.__pydantic_private__ == {'_foo': 'different'}
+
+    mae_original_private_set = AllowExtraModel()
+    mae_original_private_set._foo = 'original'
+    mae_copied_private_set = copy_method(mae_original_private_set, update={'_foo': 'different', '_extra': 'extra'})
+
+    assert mae_copied_private_set._foo == 'different'
+
+    # Deprecated copy does not properly update private or extra attributes
+    if copy_method == deprecated_copy:
+        assert mae_copied_private_set.__pydantic_extra__ == {}
+        assert mae_copied_private_set.__pydantic_private__ == {'_foo': 'original'}
+    else:
+        assert mae_copied_private_set.__pydantic_extra__ == {'_extra': 'extra'}
+        assert mae_copied_private_set.__pydantic_private__ == {'_foo': 'different'}
+
+
+def test_copy_with_update_forbid_extra_with_private_attr(copy_method):
+    class ForbidExtraModel(BaseModel):
+        model_config = ConfigDict(extra='forbid')
+
+        _foo: str = PrivateAttr()
+
+    # When extra is forbid, the private attribute is not copied
+    mfe_original_private_unset: ForbidExtraModel = ForbidExtraModel()
+    mfe_copied_private_unset: ForbidExtraModel = copy_method(
+        mfe_original_private_unset, update={'_foo': 'different', '_extra': 'extra'}
+    )
+
+    assert mfe_copied_private_unset._foo == 'different'
+    assert mfe_copied_private_unset.__pydantic_extra__ is None
+
+    # Deprecated copy does not properly update private  attributes
+    if copy_method == deprecated_copy:
+        assert mfe_copied_private_unset.__pydantic_private__ == {}
+    else:
+        assert mfe_copied_private_unset.__pydantic_private__ == {'_foo': 'different'}
+
+    mfe_original_private_set = ForbidExtraModel()
+    mfe_original_private_set._foo = 'original'
+    mfe_copied_private_set = copy_method(mfe_original_private_set, update={'_foo': 'different', '_extra': 'extra'})
+    assert mfe_copied_private_set._foo == 'different'
+    assert mfe_copied_private_set.__pydantic_extra__ is None
+
+    # Deprecated copy does not properly update private attributes
+    if copy_method == deprecated_copy:
+        assert mfe_copied_private_set.__pydantic_private__ == {'_foo': 'original'}
+    else:
+        assert mfe_copied_private_set.__pydantic_private__ == {'_foo': 'different'}
+
+
+def test_copy_with_update_ignore_extra_with_private_attr(copy_method):
+    class IgnoreExtraModel(BaseModel):
+        model_config = ConfigDict(extra='ignore')
+
+        _foo: str = PrivateAttr()
+
+    # When extra is ignore, the private attribute is copied
+    mei_original_private_unset: IgnoreExtraModel = IgnoreExtraModel()
+    mei_copied_private_unset: IgnoreExtraModel = copy_method(
+        mei_original_private_unset, update={'_foo': 'different', '_extra': 'extra'}
+    )
+
+    assert mei_copied_private_unset._foo == 'different'
+    assert mei_copied_private_unset.__pydantic_extra__ is None
+
+    # Deprecated copy does not properly copy private attributes
+    if copy_method == deprecated_copy:
+        assert mei_copied_private_unset.__pydantic_private__ == {}
+    else:
+        assert mei_copied_private_unset.__pydantic_private__ == {'_foo': 'different'}
+
+    mei_original_private_set = IgnoreExtraModel()
+    mei_original_private_set._foo = 'original'
+    mei_copied_private_set = copy_method(mei_original_private_set, update={'_foo': 'different', '_extra': 'extra'})
+    assert mei_copied_private_set._foo == 'different'
+    assert mei_copied_private_set.__pydantic_extra__ is None
+
+    # Deprecated copy does not properly copy private attributes
+    if copy_method == deprecated_copy:
+        assert mei_copied_private_set.__pydantic_private__ == {'_foo': 'original'}
+    else:
+        assert mei_copied_private_set.__pydantic_private__ == {'_foo': 'different'}
 
 
 def test_copy_update_unset(copy_method):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -297,7 +297,6 @@ def test_copy_update(ModelTwo, copy_method):
 
 
 def test_copy_update_private_attr(copy_method):
-
     class Model(BaseModel):
         model_config = ConfigDict(extra='allow')
 

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -296,12 +296,18 @@ def test_copy_update(ModelTwo, copy_method):
     assert m != m2
 
 
-def test_copy_update_private_attr(ModelTwo, copy_method):
-    m = ModelTwo(a=24, d=Model(a='12'))
-    m2 = copy_method(m, update={'_foo_': 'different'})
+def test_copy_update_private_attr(copy_method):
 
-    assert m2._foo_ == 'different'
-    assert m2.__pydantic_extra__ is None
+    class Model(BaseModel):
+        model_config = ConfigDict(extra='allow')
+
+        _foo: str = PrivateAttr()
+
+    m: Model = Model()
+    m2: Model = copy_method(m, update={'_foo': 'different'})
+
+    assert m2._foo == 'different'
+    assert m2.__pydantic_extra__ == {}
 
 
 def test_copy_update_unset(copy_method):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -296,6 +296,14 @@ def test_copy_update(ModelTwo, copy_method):
     assert m != m2
 
 
+def test_copy_update_private_attr(ModelTwo, copy_method):
+    m = ModelTwo(a=24, d=Model(a='12'))
+    m2 = copy_method(m, update={'_foo_': 'different'})
+
+    assert m2._foo_ == 'different'
+    assert m2.__pydantic_extra__ is None
+
+
 def test_copy_update_unset(copy_method):
     class Foo(BaseModel):
         foo: Optional[str] = None


### PR DESCRIPTION
## Change Summary

When using `model_copy`'s `update` feature, private attributes are not correctly updated if `extra=allow`.

## Related issue number

fix #12116 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos