### PR TITLE
Fix JSON Schema generation for extra_behavior in typed_dict_schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1419,11 +1419,19 @@ class GenerateJsonSchema:
         if cls is not None:
             self._update_class_schema(json_schema, cls, config)
         else:
-            extra = config.get('extra')
+            extra = (
+                schema.get('extra_behavior')
+                or config.get('extra')
+                or schema.get('config', {}).get('extra_fields_behavior')
+            )
             if extra == 'forbid':
                 json_schema['additionalProperties'] = False
             elif extra == 'allow':
-                json_schema['additionalProperties'] = True
+                extras_schema = schema.get('extras_schema')
+                if extras_schema is not None:
+                    json_schema['additionalProperties'] = self.generate_inner(extras_schema) or True
+                else:
+                    json_schema['additionalProperties'] = True
 
         return json_schema
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7072,3 +7072,18 @@ def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places
 ) -> None:
     pattern = get_decimal_pattern()
     assert re.fullmatch(pattern, invalid_decimal) is None
+
+
+def test_additional_properties_for_extra_behavior():
+    schema1 = core_schema.typed_dict_schema(fields={}, extra_behavior='forbid')
+    json_schema1 = GenerateJsonSchema().generate(schema1)
+    assert json_schema1['additionalProperties'] is False
+
+    extras_schema = core_schema.int_schema()
+    schema2 = core_schema.typed_dict_schema(fields={}, extra_behavior='allow', extras_schema=extras_schema)
+    json_schema2 = GenerateJsonSchema().generate(schema2)
+    assert json_schema2['additionalProperties'] == {'type': 'integer'}
+
+    schema3 = core_schema.typed_dict_schema(fields={})
+    json_schema3 = GenerateJsonSchema().generate(schema3)
+    assert 'additionalProperties' not in json_schema3


### PR DESCRIPTION
## Change Summary

Fixes incorrect `additionalProperties` behavior in `TypedDict` schema generation when `extra_behavior='forbid'` is used in the model schema.

Previously, only `config.get('extra')` was checked, which missed `extra_behavior` defined in the schema itself. This caused `forbid` behavior to be ignored.

Now, `extra` is determined by checking:

```
extra = (
    schema.get('extra_behavior')
    or config.get('extra')
    or schema.get('config', {}).get('extra_fields_behavior')
)
```
This ensures the correct `additionalProperties` value is set in the generated schema.

This PR integrates the workaround shared by @DouweM  into the codebase.”

## Related issue number

fix #12123

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
