### PR TITLE
Ignore metadata in typing.Annotated when creating model schema

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2315,8 +2315,12 @@ class GenerateSchema:
     ) -> CallbackGetCoreSchemaHandler:
         annotation_get_schema: GetCoreSchemaFunction | None = getattr(annotation, '__get_pydantic_core_schema__', None)
 
+        # Check if annotation is a BaseModel instance (not class) - these should be treated as metadata, not schema generators
+        BaseModel = import_cached_base_model()
+        is_basemodel_instance = isinstance(annotation, BaseModel)
+
         def new_handler(source: Any) -> core_schema.CoreSchema:
-            if annotation_get_schema is not None:
+            if annotation_get_schema is not None and not is_basemodel_instance:
                 schema = annotation_get_schema(source, get_inner_schema)
             else:
                 schema = get_inner_schema(source)


### PR DESCRIPTION
## Change Summary

Ignores instances of `BaseModel` in `typing.Annotated` metadata

## Related issue number

fix #12096 
fix #7833 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
