### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/help_with_pydantic.md
+++ b/docs/help_with_pydantic.md
@@ -8,7 +8,7 @@ The [usage documentation](concepts/models.md) is the most complete guide on how 
 
 ## :material-api: API Documentation
 
-The [API documentation](api/base_model.md) give reference docs for all public Pydantic APIs.
+The [API documentation](api/base_model.md) gives reference docs for all public Pydantic APIs.
 
 ## :simple-github: GitHub Discussions
 
@@ -20,6 +20,6 @@ Use the [`pydantic`](https://stackoverflow.com/questions/tagged/pydantic) tag on
 
 ## :simple-youtube: YouTube
 
-Youtube as lots of useful [videos on Pydantic](https://www.youtube.com/results?search_query=pydantic).
+Youtube has lots of useful [videos on Pydantic](https://www.youtube.com/results?search_query=pydantic).
 
 In particular Marcelo Trylesinski's video ["Pydantic V1 to V2 - The Migration"](https://youtu.be/sD_xpYl4fPU) has helped people a lot when migrating from Pydantic V1 to V2.


### PR DESCRIPTION
As is: Youtube as lots of useful [videos on Pydantic](https://www.youtube.com/results?search_query=pydantic).

To be: Youtube has lots of useful [videos on Pydantic](https://www.youtube.com/results?search_query=pydantic).

As is: The [API documentation](api/base_model.md) give reference docs for all public Pydantic APIs.

To be: The [API documentation](api/base_model.md) gives reference docs for all public Pydantic APIs.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
