### PR TITLE
Fix use of backtick in Validation Alias docs

### DIFF
--- a/docs/concepts/fields.md
+++ b/docs/concepts/fields.md
@@ -351,7 +351,7 @@ print(user.model_dump(by_alias=True))  # (2)!
 
     Even though Pydantic treats `alias` and `validation_alias` the same when creating model instances, type checkers
     only understand the `alias` field parameter. As a workaround, you can instead specify both an `alias` and
-    serialization_alias` (identical to the field name), as the `serialization_alias` will override the `alias` during
+    `serialization_alias` (identical to the field name), as the `serialization_alias` will override the `alias` during
     serialization:
 
     ```python


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes rendering of parameters in the docs, there was a missing "`"
<img width="813" height="160" alt="Screenshot 2025-08-12 at 10 08 02" src="https://github.com/user-attachments/assets/7386d205-ac39-4ed3-8cc4-7a5ae7e500df" />

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @DouweM