### PR TITLE
Update `__fields__` attribute deprecation message

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -319,10 +319,12 @@ class ModelMetaclass(ABCMeta):
         return field_names, class_vars, private_attributes
 
     @property
-    @deprecated('The `__fields__` attribute is deprecated, use `model_fields` instead.', category=None)
+    @deprecated(
+        'The `__fields__` attribute is deprecated, use the `model_fields` class property instead.', category=None
+    )
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn(
-            'The `__fields__` attribute is deprecated, use `model_fields` instead.',
+            'The `__fields__` attribute is deprecated, use the `model_fields` class property instead.',
             PydanticDeprecatedSince20,
             stacklevel=2,
         )

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1240,11 +1240,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     # ##### Deprecated methods from v1 #####
     @property
     @typing_extensions.deprecated(
-        'The `__fields__` attribute is deprecated, use `model_fields` instead.', category=None
+        'The `__fields__` attribute is deprecated, use the `model_fields` class property instead.', category=None
     )
     def __fields__(self) -> dict[str, FieldInfo]:
         warnings.warn(
-            'The `__fields__` attribute is deprecated, use `model_fields` instead.',
+            'The `__fields__` attribute is deprecated, use the `model_fields` class property instead.',
             category=PydanticDeprecatedSince20,
             stacklevel=2,
         )

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -336,7 +336,7 @@ def test_fields():
     with pytest.warns(PydanticDeprecatedSince211, match="Accessing the 'model_computed_fields' attribute"):
         assert len(m.model_computed_fields) == 1
 
-    match = '^The `__fields__` attribute is deprecated, use `model_fields` instead.'
+    match = '^The `__fields__` attribute is deprecated, use the `model_fields` class property instead.'
     with pytest.warns(PydanticDeprecatedSince20, match=match):
         assert len(Model.__fields__) == 2
     with pytest.warns(PydanticDeprecatedSince20, match=match):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

To avoid:

```
>>> from pydantic import BaseModel
>>> class MyModel(BaseModel):
...     foo: int
...
>>> MyModel(foo=2).__fields__
<stdin>:1: PydanticDeprecatedSince20: The `__fields__` attribute is deprecated, use `model_fields` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
{'foo': FieldInfo(annotation=int, required=True)}
>>> # okay ... sure ... I'll update my code
>>> MyModel(foo=2).model_fields
<stdin>:1: PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
{'foo': FieldInfo(annotation=int, required=True)}
```

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
