### PR TITLE
Allow to use property setters on Pydantic dataclasses with `validate_assignment` set

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -249,10 +249,21 @@ def dataclass(
             )
 
         if config_wrapper.validate_assignment:
+            original_setattr = cls.__setattr__
 
             @functools.wraps(cls.__setattr__)
-            def validated_setattr(instance: Any, field: str, value: str, /) -> None:
-                type(instance).__pydantic_validator__.validate_assignment(instance, field, value)
+            def validated_setattr(instance: PydanticDataclass, name: str, value: Any, /) -> None:
+                if frozen_:
+                    return original_setattr(instance, name, value)  # pyright: ignore[reportCallIssue]
+                inst_cls = type(instance)
+                attr = getattr(inst_cls, name, None)
+
+                if isinstance(attr, property):
+                    attr.__set__(instance, value)
+                elif isinstance(attr, functools.cached_property):
+                    instance.__dict__.__setitem__(name, value)
+                else:
+                    inst_cls.__pydantic_validator__.validate_assignment(instance, name, value)
 
             cls.__setattr__ = validated_setattr.__get__(None, cls)  # type: ignore
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -7,6 +7,7 @@ import traceback
 from collections.abc import Hashable
 from dataclasses import InitVar
 from datetime import date, datetime
+from functools import cached_property
 from pathlib import Path
 from typing import (
     Annotated,
@@ -174,6 +175,39 @@ def test_validate_assignment_value_change():
 
     d.a = 3
     assert d.a == 6
+
+
+def test_validate_assignment_properties() -> None:
+    """https://github.com/pydantic/pydantic/issues/12112"""
+
+    @pydantic.dataclasses.dataclass(config=ConfigDict(validate_assignment=True))
+    class MyDataclass:
+        @property
+        def prop1(self) -> int:
+            return 1
+
+        @prop1.setter
+        def prop1(self, value: int) -> None:
+            pass
+
+        @computed_field
+        @property
+        def prop2(self) -> int:
+            return 1
+
+        @prop2.setter
+        def prop2(self, value: int) -> None:
+            pass
+
+        @cached_property
+        def prop3(self) -> int:
+            return 1
+
+    m = MyDataclass()
+
+    m.prop1 = 1
+    m.prop2 = 1
+    m.prop3 = 1
 
 
 @pytest.mark.parametrize(
@@ -3137,10 +3171,8 @@ def test_frozen_with_validate_assignment() -> None:
 
     inst = MyDataclass('hello')
 
-    try:
+    with pytest.raises(dataclasses.FrozenInstanceError, match="cannot assign to field 'x'"):
         inst.x = 'other'
-    except Exception as e:
-        assert "cannot assign to field 'x'" in repr(e)
 
     @pydantic.dataclasses.dataclass(config=ConfigDict(frozen=True, validate_assignment=True))
     class MyDataclass2:
@@ -3148,11 +3180,8 @@ def test_frozen_with_validate_assignment() -> None:
 
     inst = MyDataclass2('hello')
 
-    # we want to make sure that the error raised relates to the frozen nature of the instance
-    try:
+    with pytest.raises(dataclasses.FrozenInstanceError, match="cannot assign to field 'x'"):
         inst.x = 'other'
-    except ValidationError as e:
-        assert 'Instance is frozen' in repr(e)
 
 
 def test_warns_on_double_frozen() -> None:


### PR DESCRIPTION


Fixes https://github.com/pydantic/pydantic/issues/12112.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
