### PR TITLE
fix: grammatical error in models doc

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -200,7 +200,7 @@ This is a deliberate decision of Pydantic, and is frequently the most useful app
 [here](https://github.com/pydantic/pydantic/issues/578) for a longer discussion on the subject.
 
 Nevertheless, Pydantic provides a [strict mode](strict_mode.md), where no data conversion is performed.
-Values must be of the same type than the declared field type.
+Values must be of the same type as the declared field type.
 
 This is also the case for collections. In most cases, you shouldn't make use of abstract container classes
 and just use a concrete type, such as [`list`][]:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Fixed a small grammatical error in the documentation. While comparing, "as" should be used rather than "than". It confused me a bit while reading the documentation.
<!-- Please give a short summary of the changes. -->

## Related issue number
Not Applicable

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
