### PR TITLE
Fix mypy v1 plugin for upcoming mypy release

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -863,9 +863,9 @@ def add_method(
         arg_kinds.append(arg.kind)
 
     function_type = ctx.api.named_type(f'{BUILTINS_NAME}.function')
-    signature = CallableType(arg_types, arg_kinds, arg_names, return_type, function_type)
-    if tvar_def:
-        signature.variables = [tvar_def]
+    signature = CallableType(
+        arg_types, arg_kinds, arg_names, return_type, function_type, variables=[tvar_def] if tvar_def else None
+    )
 
     func = FuncDef(name, args, Block([PassStmt()]))
     func.info = info


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

https://github.com/python/mypy/pull/19768 just changed the internal type of `CallableType.variables` from sequence to `tuple`. This causes a crash with the mypy v1 plugin.

```py
  File "/.../python3.13/site-packages/pydantic/v1/mypy.py", line 868, in add_method
    signature.variables = [tvar_def]
    ^^^^^^^^^^^^^^^^^^^
TypeError: tuple object expected; got list
```

It's better to assign `variables` in the class constructor as any input there is coerced into the correct type.

Some background: https://github.com/python/mypy/pull/19768#discussion_r2313359314

## Related issue number

--

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @DouweM