### PR TITLE
Preserve `__dict__` identity during `validate_assignment`

### DIFF
--- a/tests/test_computed_fields.py
+++ b/tests/test_computed_fields.py
@@ -21,6 +21,7 @@ from pydantic import (
     field_validator,
 )
 from pydantic.alias_generators import to_camel
+from pydantic.config import ConfigDict
 from pydantic.errors import PydanticUserError
 
 
@@ -173,6 +174,40 @@ def test_computed_fields_del():
     assert user.model_dump() == {'first': 'Pika', 'last': 'Chu', 'fullname': 'Pika Chu'}
     del user.fullname
     assert user.model_dump() == {'first': '', 'last': '', 'fullname': ' '}
+
+
+@pytest.mark.parametrize('should_validate', (True, False))
+def test_cached_property_validate_assignment(should_validate: bool):
+    class A(BaseModel):
+        model_config = ConfigDict(validate_assignment=should_validate)
+        b: int = 0
+
+        @computed_field
+        @cached_property
+        def random_number(self) -> int:
+            self.b = 123
+            return random.randint(0, 1_000)
+
+    a = A()
+    assert a.random_number == a.random_number
+
+
+def test_cached_computed_field_runs_once_with_validate_assignment():
+    class A(BaseModel):
+        model_config = ConfigDict(validate_assignment=True)
+        b: int = 0
+        _calls: int = PrivateAttr(default=0)
+
+        @computed_field
+        @cached_property
+        def random_number(self) -> int:
+            self._calls += 1
+            self.b = 123
+            return 7
+
+    a = A()
+    assert a.random_number == a.random_number == 7
+    assert a._calls == 1
 
 
 def test_cached_property():


### PR DESCRIPTION

## Change Summary

With the validate_assignment flag flipped to True, any cached properties added to model.__dict__ get lost because the dict is overwritten. This eliminates the benefit of caching expensive computed properties as they need to be recomputed everytime a change is made.

both tests break when run against current main

## Related issue number

fix #12197 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
