### PR TITLE
Add clarity around named timezone handling in documentation

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -80,7 +80,9 @@ class Event(BaseModel):
 event = Event(dt='2032-04-23T10:20:30.400+02:30')
 
 print(event.model_dump())
-#> {'dt': datetime.datetime(2032, 4, 23, 10, 20, 30, 400000, tzinfo=TzInfo(9000))}
+"""
+{'dt': datetime.datetime(2032, 4, 23, 10, 20, 30, 400000, tzinfo=TzInfo(9000))}
+"""
 print(event.model_dump(mode='json'))
 #> {'dt': '2032-04-23T10:20:30.400000+02:30'}
 print(event.model_dump_json())


### PR DESCRIPTION
## Change Summary

Updates documentation for `datetime` and `time` types to note that they currently don't support named (i.e. IANA) timezones; `datetime` may support them in the future, `time` will probably not.

## Related issue number

Closes #9571 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
