### PR TITLE
Replace "wrap" serializers with "simple" serializers for some `any` cases

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2093,10 +2093,7 @@ class GenerateSchema:
 
         if bound := typevar.__bound__:
             schema = self.generate_schema(bound)
-            schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
-                lambda x, h: h(x),
-                schema=core_schema.any_schema(),
-            )
+            schema['serialization'] = core_schema.simple_ser_schema('any')
             return schema
 
         return core_schema.any_schema()

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -445,9 +445,7 @@ else:
             while schema_to_update['type'] == 'definitions':
                 schema_to_update = schema_to_update.copy()
                 schema_to_update = schema_to_update['schema']
-            schema_to_update['serialization'] = core_schema.wrap_serializer_function_ser_schema(
-                lambda x, h: h(x), schema=core_schema.any_schema()
-            )
+            schema_to_update['serialization'] = core_schema.simple_ser_schema('any')
             return schema
 
         __hash__ = object.__hash__


### PR DESCRIPTION
## Change Summary

Use `simple_ser_schema('any')` in a couple of places we currently use `wrap_serializer_function_ser_schema`.

This should be functionally equivalent and simply more performant, as it removes a Python indirection from the serialization pathway for these cases.

## Related issue number

Found while investigating #12264, but does not fix.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
