### PR TITLE
allow functools.partial as predicate

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -596,7 +596,9 @@ def _apply_constraint(  # noqa: C901
                 try:
                     source = inspect.getsource(func).strip()
                     source = source.removesuffix(')')
-                    lambda_source_code = '`' + ''.join(''.join(source.split('lambda ')[1:]).split(':')[1:]).strip() + '`'
+                    lambda_source_code = (
+                        '`' + ''.join(''.join(source.split('lambda ')[1:]).split(':')[1:]).strip() + '`'
+                    )
                 except OSError:
                     # stringified annotations
                     lambda_source_code = 'lambda'
@@ -606,10 +608,11 @@ def _apply_constraint(  # noqa: C901
                 s = _check_func(func, func.__name__, s)
         else:
             from functools import partial
+
             if isinstance(func, partial):
-                s = _check_func(func, "partial", s)
+                s = _check_func(func, 'partial', s)
             else:
-                s = _check_func(func, "callable", s)
+                s = _check_func(func, 'callable', s)
 
     elif isinstance(constraint, _NotEq):
         value = constraint.value

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -241,6 +241,8 @@ def test_parse_str_to_int() -> None:
 
 
 def test_predicates() -> None:
+    from functools import partial
+
     ta_int = TypeAdapter[int](Annotated[int, validate_as(int).predicate(lambda x: x % 2 == 0)])
     assert ta_int.validate_python(2) == 2
     with pytest.raises(ValidationError):
@@ -251,6 +253,11 @@ def test_predicates() -> None:
     with pytest.raises(ValidationError):
         ta_str.validate_python('potato')
 
+    incr1 = partial(lambda x, incr: x == incr, incr=1)
+    ta_str_to_int = TypeAdapter[int](Annotated[int, validate_as(int).predicate(incr1)])
+    assert ta_str_to_int.validate_python(1) == 1
+    with pytest.raises(ValidationError):
+        ta_str_to_int.validate_python(2)
 
 @pytest.mark.parametrize(
     'model, expected_val_schema, expected_ser_schema',

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -259,6 +259,7 @@ def test_predicates() -> None:
     with pytest.raises(ValidationError):
         ta_str_to_int.validate_python(2)
 
+
 @pytest.mark.parametrize(
     'model, expected_val_schema, expected_ser_schema',
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Allow `functools.partial` as predicates (and all other non-lambda callables that don't have a `__name__` attribute). The previous error was, that we explicitly check for `func.__name__`, this PR relaxes the condition and provides a fallback in case this attribute does not exist. It is debatable whether we need to complicate it like I did, or if we just set the name to `callable`. See my comment on the PR for further reference 

## Related issue number
fix #12276
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
