### PR TITLE
Do not try to infer name from lambda definitions in pipelines API

### DIFF
--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -398,7 +398,7 @@ def test_predicate_error_python() -> None:
         {
             'type': 'predicate_failed',
             'loc': (),
-            'msg': 'Predicate test_predicate_error_python.<locals>.<lambda> failed',
+            'msg': "Predicate 'test_predicate_error_python.<locals>.<lambda>' failed",
             'input': -1,
         }
     ]
@@ -415,7 +415,7 @@ def test_not_operation_error_python() -> None:
         {
             'type': 'not_operation_failed',
             'loc': (),
-            'msg': 'Not of test_not_operation_error_python.<locals>.<lambda> failed',
+            'msg': "Not of 'test_not_operation_error_python.<locals>.<lambda>' failed",
             'input': 6,
         }
     ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6438,13 +6438,13 @@ def test_constraints_arbitrary_type() -> None:
         {
             'type': 'predicate_failed',
             'loc': ('predicate',),
-            'msg': 'Predicate test_constraints_arbitrary_type.<locals>.Model.<lambda> failed',
+            'msg': "Predicate 'test_constraints_arbitrary_type.<locals>.Model.<lambda>' failed",
             'input': CustomType(-1),
         },
         {
             'type': 'not_operation_failed',
             'loc': ('not_multiple_of_3',),
-            'msg': 'Not of test_constraints_arbitrary_type.<locals>.Model.<lambda> failed',
+            'msg': "Not of 'test_constraints_arbitrary_type.<locals>.Model.<lambda>' failed",
             'input': CustomType(6),
         },
     ]


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic/issues/12276.

Trying to use the source code (without any options to opt out) can have downsides, plus I noticed it wasn't working properly. Let's not rely on it.

Misc. tweaks also applied to the related annotations application code.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
