### PR TITLE
Enable `PERF` (Perflint) Ruff rules

### DIFF
--- a/.github/actions/people/people.py
+++ b/.github/actions/people/people.py
@@ -464,8 +464,7 @@ def get_issues_experts(settings: Settings) -> tuple[Counter, Counter, dict[str, 
     issue_edges = get_graphql_issue_edges(settings=settings)
 
     while issue_edges:
-        for edge in issue_edges:
-            issue_nodes.append(edge.node)
+        issue_nodes.extend(edge.node for edge in issue_edges)
         last_edge = issue_edges[-1]
         issue_edges = get_graphql_issue_edges(settings=settings, after=last_edge.cursor)
 
@@ -511,8 +510,7 @@ def get_discussions_experts(settings: Settings) -> tuple[Counter, Counter, dict[
     discussion_edges = get_graphql_question_discussion_edges(settings=settings)
 
     while discussion_edges:
-        for discussion_edge in discussion_edges:
-            discussion_nodes.append(discussion_edge.node)
+        discussion_nodes.extend(discussion_edge.node for discussion_edge in discussion_edges)
         last_edge = discussion_edges[-1]
         discussion_edges = get_graphql_question_discussion_edges(settings=settings, after=last_edge.cursor)
 
@@ -597,8 +595,7 @@ def get_contributors(settings: Settings) -> tuple[Counter, Counter, Counter, dic
     pr_edges = get_graphql_pr_edges(settings=settings)
 
     while pr_edges:
-        for edge in pr_edges:
-            pr_nodes.append(edge.node)
+        pr_nodes.extend(edge.node for edge in pr_edges)
         last_edge = pr_edges[-1]
         pr_edges = get_graphql_pr_edges(settings=settings, after=last_edge.cursor)
 

--- a/docs/plugins/conversion_table.py
+++ b/docs/plugins/conversion_table.py
@@ -84,9 +84,9 @@ class ConversionTable:
         return f'| {" | ".join(cols)} |'
 
     def as_markdown(self) -> str:
-        lines = [self.row_as_markdown(self.col_names), self.row_as_markdown(['-'] * len(self.col_names))]
-        for row in self.rows:
-            lines.append(self.row_as_markdown(self.col_values(row)))
+        lines = [self.row_as_markdown(self.col_names), self.row_as_markdown(['-'] * len(self.col_names))] + [
+            self.row_as_markdown(self.col_values(row)) for row in self.rows
+        ]
         return '\n'.join(lines)
 
     @staticmethod

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1265,7 +1265,7 @@ class GenerateSchema:
         # Convert `@field_validator` decorators to `Before/After/Plain/WrapValidator` instances:
         validators_from_decorators = []
         for decorator in filter_field_decorator_info_by_field(decorators.field_validators.values(), name):
-            validators_from_decorators.append(_mode_to_validator[decorator.info.mode]._from_decorator(decorator))
+            validators_from_decorators.append(_mode_to_validator[decorator.info.mode]._from_decorator(decorator))  # noqa PERF401
 
         with self.field_name_stack.push(name):
             if field_info.discriminator is not None:

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -512,10 +512,7 @@ def _union_orderings_key(typevar_values: Any) -> Any:
     (See https://github.com/python/cpython/issues/86483 for reference.)
     """
     if isinstance(typevar_values, tuple):
-        args_data = []
-        for value in typevar_values:
-            args_data.append(_union_orderings_key(value))
-        return tuple(args_data)
+        return tuple(_union_orderings_key(value) for value in typevar_values)
     elif typing_objects.is_union(typing_extensions.get_origin(typevar_values)):
         return get_args(typevar_values)
     else:

--- a/pydantic/_internal/_serializers.py
+++ b/pydantic/_internal/_serializers.py
@@ -42,7 +42,7 @@ def serialize_sequence_via_list(
     for index, item in enumerate(v):
         try:
             v = handler(item, index)
-        except PydanticOmit:
+        except PydanticOmit:  # noqa: PERF203
             pass
         else:
             items.append(v)

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -590,9 +590,7 @@ class GenerateJsonSchema:
                 sorted_dict[key] = self._sort_recursive(value[key], parent_key=key)
             return sorted_dict
         elif isinstance(value, list):
-            sorted_list: list[JsonSchemaValue] = []
-            for item in value:
-                sorted_list.append(self._sort_recursive(item, parent_key))
+            sorted_list: list[JsonSchemaValue] = [self._sort_recursive(item, parent_key) for item in value]
             return sorted_list
         else:
             return value
@@ -2012,7 +2010,7 @@ class GenerateJsonSchema:
         for definition in schema['definitions']:
             try:
                 self.generate_inner(definition)
-            except PydanticInvalidForJsonSchema as e:
+            except PydanticInvalidForJsonSchema as e:  # noqa: PERF203
                 core_ref: CoreRef = CoreRef(definition['ref'])  # type: ignore
                 self._core_defs_invalid_for_json_schema[self.get_defs_ref((core_ref, self.mode))] = e
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ select = [
     'T10',    # flake8-debugger
     'T20',    # flake8-print
     'C4',     # flake8-comprehensions
+    'PERF',   # Perflint
     'PIE',    # flake8-pie
     'PYI006', # flake8-pyi
     'PYI062', # flake8-pyi

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -97,7 +97,7 @@ def run_example(example: CodeExample, eval_example: EvalExample, mocker: Any) ->
     group_name = prefix_settings.get('group')
 
     eval_example.set_config(
-        ruff_ignore=['D', 'T', 'B', 'C4', 'E721', 'Q001', 'PIE790'],
+        ruff_ignore=['D', 'T', 'B', 'C4', 'E721', 'Q001', 'PERF', 'PIE790'],
         line_length=LINE_LENGTH,
         target_version=TARGET_VERSION,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Replace repeated calls to `list.append()` with a list comprehension or a single call to `list.extend()`.

% `ruff rule PERF401`
> ___Why is this bad?___
When creating a transformed list from an existing list using a for-loop, prefer a list comprehension.
List comprehensions are more readable and more performant.

> Using the below as an example, the list comprehension is ~10% faster on Python 3.11, and ~25% faster on Python 3.10.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
