### PR TITLE
Upgrade from deprecated macos-13 to macos-15-intel in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         include:
           # no pydantic-core binaries for pypy on windows, so tests take absolute ages
@@ -97,12 +97,11 @@ jobs:
           - os: ubuntu-latest
             python-version: 'pypy3.10'
         exclude:
-          # Python 3.9 is not available on macOS 14
-          - os: macos-13
+          - os: macos-15-intel
             python-version: '3.10'
-          - os: macos-13
+          - os: macos-15-intel
             python-version: '3.11'
-          - os: macos-13
+          - os: macos-15-intel
             python-version: '3.12'
           - os: macos-latest
             python-version: '3.13'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Upgrade from deprecated `macos-13` to `macos-15-intel`.

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |
* Let's prepare for actions/runner-images#13046

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
