### PR TITLE
ci: test pypy 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
             python-version: 'pypy3.9'
           - os: ubuntu-latest
             python-version: 'pypy3.10'
+          - os: ubuntu-latest
+            python-version: 'pypy3.11'
         exclude:
           - os: macos-15-intel
             python-version: '3.10'

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -148,7 +148,7 @@ def test_representation_integrations():
 
     obj = Obj()
 
-    if sys.version_info < (3, 11):
+    if sys.version_info < (3, 11) or sys.implementation.name == 'pypy':
         assert str(devtools.debug.format(obj)).split('\n')[1:] == [
             '    Obj(',
             '        int_attr=42,',

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -18,7 +18,12 @@ except ImportError:
 
 pytestmark = pytest.mark.skipif(cloudpickle is None, reason='cloudpickle is not installed')
 
-cloudpickle_xfail = pytest.mark.xfail(
+cloudpickle_pypy_xfail = pytest.mark.xfail(
+    condition=sys.implementation.name == 'pypy' and sys.version_info >= (3, 11),
+    reason='Cloudpickle issue: - possibly https://github.com/cloudpipe/cloudpickle/issues/557',
+)
+
+cloudpickle_model_xfail = pytest.mark.xfail(
     condition=sys.version_info >= (3, 14),
     reason='Cloudpickle issue: https://github.com/cloudpipe/cloudpickle/issues/572',
 )
@@ -94,7 +99,7 @@ def model_factory() -> type:
         (ImportableModel, False),
         (ImportableModel, True),
         # Locally-defined model can only be pickled with cloudpickle.
-        pytest.param(model_factory(), True, marks=cloudpickle_xfail),
+        pytest.param(model_factory(), True, marks=(cloudpickle_pypy_xfail, cloudpickle_model_xfail)),
     ],
 )
 def test_pickle_model(model_type: type, use_cloudpickle: bool):
@@ -139,7 +144,7 @@ def nested_model_factory() -> type:
         (ImportableNestedModel, False),
         (ImportableNestedModel, True),
         # Locally-defined model can only be pickled with cloudpickle.
-        pytest.param(nested_model_factory(), True, marks=cloudpickle_xfail),
+        pytest.param(nested_model_factory(), True, marks=(cloudpickle_pypy_xfail, cloudpickle_model_xfail)),
     ],
 )
 def test_pickle_nested_model(model_type: type, use_cloudpickle: bool):
@@ -213,12 +218,12 @@ def child_dataclass_factory() -> type:
         (ImportableChildDataclass, False),
         (ImportableChildDataclass, True),
         # Locally-defined Pydantic dataclass can only be pickled with cloudpickle.
-        (dataclass_factory(), True),
+        pytest.param(dataclass_factory(), True, marks=cloudpickle_pypy_xfail),
         (child_dataclass_factory(), True),
         # Pydantic dataclass generated from builtin can only be pickled with cloudpickle.
-        (pydantic.dataclasses.dataclass(ImportableBuiltinDataclass), True),
+        pytest.param(pydantic.dataclasses.dataclass(ImportableBuiltinDataclass), True, marks=cloudpickle_pypy_xfail),
         # Pydantic dataclass generated from locally-defined builtin can only be pickled with cloudpickle.
-        (pydantic.dataclasses.dataclass(builtin_dataclass_factory()), True),
+        pytest.param(pydantic.dataclasses.dataclass(builtin_dataclass_factory()), True, marks=cloudpickle_pypy_xfail),
     ],
 )
 def test_pickle_dataclass(dataclass_type: type, use_cloudpickle: bool):
@@ -270,7 +275,7 @@ def nested_dataclass_model_factory() -> type:
         (ImportableNestedDataclassModel, False),
         (ImportableNestedDataclassModel, True),
         # Locally-defined model can only be pickled with cloudpickle.
-        pytest.param(nested_dataclass_model_factory(), True, marks=cloudpickle_xfail),
+        pytest.param(nested_dataclass_model_factory(), True, marks=(cloudpickle_pypy_xfail, cloudpickle_model_xfail)),
     ],
 )
 def test_pickle_dataclass_nested_in_model(model_type: type, use_cloudpickle: bool):
@@ -308,7 +313,7 @@ def model_with_config_factory() -> type:
     [
         (ImportableModelWithConfig, False),
         (ImportableModelWithConfig, True),
-        (model_with_config_factory(), True),
+        pytest.param(model_with_config_factory(), True, marks=cloudpickle_pypy_xfail),
     ],
 )
 def test_pickle_model_with_config(model_type: type, use_cloudpickle: bool):


### PR DESCRIPTION
## Change Summary

Add testing for PyPy 3.11 to CI.

There were a few tests which needed adjusting on PyPy:
- `devtools` output diff - I'm not worried about this as a debug formatter
- `cloudpickle` issues - seems like an upstream problem, I added `xfail` for now.

Everything else works fine.

## Related issue number

Xref https://github.com/pydantic/pydantic/pull/7196#issuecomment-3351565223

@cclauss 

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
