### PR TITLE
docs: document that core schema changes between versions

### DIFF
--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -24,6 +24,7 @@ The following changes will **NOT** be considered breaking changes, and may occur
 * Adding new keys to [`ValidationError`][pydantic_core.ValidationError] exceptions &mdash; e.g. we intend to add `line_number` and `column_number` to errors when validating JSON once we migrate to a new JSON parser.
 * Adding new [`ValidationError`][pydantic_core.ValidationError] errors.
 * Changing how `__repr__` behaves, even of public classes.
+* The contents of "core schema" stored in `__pydantic_core_schema__` and `TypeAdapter.core_schema` may change between releases (this is a low-level format Pydantic uses to plan how to execute validation and serialization).
 
 In all cases we will aim to minimize churn and do so only when justified by the increase of quality of Pydantic for users.
 


### PR DESCRIPTION
## Change Summary

Document that core schema produced can change between versions. In practice this has been happening repeatedly since v2 was released, to supply new features, bugfixes, and optimizations.

We had some debate offline about whether the core schema constitutes "public API". My stance is that users consuming it should not assume the contents are stable. They have not been historically, and we would be limited in improvements and optimizations we can land if we try to preserve the exact structures going forward too.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
