### PR TITLE
Honor user-provided inline `$defs` and resolve local `$ref` during JSON Schema generation

### DIFF
--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -53,7 +53,7 @@ class GenerateJsonSchemaHandler(GetJsonSchemaHandler):
         if '$ref' not in maybe_ref_json_schema:
             return maybe_ref_json_schema
         ref = maybe_ref_json_schema['$ref']
-        json_schema = self.generate_json_schema.get_schema_from_definitions(ref)
+        json_schema = self.generate_json_schema.get_schema_from_definitions(ref, root=maybe_ref_json_schema)
         if json_schema is None:
             raise LookupError(
                 f'Could not find a ref for {ref}.'

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
 from pydantic_core import core_schema
 
 from ..annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 
 if TYPE_CHECKING:
-    from ..json_schema import GenerateJsonSchema, JsonSchemaValue
+    from ..json_schema import GenerateJsonSchema, JsonRef, JsonSchemaValue
     from ._core_utils import CoreSchemaOrField
     from ._generate_schema import GenerateSchema
     from ._namespace_utils import NamespacesTuple
@@ -53,6 +54,7 @@ class GenerateJsonSchemaHandler(GetJsonSchemaHandler):
         if '$ref' not in maybe_ref_json_schema:
             return maybe_ref_json_schema
         ref = maybe_ref_json_schema['$ref']
+        self.generate_json_schema._inline_ref_schemas.setdefault(cast('JsonRef', ref), deepcopy(maybe_ref_json_schema))
         json_schema = self.generate_json_schema.get_schema_from_definitions(ref, root=maybe_ref_json_schema)
         if json_schema is None:
             raise LookupError(

--- a/pydantic/_internal/_schema_generation_shared.py
+++ b/pydantic/_internal/_schema_generation_shared.py
@@ -80,7 +80,8 @@ class GenerateJsonSchemaHandler(GetJsonSchemaHandler):
                         break
                 if parent_tokens is not None:
                     parent_ref = self.generate_json_schema._json_pointer_from_tokens(parent_tokens)
-                    self.generate_json_schema._inline_ref_schemas.setdefault(parent_ref, wrapper_schema)
+                    if wrapper_schema.get('$ref') == parent_ref:
+                        self.generate_json_schema._inline_ref_schemas.setdefault(parent_ref, wrapper_schema)
         defs_ref = self.generate_json_schema.json_to_defs_refs.get(json_ref)
         json_schema = self.generate_json_schema.get_schema_from_definitions(ref, root=maybe_ref_json_schema)
         if json_schema is None:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2264,6 +2264,8 @@ class GenerateJsonSchema:
         extras = {k: v for k, v in json_schema.items() if k not in {'$ref', '$defs'}}
         if extras:
             restored_schema.update(extras)
+        if '$defs' in json_schema:
+            restored_schema['$defs'] = json_schema['$defs']
         return restored_schema
 
     def encode_default(self, dft: Any) -> Any:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6484,6 +6484,46 @@ def test_type_adapter_with_inline_defs_custom_schema() -> None:
     assert schema['$defs'] == {'inline': {'type': 'string', 'description': 'inline definition'}}
 
 
+def test_type_adapter_with_inline_defs_nested_resolution() -> None:
+    class InlineDefs:
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, source_type: Any, handler: GetCoreSchemaHandler
+        ) -> core_schema.CoreSchema:
+            return handler.generate_schema(str)
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return {
+                '$ref': '#/$defs/inline',
+                '$defs': {'inline': {'type': 'string'}},
+            }
+
+    class Container:
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, source_type: Any, handler: GetCoreSchemaHandler
+        ) -> core_schema.CoreSchema:
+            return core_schema.list_schema(handler.generate_schema(InlineDefs))
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            schema = handler(core_schema)
+            items_schema = schema['items']
+            resolved_schema = handler.resolve_ref_schema(items_schema)
+            resolved_schema['description'] = 'inline definition'
+            return schema
+
+    schema = TypeAdapter(Container).json_schema()
+
+    assert schema['items']['$ref'] == '#/$defs/inline'
+    assert schema['items']['$defs'] == {'inline': {'type': 'string', 'description': 'inline definition'}}
+
+
 def test_min_and_max_in_schema() -> None:
     TSeq = TypeAdapter(Annotated[Sequence[int], Field(min_length=2, max_length=5)])
     assert TSeq.json_schema() == {'items': {'type': 'integer'}, 'maxItems': 5, 'minItems': 2, 'type': 'array'}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5419,6 +5419,11 @@ def test_metadata_resolve_ref_schema_preserves_defs() -> None:
     assert wrapper_definition['description'] == 'custom description'
     assert wrapper_definition['properties'] == {'x': {'title': 'X', 'type': 'integer'}}
 
+    wrapper_schema = TypeAdapter(WrapperModel).json_schema()
+    wrapper_defs = wrapper_schema.get('$defs', {})
+    assert 'WrapperModel' in wrapper_defs
+    assert wrapper_defs['WrapperModel'] == wrapper_definition
+
 
 def test_examples_annotation() -> None:
     ListWithExamples = Annotated[

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -30,6 +30,7 @@ from uuid import UUID
 
 import pytest
 from dirty_equals import HasRepr
+from jsonschema import Draft202012Validator
 from packaging.version import Version
 from pydantic_core import CoreSchema, SchemaValidator, core_schema, to_jsonable_python
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
@@ -6482,6 +6483,7 @@ def test_type_adapter_with_inline_defs_custom_schema() -> None:
 
     assert schema['$ref'] == '#/$defs/inline'
     assert schema['$defs'] == {'inline': {'type': 'string', 'description': 'inline definition'}}
+    Draft202012Validator.check_schema(schema)
 
 
 def test_type_adapter_with_inline_defs_nested_resolution() -> None:
@@ -6521,7 +6523,8 @@ def test_type_adapter_with_inline_defs_nested_resolution() -> None:
     schema = TypeAdapter(Container).json_schema()
 
     assert schema['items']['$ref'] == '#/$defs/inline'
-    assert schema['items']['$defs'] == {'inline': {'type': 'string', 'description': 'inline definition'}}
+    assert schema['$defs']['inline'] == {'type': 'string', 'description': 'inline definition'}
+    Draft202012Validator.check_schema(schema)
 
 
 def test_type_adapter_with_inline_defs_nested_defs() -> None:
@@ -6557,6 +6560,7 @@ def test_type_adapter_with_inline_defs_nested_defs() -> None:
             }
         },
     }
+    Draft202012Validator.check_schema(schema)
 
 
 def test_min_and_max_in_schema() -> None:


### PR DESCRIPTION

## Change Summary

This change fixes a bug where user-provided inline `$defs` (for example, definitions emitted by `__get_pydantic_json_schema__`) were not registered in the generator's internal maps. As a result, local `$ref` lookups could raise `KeyError` during schema generation and garbage collection. The patch:

* Allows user-managed inline `$defs` to be stored and referenced safely during generation.
* Tracks user-supplied JSON references and defs (pending/active) to avoid premature lookups and to preserve wrapper schemas when requested by user code.
* Adds a small JSON pointer utils set and a local resolver `_resolve_json_ref` to resolve `#`-style pointers against locally-provided inline schema fragments.
* Introduces defensive cycle-safe traversal and caching to avoid infinite recursion when walking schemas containing cycles.
* Ensures definitions created by user hooks are merged into the generator's `definitions` (or deferred and merged later) so lookups succeed and `$defs` are preserved.
* Adds tests covering many inline `$defs` scenarios, escaping, nested inline definitions, and metadata-preserving behavior.

Files changed (high level):

* `pydantic/_internal/_schema_generation_shared.py`
* `pydantic/json_schema.py`
* `tests/test_json_schema.py` (new tests added)

### Key behavioral changes

* `GenerateJsonSchema` now maintains sets and caches for user-managed refs/defs and inline wrapper schemas (`_user_json_refs`, `_user_defs_refs`, `_pending_user_*`, `_inline_ref_schemas`, `_resolved_json_refs_cache`, `_deferred_definitions_updates`).
* `GenerateJsonSchemaHandler.resolve_ref_schema` now marks incoming `$ref` values that originate outside `pydantic.` as user-managed and installs inline wrapper schemas so wrappers and `$defs` are preserved.
* The JSON ref walker (`get_json_ref_counts`) and `_garbage_collect_definitions` now consult a local-resolution path for `#` pointers emitted by users, and they are cycle-safe.
* New helper functions `_json_pointer_tokens`, `_json_pointer_from_tokens`, `_encode_json_pointer_token`, `_decode_json_pointer_token`, `_re_encode_json_pointer_tokens`, `_resolve_json_ref`, and `_restore_inline_refs` support pointer handling and inline-ref restoration.

## Related issue number

<!-- Replace with a real issue if available, e.g. `fix #123` -->

fix #12145

## Rationale / Background

Calling `TypeAdapter(...).json_schema()` walks every `$ref` via `get_json_ref_counts` and expects each local `JsonRef` to already be present in `json_to_defs_refs`. However, when user code returns `$defs` directly (for example in `__get_pydantic_json_schema__`), those `$defs` were never registered in `json_to_defs_refs` and thus lookups raised `KeyError` (unless the `$ref` looked like an external URL). This PR ensures user-provided inline definitions are registered, or resolved locally when encountered during the generation pass.

## Tests

Multiple tests were added/updated to cover these scenarios (see `tests/test_json_schema.py` additions):

* `test_metadata_resolve_ref_schema_preserves_defs`
* `test_resolve_ref_schema_nested_ref_preserves_parent_mapping`
* `test_type_adapter_with_inline_defs_custom_schema`
* `test_type_adapter_with_inline_defs_nested_resolution`
* `test_type_adapter_with_inline_defs_requires_escaping`
* `test_type_adapter_with_inline_defs_nested_defs`

These tests verify:

* `$defs` emitted by user hooks are preserved and merged into final schemas.
* Local `#/$defs/...` references resolve when referenced from within wrappers or nested inline defs.
* Pointer escaping (e.g. `~1` for `/`) is honored.
* JSON Schema validity with `Draft202012Validator.check_schema(schema)` for generated schemas.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

