### PR TITLE
Disable run code documentation plugin on dev

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -92,7 +92,7 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - run: PYTHONPATH="$PWD${PYTHONPATH:+:${PYTHONPATH}}" uv run mike deploy -b docs-site dev --push
+      - run: PYTHONPATH="$PWD${PYTHONPATH:+:${PYTHONPATH}}" DISABLE_RUN_CODE=1 uv run mike deploy -b docs-site dev --push
         if: github.ref == 'refs/heads/main'
 
       - if: github.ref == 'refs/heads/docs-update' || startsWith(github.ref, 'refs/tags/')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ extra_javascript:
   - 'extra/feedback.js'
   - 'extra/fluff.js'
   - 'extra/mathjax.js'
+  # Note: this extra is used in the `on_config()` hook, make sure to keep them in sync:
   - 'https://samuelcolvin.github.io/mkdocs-run-code/run_code_main.js'
   - 'https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js'
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Considering the mess that is pyodide and micropip, we can't reasonably build wheels (especially the pydantic-core ones) for dev. This isn't a big issue anyway as the default documentation home page is latest.

Fixes https://github.com/pydantic/pydantic/issues/9012.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
