### PR TITLE
ci: run benchmarks on 3.13

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   UV_FROZEN: true
+  UV_PYTHON: 3.13
 
 jobs:
   codspeed-profiling:
@@ -24,7 +25,7 @@ jobs:
       # Using this action is still necessary for CodSpeed to work:
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ env.UV_PYTHON }}
 
       - id: core-version
         name: resolve pydantic-core tag
@@ -44,7 +45,7 @@ jobs:
           ") >> $GITHUB_OUTPUT
 
       - name: install deps
-        run: uv sync --python 3.12 --group testing-extra --extra email --frozen
+        run: uv sync --group testing-extra --extra email --frozen
 
       - name: checkout pydantic-core
         uses: actions/checkout@v5


### PR DESCRIPTION
## Change Summary

With release of Python 3.14 on the horizon, it's surely time to update benchmarking to run on 3.13? 😂 

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
