### PR TITLE
Clarify TypeAdapter configuration rules in documentation

### DIFF
--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -89,6 +89,10 @@ print(ta.validate_python([1, 2]))
 #> ['1', '2']
 ```
 
+Configuration can't be provided if the type adapter directly wraps a type that support it.
+The [configuration propagation](#configuration-propagation) rules also apply. Pydantic will raise a `PydanticUserError` in most of these cases.
+For example, attempting to allow extra fields via a `TypeAdapter` on a `BaseModel` that forbids them is not supported. 
+
 ## Configuration on other supported types
 
 If you are using [standard library dataclasses][dataclasses] or [`TypedDict`][typing.TypedDict] classes,

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -89,9 +89,9 @@ print(ta.validate_python([1, 2]))
 #> ['1', '2']
 ```
 
-Configuration can't be provided if the type adapter directly wraps a type that support it.
-The [configuration propagation](#configuration-propagation) rules also apply. Pydantic will raise a `PydanticUserError` in most of these cases.
-For example, attempting to allow extra fields via a `TypeAdapter` on a `BaseModel` that forbids them is not supported. 
+Configuration can't be provided if the type adapter directly wraps a type that support it, and a
+[usage error](../errors/usage_errors.md) is raised in this case.
+The [configuration propagation](#configuration-propagation) rules also apply.
 
 ## Configuration on other supported types
 


### PR DESCRIPTION
## Change Summary

This PR adds a warning to the documentation for TypeAdapter to clarify its behavior when wrapping self-configuring types like BaseModel.

## Related issue number

Fixes https://github.com/pydantic/pydantic/issues/9142

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
