### PR TITLE
Fix spelling in model_dump() docstring

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -449,7 +449,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             exclude_defaults: Whether to exclude fields that are set to their default value.
             exclude_none: Whether to exclude fields that have a value of `None`.
             exclude_computed_fields: Whether to exclude computed fields.
-                While this can be useful for round-tripping, it is usually recommended tu use the dedicated
+                While this can be useful for round-tripping, it is usually recommended to use the dedicated
                 `round_trip` parameter instead.
             round_trip: If True, dumped values should be valid as input for non-idempotent types such as Json[T].
             warnings: How to handle serialization errors. False/"none" ignores them, True/"warn" logs errors,


### PR DESCRIPTION
## Change Summary

Trivial change to the docstring for model_dump, fixing spelling of 'to' from 'tu'.

## Related issue number

#12334 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] N/A Unit tests for the changes exist
* [x] N/A Tests pass on CI
* [x] N/A Documentation reflects the changes where applicable
* [x] My PR is ready to review
