### PR TITLE
Make sure `None` is converted as `NoneType` in Python 3.14

### DIFF
--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -518,7 +518,19 @@ def _eval_type(
     localns: MappingNamespace | None = None,
     type_params: tuple[Any, ...] | None = None,
 ) -> Any:
-    if sys.version_info >= (3, 13):
+    if sys.version_info >= (3, 14):
+        # Starting in 3.14, `_eval_type()` does *not* apply `_type_convert()`
+        # anymore. This means the `None` -> `type(None)` conversion does not apply:
+        evaluated = typing._eval_type(  # type: ignore
+            value,
+            globalns,
+            localns,
+            type_params=type_params,
+        )
+        if evaluated is None:
+            evaluated = type(None)
+        return evaluated
+    elif sys.version_info >= (3, 13):
         return typing._eval_type(  # type: ignore
             value, globalns, localns, type_params=type_params
         )

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1524,3 +1524,16 @@ def test_implicit_type_alias_recursive_error_message() -> None:
 
     with pytest.raises(RecursionError, match='.*If you made use of an implicit recursive type alias.*'):
         TypeAdapter(Json)
+
+
+def test_none_converted_as_none_type() -> None:
+    """https://github.com/pydantic/pydantic/issues/12368.
+
+    In Python 3.14, `None` was not converted as `type(None)` by `typing._eval_type()`.
+    """
+
+    class Model(BaseModel):
+        a: 'None' = None
+
+    assert Model.model_fields['a'].annotation is type(None)
+    assert Model(a=None).a is None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/12368.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
