### PR TITLE
Raise a warning when an invalid after model validator function signature is raised

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -394,6 +394,7 @@ Model()
 
 * `@root_validator` has been deprecated, and should be replaced with
     [`@model_validator`](api/functional_validators.md#pydantic.functional_validators.model_validator), which also provides new features and improvements.
+    Be aware that the allowed signatures have changed (see the [relevant documentation](./concepts/validators.md#model-validators)).
     * Under some circumstances (such as assignment when `model_config['validate_assignment'] is True`),
         the `@model_validator` decorator will receive an instance of the model, not a dict of values. You may
         need to be careful to handle this case.

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
         PydanticDeprecatedSince29,
         PydanticDeprecatedSince210,
         PydanticDeprecatedSince211,
+        PydanticDeprecatedSince212,
         PydanticDeprecationWarning,
         PydanticExperimentalWarning,
     )
@@ -228,6 +229,7 @@ __all__ = (
     'PydanticDeprecatedSince29',
     'PydanticDeprecatedSince210',
     'PydanticDeprecatedSince211',
+    'PydanticDeprecatedSince212',
     'PydanticDeprecationWarning',
     'PydanticExperimentalWarning',
     # annotated handlers
@@ -390,6 +392,7 @@ _dynamic_imports: 'dict[str, tuple[str, str]]' = {
     'PydanticDeprecatedSince29': (__spec__.parent, '.warnings'),
     'PydanticDeprecatedSince210': (__spec__.parent, '.warnings'),
     'PydanticDeprecatedSince211': (__spec__.parent, '.warnings'),
+    'PydanticDeprecatedSince212': (__spec__.parent, '.warnings'),
     'PydanticDeprecationWarning': (__spec__.parent, '.warnings'),
     'PydanticExperimentalWarning': (__spec__.parent, '.warnings'),
     # annotated handlers

--- a/pydantic/warnings.py
+++ b/pydantic/warnings.py
@@ -10,6 +10,7 @@ __all__ = (
     'PydanticDeprecatedSince29',
     'PydanticDeprecatedSince210',
     'PydanticDeprecatedSince211',
+    'PydanticDeprecatedSince212',
     'PydanticDeprecationWarning',
     'PydanticExperimentalWarning',
     'ArbitraryTypeWarning',
@@ -85,6 +86,13 @@ class PydanticDeprecatedSince211(PydanticDeprecationWarning):
 
     def __init__(self, message: str, *args: object) -> None:
         super().__init__(message, *args, since=(2, 11), expected_removal=(3, 0))
+
+
+class PydanticDeprecatedSince212(PydanticDeprecationWarning):
+    """A specific `PydanticDeprecationWarning` subclass defining functionality deprecated since Pydantic 2.12."""
+
+    def __init__(self, message: str, *args: object) -> None:
+        super().__init__(message, *args, since=(2, 12), expected_removal=(3, 0))
 
 
 class GenericBeforeBaseModelWarning(Warning):

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -4,7 +4,13 @@ from typing import Any, cast
 
 import pytest
 
-from pydantic import BaseModel, PydanticUserError, ValidationInfo, ValidatorFunctionWrapHandler, model_validator
+from pydantic import (
+    BaseModel,
+    PydanticDeprecatedSince212,
+    ValidationInfo,
+    ValidatorFunctionWrapHandler,
+    model_validator,
+)
 
 
 def test_model_validator_wrap() -> None:
@@ -139,10 +145,51 @@ def test_nested_models() -> None:
 
 
 def test_after_validator_wrong_signature() -> None:
-    with pytest.raises(PydanticUserError):
+    with pytest.warns(PydanticDeprecatedSince212):
 
-        class Model(BaseModel):
+        class Model1(BaseModel):
             @model_validator(mode='after')
-            # This used to be converted into a classmethod, resulting
-            # in this inconsistent signature still accepted:
-            def validator(cls, model, info): ...
+            # This is converted into a class method, but deprecated
+            # as it should be an instance method:
+            def validator(cls, model, info: ValidationInfo):
+                assert isinstance(model, cls)
+                assert info.mode == 'python'
+                return model
+
+    with pytest.warns(PydanticDeprecatedSince212):
+
+        class Model2(BaseModel):
+            @model_validator(mode='after')
+            # This is accepted as a class method, but deprecated
+            # as it should be an instance method:
+            @classmethod
+            def validator(cls, model, info: ValidationInfo):
+                assert isinstance(model, cls)
+                assert info.mode == 'python'
+                return model
+
+    with pytest.warns(PydanticDeprecatedSince212):
+
+        class Model3(BaseModel):
+            @model_validator(mode='after')
+            # This is converted into a class method, but deprecated
+            # as it should be an instance method:
+            def validator(cls, model):
+                assert isinstance(model, cls)
+                return model
+
+    with pytest.warns(PydanticDeprecatedSince212):
+
+        class Model4(BaseModel):
+            @model_validator(mode='after')
+            # This is accepted as a class method, but deprecated
+            # as it should be an instance method:
+            @classmethod
+            def validator(cls, model):
+                assert isinstance(model, cls)
+                return model
+
+    Model1()
+    Model2()
+    Model3()
+    Model4()


### PR DESCRIPTION

Reverts https://github.com/pydantic/pydantic/pull/11957.

Fixes https://github.com/pydantic/pydantic/issues/12413.

The reported flawed signature from the original issue was using the following signature: `(cls, values, info) -> ...`. However, https://github.com/pydantic/pydantic/pull/11957 resulted in the much more common (as per this [GH search](https://github.com/search?q=lang%3Apython+%2F%40model_validator%5C%28mode%3D%5B%27%22%5Dafter%5B%22%27%5D%5C%29%5Cs%2Bdef%5Cs.%2B%5C%28cls%2F&type=code)) `(cls, values) -> ...` signature (also not supposed to be accepted) to be confusingly broken (not rejected at build time, but the `values` argument is now the validation info).

According to [this comment](https://github.com/apache/iceberg-python/pull/2626#issuecomment-3407935823), the high usage of the invalid signature is probably due to V1 root validators changed to _after_ model validators, without changing from a class method to an instance method. As such, I updated the migration guide to mention this change.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
