### PR TITLE
Add xfail test related to after-validator re-execution

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3102,12 +3102,16 @@ def test_after_and_wrap_combo_called_once() -> None:
     my_model = MyParentModel.model_validate({'nested': {'inner_value': 'foo'}})
     assert my_model.nested.inner_value == 'after_prefix:wrap_prefix:foo'
 
-@pytest.mark.xfail(reason="Bug: Nested 'after' model_validator is re-executed. See issue #8452.", raises=ValidationError)
+
+@pytest.mark.xfail(
+    reason="Bug: Nested 'after' model_validator is re-executed. See issue #8452.", raises=ValidationError
+)
 def test_nested_model_validator_not_reexecuted():
     """See https://github.com/pydantic/pydantic/issues/8452 for context.
 
     Reproduces the bug in issue #8452 where a nested model's `model_validator` with `mode='after'` is unexpectedly re-executed.
     """
+
     class Sub(BaseModel):
         @model_validator(mode='after')
         def _validate(self):
@@ -3115,9 +3119,10 @@ def test_nested_model_validator_not_reexecuted():
             assert False, 'Sub model_validator was re-executed'
 
     class Base(BaseModel):
-        sub: Sub #<-- This throws AssertionError
+        sub: Sub  # <-- This throws AssertionError
 
-    sub: Sub = Sub.model_construct() # Create a Sub instance without triggering validation (e.g., using model_construct)
-    
+    sub: Sub = (
+        Sub.model_construct()
+    )  # Create a Sub instance without triggering validation (e.g., using model_construct)
     # Attempt to create Base with the Sub instance. This line should succeed if the bug is fixed, but currently raises ValidationError.
-    Base(sub=sub) # <-- This throws AssertionError because Sub's 'after' validator runs again.
+    Base(sub=sub)  # <-- This throws AssertionError because Sub's 'after' validator runs again.


### PR DESCRIPTION
…tion)

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
This PR adds a regression test case for the bug described in issue https://github.com/pydantic/pydantic/issues/8452, where a nested model's @model_validator(mode='after') is unexpectedly re-executed when the outer model is validated. The test is marked as xfail because the underlying bug still exists. Additionally, this PR includes an analysis of the potential root cause in pydantic/_internal/_generate_schema.py
<!-- Please give a short summary of the changes. -->

## Related issue number
See issue https://github.com/pydantic/pydantic/issues/8452 for relaed comments. Since this pull request doesn't solve the bug I've documented my findings in https://github.com/pydantic/pydantic/issues/8452:s comment thread. View this pull request more as a start to the solving of the bug.

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @DouweM