### PR TITLE
Correct patch release version in v2.12.3 changelog

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,7 +8,7 @@
 
 ### What's Changed
 
-This is the third 2.13 patch release, fixing issues related to the `FieldInfo` class, and reverting a change to the supported
+This is the third 2.12 patch release, fixing issues related to the `FieldInfo` class, and reverting a change to the supported
 [*after* model validator](https://docs.pydantic.dev/latest/concepts/validators/#model-validators) function signatures.
 
 * Raise a warning when an invalid after model validator function signature is raised by @Viicos in [#12414](https://github.com/pydantic/pydantic/pull/12414).


### PR DESCRIPTION
## Change Summary

`2.13` -> `2.12`, as the v2.12.3 changelog says it's the "third 2.13 patch release".

This should probably be fixed in the [release notes for v2.12.3](https://github.com/pydantic/pydantic/releases/tag/v2.12.3) as well.

## Related issue number

N/A

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [N/A] Unit tests for the changes exist
* [N/A] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Selected Reviewer: @DouweM