### PR TITLE
Fix example of for `bytes_invalid_encoding` validation error

### DIFF
--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -98,7 +98,7 @@ This error is also raised for strict fields when the input value is not an insta
 ## `bytes_invalid_encoding`
 
 This error is raised when a `bytes` value is invalid under the configured encoding.
-In the following example, `b'a'` is invalid hex (odd number of digits).
+In the following example, `'a'` is invalid hex (odd number of digits).
 
 ```python
 from pydantic import BaseModel, ValidationError
@@ -110,7 +110,7 @@ class Model(BaseModel):
 
 
 try:
-    Model(x=b'a')
+    Model(x='a')
 except ValidationError as exc:
     print(repr(exc.errors()[0]['type']))
     #> 'bytes_invalid_encoding'


### PR DESCRIPTION
## Change Summary

Fixes the [`bytes_invalid_encoding`](https://docs.pydantic.dev/latest/errors/validation_errors/#bytes_invalid_encoding) example in docs.

The current example runs without the expected error on version 2.12.3 (core 2.41.4, python 3.13.5).

please review