### PR TITLE
Use  in-tree `pydantic-core` when building docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,16 @@ jobs:
         # Unlike the docs build, we don't use mkdocs_material-insiders
         # Because the secret for accessing the library is not accessible from forks, but we still want to run
         # this job on public CI runs.
-        run: uv sync --group docs
+        run: |
+          uv sync --group docs
+          uv tool run maturin develop -m pydantic-core/Cargo.toml
 
       - run: uv run python -c 'import docs.plugins.main'
 
       # Taken from docs-build.sh
       - name: prepare shortcuts for extra modules
         run: |
-          ln -s .venv/lib/python*/site-packages/pydantic_core pydantic_core
+          ln -s pydantic-core/python/pydantic_core pydantic_core
           ln -s .venv/lib/python*/site-packages/pydantic_settings pydantic_settings
           ln -s .venv/lib/python*/site-packages/pydantic_extra_types pydantic_extra_types
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -72,7 +72,9 @@ jobs:
         with:
           python-version: '3.13'
 
-      - run: uv sync --group docs --group docs-upload
+      - run: |
+          uv sync --group docs --group docs-upload
+          uv tool run maturin develop -m pydantic-core/Cargo.toml
 
       - run: uv pip install --default-index https://pydantic:${PPPR_TOKEN}@pppr.pydantic.dev/simple/ mkdocs-material
         env:
@@ -83,7 +85,7 @@ jobs:
       # Taken from docs-build.sh
       - name: Prepare shortcuts for extra modules
         run: |
-          ln -s .venv/lib/python*/site-packages/pydantic_core pydantic_core
+          ln -s pydantic-core/python/pydantic_core pydantic_core
           ln -s .venv/lib/python*/site-packages/pydantic_settings pydantic_settings
           ln -s .venv/lib/python*/site-packages/pydantic_extra_types pydantic_extra_types
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ pydantic/*.so
 .auto-format
 /sandbox/
 /worktrees/
+
+# Rust build files
+/target/

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -6,20 +6,25 @@
 set -e
 set -x
 
-python3 -V
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source $HOME/.cargo/env
 
-python3 -m pip install --user uv
-python3 -m uv sync --python 3.12 --group docs --frozen
-python3 -m uv run python -c 'import docs.plugins.main'
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+uv sync --python 3.12 --group docs --frozen
+uv tool run maturin develop -m pydantic-core/Cargo.toml
+uv run --no-sync python -c 'import docs.plugins.main'
 
 # Adding local symlinks gets nice source locations like
 #   pydantic_core/core_schema.py
 # instead of
-#   .venv/lib/python3.10/site-packages/pydantic_core/core_schema.py
+#   pydantic-core/python/pydantic_core/core_schema.py
 # See also: mkdocs.yml:mkdocstrings:handlers:python:paths: [.]:
-ln -s .venv/lib/python*/site-packages/pydantic_core pydantic_core
+ln -s pydantic-core/python/pydantic_core pydantic_core
 ln -s .venv/lib/python*/site-packages/pydantic_settings pydantic_settings
 ln -s .venv/lib/python*/site-packages/pydantic_extra_types pydantic_extra_types
 # Put these at the front of PYTHONPATH (otherwise, symlinked
 # entries will still have "Source code in .venv/lib/.../*.py ":
-PYTHONPATH="$PWD${PYTHONPATH:+:${PYTHONPATH}}" python3 -m uv run --no-sync mkdocs build
+PYTHONPATH="$PWD${PYTHONPATH:+:${PYTHONPATH}}" uv run --no-sync mkdocs build


### PR DESCRIPTION
## Change Summary

This updates documentation builds to use the in-tree `pydantic-core`, rather than the released one.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
