### PR TITLE
Add pre-commit hook for Rust linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,14 @@ repos:
     hooks:
       - id: lint
         name: Lint
-        entry: make lint
+        entry: make lint-python
         types: [python]
+        language: system
+        pass_filenames: false
+      - id: lint rust
+        name: Lint Rust
+        entry: make lint-rust
+        types: [rust]
         language: system
         pass_filenames: false
       - id: typecheck

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,19 @@ rebuild-lockfiles: .uv
 format: .uv
 	uv run ruff check --fix $(sources)
 	uv run ruff format $(sources)
+	cargo fmt --manifest-path pydantic-core/Cargo.toml
 
-.PHONY: lint  ## Lint python source files
-lint: .uv
+.PHONY: lint-python  ## Lint python source files
+lint-python: .uv
 	uv run ruff check $(sources)
 	uv run ruff format --check $(sources)
+
+.PHONY: lint-rust  ## Lint Rust source files
+lint-rust:
+	$(MAKE) -C pydantic-core lint-rust
+
+.PHONY: lint  ## Lint all source files
+lint: lint-python lint-rust
 
 .PHONY: codespell  ## Use Codespell to do spellchecking
 codespell: .pre-commit

--- a/pydantic-core/src/errors/types.rs
+++ b/pydantic-core/src/errors/types.rs
@@ -801,6 +801,8 @@ impl From<Int> for Number {
 
 impl FromPyObject<'_, '_> for Number {
     type Error = PyErr;
+
+    #[allow(clippy::same_functions_in_if_condition)] // https://github.com/rust-lang/rust-clippy/issues/10928
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         if let Ok(int) = obj.extract() {
             Ok(Number::Int(int))

--- a/pydantic-core/src/input/return_enums.rs
+++ b/pydantic-core/src/input/return_enums.rs
@@ -708,6 +708,8 @@ impl Rem for &Int {
 
 impl FromPyObject<'_, '_> for Int {
     type Error = PyErr;
+
+    #[allow(clippy::same_functions_in_if_condition)] // https://github.com/rust-lang/rust-clippy/issues/10928
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         if let Ok(i) = obj.extract() {
             Ok(Int::I64(i))


### PR DESCRIPTION
## Change Summary

Extends pre-commit confirguration such that modifying Rust sources will trigger linting on pre-commit (and thus also in the CI pipeline).

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
