### PR TITLE
Require test suite to pass with free threading, switch back to global generic types cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,6 @@ jobs:
 
       - name: Run pytest
         run: make test NUM_THREADS=${{ endsWith(matrix.python-version, 't') && '4' || '1' }}
-        # Free threaded is flaky, allow failures for now:
-        continue-on-error: ${{ endsWith(matrix.python-version, 't') }}
         env:
           COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}
           CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}-without-deps

--- a/pydantic-core/tests/test_errors.py
+++ b/pydantic-core/tests/test_errors.py
@@ -6,10 +6,11 @@ import subprocess
 import sys
 from decimal import Decimal
 from typing import Any, Optional
-from unittest.mock import patch
 
 import pytest
 from dirty_equals import HasRepr, IsInstance, IsJson, IsStr
+from pytest_mock import MockerFixture
+
 from pydantic_core import (
     CoreConfig,
     PydanticCustomError,
@@ -695,32 +696,34 @@ class CauseResult(enum.Enum):
         ('Disabled implicitly', {}, CauseResult.NO_CAUSE),
     ],
 )
-def test_validation_error_cause_config_variants(desc: str, config: CoreConfig, expected_result: CauseResult):
+def test_validation_error_cause_config_variants(
+    desc: str, config: CoreConfig, expected_result: CauseResult, mocker: MockerFixture
+):
     # Simulate the package being missing:
-    with patch.dict('sys.modules', {'exceptiongroup': None}):
+    mocker.patch.dict('sys.modules', {'exceptiongroup': None})
 
-        def singular_raise_py_error(v: Any) -> Any:
-            raise ValueError('Oh no!')
+    def singular_raise_py_error(v: Any) -> Any:
+        raise ValueError('Oh no!')
 
-        s = SchemaValidator(core_schema.no_info_plain_validator_function(singular_raise_py_error), config=config)
+    s = SchemaValidator(core_schema.no_info_plain_validator_function(singular_raise_py_error), config=config)
 
-        if expected_result is CauseResult.IMPORT_ERROR:
-            # Confirm error message contains "requires the exceptiongroup module" in the middle of the string:
-            with pytest.raises(ImportError, match='requires the exceptiongroup module'):
-                s.validate_python('anything')
-        elif expected_result is CauseResult.CAUSE:
-            with pytest.raises(ValidationError) as exc_info:
-                s.validate_python('anything')
-            assert exc_info.value.__cause__ is not None
-            assert hasattr(exc_info.value.__cause__, 'exceptions')
-            assert len(exc_info.value.__cause__.exceptions) == 1
-            assert repr(exc_info.value.__cause__.exceptions[0]) == repr(ValueError('Oh no!'))
-        elif expected_result is CauseResult.NO_CAUSE:
-            with pytest.raises(ValidationError) as exc_info:
-                s.validate_python('anything')
-            assert exc_info.value.__cause__ is None
-        else:
-            raise AssertionError(f'Unhandled result: {expected_result}')
+    if expected_result is CauseResult.IMPORT_ERROR:
+        # Confirm error message contains "requires the exceptiongroup module" in the middle of the string:
+        with pytest.raises(ImportError, match='requires the exceptiongroup module'):
+            s.validate_python('anything')
+    elif expected_result is CauseResult.CAUSE:
+        with pytest.raises(ValidationError) as exc_info:
+            s.validate_python('anything')
+        assert exc_info.value.__cause__ is not None
+        assert hasattr(exc_info.value.__cause__, 'exceptions')
+        assert len(exc_info.value.__cause__.exceptions) == 1
+        assert repr(exc_info.value.__cause__.exceptions[0]) == repr(ValueError('Oh no!'))
+    elif expected_result is CauseResult.NO_CAUSE:
+        with pytest.raises(ValidationError) as exc_info:
+            s.validate_python('anything')
+        assert exc_info.value.__cause__ is None
+    else:
+        raise AssertionError(f'Unhandled result: {expected_result}')
 
 
 def test_validation_error_cause_traceback_preserved():

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -22,6 +22,7 @@ from typing import (
 import pytest
 from dirty_equals import HasRepr, IsStr
 from pydantic_core import CoreSchema, core_schema
+from pytest_mock import MockerFixture
 from typing_extensions import (
     Literal,
     Never,
@@ -53,7 +54,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic._internal._generics import (
-    _GENERIC_TYPES_CACHE,
     _LIMITED_DICT_SIZE,
     GenericTypesCache,
     LimitedDict,
@@ -63,21 +63,6 @@ from pydantic._internal._generics import (
     replace_types,
 )
 from pydantic.warnings import GenericBeforeBaseModelWarning
-
-
-# Note: this isn't implemented as a fixture, as pytest fixtures
-# are shared between threads by pytest-run-parallel:
-def get_clean_cache() -> GenericTypesCache:
-    generic_types_cache = _GENERIC_TYPES_CACHE.get()
-    if generic_types_cache is None:
-        generic_types_cache = GenericTypesCache()
-        _GENERIC_TYPES_CACHE.set(generic_types_cache)
-    # cleans up _GENERIC_TYPES_CACHE for checking item counts in the cache
-    generic_types_cache.clear()
-    gc.collect(0)
-    gc.collect(1)
-    gc.collect(2)
-    return generic_types_cache
 
 
 def test_generic_name():
@@ -349,8 +334,9 @@ def test_arguments_count_validation() -> None:
     assert Model[int, int, str].__pydantic_generic_metadata__['args'] == (int, int, str)
 
 
-def test_cover_cache():
-    cache = get_clean_cache()
+@pytest.mark.thread_unsafe(reason='testing behaviour of global cache')
+def test_cover_cache(mocker: MockerFixture):
+    cache = mocker.patch('pydantic._internal._generics._GENERIC_TYPES_CACHE', GenericTypesCache())
     cache_size = len(cache)
     T = TypeVar('T')
 
@@ -366,8 +352,8 @@ def test_cover_cache():
     del models
 
 
-def test_cache_keys_are_hashable():
-    cache = get_clean_cache()
+def test_cache_keys_are_hashable(mocker: MockerFixture):
+    cache = mocker.patch('pydantic._internal._generics._GENERIC_TYPES_CACHE', GenericTypesCache())
     cache_size = len(cache)
     T = TypeVar('T')
     C = Callable[[str, dict[str, Any]], Iterable[str]]
@@ -400,8 +386,8 @@ def test_cache_keys_are_hashable():
 
 @pytest.mark.thread_unsafe(reason='GC is flaky')
 @pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='PyPy does not play nice with PyO3 gc')
-def test_caches_get_cleaned_up():
-    cache = get_clean_cache()
+def test_caches_get_cleaned_up(mocker: MockerFixture):
+    cache = mocker.patch('pydantic._internal._generics._GENERIC_TYPES_CACHE', GenericTypesCache())
     initial_types_cache_size = len(cache)
     T = TypeVar('T')
 
@@ -428,8 +414,8 @@ def test_caches_get_cleaned_up():
 
 
 @pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='PyPy does not play nice with PyO3 gc')
-def test_caches_get_cleaned_up_with_aliased_parametrized_bases():
-    cache = get_clean_cache()
+def test_caches_get_cleaned_up_with_aliased_parametrized_bases(mocker: MockerFixture):
+    cache = mocker.patch('pydantic._internal._generics._GENERIC_TYPES_CACHE', GenericTypesCache())
     types_cache_size = len(cache)
 
     def run() -> None:  # Run inside nested function to get classes in local vars cleaned also
@@ -458,8 +444,8 @@ def test_caches_get_cleaned_up_with_aliased_parametrized_bases():
 @pytest.mark.thread_unsafe(reason='GC is flaky')
 @pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='PyPy does not play nice with PyO3 gc')
 @pytest.mark.skipif(sys.version_info[:2] == (3, 9), reason='The test randomly fails on Python 3.9')
-def test_circular_generic_refs_get_cleaned_up():
-    cache = get_clean_cache()
+def test_circular_generic_refs_get_cleaned_up(mocker: MockerFixture):
+    cache = mocker.patch('pydantic._internal._generics._GENERIC_TYPES_CACHE', GenericTypesCache())
     initial_cache_size = len(cache)
 
     def fn():
@@ -486,8 +472,8 @@ def test_circular_generic_refs_get_cleaned_up():
     assert len(cache) == initial_cache_size
 
 
-def test_generics_work_with_many_parametrized_base_models():
-    cache = get_clean_cache()
+def test_generics_work_with_many_parametrized_base_models(mocker: MockerFixture):
+    cache = mocker.patch('pydantic._internal._generics._GENERIC_TYPES_CACHE', GenericTypesCache())
     cache_size = len(cache)
     count_create_models = 1000
     T = TypeVar('T')
@@ -1055,7 +1041,7 @@ def test_generic_model_redefined_without_cache_fail(create_module, monkeypatch):
         class Model(BaseModel): ...
 
         concrete = MyGeneric[Model]
-        _GENERIC_TYPES_CACHE.get().clear()  # pyright: ignore[reportOptionalMemberAccess], guaranteed to be set
+        _GENERIC_TYPES_CACHE.clear()  # pyright: ignore[reportOptionalMemberAccess], guaranteed to be set
         second_concrete = MyGeneric[Model]
 
         class Model(BaseModel):  # same name, but type different, so it's not in cache

--- a/uv.lock
+++ b/uv.lock
@@ -2717,14 +2717,14 @@ wheels = [
 
 [[package]]
 name = "pytest-run-parallel"
-version = "0.3.1"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/13/d3bcb2c52f63b774be612cbee51f33a5cf2fa97d2f60fe26264f6720477b/pytest_run_parallel-0.3.1.tar.gz", hash = "sha256:636306d3ed6838898d8d42b3cd379dac7b327ce6d68df1bcc30d55a208d5081e", size = 14142, upload-time = "2025-02-05T20:29:11.504Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/d8/51206a0a30fa19607552625160deeeb29503e0fc7fc43bf229026084057d/pytest_run_parallel-0.7.1.tar.gz", hash = "sha256:ba53069f6c16147d6f5c275f5123947d1d0c31bd6ba57efc27e845a79afbe79e", size = 65445, upload-time = "2025-10-23T12:49:19.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/67/4943178bb5dacb2e0b745b4db4ab126112dafab66266f2262896e791dbbe/pytest_run_parallel-0.3.1-py3-none-any.whl", hash = "sha256:0675c9e4c8e843085333c66bc0ce6b8091e3509dc8e6df3429f05c28f5345b17", size = 9468, upload-time = "2025-02-05T20:29:10.406Z" },
+    { url = "https://files.pythonhosted.org/packages/64/30/14493dd5282439661a09649685f04e45434c750f7301a1bb5f6e1e2d5308/pytest_run_parallel-0.7.1-py3-none-any.whl", hash = "sha256:91cf4b1760a4f1f93b5e707bb715909858c803debc2d46e4991f2805b0538292", size = 19107, upload-time = "2025-10-23T12:49:17.992Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change Summary

With 3.14t an officially supported Python build, I think we should be requiring the pipeline to pass on free-threaded Python.

This makes two changes which gets the pipeline passing for me locally:
- use `pytest-mock` fixture when mocking, which `pytest-run-parallel` automatically recognises as not thread safe
- revert change from #11516 to have a per-thread generic types cache, and instead just use mocking to insert a clean cache in tests which need one. As such, fixes https://github.com/pydantic/pydantic/issues/12100.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
