### PR TITLE
docs: add example showing how ValueError is captured during validation

### DIFF
--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -2291,3 +2291,25 @@ except ValidationError as exc:
     print(repr(exc.errors()[0]['type']))
     #> 'value_error'
 ```
+## Additional Example: Handling `ValueError` during validation
+
+Pydantic automatically captures Python `ValueError` exceptions raised inside
+validators and converts them into structured validation errors. This makes
+the source of the problem clear to the user.
+
+```python
+from pydantic import BaseModel, field_validator
+
+class Temperature(BaseModel):
+    celsius: float
+
+    @field_validator("celsius")
+    def check_temperature(cls, v):
+        if v < -273.15:
+            raise ValueError("Temperature cannot be below absolute zero")
+        return v
+
+try:
+    Temperature(celsius=-500)
+except Exception as e:
+    print(e)


### PR DESCRIPTION
Thank you for your contribution! 
Unless your change is trivial, please create an issue to discuss the change before creating a PR 
 Change Summary
This pull request adds a new example to the `validation_errors.md` documentation file.  
The example shows how Pydantic captures and displays a Python `ValueError` raised inside a validator, converting it into a structured validation error.  
This helps new users understand how internal validation exceptions become readable error messages.
 Related issue number
No related issue,this is a documentation improvement.
 Checklist
[x] The pull request title is a good summary of the changes
[ ] Unit tests for the changes exist  
      (Not required — documentation-only change)*
[ ] Tests pass on CI  
      *(Not required — documentation change)*  
[x] Documentation reflects the changes where applicable
[x] My PR is ready to review — **please review**
