### PR TITLE
Bump Rust minimum version to 1.85, use edition 2024

### DIFF
--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pydantic-core"
 version = "2.41.5"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic-core"
 repository = "https://github.com/pydantic/pydantic-core.git"
@@ -22,7 +22,7 @@ include = [
     "!tests/.pytest_cache",
     "!*.so",
 ]
-rust-version = "1.75"
+rust-version = "1.85"
 
 [dependencies]
 # TODO it would be very nice to remove the "py-clone" feature as it can panic,

--- a/pydantic-core/benches/main.rs
+++ b/pydantic-core/benches/main.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use std::ffi::{CStr, CString};
-use test::{black_box, Bencher};
+use test::{Bencher, black_box};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};

--- a/pydantic-core/src/build_tools.rs
+++ b/pydantic-core/src/build_tools.rs
@@ -7,12 +7,12 @@ use std::sync::OnceLock;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString};
-use pyo3::{intern, PyErrArguments};
+use pyo3::{PyErrArguments, intern};
 
+use crate::ValidationError;
 use crate::errors::{PyLineError, ValError};
 use crate::input::InputType;
 use crate::tools::SchemaDict;
-use crate::ValidationError;
 
 pub fn schema_or_config<'py, T>(
     schema: &Bound<'py, PyDict>,

--- a/pydantic-core/src/definitions.rs
+++ b/pydantic-core/src/definitions.rs
@@ -8,12 +8,12 @@ use std::{
     collections::hash_map::Entry,
     fmt::Debug,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, OnceLock, Weak,
+        atomic::{AtomicBool, Ordering},
     },
 };
 
-use pyo3::{prelude::*, PyTraverseError, PyVisit};
+use pyo3::{PyTraverseError, PyVisit, prelude::*};
 
 use ahash::AHashMap;
 

--- a/pydantic-core/src/errors/line_error.rs
+++ b/pydantic-core/src/errors/line_error.rs
@@ -1,9 +1,9 @@
 use std::convert::Infallible;
 
-use pyo3::exceptions::PyTypeError;
-use pyo3::prelude::*;
 use pyo3::CastError;
 use pyo3::CastIntoError;
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
 
 use jiter::JsonValue;
 

--- a/pydantic-core/src/errors/location.rs
+++ b/pydantic-core/src/errors/location.rs
@@ -138,7 +138,7 @@ impl Location {
 
     pub fn with_outer(&mut self, loc_item: LocItem) {
         match self {
-            Self::List(ref mut loc) => loc.push(loc_item),
+            Self::List(loc) => loc.push(loc_item),
             Self::Empty => {
                 *self = Self::new_some(loc_item);
             }

--- a/pydantic-core/src/errors/mod.rs
+++ b/pydantic-core/src/errors/mod.rs
@@ -8,7 +8,7 @@ mod value_exception;
 
 pub use self::line_error::{InputValue, ToErrorValue, ValError, ValLineError, ValResult};
 pub use self::location::{LocItem, Location};
-pub use self::types::{list_all_errors, ErrorType, ErrorTypeDefaults, Number};
+pub use self::types::{ErrorType, ErrorTypeDefaults, Number, list_all_errors};
 pub use self::validation_exception::{PyLineError, ValidationError};
 pub use self::value_exception::{PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault};
 

--- a/pydantic-core/src/errors/types.rs
+++ b/pydantic-core/src/errors/types.rs
@@ -461,11 +461,7 @@ macro_rules! to_string_render {
 }
 
 fn plural_s<T: From<u8> + PartialEq>(value: T) -> &'static str {
-    if value == 1.into() {
-        ""
-    } else {
-        "s"
-    }
+    if value == 1.into() { "" } else { "s" }
 }
 
 static ERROR_TYPE_LOOKUP: PyOnceLock<AHashMap<String, ErrorType>> = PyOnceLock::new();
@@ -480,112 +476,136 @@ impl ErrorType {
     }
 
     pub fn message_template_python(&self) -> &'static str {
-        #[allow(clippy::match_same_arms)]  // much nicer to have the messages explicitly listed
+        #[allow(clippy::match_same_arms)] // much nicer to have the messages explicitly listed
         match self {
-            Self::NoSuchAttribute {..} => "Object has no attribute '{attribute}'",
-            Self::JsonInvalid {..} => "Invalid JSON: {error}",
-            Self::JsonType {..} => "JSON input should be string, bytes or bytearray",
-            Self::NeedsPythonObject {..} => "Cannot check `{method_name}` when validating from json, use a JsonOrPython validator instead",
-            Self::RecursionLoop {..} => "Recursion error - cyclic reference detected",
-            Self::Missing {..} => "Field required",
-            Self::FrozenField {..} => "Field is frozen",
-            Self::FrozenInstance {..} => "Instance is frozen",
-            Self::ExtraForbidden {..} => "Extra inputs are not permitted",
-            Self::InvalidKey {..} => "Keys should be strings",
-            Self::GetAttributeError {..} => "Error extracting attribute: {error}",
-            Self::ModelType {..} => "Input should be a valid dictionary or instance of {class_name}",
-            Self::ModelAttributesType {..} => "Input should be a valid dictionary or object to extract fields from",
-            Self::DataclassType {..} => "Input should be a dictionary or an instance of {class_name}",
-            Self::DataclassExactType {..} => "Input should be an instance of {class_name}",
-            Self::DefaultFactoryNotCalled {..} => "The default factory uses validated data, but at least one validation error occurred",
-            Self::NoneRequired {..} => "Input should be None",
-            Self::GreaterThan {..} => "Input should be greater than {gt}",
-            Self::GreaterThanEqual {..} => "Input should be greater than or equal to {ge}",
-            Self::LessThan {..} => "Input should be less than {lt}",
-            Self::LessThanEqual {..} => "Input should be less than or equal to {le}",
-            Self::MultipleOf {..} => "Input should be a multiple of {multiple_of}",
-            Self::FiniteNumber {..} => "Input should be a finite number",
-            Self::TooShort {..} => "{field_type} should have at least {min_length} item{expected_plural} after validation, not {actual_length}",
-            Self::TooLong {..} => "{field_type} should have at most {max_length} item{expected_plural} after validation, not {actual_length}",
-            Self::IterableType {..} => "Input should be iterable",
-            Self::IterationError {..} => "Error iterating over object, error: {error}",
-            Self::StringType {..} => "Input should be a valid string",
-            Self::StringSubType {..} => "Input should be a string, not an instance of a subclass of str",
-            Self::StringUnicode {..} => "Input should be a valid string, unable to parse raw data as a unicode string",
-            Self::StringTooShort {..} => "String should have at least {min_length} character{expected_plural}",
-            Self::StringTooLong {..} => "String should have at most {max_length} character{expected_plural}",
-            Self::StringPatternMismatch {..} => "String should match pattern '{pattern}'",
-            Self::Enum {..} => "Input should be {expected}",
-            Self::DictType {..} => "Input should be a valid dictionary",
-            Self::MappingType {..} => "Input should be a valid mapping, error: {error}",
-            Self::ListType {..} => "Input should be a valid list",
-            Self::TupleType {..} => "Input should be a valid tuple",
-            Self::SetType {..} => "Input should be a valid set",
-            Self::SetItemNotHashable {..} => "Set items should be hashable",
-            Self::BoolType {..} => "Input should be a valid boolean",
-            Self::BoolParsing {..} => "Input should be a valid boolean, unable to interpret input",
-            Self::IntType {..} => "Input should be a valid integer",
-            Self::IntParsing {..} => "Input should be a valid integer, unable to parse string as an integer",
-            Self::IntFromFloat {..} => "Input should be a valid integer, got a number with a fractional part",
-            Self::IntParsingSize {..} => "Unable to parse input string as an integer, exceeded maximum size",
-            Self::FloatType {..} => "Input should be a valid number",
-            Self::FloatParsing {..} => "Input should be a valid number, unable to parse string as a number",
-            Self::BytesType {..} => "Input should be a valid bytes",
-            Self::BytesTooShort {..} => "Data should have at least {min_length} byte{expected_plural}",
-            Self::BytesTooLong {..} => "Data should have at most {max_length} byte{expected_plural}",
+            Self::NoSuchAttribute { .. } => "Object has no attribute '{attribute}'",
+            Self::JsonInvalid { .. } => "Invalid JSON: {error}",
+            Self::JsonType { .. } => "JSON input should be string, bytes or bytearray",
+            Self::NeedsPythonObject { .. } => {
+                "Cannot check `{method_name}` when validating from json, use a JsonOrPython validator instead"
+            }
+            Self::RecursionLoop { .. } => "Recursion error - cyclic reference detected",
+            Self::Missing { .. } => "Field required",
+            Self::FrozenField { .. } => "Field is frozen",
+            Self::FrozenInstance { .. } => "Instance is frozen",
+            Self::ExtraForbidden { .. } => "Extra inputs are not permitted",
+            Self::InvalidKey { .. } => "Keys should be strings",
+            Self::GetAttributeError { .. } => "Error extracting attribute: {error}",
+            Self::ModelType { .. } => "Input should be a valid dictionary or instance of {class_name}",
+            Self::ModelAttributesType { .. } => "Input should be a valid dictionary or object to extract fields from",
+            Self::DataclassType { .. } => "Input should be a dictionary or an instance of {class_name}",
+            Self::DataclassExactType { .. } => "Input should be an instance of {class_name}",
+            Self::DefaultFactoryNotCalled { .. } => {
+                "The default factory uses validated data, but at least one validation error occurred"
+            }
+            Self::NoneRequired { .. } => "Input should be None",
+            Self::GreaterThan { .. } => "Input should be greater than {gt}",
+            Self::GreaterThanEqual { .. } => "Input should be greater than or equal to {ge}",
+            Self::LessThan { .. } => "Input should be less than {lt}",
+            Self::LessThanEqual { .. } => "Input should be less than or equal to {le}",
+            Self::MultipleOf { .. } => "Input should be a multiple of {multiple_of}",
+            Self::FiniteNumber { .. } => "Input should be a finite number",
+            Self::TooShort { .. } => {
+                "{field_type} should have at least {min_length} item{expected_plural} after validation, not {actual_length}"
+            }
+            Self::TooLong { .. } => {
+                "{field_type} should have at most {max_length} item{expected_plural} after validation, not {actual_length}"
+            }
+            Self::IterableType { .. } => "Input should be iterable",
+            Self::IterationError { .. } => "Error iterating over object, error: {error}",
+            Self::StringType { .. } => "Input should be a valid string",
+            Self::StringSubType { .. } => "Input should be a string, not an instance of a subclass of str",
+            Self::StringUnicode { .. } => {
+                "Input should be a valid string, unable to parse raw data as a unicode string"
+            }
+            Self::StringTooShort { .. } => "String should have at least {min_length} character{expected_plural}",
+            Self::StringTooLong { .. } => "String should have at most {max_length} character{expected_plural}",
+            Self::StringPatternMismatch { .. } => "String should match pattern '{pattern}'",
+            Self::Enum { .. } => "Input should be {expected}",
+            Self::DictType { .. } => "Input should be a valid dictionary",
+            Self::MappingType { .. } => "Input should be a valid mapping, error: {error}",
+            Self::ListType { .. } => "Input should be a valid list",
+            Self::TupleType { .. } => "Input should be a valid tuple",
+            Self::SetType { .. } => "Input should be a valid set",
+            Self::SetItemNotHashable { .. } => "Set items should be hashable",
+            Self::BoolType { .. } => "Input should be a valid boolean",
+            Self::BoolParsing { .. } => "Input should be a valid boolean, unable to interpret input",
+            Self::IntType { .. } => "Input should be a valid integer",
+            Self::IntParsing { .. } => "Input should be a valid integer, unable to parse string as an integer",
+            Self::IntFromFloat { .. } => "Input should be a valid integer, got a number with a fractional part",
+            Self::IntParsingSize { .. } => "Unable to parse input string as an integer, exceeded maximum size",
+            Self::FloatType { .. } => "Input should be a valid number",
+            Self::FloatParsing { .. } => "Input should be a valid number, unable to parse string as a number",
+            Self::BytesType { .. } => "Input should be a valid bytes",
+            Self::BytesTooShort { .. } => "Data should have at least {min_length} byte{expected_plural}",
+            Self::BytesTooLong { .. } => "Data should have at most {max_length} byte{expected_plural}",
             Self::BytesInvalidEncoding { .. } => "Data should be valid {encoding}: {encoding_error}",
-            Self::ValueError {..} => "Value error, {error}",
-            Self::AssertionError {..} => "Assertion failed, {error}",
-            Self::CustomError {..} => "",  // custom errors are handled separately
-            Self::LiteralError {..} => "Input should be {expected}",
+            Self::ValueError { .. } => "Value error, {error}",
+            Self::AssertionError { .. } => "Assertion failed, {error}",
+            Self::CustomError { .. } => "", // custom errors are handled separately
+            Self::LiteralError { .. } => "Input should be {expected}",
             Self::MissingSentinelError { .. } => "Input should be the 'MISSING' sentinel",
-            Self::DateType {..} => "Input should be a valid date",
-            Self::DateParsing {..} => "Input should be a valid date in the format YYYY-MM-DD, {error}",
-            Self::DateFromDatetimeParsing {..} => "Input should be a valid date or datetime, {error}",
-            Self::DateFromDatetimeInexact {..} => "Datetimes provided to dates should have zero time - e.g. be exact dates",
-            Self::DatePast {..} => "Date should be in the past",
-            Self::DateFuture {..} => "Date should be in the future",
-            Self::TimeType {..} => "Input should be a valid time",
-            Self::TimeParsing {..} => "Input should be in a valid time format, {error}",
-            Self::DatetimeType {..} => "Input should be a valid datetime",
-            Self::DatetimeParsing {..} => "Input should be a valid datetime, {error}",
-            Self::DatetimeObjectInvalid {..} => "Invalid datetime object, got {error}",
-            Self::DatetimeFromDateParsing {..} => "Input should be a valid datetime or date, {error}",
-            Self::DatetimePast {..} => "Input should be in the past",
-            Self::DatetimeFuture {..} => "Input should be in the future",
-            Self::TimezoneNaive {..} => "Input should not have timezone info",
-            Self::TimezoneAware {..} => "Input should have timezone info",
-            Self::TimezoneOffset {..} => "Timezone offset of {tz_expected} required, got {tz_actual}",
-            Self::TimeDeltaType {..} => "Input should be a valid timedelta",
-            Self::TimeDeltaParsing {..} => "Input should be a valid timedelta, {error}",
-            Self::FrozenSetType {..} => "Input should be a valid frozenset",
-            Self::IsInstanceOf {..} => "Input should be an instance of {class}",
-            Self::IsSubclassOf {..} => "Input should be a subclass of {class}",
-            Self::CallableType {..} => "Input should be callable",
-            Self::UnionTagInvalid {..} => "Input tag '{tag}' found using {discriminator} does not match any of the expected tags: {expected_tags}",
-            Self::UnionTagNotFound {..} => "Unable to extract tag using discriminator {discriminator}",
-            Self::ArgumentsType {..} => "Arguments must be a tuple, list or a dictionary",
-            Self::MissingArgument {..} => "Missing required argument",
-            Self::UnexpectedKeywordArgument {..} => "Unexpected keyword argument",
-            Self::MissingKeywordOnlyArgument {..} => "Missing required keyword only argument",
-            Self::UnexpectedPositionalArgument {..} => "Unexpected positional argument",
-            Self::MissingPositionalOnlyArgument {..} => "Missing required positional only argument",
-            Self::MultipleArgumentValues {..} => "Got multiple values for argument",
-            Self::UrlType {..} => "URL input should be a string or URL",
-            Self::UrlParsing {..} => "Input should be a valid URL, {error}",
-            Self::UrlSyntaxViolation {..} => "Input violated strict URL syntax rules, {error}",
-            Self::UrlTooLong {..} => "URL should have at most {max_length} character{expected_plural}",
-            Self::UrlScheme {..} => "URL scheme should be {expected_schemes}",
-            Self::UuidType {..} => "UUID input should be a string, bytes or UUID object",
-            Self::UuidParsing {..} => "Input should be a valid UUID, {error}",
-            Self::UuidVersion {..} => "UUID version {expected_version} expected",
-            Self::DecimalType {..} => "Decimal input should be an integer, float, string or Decimal object",
-            Self::DecimalParsing {..} => "Input should be a valid decimal",
-            Self::DecimalMaxDigits {..} => "Decimal input should have no more than {max_digits} digit{expected_plural} in total",
-            Self::DecimalMaxPlaces {..} => "Decimal input should have no more than {decimal_places} decimal place{expected_plural}",
-            Self::DecimalWholeDigits {..} => "Decimal input should have no more than {whole_digits} digit{expected_plural} before the decimal point",
-            Self::ComplexType {..} => "Input should be a valid python complex object, a number, or a valid complex string following the rules at https://docs.python.org/3/library/functions.html#complex",
-            Self::ComplexStrParsing {..} => "Input should be a valid complex string following the rules at https://docs.python.org/3/library/functions.html#complex",
+            Self::DateType { .. } => "Input should be a valid date",
+            Self::DateParsing { .. } => "Input should be a valid date in the format YYYY-MM-DD, {error}",
+            Self::DateFromDatetimeParsing { .. } => "Input should be a valid date or datetime, {error}",
+            Self::DateFromDatetimeInexact { .. } => {
+                "Datetimes provided to dates should have zero time - e.g. be exact dates"
+            }
+            Self::DatePast { .. } => "Date should be in the past",
+            Self::DateFuture { .. } => "Date should be in the future",
+            Self::TimeType { .. } => "Input should be a valid time",
+            Self::TimeParsing { .. } => "Input should be in a valid time format, {error}",
+            Self::DatetimeType { .. } => "Input should be a valid datetime",
+            Self::DatetimeParsing { .. } => "Input should be a valid datetime, {error}",
+            Self::DatetimeObjectInvalid { .. } => "Invalid datetime object, got {error}",
+            Self::DatetimeFromDateParsing { .. } => "Input should be a valid datetime or date, {error}",
+            Self::DatetimePast { .. } => "Input should be in the past",
+            Self::DatetimeFuture { .. } => "Input should be in the future",
+            Self::TimezoneNaive { .. } => "Input should not have timezone info",
+            Self::TimezoneAware { .. } => "Input should have timezone info",
+            Self::TimezoneOffset { .. } => "Timezone offset of {tz_expected} required, got {tz_actual}",
+            Self::TimeDeltaType { .. } => "Input should be a valid timedelta",
+            Self::TimeDeltaParsing { .. } => "Input should be a valid timedelta, {error}",
+            Self::FrozenSetType { .. } => "Input should be a valid frozenset",
+            Self::IsInstanceOf { .. } => "Input should be an instance of {class}",
+            Self::IsSubclassOf { .. } => "Input should be a subclass of {class}",
+            Self::CallableType { .. } => "Input should be callable",
+            Self::UnionTagInvalid { .. } => {
+                "Input tag '{tag}' found using {discriminator} does not match any of the expected tags: {expected_tags}"
+            }
+            Self::UnionTagNotFound { .. } => "Unable to extract tag using discriminator {discriminator}",
+            Self::ArgumentsType { .. } => "Arguments must be a tuple, list or a dictionary",
+            Self::MissingArgument { .. } => "Missing required argument",
+            Self::UnexpectedKeywordArgument { .. } => "Unexpected keyword argument",
+            Self::MissingKeywordOnlyArgument { .. } => "Missing required keyword only argument",
+            Self::UnexpectedPositionalArgument { .. } => "Unexpected positional argument",
+            Self::MissingPositionalOnlyArgument { .. } => "Missing required positional only argument",
+            Self::MultipleArgumentValues { .. } => "Got multiple values for argument",
+            Self::UrlType { .. } => "URL input should be a string or URL",
+            Self::UrlParsing { .. } => "Input should be a valid URL, {error}",
+            Self::UrlSyntaxViolation { .. } => "Input violated strict URL syntax rules, {error}",
+            Self::UrlTooLong { .. } => "URL should have at most {max_length} character{expected_plural}",
+            Self::UrlScheme { .. } => "URL scheme should be {expected_schemes}",
+            Self::UuidType { .. } => "UUID input should be a string, bytes or UUID object",
+            Self::UuidParsing { .. } => "Input should be a valid UUID, {error}",
+            Self::UuidVersion { .. } => "UUID version {expected_version} expected",
+            Self::DecimalType { .. } => "Decimal input should be an integer, float, string or Decimal object",
+            Self::DecimalParsing { .. } => "Input should be a valid decimal",
+            Self::DecimalMaxDigits { .. } => {
+                "Decimal input should have no more than {max_digits} digit{expected_plural} in total"
+            }
+            Self::DecimalMaxPlaces { .. } => {
+                "Decimal input should have no more than {decimal_places} decimal place{expected_plural}"
+            }
+            Self::DecimalWholeDigits { .. } => {
+                "Decimal input should have no more than {whole_digits} digit{expected_plural} before the decimal point"
+            }
+            Self::ComplexType { .. } => {
+                "Input should be a valid python complex object, a number, or a valid complex string following the rules at https://docs.python.org/3/library/functions.html#complex"
+            }
+            Self::ComplexStrParsing { .. } => {
+                "Input should be a valid complex string following the rules at https://docs.python.org/3/library/functions.html#complex"
+            }
         }
     }
 

--- a/pydantic-core/src/errors/validation_exception.rs
+++ b/pydantic-core/src/errors/validation_exception.rs
@@ -20,7 +20,7 @@ use crate::errors::LocItem;
 use crate::get_pydantic_version;
 use crate::input::InputType;
 use crate::serializers::{Extra, SerMode, SerializationConfig, SerializationState, WarningsMode};
-use crate::tools::{safe_repr, write_truncated_to_limited_bytes, SchemaDict};
+use crate::tools::{SchemaDict, safe_repr, write_truncated_to_limited_bytes};
 
 use super::line_error::ValLineError;
 use super::location::Location;
@@ -111,7 +111,9 @@ impl ValidationError {
     }
 
     pub fn use_default_error() -> PyErr {
-        py_schema_error_type!("Uncaught `PydanticUseDefault` exception: the error was raised in a field validator and no default value is available for that field.")
+        py_schema_error_type!(
+            "Uncaught `PydanticUseDefault` exception: the error was raised in a field validator and no default value is available for that field."
+        )
     }
 
     fn maybe_add_cause(self_: PyRef<'_, Self>, py: Python) -> Option<PyErr> {
@@ -180,7 +182,11 @@ impl ValidationError {
                         Ok(group_cls) => group_cls.call1((title, user_py_errs)).ok(),
                         Err(_) => None,
                     },
-                    Err(_) => return Some(PyImportError::new_err("validation_error_cause flag requires the exceptiongroup module backport to be installed when used on Python <3.11.")),
+                    Err(_) => {
+                        return Some(PyImportError::new_err(
+                            "validation_error_cause flag requires the exceptiongroup module backport to be installed when used on Python <3.11.",
+                        ));
+                    }
                 }
             };
 
@@ -237,11 +243,7 @@ fn get_formated_url(py: Python) -> &'static str {
 }
 
 fn get_url_prefix(py: Python<'_>, include_url: bool) -> Option<&str> {
-    if include_url {
-        Some(get_formated_url(py))
-    } else {
-        None
-    }
+    if include_url { Some(get_formated_url(py)) } else { None }
 }
 
 // used to convert a validation error back to ValError for wrap functions

--- a/pydantic-core/src/input/datetime.rs
+++ b/pydantic-core/src/input/datetime.rs
@@ -1,11 +1,11 @@
 use pyo3::intern;
 use pyo3::prelude::*;
 
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::pyclass::CompareOp;
 use pyo3::types::PyTuple;
 use pyo3::types::{PyDate, PyDateTime, PyDelta, PyDeltaAccess, PyDict, PyTime, PyTzInfo};
-use pyo3::IntoPyObjectExt;
 use speedate::DateConfig;
 use speedate::{
     Date, DateTime, DateTimeConfig, Duration, MicrosecondsPrecisionOverflowBehavior, ParseError, Time, TimeConfig,

--- a/pydantic-core/src/input/input_abstract.rs
+++ b/pydantic-core/src/input/input_abstract.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyDict, PyList, PyString};
-use pyo3::{intern, prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern, prelude::*};
 
 use crate::errors::{ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::lookup_key::{LookupKey, LookupPath};
@@ -120,11 +120,7 @@ pub trait Input<'py>: fmt::Debug {
         Self: 'a;
 
     fn validate_dict(&self, strict: bool) -> ValResult<Self::Dict<'_>> {
-        if strict {
-            self.strict_dict()
-        } else {
-            self.lax_dict()
-        }
+        if strict { self.strict_dict() } else { self.lax_dict() }
     }
     fn strict_dict(&self) -> ValResult<Self::Dict<'_>>;
     #[cfg_attr(has_coverage_attribute, coverage(off))]

--- a/pydantic-core/src/input/input_json.rs
+++ b/pydantic-core/src/input/input_json.rs
@@ -16,8 +16,8 @@ use crate::validators::decimal::create_decimal;
 use crate::validators::{TemporalUnitMode, ValBytesMode};
 
 use super::datetime::{
-    bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, float_as_datetime, float_as_duration,
-    float_as_time, int_as_datetime, int_as_duration, int_as_time, EitherDate, EitherDateTime, EitherTime,
+    EitherDate, EitherDateTime, EitherTime, bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta,
+    float_as_datetime, float_as_duration, float_as_time, int_as_datetime, int_as_duration, int_as_time,
 };
 use super::input_abstract::{ConsumeIterator, Never, ValMatch};
 use super::return_enums::ValidationMatch;

--- a/pydantic-core/src/input/input_python.rs
+++ b/pydantic-core/src/input/input_python.rs
@@ -14,27 +14,15 @@ use pyo3::PyTypeCheck;
 use pyo3::PyTypeInfo;
 use speedate::MicrosecondsPrecisionOverflowBehavior;
 
+use crate::ArgsKwargs;
 use crate::errors::{ErrorType, ErrorTypeDefaults, InputValue, LocItem, ValError, ValResult};
 use crate::tools::safe_repr;
-use crate::validators::complex::{get_complex_type, string_to_complex};
-use crate::validators::decimal::{create_decimal, get_decimal_type};
 use crate::validators::Exactness;
 use crate::validators::TemporalUnitMode;
 use crate::validators::ValBytesMode;
-use crate::ArgsKwargs;
+use crate::validators::complex::{get_complex_type, string_to_complex};
+use crate::validators::decimal::{create_decimal, get_decimal_type};
 
-use super::datetime::{
-    bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, date_as_datetime, float_as_datetime,
-    float_as_duration, float_as_time, int_as_datetime, int_as_duration, int_as_time, EitherDate, EitherDateTime,
-    EitherTime,
-};
-use super::input_abstract::ValMatch;
-use super::return_enums::EitherComplex;
-use super::return_enums::{iterate_attributes, iterate_mapping_items, ValidationMatch};
-use super::shared::{
-    decimal_as_int, float_as_int, fraction_as_int, get_enum_meta_object, int_as_bool, str_as_bool, str_as_float,
-    str_as_int,
-};
 use super::Arguments;
 use super::ConsumeIterator;
 use super::KeywordArgs;
@@ -43,9 +31,21 @@ use super::ValidatedDict;
 use super::ValidatedList;
 use super::ValidatedSet;
 use super::ValidatedTuple;
+use super::datetime::{
+    EitherDate, EitherDateTime, EitherTime, bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta,
+    date_as_datetime, float_as_datetime, float_as_duration, float_as_time, int_as_datetime, int_as_duration,
+    int_as_time,
+};
+use super::input_abstract::ValMatch;
+use super::return_enums::EitherComplex;
+use super::return_enums::{ValidationMatch, iterate_attributes, iterate_mapping_items};
+use super::shared::{
+    decimal_as_int, float_as_int, fraction_as_int, get_enum_meta_object, int_as_bool, str_as_bool, str_as_float,
+    str_as_int,
+};
 use super::{
-    py_string_str, BorrowInput, EitherBytes, EitherFloat, EitherInt, EitherString, EitherTimedelta, GenericIterator,
-    Input,
+    BorrowInput, EitherBytes, EitherFloat, EitherInt, EitherString, EitherTimedelta, GenericIterator, Input,
+    py_string_str,
 };
 
 static FRACTION_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
@@ -257,7 +257,7 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
                         .as_bool()
                         .ok_or_else(|| ValError::new(ErrorTypeDefaults::BoolParsing, self))
                         .map(ValidationMatch::lax);
-                };
+                }
             }
         }
 

--- a/pydantic-core/src/input/input_string.rs
+++ b/pydantic-core/src/input/input_string.rs
@@ -12,7 +12,7 @@ use crate::validators::decimal::create_decimal;
 use crate::validators::{TemporalUnitMode, ValBytesMode};
 
 use super::datetime::{
-    bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta, EitherDate, EitherDateTime, EitherTime,
+    EitherDate, EitherDateTime, EitherTime, bytes_as_date, bytes_as_datetime, bytes_as_time, bytes_as_timedelta,
 };
 use super::input_abstract::{Never, ValMatch};
 use super::return_enums::EitherComplex;

--- a/pydantic-core/src/input/mod.rs
+++ b/pydantic-core/src/input/mod.rs
@@ -12,8 +12,8 @@ mod shared;
 
 pub use datetime::TzInfo;
 pub(crate) use datetime::{
-    duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time, EitherDate, EitherDateTime,
-    EitherTimedelta,
+    EitherDate, EitherDateTime, EitherTimedelta, duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime,
+    pytime_as_time,
 };
 pub(crate) use input_abstract::{
     Arguments, BorrowInput, ConsumeIterator, Input, InputType, KeywordArgs, PositionalArgs, ValidatedDict,
@@ -22,15 +22,11 @@ pub(crate) use input_abstract::{
 pub(crate) use input_python::{downcast_python_input, input_as_python_instance};
 pub(crate) use input_string::StringMapping;
 pub(crate) use return_enums::{
-    no_validator_iter_to_vec, py_string_str, validate_iter_to_set, validate_iter_to_vec, EitherBytes, EitherFloat,
-    EitherInt, EitherString, GenericIterator, Int, MaxLengthCheck, ValidationMatch,
+    EitherBytes, EitherFloat, EitherInt, EitherString, GenericIterator, Int, MaxLengthCheck, ValidationMatch,
+    no_validator_iter_to_vec, py_string_str, validate_iter_to_set, validate_iter_to_vec,
 };
 
 // Defined here as it's not exported by pyo3
 pub fn py_error_on_minusone(py: Python<'_>, result: c_int) -> PyResult<()> {
-    if result != -1 {
-        Ok(())
-    } else {
-        Err(PyErr::fetch(py))
-    }
+    if result != -1 { Ok(()) } else { Err(PyErr::fetch(py)) }
 }

--- a/pydantic-core/src/input/return_enums.rs
+++ b/pydantic-core/src/input/return_enums.rs
@@ -15,16 +15,16 @@ use pyo3::types::PyFunction;
 use pyo3::types::{PyBytes, PyComplex, PyFloat, PyFrozenSet, PyIterator, PyMapping, PySet, PyString};
 
 use pyo3::IntoPyObjectExt;
-use serde::{ser::Error, Serialize, Serializer};
+use serde::{Serialize, Serializer, ser::Error};
 
 use crate::errors::{
-    py_err_string, ErrorType, ErrorTypeDefaults, InputValue, ToErrorValue, ValError, ValLineError, ValResult,
+    ErrorType, ErrorTypeDefaults, InputValue, ToErrorValue, ValError, ValLineError, ValResult, py_err_string,
 };
 use crate::py_gc::PyGcTraverse;
 use crate::tools::new_py_string;
 use crate::validators::{CombinedValidator, Exactness, ValidationState, Validator};
 
-use super::{py_error_on_minusone, BorrowInput, Input};
+use super::{BorrowInput, Input, py_error_on_minusone};
 
 pub struct ValidationMatch<T>(T, Exactness);
 

--- a/pydantic-core/src/input/shared.rs
+++ b/pydantic-core/src/input/shared.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
-use pyo3::{intern, Py, PyAny, Python};
+use pyo3::{Py, PyAny, Python, intern};
 
 use jiter::{JsonErrorType, NumberInt};
 

--- a/pydantic-core/src/lib.rs
+++ b/pydantic-core/src/lib.rs
@@ -4,7 +4,7 @@ extern crate core;
 
 use std::sync::OnceLock;
 
-use jiter::{map_json_error, FloatMode, PartialMode, PythonParse, StringCacheMode};
+use jiter::{FloatMode, PartialMode, PythonParse, StringCacheMode, map_json_error};
 use pyo3::exceptions::PyTypeError;
 use pyo3::{prelude::*, sync::PyOnceLock};
 use serializers::BytesMode;
@@ -33,11 +33,11 @@ pub use self::url::{PyMultiHostUrl, PyUrl};
 pub use argument_markers::{ArgsKwargs, PydanticUndefinedType};
 pub use build_tools::SchemaError;
 pub use errors::{
-    list_all_errors, PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault, ValidationError,
+    PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticUseDefault, ValidationError, list_all_errors,
 };
 pub use serializers::{
-    to_json, to_jsonable_python, PydanticSerializationError, PydanticSerializationUnexpectedValue, SchemaSerializer,
-    WarningsArg,
+    PydanticSerializationError, PydanticSerializationUnexpectedValue, SchemaSerializer, WarningsArg, to_json,
+    to_jsonable_python,
 };
 pub use validators::{PySome, SchemaValidator};
 
@@ -113,10 +113,10 @@ pub mod _pydantic_core {
 
     #[pymodule_export]
     use crate::{
-        from_json, list_all_errors, to_json, to_jsonable_python, ArgsKwargs, PyMultiHostUrl, PySome, PyUrl,
-        PydanticCustomError, PydanticKnownError, PydanticOmit, PydanticSerializationError,
-        PydanticSerializationUnexpectedValue, PydanticUndefinedType, PydanticUseDefault, SchemaError, SchemaSerializer,
-        SchemaValidator, TzInfo, ValidationError,
+        ArgsKwargs, PyMultiHostUrl, PySome, PyUrl, PydanticCustomError, PydanticKnownError, PydanticOmit,
+        PydanticSerializationError, PydanticSerializationUnexpectedValue, PydanticUndefinedType, PydanticUseDefault,
+        SchemaError, SchemaSerializer, SchemaValidator, TzInfo, ValidationError, from_json, list_all_errors, to_json,
+        to_jsonable_python,
     };
 
     #[pymodule_init]

--- a/pydantic-core/src/lookup_key.rs
+++ b/pydantic-core/src/lookup_key.rs
@@ -1,15 +1,15 @@
 use std::convert::Infallible;
 use std::fmt;
 
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{PyAttributeError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyMapping, PyString};
-use pyo3::IntoPyObjectExt;
 
 use jiter::{JsonObject, JsonValue};
 
 use crate::build_tools::py_schema_err;
-use crate::errors::{py_err_string, ErrorType, LocItem, Location, ToErrorValue, ValError, ValLineError, ValResult};
+use crate::errors::{ErrorType, LocItem, Location, ToErrorValue, ValError, ValLineError, ValResult, py_err_string};
 use crate::input::StringMapping;
 use crate::tools::{mapping_get, py_err};
 

--- a/pydantic-core/src/serializers/computed_fields.rs
+++ b/pydantic-core/src/serializers/computed_fields.rs
@@ -2,17 +2,17 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString};
-use pyo3::{intern, PyTraverseError, PyVisit};
+use pyo3::{PyTraverseError, PyVisit, intern};
 use serde::ser::SerializeMap;
 
 use crate::build_tools::py_schema_error_type;
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
+use crate::serializers::SerializationState;
 use crate::serializers::extra::FieldName;
 use crate::serializers::filter::SchemaFilter;
 use crate::serializers::shared::{BuildSerializer, CombinedSerializer, PydanticSerializer};
-use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 use super::errors::py_err_se_err;

--- a/pydantic-core/src/serializers/config.rs
+++ b/pydantic-core/src/serializers/config.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
-use std::str::{from_utf8, FromStr, Utf8Error};
+use std::str::{FromStr, Utf8Error, from_utf8};
 
 use base64::Engine;
 use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateTime, PyDict, PyString, PyTime};
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 use serde::ser::Error;
 

--- a/pydantic-core/src/serializers/extra.rs
+++ b/pydantic-core/src/serializers/extra.rs
@@ -7,18 +7,18 @@ use std::string::ToString;
 use pyo3::exceptions::{PyTypeError, PyUserWarning, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyString};
-use pyo3::{intern, PyTypeInfo};
+use pyo3::{PyTypeInfo, intern};
 
 use serde::ser::Error;
 
 use super::config::SerializationConfig;
 use super::errors::{PydanticSerializationUnexpectedValue, UNEXPECTED_TYPE_SER_MARKER};
 use super::ob_type::ObTypeLookup;
+use crate::PydanticSerializationError;
 use crate::recursion_guard::ContainsRecursionState;
 use crate::recursion_guard::RecursionError;
 use crate::recursion_guard::RecursionGuard;
 use crate::recursion_guard::RecursionState;
-use crate::PydanticSerializationError;
 
 /// this is ugly, would be much better if extra could be stored in `SerializationState`
 /// then `SerializationState` got a `serialize_infer` method, but I couldn't get it to work
@@ -427,11 +427,7 @@ impl FromPyObject<'_, '_> for WarningsMode {
 
 impl From<bool> for WarningsMode {
     fn from(mode: bool) -> Self {
-        if mode {
-            Self::Warn
-        } else {
-            Self::None
-        }
+        if mode { Self::Warn } else { Self::None }
     }
 }
 

--- a/pydantic-core/src/serializers/fields.rs
+++ b/pydantic-core/src/serializers/fields.rs
@@ -9,18 +9,18 @@ use ahash::AHashMap;
 use serde::ser::SerializeMap;
 use smallvec::SmallVec;
 
+use crate::PydanticSerializationUnexpectedValue;
 use crate::common::missing_sentinel::get_missing_sentinel_object;
+use crate::serializers::SerializationState;
 use crate::serializers::extra::{FieldName, SerCheck};
 use crate::serializers::type_serializers::any::AnySerializer;
 use crate::serializers::type_serializers::function::{FunctionPlainSerializer, FunctionWrapSerializer};
-use crate::serializers::SerializationState;
-use crate::PydanticSerializationUnexpectedValue;
 
 use super::computed_fields::ComputedFields;
 use super::errors::py_err_se_err;
 use super::extra::Extra;
 use super::filter::SchemaFilter;
-use super::infer::{infer_json_key, infer_serialize, infer_to_python, SerializeInfer};
+use super::infer::{SerializeInfer, infer_json_key, infer_serialize, infer_to_python};
 use super::shared::{CombinedSerializer, PydanticSerializer, TypeSerializer};
 
 /// representation of a field for serialization

--- a/pydantic-core/src/serializers/mod.rs
+++ b/pydantic-core/src/serializers/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyTuple, PyType};
@@ -13,8 +13,8 @@ use crate::py_gc::PyGcTraverse;
 pub(crate) use config::{BytesMode, SerializationConfig};
 pub use errors::{PydanticSerializationError, PydanticSerializationUnexpectedValue};
 pub(crate) use extra::{Extra, SerMode, SerializationState, WarningsMode};
-use shared::to_json_bytes;
 pub use shared::CombinedSerializer;
+use shared::to_json_bytes;
 
 mod computed_fields;
 mod config;

--- a/pydantic-core/src/serializers/ob_type.rs
+++ b/pydantic-core/src/serializers/ob_type.rs
@@ -4,7 +4,7 @@ use pyo3::types::{
     PyBool, PyByteArray, PyBytes, PyComplex, PyDate, PyDateTime, PyDelta, PyDict, PyFloat, PyFrozenSet, PyInt,
     PyIterator, PyList, PyNone, PySet, PyString, PyTime, PyTuple, PyType,
 };
-use pyo3::{intern, PyTypeInfo};
+use pyo3::{PyTypeInfo, intern};
 
 use strum::Display;
 use strum_macros::EnumString;

--- a/pydantic-core/src/serializers/prebuilt.rs
+++ b/pydantic-core/src/serializers/prebuilt.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::SchemaSerializer;
 use crate::common::prebuilt::get_prebuilt;
 use crate::serializers::SerializationState;
-use crate::SchemaSerializer;
 
 use super::shared::{CombinedSerializer, TypeSerializer};
 

--- a/pydantic-core/src/serializers/ser.rs
+++ b/pydantic-core/src/serializers/ser.rs
@@ -1,6 +1,6 @@
 use std::{io, num::FpCategory};
 
-use serde::{ser::Impossible, Serialize, Serializer};
+use serde::{Serialize, Serializer, ser::Impossible};
 use serde_json::ser::{CompactFormatter, Formatter, PrettyFormatter, State};
 
 use super::errors::PythonSerializerError;
@@ -247,43 +247,50 @@ where
         variant: &'static str,
         value: &T,
     ) -> Result<Self::Ok> {
-        tri!(self
-            .formatter
-            .begin_object(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .formatter
-            .begin_object_key(&mut self.writer, true)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .begin_object(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.formatter
+                .begin_object_key(&mut self.writer, true)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         tri!(self.serialize_str(variant));
-        tri!(self
-            .formatter
-            .end_object_key(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .formatter
-            .begin_object_value(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .end_object_key(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.formatter
+                .begin_object_value(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         tri!(value.serialize(&mut *self));
-        tri!(self
-            .formatter
-            .end_object_value(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .end_object_value(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         self.formatter
             .end_object(&mut self.writer)
             .map_err(|e| PythonSerializerError { message: e.to_string() })
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
-        tri!(self
-            .formatter
-            .begin_array(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .begin_array(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         if len == Some(0) {
-            tri!(self
-                .formatter
-                .end_array(&mut self.writer)
-                .map_err(|e| PythonSerializerError { message: e.to_string() }));
+            tri!(
+                self.formatter
+                    .end_array(&mut self.writer)
+                    .map_err(|e| PythonSerializerError { message: e.to_string() })
+            );
             Ok(Compound::Map {
                 ser: self,
                 state: State::Empty,
@@ -311,36 +318,42 @@ where
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        tri!(self
-            .formatter
-            .begin_object(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .formatter
-            .begin_object_key(&mut self.writer, true)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .begin_object(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.formatter
+                .begin_object_key(&mut self.writer, true)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         tri!(self.serialize_str(variant));
-        tri!(self
-            .formatter
-            .end_object_key(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .formatter
-            .begin_object_value(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .end_object_key(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.formatter
+                .begin_object_value(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         self.serialize_seq(Some(len))
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
-        tri!(self
-            .formatter
-            .begin_object(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .begin_object(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         if len == Some(0) {
-            tri!(self
-                .formatter
-                .end_object(&mut self.writer)
-                .map_err(|e| PythonSerializerError { message: e.to_string() }));
+            tri!(
+                self.formatter
+                    .end_object(&mut self.writer)
+                    .map_err(|e| PythonSerializerError { message: e.to_string() })
+            );
             Ok(Compound::Map {
                 ser: self,
                 state: State::Empty,
@@ -367,23 +380,27 @@ where
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        tri!(self
-            .formatter
-            .begin_object(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .formatter
-            .begin_object_key(&mut self.writer, true)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .begin_object(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.formatter
+                .begin_object_key(&mut self.writer, true)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         tri!(self.serialize_str(variant));
-        tri!(self
-            .formatter
-            .end_object_key(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .formatter
-            .begin_object_value(&mut self.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.formatter
+                .end_object_key(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.formatter
+                .begin_object_value(&mut self.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         self.serialize_map(Some(len))
     }
 }
@@ -403,16 +420,18 @@ where
     {
         match self {
             Compound::Map { ser, state } => {
-                tri!(ser
-                    .formatter
-                    .begin_array_value(&mut ser.writer, *state == State::First)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .begin_array_value(&mut ser.writer, *state == State::First)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 *state = State::Rest;
                 tri!(value.serialize(&mut **ser));
-                tri!(ser
-                    .formatter
-                    .end_array_value(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .end_array_value(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 Ok(())
             }
             Compound::Number { .. } => unreachable!(),
@@ -424,10 +443,11 @@ where
             Compound::Map { ser, state } => {
                 match state {
                     State::Empty => {}
-                    _ => tri!(ser
-                        .formatter
-                        .end_array(&mut ser.writer)
-                        .map_err(|e| PythonSerializerError { message: e.to_string() })),
+                    _ => tri!(
+                        ser.formatter
+                            .end_array(&mut ser.writer)
+                            .map_err(|e| PythonSerializerError { message: e.to_string() })
+                    ),
                 }
                 Ok(())
             }
@@ -502,19 +522,22 @@ where
             Compound::Map { ser, state } => {
                 match state {
                     State::Empty => {}
-                    _ => tri!(ser
-                        .formatter
-                        .end_array(&mut ser.writer)
-                        .map_err(|e| PythonSerializerError { message: e.to_string() })),
+                    _ => tri!(
+                        ser.formatter
+                            .end_array(&mut ser.writer)
+                            .map_err(|e| PythonSerializerError { message: e.to_string() })
+                    ),
                 }
-                tri!(ser
-                    .formatter
-                    .end_object_value(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
-                tri!(ser
-                    .formatter
-                    .end_object(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .end_object_value(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
+                tri!(
+                    ser.formatter
+                        .end_object(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 Ok(())
             }
             Compound::Number { .. } => unreachable!(),
@@ -537,18 +560,20 @@ where
     {
         match self {
             Compound::Map { ser, state } => {
-                tri!(ser
-                    .formatter
-                    .begin_object_key(&mut ser.writer, *state == State::First)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .begin_object_key(&mut ser.writer, *state == State::First)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 *state = State::Rest;
 
                 tri!(key.serialize(MapKeySerializer { ser: *ser }));
 
-                tri!(ser
-                    .formatter
-                    .end_object_key(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .end_object_key(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 Ok(())
             }
             Compound::Number { .. } => unreachable!(),
@@ -562,15 +587,17 @@ where
     {
         match self {
             Compound::Map { ser, .. } => {
-                tri!(ser
-                    .formatter
-                    .begin_object_value(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .begin_object_value(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 tri!(value.serialize(&mut **ser));
-                tri!(ser
-                    .formatter
-                    .end_object_value(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .end_object_value(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 Ok(())
             }
             Compound::Number { .. } => unreachable!(),
@@ -583,10 +610,11 @@ where
             Compound::Map { ser, state } => {
                 match state {
                     State::Empty => {}
-                    _ => tri!(ser
-                        .formatter
-                        .end_object(&mut ser.writer)
-                        .map_err(|e| PythonSerializerError { message: e.to_string() })),
+                    _ => tri!(
+                        ser.formatter
+                            .end_object(&mut ser.writer)
+                            .map_err(|e| PythonSerializerError { message: e.to_string() })
+                    ),
                 }
                 Ok(())
             }
@@ -655,19 +683,22 @@ where
             Compound::Map { ser, state } => {
                 match state {
                     State::Empty => {}
-                    _ => tri!(ser
-                        .formatter
-                        .end_object(&mut ser.writer)
-                        .map_err(|e| PythonSerializerError { message: e.to_string() })),
+                    _ => tri!(
+                        ser.formatter
+                            .end_object(&mut ser.writer)
+                            .map_err(|e| PythonSerializerError { message: e.to_string() })
+                    ),
                 }
-                tri!(ser
-                    .formatter
-                    .end_object_value(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
-                tri!(ser
-                    .formatter
-                    .end_object(&mut ser.writer)
-                    .map_err(|e| PythonSerializerError { message: e.to_string() }));
+                tri!(
+                    ser.formatter
+                        .end_object_value(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
+                tri!(
+                    ser.formatter
+                        .end_object(&mut ser.writer)
+                        .map_err(|e| PythonSerializerError { message: e.to_string() })
+                );
                 Ok(())
             }
             Compound::Number { .. } => unreachable!(),
@@ -833,192 +864,222 @@ where
     }
 
     fn serialize_i8(self, value: i8) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_i8(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_i8(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_i16(self, value: i16) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_i16(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_i16(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_i32(self, value: i32) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_i32(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_i32(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_i64(self, value: i64) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_i64(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_i64(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_i128(self, value: i128) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_number_str(&mut self.ser.writer, &value.to_string())
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_number_str(&mut self.ser.writer, &value.to_string())
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_u8(self, value: u8) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_u8(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_u8(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_u16(self, value: u16) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_u16(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_u16(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_u32(self, value: u32) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_u32(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_u32(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_u64(self, value: u64) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_u64(&mut self.ser.writer, value)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_u64(&mut self.ser.writer, value)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 
     fn serialize_u128(self, value: u128) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .write_number_str(&mut self.ser.writer, &value.to_string())
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(|e| PythonSerializerError { message: e.to_string() }));
+        tri!(
+            self.ser
+                .formatter
+                .begin_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .write_number_str(&mut self.ser.writer, &value.to_string())
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
+        tri!(
+            self.ser
+                .formatter
+                .end_string(&mut self.ser.writer)
+                .map_err(|e| PythonSerializerError { message: e.to_string() })
+        );
         Ok(())
     }
 

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use pyo3::exceptions::PyTypeError;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyDict, PyString};
-use pyo3::{intern, PyTraverseError, PyVisit};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
+use pyo3::{PyTraverseError, PyVisit, intern};
 
 use enum_dispatch::enum_dispatch;
 use serde::{Serialize, Serializer};
@@ -21,7 +21,7 @@ use crate::py_gc::PyGcTraverse;
 use crate::serializers::errors::WrappedSerError;
 use crate::serializers::ser::PythonSerializer;
 use crate::serializers::type_serializers::any::AnySerializer;
-use crate::tools::{py_err, SchemaDict};
+use crate::tools::{SchemaDict, py_err};
 
 use super::errors::se_err_py_err;
 use super::extra::SerializationState;
@@ -212,7 +212,7 @@ impl CombinedSerializer {
                     // instead of `schema.type`. In this case it's an error if a serializer isn't found.
                     return Self::find_serializer(ser_type, &ser_schema, config, definitions);
                 }
-            };
+            }
         }
 
         let type_: Bound<'_, PyString> = schema.get_as_req(type_key)?;
@@ -364,7 +364,7 @@ impl PyGcTraverse for CombinedSerializer {
 #[enum_dispatch(CombinedSerializer)]
 pub(crate) trait TypeSerializer: Send + Sync + Debug {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'_, 'py>)
-        -> PyResult<Py<PyAny>>;
+    -> PyResult<Py<PyAny>>;
 
     fn json_key<'a, 'py>(
         &self,

--- a/pydantic-core/src/serializers/type_serializers/any.rs
+++ b/pydantic-core/src/serializers/type_serializers/any.rs
@@ -10,7 +10,7 @@ use serde::ser::Serializer;
 
 use crate::{definitions::DefinitionsBuilder, serializers::SerializationState};
 
-use super::{infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, infer_serialize, infer_to_python};
 
 #[derive(Debug, Clone, Default)]
 pub struct AnySerializer;

--- a/pydantic-core/src/serializers/type_serializers/bytes.rs
+++ b/pydantic-core/src/serializers/type_serializers/bytes.rs
@@ -2,15 +2,15 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use pyo3::types::{PyBytes, PyDict};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
-use crate::serializers::config::{BytesMode, FromConfig};
 use crate::serializers::SerializationState;
+use crate::serializers::config::{BytesMode, FromConfig};
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/complex.rs
+++ b/pydantic-core/src/serializers/type_serializers/complex.rs
@@ -2,13 +2,13 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use pyo3::types::{PyComplex, PyDict};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 
-use super::{infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, SerMode, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_serialize, infer_to_python};
 
 #[derive(Debug, Clone)]
 pub struct ComplexSerializer {}

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -7,15 +7,14 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use serde::ser::SerializeMap;
 
-use crate::build_tools::{py_schema_error_type, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, py_schema_error_type};
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 use super::{
-    infer_json_key, infer_json_key_known, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer,
-    CombinedSerializer, ComputedFields, FieldsMode, GeneralFieldsSerializer, ObType, SerCheck, SerField,
-    TypeSerializer,
+    BuildSerializer, CombinedSerializer, ComputedFields, FieldsMode, GeneralFieldsSerializer, ObType, SerCheck,
+    SerField, TypeSerializer, infer_json_key, infer_json_key_known, infer_serialize, infer_to_python, py_err_se_err,
 };
 
 pub struct DataclassArgsBuilder;

--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -5,13 +5,13 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateTime, PyDict, PyTime};
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
+use crate::PydanticSerializationUnexpectedValue;
 use crate::definitions::DefinitionsBuilder;
 use crate::input::{pydate_as_date, pydatetime_as_datetime, pytime_as_time};
-use crate::serializers::config::{FromConfig, TemporalMode};
 use crate::serializers::SerializationState;
-use crate::PydanticSerializationUnexpectedValue;
+use crate::serializers::config::{FromConfig, TemporalMode};
 
 pub(crate) fn datetime_to_string(py_dt: &Bound<'_, PyDateTime>) -> PyResult<String> {
     pydatetime_as_datetime(py_dt).map(|dt| dt.to_string())

--- a/pydantic-core/src/serializers/type_serializers/decimal.rs
+++ b/pydantic-core/src/serializers/type_serializers/decimal.rs
@@ -6,11 +6,11 @@ use pyo3::types::PyDict;
 
 use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
+use crate::serializers::SerializationState;
 use crate::serializers::infer::{infer_json_key_known, infer_serialize_known, infer_to_python_known};
 use crate::serializers::ob_type::{IsType, ObType};
-use crate::serializers::SerializationState;
 
-use super::{infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, infer_serialize, infer_to_python};
 
 #[derive(Debug)]
 pub struct DecimalSerializer {}

--- a/pydantic-core/src/serializers/type_serializers/definitions.rs
+++ b/pydantic-core/src/serializers/type_serializers/definitions.rs
@@ -12,7 +12,7 @@ use crate::definitions::{DefinitionRef, RecursionSafeCache};
 use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
-use super::{py_err_se_err, BuildSerializer, CombinedSerializer, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, TypeSerializer, py_err_se_err};
 
 #[derive(Debug)]
 pub struct DefinitionsSerializerBuilder;

--- a/pydantic-core/src/serializers/type_serializers/dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/dict.rs
@@ -14,8 +14,8 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, PydanticSerializer,
-    SchemaFilter, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerMode, TypeSerializer, infer_serialize,
+    infer_to_python, py_err_se_err,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/float.rs
+++ b/pydantic-core/src/serializers/type_serializers/float.rs
@@ -1,5 +1,5 @@
 use pyo3::types::PyDict;
-use pyo3::{intern, prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern, prelude::*};
 
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -8,14 +8,14 @@ use serde::Serializer;
 
 use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
-use crate::serializers::config::InfNanMode;
 use crate::serializers::SerializationState;
+use crate::serializers::config::InfNanMode;
 use crate::tools::SchemaDict;
 
 use super::simple::to_str_json_key;
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, IsType, ObType, SerCheck,
-    SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, IsType, ObType, SerCheck, SerMode, TypeSerializer, infer_json_key,
+    infer_serialize, infer_to_python,
 };
 use crate::serializers::errors::PydanticSerializationUnexpectedValue;
 

--- a/pydantic-core/src/serializers/type_serializers/format.rs
+++ b/pydantic-core/src/serializers/type_serializers/format.rs
@@ -9,15 +9,15 @@ use serde::ser::Error;
 
 use crate::build_tools::py_schema_err;
 use crate::definitions::DefinitionsBuilder;
+use crate::serializers::SerializationState;
 use crate::serializers::errors::unwrap_ser_error;
+use crate::serializers::shared::DoSerialize;
 use crate::serializers::shared::serialize_to_json;
 use crate::serializers::shared::serialize_to_python;
-use crate::serializers::shared::DoSerialize;
-use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 use super::simple::none_json_key;
-use super::{py_err_se_err, BuildSerializer, CombinedSerializer, Extra, PydanticSerializationError, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, Extra, PydanticSerializationError, TypeSerializer, py_err_se_err};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(super) enum WhenUsed {

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use pyo3::PyTraverseError;
 use pyo3::exceptions::{PyAttributeError, PyRecursionError, PyRuntimeError};
 use pyo3::gc::PyVisit;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::PyTraverseError;
 
 use pyo3::types::PyString;
 
@@ -21,8 +21,8 @@ use super::format::WhenUsed;
 
 use super::any::AnySerializer;
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, py_err_se_err, AnyFilter, BuildSerializer, CombinedSerializer,
-    ExtraOwned, PydanticSerializationError, SerMode, TypeSerializer,
+    AnyFilter, BuildSerializer, CombinedSerializer, ExtraOwned, PydanticSerializationError, SerMode, TypeSerializer,
+    infer_json_key, infer_serialize, infer_to_python, py_err_se_err,
 };
 
 pub struct FunctionBeforeSerializerBuilder;
@@ -159,7 +159,9 @@ impl FunctionPlainSerializer {
                         self.func.call1(py, (model, value))?
                     }
                 } else {
-                    return Err(PyRuntimeError::new_err("Function plain serializer expected to be run inside the context of a model field but no model was found"));
+                    return Err(PyRuntimeError::new_err(
+                        "Function plain serializer expected to be run inside the context of a model field but no model was found",
+                    ));
                 }
             } else if self.info_arg {
                 let info = SerializationInfo::new(state, self.is_field_serializer)?;
@@ -399,7 +401,9 @@ impl FunctionWrapSerializer {
                         self.func.call1(py, (model, value, serialize))?
                     }
                 } else {
-                    return Err(PyRuntimeError::new_err("Function wrap serializer expected to be run inside the context of a model field but no model was found"));
+                    return Err(PyRuntimeError::new_err(
+                        "Function wrap serializer expected to be run inside the context of a model field but no model was found",
+                    ));
                 }
             } else if self.info_arg {
                 let info = SerializationInfo::new(state, self.is_field_serializer)?;
@@ -665,9 +669,5 @@ impl SerializationInfo {
 }
 
 fn py_bool(value: bool) -> &'static str {
-    if value {
-        "True"
-    } else {
-        "False"
-    }
+    if value { "True" } else { "False" }
 }

--- a/pydantic-core/src/serializers/type_serializers/generator.rs
+++ b/pydantic-core/src/serializers/type_serializers/generator.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use pyo3::IntoPyObjectExt;
+use pyo3::PyTraverseError;
 use pyo3::gc::PyVisit;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyIterator};
-use pyo3::IntoPyObjectExt;
-use pyo3::PyTraverseError;
 
 use serde::ser::SerializeSeq;
 
@@ -17,8 +17,8 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, ExtraOwned,
-    PydanticSerializer, SchemaFilter, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, ExtraOwned, PydanticSerializer, SchemaFilter, SerMode, TypeSerializer,
+    infer_serialize, infer_to_python, py_err_se_err,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/json.rs
+++ b/pydantic-core/src/serializers/type_serializers/json.rs
@@ -15,7 +15,7 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    infer_json_key, py_err_se_err, to_json_bytes, utf8_py_error, BuildSerializer, CombinedSerializer, TypeSerializer,
+    BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, py_err_se_err, to_json_bytes, utf8_py_error,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/list.rs
+++ b/pydantic-core/src/serializers/type_serializers/list.rs
@@ -14,8 +14,8 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, PydanticSerializer,
-    SchemaFilter, TypeSerializer,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, TypeSerializer, infer_serialize,
+    infer_to_python, py_err_se_err,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/literal.rs
+++ b/pydantic-core/src/serializers/type_serializers/literal.rs
@@ -15,8 +15,8 @@ use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, SerMode,
-    TypeSerializer,
+    BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
+    py_err_se_err,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
+++ b/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
@@ -12,9 +12,9 @@ use pyo3::types::PyDict;
 
 use serde::ser::Error;
 
+use crate::PydanticSerializationUnexpectedValue;
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
-use crate::PydanticSerializationUnexpectedValue;
 use crate::{build_tools::LazyLock, common::missing_sentinel::get_missing_sentinel_object};
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer};

--- a/pydantic-core/src/serializers/type_serializers/mod.rs
+++ b/pydantic-core/src/serializers/type_serializers/mod.rs
@@ -32,10 +32,10 @@ pub mod with_default;
 
 use super::computed_fields::ComputedFields;
 use super::config::utf8_py_error;
-use super::errors::{py_err_se_err, PydanticSerializationError};
+use super::errors::{PydanticSerializationError, py_err_se_err};
 use super::extra::{Extra, ExtraOwned, SerCheck, SerMode};
 use super::fields::{FieldsMode, GeneralFieldsSerializer, SerField};
 use super::filter::{AnyFilter, SchemaFilter};
 use super::infer::{infer_json_key, infer_json_key_known, infer_serialize, infer_to_python};
 use super::ob_type::{IsType, ObType};
-use super::shared::{to_json_bytes, BuildSerializer, CombinedSerializer, PydanticSerializer, TypeSerializer};
+use super::shared::{BuildSerializer, CombinedSerializer, PydanticSerializer, TypeSerializer, to_json_bytes};

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -9,20 +9,20 @@ use ahash::AHashMap;
 use pyo3::IntoPyObjectExt;
 
 use super::{
-    infer_json_key, infer_json_key_known, BuildSerializer, CombinedSerializer, ComputedFields, Extra, FieldsMode,
-    GeneralFieldsSerializer, ObType, SerCheck, SerField, TypeSerializer,
+    BuildSerializer, CombinedSerializer, ComputedFields, Extra, FieldsMode, GeneralFieldsSerializer, ObType, SerCheck,
+    SerField, TypeSerializer, infer_json_key, infer_json_key_known,
 };
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{py_schema_error_type, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, py_schema_error_type};
 use crate::definitions::DefinitionsBuilder;
+use crate::serializers::SerializationState;
 use crate::serializers::extra::FieldName;
+use crate::serializers::shared::DoSerialize;
 use crate::serializers::shared::serialize_to_json;
 use crate::serializers::shared::serialize_to_python;
-use crate::serializers::shared::DoSerialize;
 use crate::serializers::type_serializers::any::AnySerializer;
 use crate::serializers::type_serializers::function::FunctionPlainSerializer;
 use crate::serializers::type_serializers::function::FunctionWrapSerializer;
-use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 const ROOT_FIELD: &str = "root";

--- a/pydantic-core/src/serializers/type_serializers/nullable.rs
+++ b/pydantic-core/src/serializers/type_serializers/nullable.rs
@@ -9,7 +9,7 @@ use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
-use super::{infer_json_key_known, BuildSerializer, CombinedSerializer, IsType, ObType, TypeSerializer};
+use super::{BuildSerializer, CombinedSerializer, IsType, ObType, TypeSerializer, infer_json_key_known};
 
 #[derive(Debug)]
 pub struct NullableSerializer {

--- a/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
+++ b/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyFrozenSet, PyList, PySet};
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 use serde::ser::SerializeSeq;
 
@@ -13,7 +13,7 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, PydanticSerializer, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SerMode, TypeSerializer, infer_serialize, infer_to_python,
 };
 
 macro_rules! build_serializer {

--- a/pydantic-core/src/serializers/type_serializers/simple.rs
+++ b/pydantic-core/src/serializers/type_serializers/simple.rs
@@ -1,21 +1,21 @@
+use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::IntoPyObjectExt;
 
 use std::borrow::Cow;
 use std::sync::Arc;
 
 use serde::Serialize;
 
-use crate::build_tools::LazyLock;
 use crate::PydanticSerializationUnexpectedValue;
+use crate::build_tools::LazyLock;
 use crate::{definitions::DefinitionsBuilder, input::Int};
 
 use crate::serializers::SerializationState;
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, IsType, ObType, SerCheck,
-    SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, IsType, ObType, SerCheck, SerMode, TypeSerializer, infer_json_key,
+    infer_serialize, infer_to_python,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/string.rs
+++ b/pydantic-core/src/serializers/type_serializers/string.rs
@@ -2,17 +2,17 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use pyo3::types::{PyDict, PyString};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
-use crate::serializers::errors::unwrap_ser_error;
-use crate::serializers::shared::{serialize_to_json, DoSerialize};
 use crate::serializers::SerializationState;
+use crate::serializers::errors::unwrap_ser_error;
+use crate::serializers::shared::{DoSerialize, serialize_to_json};
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, IsType, ObType, SerMode,
-    TypeSerializer,
+    BuildSerializer, CombinedSerializer, IsType, ObType, SerMode, TypeSerializer, infer_json_key, infer_serialize,
+    infer_to_python,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/timedelta.rs
+++ b/pydantic-core/src/serializers/type_serializers/timedelta.rs
@@ -6,11 +6,11 @@ use std::sync::Arc;
 
 use crate::definitions::DefinitionsBuilder;
 use crate::input::EitherTimedelta;
-use crate::serializers::config::{FromConfig, TemporalMode, TimedeltaMode};
 use crate::serializers::SerializationState;
+use crate::serializers::config::{FromConfig, TemporalMode, TimedeltaMode};
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/tuple.rs
+++ b/pydantic-core/src/serializers/type_serializers/tuple.rs
@@ -7,16 +7,16 @@ use std::sync::Arc;
 
 use serde::ser::SerializeSeq;
 
+use crate::PydanticSerializationUnexpectedValue;
 use crate::definitions::DefinitionsBuilder;
+use crate::serializers::SerializationState;
 use crate::serializers::extra::SerCheck;
 use crate::serializers::type_serializers::any::AnySerializer;
-use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
-use crate::PydanticSerializationUnexpectedValue;
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer,
-    PydanticSerializer, SchemaFilter, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerMode, TypeSerializer, infer_json_key,
+    infer_serialize, infer_to_python, py_err_se_err,
 };
 
 #[derive(Debug)]
@@ -203,7 +203,7 @@ impl TupleSerializer {
             let n_variadic_items = (n_items + 1).saturating_sub(self.serializers.len());
             let serializers_iter = self.serializers[..variadic_item_index]
                 .iter()
-                .chain(iter::repeat(&self.serializers[variadic_item_index]).take(n_variadic_items))
+                .chain(iter::repeat_n(&self.serializers[variadic_item_index], n_variadic_items))
                 .chain(self.serializers[variadic_item_index + 1..].iter());
             use_serializers!(serializers_iter);
         } else if state.check == SerCheck::Strict && n_items != self.serializers.len() {

--- a/pydantic-core/src/serializers/type_serializers/typed_dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/typed_dict.rs
@@ -8,10 +8,10 @@ use pyo3::types::{PyDict, PyString};
 use ahash::AHashMap;
 
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{py_schema_error_type, schema_or_config, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, py_schema_error_type, schema_or_config};
 use crate::definitions::DefinitionsBuilder;
-use crate::serializers::shared::TypeSerializer;
 use crate::serializers::SerializationState;
+use crate::serializers::shared::TypeSerializer;
 use crate::tools::SchemaDict;
 
 use super::{BuildSerializer, CombinedSerializer, ComputedFields, FieldsMode, GeneralFieldsSerializer, SerField};

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -14,7 +14,7 @@ use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, SerCheck, TypeSerializer,
+    BuildSerializer, CombinedSerializer, SerCheck, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/type_serializers/url.rs
+++ b/pydantic-core/src/serializers/type_serializers/url.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::LazyLock;
 use crate::definitions::DefinitionsBuilder;
@@ -11,7 +11,7 @@ use crate::serializers::SerializationState;
 use crate::url::{PyMultiHostUrl, PyUrl};
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, BuildSerializer, CombinedSerializer, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
 macro_rules! build_serializer {

--- a/pydantic-core/src/serializers/type_serializers/uuid.rs
+++ b/pydantic-core/src/serializers/type_serializers/uuid.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use pyo3::types::PyDict;
-use pyo3::{intern, prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern, prelude::*};
 use uuid::Uuid;
 
 use crate::build_tools::LazyLock;
@@ -10,8 +10,8 @@ use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 
 use super::{
-    infer_json_key, infer_serialize, infer_to_python, py_err_se_err, BuildSerializer, CombinedSerializer, IsType,
-    ObType, SerMode, TypeSerializer,
+    BuildSerializer, CombinedSerializer, IsType, ObType, SerMode, TypeSerializer, infer_json_key, infer_serialize,
+    infer_to_python, py_err_se_err,
 };
 
 pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {

--- a/pydantic-core/src/tools.rs
+++ b/pydantic-core/src/tools.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyMapping, PyString};
 
 use crate::PydanticUndefinedType;
-use jiter::{cached_py_string, StringCacheMode};
+use jiter::{StringCacheMode, cached_py_string};
 
 pub trait SchemaDict<'py> {
     fn get_as<T>(&self, key: &Bound<'py, PyString>) -> PyResult<Option<T>>

--- a/pydantic-core/src/url.rs
+++ b/pydantic-core/src/url.rs
@@ -7,20 +7,20 @@ use std::sync::OnceLock;
 
 use idna::punycode::decode_to_string;
 use jiter::{PartialMode, StringCacheMode};
-use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{AsciiSet, CONTROLS, percent_encode};
 use pyo3::exceptions::PyValueError;
 use pyo3::pyclass::CompareOp;
 use pyo3::sync::OnceLockExt;
 use pyo3::types::{PyDict, PyType};
-use pyo3::{intern, prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern, prelude::*};
 use url::Url;
 
+use crate::ValidationError;
 use crate::input::InputType;
 use crate::recursion_guard::RecursionState;
 use crate::tools::SchemaDict;
 use crate::validators::url::{MultiHostUrlValidator, UrlValidator};
 use crate::validators::{Extra, ValidationState, Validator};
-use crate::ValidationError;
 
 #[pyclass(name = "Url", module = "pydantic_core._pydantic_core", subclass, frozen)]
 #[derive(Clone)]

--- a/pydantic-core/src/validators/any.rs
+++ b/pydantic-core/src/validators/any.rs
@@ -7,7 +7,7 @@ use crate::input::Input;
 use crate::{build_tools::LazyLock, errors::ValResult};
 
 use super::{
-    validation_state::Exactness, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator,
+    BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, validation_state::Exactness,
 };
 
 /// This might seem useless, but it's useful in DictValidator to avoid Option<Validator> a lot

--- a/pydantic-core/src/validators/arguments.rs
+++ b/pydantic-core/src/validators/arguments.rs
@@ -9,14 +9,14 @@ use ahash::AHashSet;
 use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{schema_or_config_same, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, schema_or_config_same};
 use crate::errors::{ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::{Arguments, BorrowInput, Input, KeywordArgs, PositionalArgs, ValidationMatch};
 use crate::lookup_key::LookupKeyCollection;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
 
 #[derive(Debug, PartialEq)]
 enum VarKwargsMode {

--- a/pydantic-core/src/validators/arguments_v3.rs
+++ b/pydantic-core/src/validators/arguments_v3.rs
@@ -9,7 +9,7 @@ use ahash::AHashSet;
 use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{schema_or_config_same, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, schema_or_config_same};
 use crate::errors::LocItem;
 use crate::errors::{ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::ConsumeIterator;
@@ -20,7 +20,7 @@ use crate::lookup_key::LookupKeyCollection;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
 
 #[derive(Debug, PartialEq)]
 enum ParameterMode {

--- a/pydantic-core/src/validators/bool.rs
+++ b/pydantic-core/src/validators/bool.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use pyo3::types::PyDict;
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
 
-use crate::build_tools::{is_strict, LazyLock};
+use crate::build_tools::{LazyLock, is_strict};
 use crate::errors::ValResult;
 use crate::input::Input;
 

--- a/pydantic-core/src/validators/bytes.rs
+++ b/pydantic-core/src/validators/bytes.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use pyo3::IntoPyObjectExt;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};

--- a/pydantic-core/src/validators/call.rs
+++ b/pydantic-core/src/validators/call.rs
@@ -12,7 +12,7 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct CallValidator {

--- a/pydantic-core/src/validators/chain.rs
+++ b/pydantic-core/src/validators/chain.rs
@@ -10,7 +10,7 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct ChainValidator {

--- a/pydantic-core/src/validators/complex.rs
+++ b/pydantic-core/src/validators/complex.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyComplex, PyDict, PyString, PyType};
 
-use crate::build_tools::{is_strict, LazyLock};
+use crate::build_tools::{LazyLock, is_strict};
 use crate::errors::{ErrorTypeDefaults, ToErrorValue, ValError, ValResult};
 use crate::input::Input;
 

--- a/pydantic-core/src/validators/config.rs
+++ b/pydantic-core/src/validators/config.rs
@@ -8,7 +8,7 @@ use crate::serializers::BytesMode;
 use crate::tools::SchemaDict;
 use base64::engine::general_purpose::GeneralPurpose;
 use base64::engine::{DecodePaddingMode, GeneralPurposeConfig};
-use base64::{alphabet, DecodeError, Engine};
+use base64::{DecodeError, Engine, alphabet};
 use pyo3::types::{PyDict, PyString};
 use pyo3::{intern, prelude::*};
 use speedate::TimestampUnit;

--- a/pydantic-core/src/validators/custom_error.rs
+++ b/pydantic-core/src/validators/custom_error.rs
@@ -11,7 +11,7 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
 
 #[derive(Debug, Clone)]
 pub enum CustomError {
@@ -53,8 +53,8 @@ impl CustomError {
 
     pub fn as_val_error(&self, input: impl ToErrorValue) -> ValError {
         match self {
-            CustomError::KnownError(ref known_error) => known_error.clone().into_val_error(input),
-            CustomError::Custom(ref custom_error) => custom_error.clone().into_val_error(input),
+            CustomError::KnownError(known_error) => known_error.clone().into_val_error(input),
+            CustomError::Custom(custom_error) => custom_error.clone().into_val_error(input),
         }
     }
 }

--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -9,18 +9,18 @@ use ahash::AHashSet;
 use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{is_strict, schema_or_config_same, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, is_strict, schema_or_config_same};
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::{
-    input_as_python_instance, Arguments, BorrowInput, Input, InputType, KeywordArgs, PositionalArgs, ValidationMatch,
+    Arguments, BorrowInput, Input, InputType, KeywordArgs, PositionalArgs, ValidationMatch, input_as_python_instance,
 };
 use crate::lookup_key::LookupKeyCollection;
 use crate::tools::SchemaDict;
 use crate::validators::function::convert_err;
 
-use super::model::{create_class, force_setattr, Revalidate};
+use super::model::{Revalidate, create_class, force_setattr};
 use super::validation_state::Exactness;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 struct Field {
@@ -360,7 +360,7 @@ impl Validator for DataclassArgsValidator {
                             }
                         }
                         Err(err) => return Err(err),
-                    };
+                    }
                 }
             }
         }

--- a/pydantic-core/src/validators/datetime.rs
+++ b/pydantic-core/src/validators/datetime.rs
@@ -11,7 +11,7 @@ use strum::EnumMessage;
 use crate::build_tools::{is_strict, py_schema_error_type};
 use crate::build_tools::{py_schema_err, schema_or_config_same};
 use crate::errors::ToErrorValue;
-use crate::errors::{py_err_string, ErrorType, ErrorTypeDefaults, ValError, ValResult};
+use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult, py_err_string};
 use crate::input::{EitherDateTime, Input};
 
 use super::Exactness;

--- a/pydantic-core/src/validators/decimal.rs
+++ b/pydantic-core/src/validators/decimal.rs
@@ -4,7 +4,7 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::{IntoPyDict, PyDict, PyString, PyTuple, PyType};
-use pyo3::{prelude::*, PyTypeInfo};
+use pyo3::{PyTypeInfo, prelude::*};
 
 use crate::build_tools::{is_strict, schema_or_config_same};
 use crate::errors::ErrorType;

--- a/pydantic-core/src/validators/definitions.rs
+++ b/pydantic-core/src/validators/definitions.rs
@@ -12,7 +12,7 @@ use crate::input::Input;
 use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug, Clone)]
 pub struct DefinitionsValidatorBuilder;

--- a/pydantic-core/src/validators/dict.rs
+++ b/pydantic-core/src/validators/dict.rs
@@ -14,7 +14,7 @@ use crate::tools::SchemaDict;
 
 use super::any::AnyValidator;
 use super::list::length_check;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct DictValidator {

--- a/pydantic-core/src/validators/enum_.rs
+++ b/pydantic-core/src/validators/enum_.rs
@@ -10,10 +10,10 @@ use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyType};
 use crate::build_tools::{is_strict, py_schema_err};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{Input, InputType};
-use crate::tools::{safe_repr, SchemaDict};
+use crate::tools::{SchemaDict, safe_repr};
 
 use super::is_instance::class_repr;
-use super::literal::{expected_repr_name, LiteralLookup};
+use super::literal::{LiteralLookup, expected_repr_name};
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator};
 
 #[derive(Debug, Clone)]

--- a/pydantic-core/src/validators/float.rs
+++ b/pydantic-core/src/validators/float.rs
@@ -1,10 +1,10 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+use pyo3::IntoPyObjectExt;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::{is_strict, schema_or_config_same};
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};

--- a/pydantic-core/src/validators/frozenset.rs
+++ b/pydantic-core/src/validators/frozenset.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use pyo3::types::{PyDict, PyFrozenSet};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::errors::ValResult;
-use crate::input::{validate_iter_to_set, BorrowInput, ConsumeIterator, Input, ValidatedSet};
+use crate::input::{BorrowInput, ConsumeIterator, Input, ValidatedSet, validate_iter_to_set};
 use crate::tools::SchemaDict;
 
 use super::list::min_length_check;

--- a/pydantic-core/src/validators/function.rs
+++ b/pydantic-core/src/validators/function.rs
@@ -3,21 +3,21 @@ use std::sync::Arc;
 use pyo3::exceptions::{PyAssertionError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyString};
-use pyo3::{intern, PyTraverseError, PyVisit};
+use pyo3::{PyTraverseError, PyVisit, intern};
 
+use crate::PydanticUseDefault;
 use crate::errors::{
     ErrorType, PydanticCustomError, PydanticKnownError, PydanticOmit, ToErrorValue, ValError, ValResult,
     ValidationError,
 };
 use crate::input::Input;
 use crate::py_gc::PyGcTraverse;
-use crate::tools::{function_name, safe_repr, SchemaDict};
-use crate::PydanticUseDefault;
+use crate::tools::{SchemaDict, function_name, safe_repr};
 
 use super::generator::InternalValidator;
 use super::{
-    build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, InputType, ValidationState,
-    Validator,
+    BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, InputType, ValidationState, Validator,
+    build_validator,
 };
 
 struct FunctionInfo {

--- a/pydantic-core/src/validators/generator.rs
+++ b/pydantic-core/src/validators/generator.rs
@@ -2,15 +2,15 @@ use std::fmt;
 use std::sync::Arc;
 
 use pyo3::types::{PyDict, PyString};
-use pyo3::{prelude::*, IntoPyObjectExt, PyTraverseError, PyVisit};
+use pyo3::{IntoPyObjectExt, PyTraverseError, PyVisit, prelude::*};
 
+use crate::ValidationError;
 use crate::build_tools::ExtraBehavior;
 use crate::errors::{ErrorType, LocItem, ValError, ValResult};
 use crate::input::{BorrowInput, GenericIterator, Input};
 use crate::py_gc::PyGcTraverse;
 use crate::recursion_guard::RecursionState;
 use crate::tools::SchemaDict;
-use crate::ValidationError;
 
 use super::list::get_items_schema;
 use super::{
@@ -185,8 +185,8 @@ impl ValidatorIterator {
         }
 
         match iterator {
-            GenericIterator::PyIterator(ref mut iter) => next!(iter),
-            GenericIterator::JsonArray(ref mut iter) => next!(iter),
+            GenericIterator::PyIterator(iter) => next!(iter),
+            GenericIterator::JsonArray(iter) => next!(iter),
         }
     }
 

--- a/pydantic-core/src/validators/int.rs
+++ b/pydantic-core/src/validators/int.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use num_bigint::BigInt;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
-use pyo3::IntoPyObjectExt;
 
-use crate::build_tools::is_strict;
 use crate::build_tools::LazyLock;
+use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{Input, Int};
 

--- a/pydantic-core/src/validators/json.rs
+++ b/pydantic-core/src/validators/json.rs
@@ -12,7 +12,7 @@ use crate::serializers::BytesMode;
 use crate::tools::SchemaDict;
 
 use super::config::ValBytesMode;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct JsonValidator {

--- a/pydantic-core/src/validators/json_or_python.rs
+++ b/pydantic-core/src/validators/json_or_python.rs
@@ -9,7 +9,7 @@ use crate::errors::ValResult;
 use crate::input::Input;
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, InputType, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, InputType, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct JsonOrPython {

--- a/pydantic-core/src/validators/lax_or_strict.rs
+++ b/pydantic-core/src/validators/lax_or_strict.rs
@@ -11,7 +11,7 @@ use crate::tools::SchemaDict;
 
 use super::Exactness;
 use super::ValidationState;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct LaxOrStrictValidator {

--- a/pydantic-core/src/validators/list.rs
+++ b/pydantic-core/src/validators/list.rs
@@ -1,15 +1,15 @@
 use std::sync::{Arc, OnceLock};
 
 use pyo3::types::PyDict;
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::errors::ValResult;
 use crate::input::{
-    no_validator_iter_to_vec, validate_iter_to_vec, BorrowInput, ConsumeIterator, Input, MaxLengthCheck, ValidatedList,
+    BorrowInput, ConsumeIterator, Input, MaxLengthCheck, ValidatedList, no_validator_iter_to_vec, validate_iter_to_vec,
 };
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct ListValidator {

--- a/pydantic-core/src/validators/literal.rs
+++ b/pydantic-core/src/validators/literal.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyInt, PyList};
-use pyo3::{intern, PyTraverseError, PyVisit};
+use pyo3::{PyTraverseError, PyVisit, intern};
 
 use ahash::AHashMap;
 

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -7,10 +7,10 @@ use jiter::{PartialMode, StringCacheMode};
 
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::types::{PyAny, PyDict, PyString, PyTuple, PyType};
-use pyo3::{intern, PyTraverseError, PyVisit};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
+use pyo3::{PyTraverseError, PyVisit, intern};
 
-use crate::build_tools::{py_schema_err, py_schema_error_type, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, py_schema_err, py_schema_error_type};
 use crate::definitions::{Definitions, DefinitionsBuilder};
 use crate::errors::{LocItem, ValError, ValResult, ValidationError};
 use crate::input::{Input, InputType, StringMapping};

--- a/pydantic-core/src/validators/model.rs
+++ b/pydantic-core/src/validators/model.rs
@@ -3,20 +3,20 @@ use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::types::{PyDict, PySet, PyString, PyTuple, PyType};
-use pyo3::{ffi, BoundObject, IntoPyObjectExt};
+use pyo3::{BoundObject, IntoPyObjectExt, ffi};
 use pyo3::{intern, prelude::*};
 
 use super::function::convert_err;
 use super::validation_state::Exactness;
 use super::{
-    build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, ValidationState, Validator,
+    BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, ValidationState, Validator, build_validator,
 };
+use crate::PydanticUndefinedType;
 use crate::build_tools::py_schema_err;
 use crate::build_tools::schema_or_config_same;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
-use crate::input::{input_as_python_instance, py_error_on_minusone, Input};
-use crate::tools::{py_err, SchemaDict};
-use crate::PydanticUndefinedType;
+use crate::input::{Input, input_as_python_instance, py_error_on_minusone};
+use crate::tools::{SchemaDict, py_err};
 
 const ROOT_FIELD: &str = "root";
 const DUNDER_DICT: &str = "__dict__";

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -9,7 +9,7 @@ use ahash::AHashSet;
 use pyo3::IntoPyObjectExt;
 
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{is_strict, schema_or_config_same, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, is_strict, schema_or_config_same};
 use crate::errors::LocItem;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::ConsumeIterator;
@@ -17,7 +17,7 @@ use crate::input::{BorrowInput, Input, ValidatedDict, ValidationMatch};
 use crate::lookup_key::LookupKeyCollection;
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 struct Field {
@@ -459,7 +459,7 @@ impl Validator for ModelFieldsValidator {
                             },
                             field_value,
                             field_name.to_string(),
-                        ))
+                        ));
                     }
                 }
             }

--- a/pydantic-core/src/validators/nullable.rs
+++ b/pydantic-core/src/validators/nullable.rs
@@ -9,7 +9,7 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::ValidationState;
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct NullableValidator {

--- a/pydantic-core/src/validators/set.rs
+++ b/pydantic-core/src/validators/set.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use pyo3::types::{PyDict, PySet};
-use pyo3::{prelude::*, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::errors::ValResult;
-use crate::input::{validate_iter_to_set, BorrowInput, ConsumeIterator, Input, ValidatedSet};
+use crate::input::{BorrowInput, ConsumeIterator, Input, ValidatedSet, validate_iter_to_set};
 use crate::tools::SchemaDict;
 
 use super::list::min_length_check;

--- a/pydantic-core/src/validators/string.rs
+++ b/pydantic-core/src/validators/string.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use pyo3::IntoPyObjectExt;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
-use pyo3::IntoPyObjectExt;
 use regex::Regex;
 
 use crate::build_tools::LazyLock;

--- a/pydantic-core/src/validators/time.rs
+++ b/pydantic-core/src/validators/time.rs
@@ -12,8 +12,8 @@ use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
-use super::datetime::extract_microseconds_precision;
 use super::datetime::TZConstraint;
+use super::datetime::extract_microseconds_precision;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 #[derive(Debug, Clone)]

--- a/pydantic-core/src/validators/timedelta.rs
+++ b/pydantic-core/src/validators/timedelta.rs
@@ -8,7 +8,7 @@ use speedate::{Duration, MicrosecondsPrecisionOverflowBehavior};
 
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ValError, ValResult};
-use crate::input::{duration_as_pytimedelta, Input};
+use crate::input::{Input, duration_as_pytimedelta};
 
 use super::datetime::extract_microseconds_precision;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};

--- a/pydantic-core/src/validators/tuple.rs
+++ b/pydantic-core/src/validators/tuple.rs
@@ -6,12 +6,12 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
 
 use crate::build_tools::is_strict;
-use crate::errors::{py_err_string, ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult};
+use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValLineError, ValResult, py_err_string};
 use crate::input::ConsumeIterator;
 use crate::input::{BorrowInput, Input, ValidatedTuple};
 use crate::tools::SchemaDict;
 
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 pub struct TupleValidator {

--- a/pydantic-core/src/validators/typed_dict.rs
+++ b/pydantic-core/src/validators/typed_dict.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString, PyType};
 
 use crate::build_tools::py_schema_err;
-use crate::build_tools::{is_strict, schema_or_config, ExtraBehavior};
+use crate::build_tools::{ExtraBehavior, is_strict, schema_or_config};
 use crate::errors::LocItem;
 use crate::errors::{ErrorTypeDefaults, ValError, ValLineError, ValResult};
 use crate::input::BorrowInput;
@@ -17,7 +17,7 @@ use crate::tools::SchemaDict;
 use ahash::AHashSet;
 use jiter::PartialMode;
 
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
 #[derive(Debug)]
 struct TypedDictField {
@@ -95,7 +95,7 @@ impl BuildValidator for TypedDictValidator {
             let required = match field_info.get_as::<bool>(intern!(py, "required"))? {
                 Some(required) => {
                     if required {
-                        if let CombinedValidator::WithDefault(ref val) = validator.as_ref() {
+                        if let CombinedValidator::WithDefault(val) = validator.as_ref() {
                             if val.has_default() {
                                 return py_schema_err!(
                                     "Field '{}': a required field cannot have a default value",
@@ -110,7 +110,7 @@ impl BuildValidator for TypedDictValidator {
             };
 
             if required {
-                if let CombinedValidator::WithDefault(ref val) = validator.as_ref() {
+                if let CombinedValidator::WithDefault(val) = validator.as_ref() {
                     if val.omit_on_error() {
                         return py_schema_err!(
                             "Field '{}': 'on_error = omit' cannot be set for required fields",

--- a/pydantic-core/src/validators/union.rs
+++ b/pydantic-core/src/validators/union.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::py_gc::PyGcTraverse;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString, PyTuple};
-use pyo3::{intern, PyTraverseError, PyVisit};
+use pyo3::{PyTraverseError, PyVisit, intern};
 use smallvec::SmallVec;
 
 use crate::build_tools::py_schema_err;
@@ -18,7 +18,7 @@ use crate::tools::SchemaDict;
 use super::custom_error::CustomError;
 use super::literal::LiteralLookup;
 use super::{
-    build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator,
+    BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator, build_validator,
 };
 
 #[derive(Debug)]
@@ -144,7 +144,7 @@ impl UnionValidator {
                         let new_success_is_best_match: bool =
                             best_match
                                 .as_ref()
-                                .map_or(true, |(_, cur_exactness, cur_fields_set_count)| {
+                                .is_none_or(|(_, cur_exactness, cur_fields_set_count)| {
                                     match (*cur_fields_set_count, new_fields_set_count) {
                                         (Some(cur), Some(new)) if cur != new => cur < new,
                                         _ => *cur_exactness < new_exactness,

--- a/pydantic-core/src/validators/url.rs
+++ b/pydantic-core/src/validators/url.rs
@@ -11,18 +11,18 @@ use ahash::AHashSet;
 use pyo3::IntoPyObjectExt;
 use url::{ParseError, SyntaxViolation, Url};
 
-use crate::build_tools::schema_or_config;
 use crate::build_tools::LazyLock;
+use crate::build_tools::schema_or_config;
 use crate::build_tools::{is_strict, py_schema_err};
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
-use crate::input::downcast_python_input;
 use crate::input::Input;
 use crate::input::ValidationMatch;
+use crate::input::downcast_python_input;
 use crate::tools::SchemaDict;
-use crate::url::{scheme_is_special, PyMultiHostUrl, PyUrl};
+use crate::url::{PyMultiHostUrl, PyUrl, scheme_is_special};
 
-use super::literal::expected_repr_name;
 use super::Exactness;
+use super::literal::expected_repr_name;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
 type AllowedSchemes = Option<(AHashSet<String>, String)>;

--- a/pydantic-core/src/validators/uuid.rs
+++ b/pydantic-core/src/validators/uuid.rs
@@ -10,10 +10,10 @@ use uuid::Variant;
 
 use crate::build_tools::is_strict;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
-use crate::input::input_as_python_instance;
 use crate::input::Input;
 use crate::input::InputType;
 use crate::input::ValidationMatch;
+use crate::input::input_as_python_instance;
 use crate::serializers::BytesMode;
 use crate::tools::SchemaDict;
 

--- a/pydantic-core/src/validators/validation_state.rs
+++ b/pydantic-core/src/validators/validation_state.rs
@@ -87,7 +87,7 @@ impl<'a, 'py> ValidationState<'a, 'py> {
         &self.extra
     }
 
-    pub fn enumerate_last_partial<I>(&self, iter: impl Iterator<Item = I>) -> impl Iterator<Item = (usize, bool, I)> {
+    pub fn enumerate_last_partial<I: Iterator>(&self, iter: I) -> EnumerateLastPartial<I> {
         EnumerateLastPartial::new(iter, self.allow_partial)
     }
 

--- a/pydantic-core/src/validators/with_default.rs
+++ b/pydantic-core/src/validators/with_default.rs
@@ -1,21 +1,21 @@
 use std::sync::Arc;
 
+use pyo3::PyTraverseError;
+use pyo3::PyVisit;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::PyDict;
 use pyo3::types::PyString;
-use pyo3::PyTraverseError;
-use pyo3::PyVisit;
 
-use super::{build_validator, BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::PydanticUndefinedType;
 use crate::build_tools::py_schema_err;
 use crate::build_tools::schema_or_config_same;
 use crate::errors::{ErrorTypeDefaults, LocItem, ValError, ValResult};
 use crate::input::Input;
 use crate::py_gc::PyGcTraverse;
 use crate::tools::SchemaDict;
-use crate::PydanticUndefinedType;
 
 static COPY_DEEPCOPY: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
@@ -51,8 +51,8 @@ impl DefaultType {
 
     pub fn default_value(&self, py: Python, validated_data: Option<&Bound<PyDict>>) -> PyResult<Option<Py<PyAny>>> {
         match self {
-            Self::Default(ref default) => Ok(Some(default.clone_ref(py))),
-            Self::DefaultFactory(ref default_factory, ref takes_data) => {
+            Self::Default(default) => Ok(Some(default.clone_ref(py))),
+            Self::DefaultFactory(default_factory, takes_data) => {
                 let result = if *takes_data {
                     if let Some(data) = validated_data {
                         default_factory.call1(py, (data,))


### PR DESCRIPTION
## Change Summary

We will be considering a Rust version bump soon for PyO3 anyway (next version will be Rust 1.83). I propose we go slightly further, to 1.85, so that we can adopt the new edition's improved semantics.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
