### PR TITLE
Remove internal deprecated keyword argument due to python 3.14 change

### DIFF
--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -532,7 +532,6 @@ def _eval_type(
             # infer it from the `ForwardRef.__forward_module__` attribute instead (`typing.get_type_hints()`
             # does the same). Note that this would probably be unnecessary if we properly iterated over the
             # `__orig_bases__` for TypedDicts in `get_cls_type_hints()`:
-            prefer_fwd_module=True,
         )
         if evaluated is None:
             evaluated = type(None)


### PR DESCRIPTION
Python 3.14 introduced breaking changes in typing and _eval_type(). This keyword argument does not exist anymore.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Ran into this issue using a str | None type on an attribute.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
