### PR TITLE
Add `pydantic_core` coverage to pydantic coverage measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ pydocstyle = { convention = 'google' }
 quote-style = 'single'
 
 [tool.coverage.run]
-source = ['pydantic']
+source = ['pydantic', 'pydantic_core']
 omit = ['pydantic/deprecated/*', 'pydantic/v1/*']
 branch = true
 relative_files = true


### PR DESCRIPTION
## Change Summary

This PR adds coverage of `pydantic_core` Python files to the coverage report generated by CI. A follow-up change to come to add Rust coverage for `pydantic_core`.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
