### PR TITLE
Fix typo in Standard Library Types documentation

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -266,7 +266,7 @@ Standard library type: [`enum.IntEnum`][].
 <h4>Validation</h4>
 
 * If the [`enum.IntEnum`][] type is used directly, any [`enum.IntEnum`][] instance is validated as-is
-* Id an [`enum.IntEnum`][] subclass is used as a type, any enum member or value that correspond to the
+* If an [`enum.IntEnum`][] subclass is used as a type, any enum member or value that correspond to the
   enum members values is validated as-is.
 
 See [Enums](#enums) for more details.
@@ -690,7 +690,7 @@ Standard library type: [`enum.Enum`][].
 <h3>Validation</h3>
 
 * If the [`enum.Enum`][] type is used directly, any [`enum.Enum`][] instance is validated as-is.
-* Id an [`enum.Enum`][] subclass is used as a type, any enum member or value that correspond to the
+* If an [`enum.Enum`][] subclass is used as a type, any enum member or value that correspond to the
   enum members [values][enum.Enum.value] is validated as-is.
 
 <h3>Serialization</h3>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Corrects "Id" to "If" in Integer enums and Enums section in Standard Library Types.

## Related issue number

None

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

<!-- please review -->