### PR TITLE
Do not add claim of UUID "safety" provision

### DIFF
--- a/pydantic-core/tests/validators/test_uuid.py
+++ b/pydantic-core/tests/validators/test_uuid.py
@@ -1,6 +1,6 @@
 import copy
 import re
-from uuid import UUID
+from uuid import UUID, SafeUUID
 
 import pytest
 
@@ -234,3 +234,8 @@ def test_uuid_wrap_json():
     assert v.validate_json('"a6cc5730-2261-11ee-9c43-2eb5a363657c"', strict=True) == UUID(
         'a6cc5730-2261-11ee-9c43-2eb5a363657c'
     )
+
+
+def uuid_safety_unknown():
+    output = SchemaValidator(core_schema.uuid_schema()).validate_python('a6cc5730-2261-11ee-9c43-2eb5a363657c')
+    assert output.is_safe is SafeUUID.unknown


### PR DESCRIPTION
## Change Summary

This changes validate UUIDs to have `is_safe` set to `SafeUUID.unknown` rather than `SafeUUID.safe`. This seems to have changed in #6831 with no justification why, and doesn't really match the stdlib constructors which typically do not set this (except for `uuid1()`).

At the same time, I added caching for the value of the enum member - I first noticed this when studying #12550 as to why the north star JSON validation was not improved by the changes and discovered some (small) overhead here.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
