### PR TITLE
Optimize implementation of `LookupKey`

### DIFF
--- a/pydantic-core/src/common/union.rs
+++ b/pydantic-core/src/common/union.rs
@@ -13,12 +13,12 @@ pub enum Discriminator {
 }
 
 impl Discriminator {
-    pub fn new(py: Python, raw: &Bound<'_, PyAny>) -> PyResult<Self> {
+    pub fn new(raw: &Bound<'_, PyAny>) -> PyResult<Self> {
         if raw.is_callable() {
             return Ok(Self::Function(raw.clone().unbind()));
         }
 
-        let lookup_key = LookupKey::from_py(py, raw, None)?;
+        let lookup_key = LookupKey::from_py(raw, None)?;
         Ok(Self::LookupKey(lookup_key))
     }
 

--- a/pydantic-core/src/lookup_key.rs
+++ b/pydantic-core/src/lookup_key.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyList, PyMapping, PyString};
 
 use jiter::{JsonObject, JsonValue};
@@ -46,14 +47,13 @@ impl fmt::Display for LookupKey {
 }
 
 impl LookupKey {
-    pub fn from_py(py: Python, value: &Bound<'_, PyAny>, alt_alias: Option<&str>) -> PyResult<Self> {
+    pub fn from_py(value: &Bound<'_, PyAny>, alt_alias: Option<&Bound<'_, PyString>>) -> PyResult<Self> {
         if let Ok(alias_py) = value.cast::<PyString>() {
-            let alias: String = alias_py.extract()?;
-            let path1 = LookupPath::from_str(py, &alias, Some(alias_py.clone()));
+            let path1 = LookupPath::from_str(alias_py.clone())?;
             match alt_alias {
                 Some(alt_alias) => Ok(Self::Choice {
                     path1,
-                    path2: LookupPath::from_str(py, alt_alias, None),
+                    path2: LookupPath::from_str(alt_alias.clone())?,
                 }),
                 None => Ok(Self::Simple(path1)),
             }
@@ -72,29 +72,17 @@ impl LookupKey {
             };
 
             if let Some(alt_alias) = alt_alias {
-                locs.push(LookupPath::from_str(py, alt_alias, None));
+                locs.push(LookupPath::from_str(alt_alias.clone())?);
             }
             Ok(Self::PathChoices(locs))
         }
-    }
-
-    pub fn from_string(py: Python, key: &str) -> Self {
-        Self::simple(py, key, None)
-    }
-
-    fn simple(py: Python, key: &str, opt_py_key: Option<Bound<'_, PyString>>) -> Self {
-        Self::Simple(LookupPath::from_str(py, key, opt_py_key))
     }
 
     pub fn py_get_dict_item<'py, 's>(
         &'s self,
         dict: &Bound<'py, PyDict>,
     ) -> PyResult<Option<(&'s LookupPath, Bound<'py, PyAny>)>> {
-        self.get_impl(
-            dict,
-            |dict, path| dict.get_item(&path.py_key),
-            |d, loc| Ok(loc.py_get_item(&d)),
-        )
+        self.get_impl(dict, PyDictMethods::get_item, |d, loc| Ok(loc.py_get_item(&d)))
     }
 
     pub fn py_get_string_mapping_item<'py, 's>(
@@ -113,22 +101,14 @@ impl LookupKey {
         &'s self,
         dict: &Bound<'py, PyMapping>,
     ) -> PyResult<Option<(&'s LookupPath, Bound<'py, PyAny>)>> {
-        self.get_impl(
-            dict,
-            |dict, path| mapping_get(dict, &path.py_key),
-            |d, loc| Ok(loc.py_get_item(&d)),
-        )
+        self.get_impl(dict, mapping_get, |d, loc| Ok(loc.py_get_item(&d)))
     }
 
     pub fn simple_py_get_attr<'py, 's>(
         &'s self,
         obj: &Bound<'py, PyAny>,
     ) -> PyResult<Option<(&'s LookupPath, Bound<'py, PyAny>)>> {
-        self.get_impl(
-            obj,
-            |obj, path| obj.getattr_opt(&path.py_key),
-            |d, loc| loc.py_get_attrs(&d),
-        )
+        self.get_impl(obj, PyAnyMethods::getattr_opt, |d, loc| loc.py_get_attrs(&d))
     }
 
     pub fn py_get_attr<'py, 's>(
@@ -290,7 +270,7 @@ impl LookupKey {
             for item in lookup_path.rest.iter().rev() {
                 location.push(item.to_loc_item());
             }
-            location.push(LocItem::from(&lookup_path.first_item.key));
+            location.push(LocItem::from(lookup_path.first_item.0.clone()));
 
             ValLineError::new_with_full_loc(error_type, input, Location::List(location))
         } else {
@@ -318,18 +298,11 @@ impl fmt::Display for LookupPath {
 }
 
 impl LookupPath {
-    fn from_str(py: Python, key: &str, py_key: Option<Bound<'_, PyString>>) -> Self {
-        let py_key = match py_key {
-            Some(py_key) => py_key,
-            None => PyString::new(py, key),
-        };
-        Self {
-            first_item: PathItemString {
-                key: key.to_string(),
-                py_key: py_key.clone().unbind(),
-            },
+    fn from_str(py_key: Bound<'_, PyString>) -> PyResult<Self> {
+        Ok(Self {
+            first_item: PathItemString(py_key.try_into()?),
             rest: Vec::new(),
-        }
+        })
     }
 
     fn from_list(obj: &Bound<'_, PyAny>) -> PyResult<LookupPath> {
@@ -343,10 +316,7 @@ impl LookupPath {
             return py_err!(PyTypeError; "The first item in an alias path should be a string");
         };
 
-        let first_item = PathItemString {
-            key: first_item_py_str.to_str()?.to_owned(),
-            py_key: first_item_py_str.clone().unbind(),
-        };
+        let first_item = PathItemString(first_item_py_str.try_into()?);
 
         let rest = iter.map(PathItem::from_py).collect::<PyResult<_>>()?;
 
@@ -358,7 +328,7 @@ impl LookupPath {
             for path_item in self.rest.iter().rev() {
                 line_error = line_error.with_outer_location(path_item.to_loc_item());
             }
-            line_error = line_error.with_outer_location(&self.first_item.key);
+            line_error = line_error.with_outer_location(self.first_item.0.clone());
             line_error
         } else {
             line_error.with_outer_location(field_name)
@@ -368,7 +338,7 @@ impl LookupPath {
     /// get the `str` from the first item in the path, note paths always have length > 0, and the first item
     /// is always a string
     pub fn first_key(&self) -> &str {
-        &self.first_item.key
+        &self.first_item
     }
 }
 
@@ -380,12 +350,25 @@ pub(crate) enum PathItem {
     Neg(usize),
 }
 
-/// string type key, used to get or identify items from a dict or anything that implements `__getitem__`
-/// we store both the string and pystring to save creating the pystring for python
+/// String type key, used to get or identify items from a dict or anything that implements `__getitem__`
 #[derive(Debug, Clone)]
-pub(crate) struct PathItemString {
-    key: String,
-    py_key: Py<PyString>,
+pub(crate) struct PathItemString(
+    // stores the original Python value, easily accessible as a Rust &str
+    PyBackedStr,
+);
+
+impl fmt::Display for PathItemString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "'{key}'", key = &self.0)
+    }
+}
+
+impl std::ops::Deref for PathItemString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl fmt::Display for PathItem {
@@ -395,12 +378,6 @@ impl fmt::Display for PathItem {
             Self::Pos(key) => write!(f, "{key}"),
             Self::Neg(key) => write!(f, "-{key}"),
         }
-    }
-}
-
-impl fmt::Display for PathItemString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "'{key}'", key = &self.key)
     }
 }
 
@@ -421,13 +398,16 @@ impl<'py> IntoPyObject<'py> for &'_ PathItem {
     }
 }
 
-impl<'a, 'py> IntoPyObject<'py> for &'a PathItemString {
+impl<'py> IntoPyObject<'py> for &'_ PathItemString {
     type Target = PyString;
-    type Output = Borrowed<'a, 'py, PyString>;
+    type Output = Bound<'py, PyString>;
     type Error = Infallible;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(self.py_key.bind_borrowed(py))
+        (&self.0).into_pyobject(py).map(|obj|
+            // SAFETY: `PyBackedStr` always returns a `PyString`, should open a PyO3 issue to not
+            // need this unsafe cast
+            unsafe { obj.cast_into_unchecked() })
     }
 }
 
@@ -435,11 +415,7 @@ impl PathItem {
     pub fn from_py(obj: Bound<'_, PyAny>) -> PyResult<Self> {
         let obj = match obj.cast_into::<PyString>() {
             Ok(py_str_key) => {
-                let str_key = py_str_key.to_str()?.to_string();
-                return Ok(Self::S(PathItemString {
-                    key: str_key,
-                    py_key: py_str_key.unbind(),
-                }));
+                return Ok(Self::S(PathItemString(py_str_key.try_into()?)));
             }
             Err(e) => e.into_inner(),
         };
@@ -492,14 +468,14 @@ impl PathItem {
 
     pub fn json_obj_get<'a, 'data>(&self, json_obj: &'a JsonObject<'data>) -> Option<&'a JsonValue<'data>> {
         match self {
-            Self::S(PathItemString { key, .. }) => json_obj.iter().rev().find_map(|(k, v)| (k == key).then_some(v)),
+            Self::S(PathItemString(key)) => json_obj.iter().rev().find_map(|(k, v)| (k == &**key).then_some(v)),
             _ => None,
         }
     }
 
     fn to_loc_item(&self) -> LocItem {
         match self {
-            Self::S(PathItemString { key, .. }) => LocItem::from(key),
+            Self::S(PathItemString(key)) => LocItem::from(key.clone()),
             Self::Pos(index) => LocItem::from(*index),
             Self::Neg(index) => LocItem::from(-(*index as i64)),
         }
@@ -510,13 +486,13 @@ impl PathItemString {
     fn py_get_attrs<'py>(&self, obj: &Bound<'py, PyAny>) -> PyResult<Option<Bound<'py, PyAny>>> {
         // if obj is a dict, we want to use get_item, not getattr
         if let Ok(d) = obj.cast_exact::<PyDict>() {
-            d.get_item(&self.py_key)
+            d.get_item(self)
         } else if obj.is_instance_of::<PyDict>() {
             // NB this deliberately goes through PyAnyMethods::get_item to allow subclasses of dict to override getitem
-            // FIXME: should this instance check be for Mapping instead of Dict?
-            Ok(obj.get_item(&self.py_key).ok())
+            // FIXME: should this instance check be for Mapping instead of Dict, and use `mapping_get`?
+            Ok(obj.get_item(self).ok())
         } else {
-            obj.getattr_opt(&self.py_key)
+            obj.getattr_opt(self)
         }
     }
 }
@@ -530,12 +506,12 @@ pub struct LookupKeyCollection {
 }
 
 impl LookupKeyCollection {
-    pub fn new(py: Python, validation_alias: Option<Bound<'_, PyAny>>, field_name: &str) -> PyResult<Self> {
-        let by_name = LookupKey::from_string(py, field_name);
+    pub fn new(validation_alias: Option<Bound<'_, PyAny>>, field_name: &Bound<'_, PyString>) -> PyResult<Self> {
+        let by_name = LookupKey::from_py(field_name, None)?;
 
         if let Some(va) = validation_alias {
-            let by_alias = Some(LookupKey::from_py(py, &va, None)?);
-            let by_alias_then_name = Some(LookupKey::from_py(py, &va, Some(field_name))?);
+            let by_alias = Some(LookupKey::from_py(&va, None)?);
+            let by_alias_then_name = Some(LookupKey::from_py(&va, Some(field_name))?);
             Ok(Self {
                 by_name,
                 by_alias,

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -204,7 +204,7 @@ impl BuildSerializer for TaggedUnionSerializer {
         definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
     ) -> PyResult<Arc<CombinedSerializer>> {
         let py = schema.py();
-        let discriminator = Discriminator::new(py, &schema.get_as_req(intern!(py, "discriminator"))?)?;
+        let discriminator = Discriminator::new(&schema.get_as_req(intern!(py, "discriminator"))?)?;
 
         // TODO: guarantee at least 1 choice
         let choices_map: Bound<PyDict> = schema.get_as_req(intern!(py, "choices"))?;

--- a/pydantic-core/src/validators/arguments.rs
+++ b/pydantic-core/src/validators/arguments.rs
@@ -99,6 +99,9 @@ impl BuildValidator for ArgumentsValidator {
                 had_keyword_only = true;
             }
 
+            let validation_alias = arg.get_item(intern!(py, "alias"))?;
+            let lookup_key_collection = LookupKeyCollection::new(validation_alias, &py_name)?;
+
             let kwarg_key = if matches!(mode, "keyword_only" | "positional_or_keyword") {
                 Some(py_name.unbind())
             } else {
@@ -127,9 +130,6 @@ impl BuildValidator for ArgumentsValidator {
             } else if has_default {
                 had_default_arg = true;
             }
-
-            let validation_alias = arg.get_item(intern!(py, "alias"))?;
-            let lookup_key_collection = LookupKeyCollection::new(py, validation_alias, name.as_str())?;
 
             parameters.push(Parameter {
                 positional,

--- a/pydantic-core/src/validators/arguments_v3.rs
+++ b/pydantic-core/src/validators/arguments_v3.rs
@@ -185,7 +185,7 @@ impl BuildValidator for ArgumentsV3Validator {
             }
 
             let validation_alias = arg.get_item(intern!(py, "alias"))?;
-            let lookup_key_collection = LookupKeyCollection::new(py, validation_alias, name.as_str())?;
+            let lookup_key_collection = LookupKeyCollection::new(validation_alias, &py_name)?;
 
             parameters.push(Parameter {
                 name,

--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -96,7 +96,7 @@ impl BuildValidator for DataclassArgsValidator {
             }
 
             let validation_alias = field.get_item(intern!(py, "validation_alias"))?;
-            let lookup_key_collection = LookupKeyCollection::new(py, validation_alias, name.as_str())?;
+            let lookup_key_collection = LookupKeyCollection::new(validation_alias, &name_py)?;
 
             fields.push(Field {
                 kw_only,

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -90,7 +90,7 @@ impl BuildValidator for ModelFieldsValidator {
             };
 
             let validation_alias = field_info.get_item(intern!(py, "validation_alias"))?;
-            let lookup_key_collection = LookupKeyCollection::new(py, validation_alias, field_name)?;
+            let lookup_key_collection = LookupKeyCollection::new(validation_alias, &field_name_py)?;
 
             fields.push(Field {
                 name: field_name.to_string(),

--- a/pydantic-core/src/validators/typed_dict.rs
+++ b/pydantic-core/src/validators/typed_dict.rs
@@ -121,7 +121,7 @@ impl BuildValidator for TypedDictValidator {
             }
 
             let validation_alias = field_info.get_item(intern!(py, "validation_alias"))?;
-            let lookup_key_collection = LookupKeyCollection::new(py, validation_alias, field_name)?;
+            let lookup_key_collection = LookupKeyCollection::new(validation_alias, &field_name_py)?;
 
             fields.push(TypedDictField {
                 name: field_name.to_string(),

--- a/pydantic-core/src/validators/union.rs
+++ b/pydantic-core/src/validators/union.rs
@@ -300,7 +300,7 @@ impl BuildValidator for TaggedUnionValidator {
         definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
-        let discriminator = Discriminator::new(py, &schema.get_as_req(intern!(py, "discriminator"))?)?;
+        let discriminator = Discriminator::new(&schema.get_as_req(intern!(py, "discriminator"))?)?;
         let discriminator_repr = discriminator.to_string_py(py)?;
 
         let choices = PyDict::new(py);


### PR DESCRIPTION
## Change Summary

Attempting to win back some of the schema build performance lost in #12550 

The main goal here is to avoid creating `String` values in Rust when we already have a Python `str`. PyO3 has a `PyBackedStr` type which contains the Python value while allowing easier readability, so I use this instead of `String` + `Py<PyString>` inside `LookupKey`.

There may be other places in the code where we can do similar, this one seemed most obviously worth doing.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
