### PR TITLE
Use inline format arguments in Rust error handling macros

### DIFF
--- a/pydantic-core/src/build_tools.rs
+++ b/pydantic-core/src/build_tools.rs
@@ -159,21 +159,15 @@ impl SchemaError {
 }
 
 macro_rules! py_schema_error_type {
-    ($msg:expr) => {
-        crate::tools::py_error_type!(crate::build_tools::SchemaError; $msg)
-    };
-    ($msg:expr, $( $msg_args:expr ),+ ) => {
-        crate::tools::py_error_type!(crate::build_tools::SchemaError; $msg, $( $msg_args ),+)
+    ($( $msg_args:expr ),+ ) => {
+        crate::tools::py_error_type!(crate::build_tools::SchemaError; $( $msg_args ),+)
     };
 }
 pub(crate) use py_schema_error_type;
 
 macro_rules! py_schema_err {
-    ($msg:expr) => {
-        Err(crate::build_tools::py_schema_error_type!($msg))
-    };
-    ($msg:expr, $( $msg_args:expr ),+ ) => {
-        Err(crate::build_tools::py_schema_error_type!($msg, $( $msg_args ),+))
+    ($( $msg_args:expr ),+ ) => {
+        Err(crate::build_tools::py_schema_error_type!($( $msg_args ),+))
     };
 }
 pub(crate) use py_schema_err;
@@ -215,7 +209,7 @@ impl FromStr for ExtraBehavior {
             "allow" => Ok(Self::Allow),
             "forbid" => Ok(Self::Forbid),
             "ignore" => Ok(Self::Ignore),
-            s => py_schema_err!("Invalid extra_behavior: `{}`", s),
+            s => py_schema_err!("Invalid extra_behavior: `{s}`"),
         }
     }
 }

--- a/pydantic-core/src/definitions.rs
+++ b/pydantic-core/src/definitions.rs
@@ -169,7 +169,7 @@ impl<T: std::fmt::Debug> DefinitionsBuilder<T> {
                 let definition = entry.into_mut();
                 match definition.value.set(value) {
                     Ok(()) => definition,
-                    Err(_) => return py_schema_err!("Duplicate ref: `{}`", reference),
+                    Err(_) => return py_schema_err!("Duplicate ref: `{reference}`"),
                 }
             }
             Entry::Vacant(entry) => entry.insert(Definition {
@@ -188,7 +188,7 @@ impl<T: std::fmt::Debug> DefinitionsBuilder<T> {
     pub fn finish(self) -> PyResult<Definitions<T>> {
         for (reference, def) in &self.definitions.0 {
             if def.value.get().is_none() {
-                return py_schema_err!("Definitions error: definition `{}` was never filled", reference);
+                return py_schema_err!("Definitions error: definition `{reference}` was never filled");
             }
         }
         Ok(self.definitions)

--- a/pydantic-core/src/errors/types.rs
+++ b/pydantic-core/src/errors/types.rs
@@ -49,11 +49,13 @@ fn field_from_context<'py, T: FromPyObjectOwned<'py>>(
     type_name_fn: fn() -> &'static str,
 ) -> PyResult<T> {
     context
-        .ok_or_else(|| py_error_type!(PyTypeError; "{}: '{}' required in context", enum_name, field_name))?
+        .ok_or_else(|| py_error_type!(PyTypeError; "{enum_name}: '{field_name}' required in context"))?
         .get_item(field_name)?
-        .ok_or_else(|| py_error_type!(PyTypeError; "{}: '{}' required in context", enum_name, field_name))?
+        .ok_or_else(|| py_error_type!(PyTypeError; "{enum_name}: '{field_name}' required in context"))?
         .extract::<T>()
-        .map_err(|_| py_error_type!(PyTypeError; "{}: '{}' context value must be a {}", enum_name, field_name, type_name_fn()))
+        .map_err(
+            |_| py_error_type!(PyTypeError; "{enum_name}: '{field_name}' context value must be a {}", type_name_fn()),
+        )
 }
 
 fn cow_field_from_context<'py, T: FromPyObjectOwned<'py>, B: ToOwned<Owned = T> + ?Sized + 'static>(
@@ -102,7 +104,7 @@ macro_rules! error_types {
                 let lookup = ERROR_TYPE_LOOKUP.get_or_init(py, Self::build_lookup);
                 let error_type = match lookup.get(value) {
                     Some(error_type) => error_type.clone(),
-                    None => return py_err!(PyKeyError; "Invalid error type: '{}'", value),
+                    None => return py_err!(PyKeyError; "Invalid error type: '{value}'"),
                 };
                 match error_type {
                     $(

--- a/pydantic-core/src/input/input_abstract.rs
+++ b/pydantic-core/src/input/input_abstract.rs
@@ -44,7 +44,7 @@ impl TryFrom<&str> for InputType {
             "python" => Ok(Self::Python),
             "json" => Ok(Self::Json),
             "string" => Ok(Self::String),
-            s => py_err!(PyValueError; "Invalid error mode: {}", s),
+            s => py_err!(PyValueError; "Invalid error mode: {s}"),
         }
     }
 }

--- a/pydantic-core/src/serializers/computed_fields.rs
+++ b/pydantic-core/src/serializers/computed_fields.rs
@@ -173,7 +173,7 @@ impl ComputedField {
         let property_name: Bound<'_, PyString> = schema.get_as_req(intern!(py, "property_name"))?;
         let return_schema = schema.get_as_req(intern!(py, "return_schema"))?;
         let serializer = CombinedSerializer::build(&return_schema, config, definitions)
-            .map_err(|e| py_schema_error_type!("Computed field `{}`:\n  {}", property_name, e))?;
+            .map_err(|e| py_schema_error_type!("Computed field `{property_name}`:\n  {e}"))?;
         let alias_py = schema
             .get_as(intern!(py, "alias"))?
             .unwrap_or_else(|| property_name.clone());

--- a/pydantic-core/src/serializers/errors.rs
+++ b/pydantic-core/src/serializers/errors.rs
@@ -86,8 +86,8 @@ impl fmt::Display for PydanticSerializationError {
 }
 
 impl PydanticSerializationError {
-    pub(crate) fn new_err(msg: String) -> PyErr {
-        PyErr::new::<Self, String>(msg)
+    pub(crate) fn new_err<T: Into<String>>(msg: T) -> PyErr {
+        PyErr::new::<Self, String>(msg.into())
     }
 }
 

--- a/pydantic-core/src/serializers/infer.rs
+++ b/pydantic-core/src/serializers/infer.rs
@@ -568,7 +568,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
             Ok(Cow::Owned(key_build.finish()))
         }
         ObType::List | ObType::Set | ObType::Frozenset | ObType::Dict | ObType::Generator => {
-            py_err!(PyTypeError; "`{}` not valid as object key", ob_type)
+            py_err!(PyTypeError; "`{ob_type}` not valid as object key")
         }
         ObType::Dataclass | ObType::PydanticSerializable => {
             // check that the instance is hashable

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -63,16 +63,16 @@ macro_rules! combined_serializer {
                     $(
                         <$b_serializer>::EXPECTED_TYPE => match <$b_serializer>::build(schema, config, definitions) {
                             Ok(serializer) => Ok(serializer),
-                            Err(err) => py_schema_err!("Error building `{}` serializer:\n  {}", lookup_type, err),
+                            Err(err) => py_schema_err!("Error building `{lookup_type}` serializer:\n  {err}"),
                         },
                     )*
                     $(
                         <$builder>::EXPECTED_TYPE => match <$builder>::build(schema, config, definitions) {
                             Ok(serializer) => Ok(serializer),
-                            Err(err) => py_schema_err!("Error building `{}` serializer:\n  {}", lookup_type, err),
+                            Err(err) => py_schema_err!("Error building `{lookup_type}` serializer:\n  {err}"),
                         },
                     )*
-                    _ => py_schema_err!("Unknown serialization schema type: `{}`", lookup_type),
+                    _ => py_schema_err!("Unknown serialization schema type: `{lookup_type}`"),
                 }
             }
         }
@@ -186,7 +186,7 @@ impl CombinedSerializer {
                         config,
                         definitions,
                     )
-                    .map_err(|err| py_schema_error_type!("Error building `function-plain` serializer:\n  {}", err));
+                    .map_err(|err| py_schema_error_type!("Error building `function-plain` serializer:\n  {err}"));
                 }
                 Some("function-wrap") => {
                     // `function-wrap` is also a special case, not included in `find_serializer` since it mean
@@ -197,7 +197,7 @@ impl CombinedSerializer {
                         config,
                         definitions,
                     )
-                    .map_err(|err| py_schema_error_type!("Error building `function-wrap` serializer:\n  {}", err));
+                    .map_err(|err| py_schema_error_type!("Error building `function-wrap` serializer:\n  {err}"));
                 }
                 Some(
                     // applies to lists tuples and dicts, does not override the main schema `type`
@@ -379,7 +379,7 @@ pub(crate) trait TypeSerializer: Send + Sync + Debug {
         expected_type: &'static str,
     ) -> PyResult<Cow<'a, str>> {
         match state.extra.ob_type_lookup.is_type(key, ObType::None) {
-            IsType::Exact | IsType::Subclass => py_err!(PyTypeError; "`{}` not valid as object key", expected_type),
+            IsType::Exact | IsType::Subclass => py_err!(PyTypeError; "`{expected_type}` not valid as object key"),
             IsType::False => {
                 state.warn_fallback_py(self.get_name(), key)?;
                 infer_json_key(key, state)

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -53,7 +53,7 @@ impl BuildSerializer for DataclassArgsBuilder {
                 } else {
                     let schema = field_info.get_as_req(intern!(py, "schema"))?;
                     let serializer = CombinedSerializer::build(&schema, config, definitions)
-                        .map_err(|e| py_schema_error_type!("Field `{}`:\n  {}", index, e))?;
+                        .map_err(|e| py_schema_error_type!("Field `{index}`:\n  {e}"))?;
 
                     let alias = field_info.get_as(intern!(py, "serialization_alias"))?;
                     let serialization_exclude_if: Option<Py<PyAny>> =

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -200,11 +200,11 @@ fn on_error(py: Python, err: PyErr, function_name: &str, state: &mut Serializati
             Ok(())
         }
     } else if let Ok(err) = exception.extract::<PydanticSerializationError>() {
-        py_err!(PydanticSerializationError; "{}", err)
+        py_err!(PydanticSerializationError; "{err}")
     } else if exception.is_instance_of::<PyRecursionError>() {
-        py_err!(PydanticSerializationError; "Error calling function `{}`: RecursionError", function_name)
+        py_err!(PydanticSerializationError; "Error calling function `{function_name}`: RecursionError")
     } else {
-        let new_err = py_error_type!(PydanticSerializationError; "Error calling function `{}`: {}", function_name, err);
+        let new_err = py_error_type!(PydanticSerializationError; "Error calling function `{function_name}`: {err}");
         new_err.set_cause(py, Some(err));
         Err(new_err)
     }

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -73,7 +73,7 @@ impl BuildSerializer for ModelFieldsBuilder {
                     field_info.get_as(intern!(py, "serialization_exclude_if"))?;
                 let schema = field_info.get_as_req(intern!(py, "schema"))?;
                 let serializer = CombinedSerializer::build(&schema, config, definitions)
-                    .map_err(|e| py_schema_error_type!("Field `{}`:\n  {}", key, e))?;
+                    .map_err(|e| py_schema_error_type!("Field `{key}`:\n  {e}"))?;
 
                 fields.insert(
                     key,

--- a/pydantic-core/src/serializers/type_serializers/typed_dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/typed_dict.rs
@@ -73,7 +73,7 @@ impl BuildSerializer for TypedDictSerializer {
                     field_info.get_as(intern!(py, "serialization_exclude_if"))?;
                 let schema = field_info.get_as_req(intern!(py, "schema"))?;
                 let serializer = CombinedSerializer::build(&schema, config, definitions)
-                    .map_err(|e| py_schema_error_type!("Field `{}`:\n  {}", key, e))?;
+                    .map_err(|e| py_schema_error_type!("Field `{key}`:\n  {e}"))?;
                 fields.insert(
                     key,
                     SerField::new(

--- a/pydantic-core/src/validators/arguments.rs
+++ b/pydantic-core/src/validators/arguments.rs
@@ -112,13 +112,13 @@ impl BuildValidator for ArgumentsValidator {
 
             let validator = match build_validator(&schema, config, definitions) {
                 Ok(v) => v,
-                Err(err) => return py_schema_err!("Parameter '{}':\n  {}", name, err),
+                Err(err) => return py_schema_err!("Parameter '{name}':\n  {err}"),
             };
 
             let has_default = match validator.as_ref() {
                 CombinedValidator::WithDefault(v) => {
                     if v.omit_on_error() {
-                        return py_schema_err!("Parameter '{}': omit_on_error cannot be used with arguments", name);
+                        return py_schema_err!("Parameter '{name}': omit_on_error cannot be used with arguments");
                     }
                     v.has_default()
                 }
@@ -126,7 +126,7 @@ impl BuildValidator for ArgumentsValidator {
             };
 
             if had_default_arg && !has_default && !had_keyword_only {
-                return py_schema_err!("Non-default argument '{}' follows default argument", name);
+                return py_schema_err!("Non-default argument '{name}' follows default argument");
             } else if has_default {
                 had_default_arg = true;
             }

--- a/pydantic-core/src/validators/arguments_v3.rs
+++ b/pydantic-core/src/validators/arguments_v3.rs
@@ -43,7 +43,7 @@ impl FromStr for ParameterMode {
             "keyword_only" => Ok(Self::KeywordOnly),
             "var_kwargs_uniform" => Ok(Self::VarKwargsUniform),
             "var_kwargs_unpacked_typed_dict" => Ok(Self::VarKwargsUnpackedTypedDict),
-            s => py_schema_err!("Invalid var_kwargs mode: `{}`", s),
+            s => py_schema_err!("Invalid var_kwargs mode: `{s}`"),
         }
     }
 }
@@ -102,7 +102,7 @@ impl BuildValidator for ArgumentsV3Validator {
             let py_name: Bound<PyString> = arg.get_as_req(intern!(py, "name"))?;
             let name = py_name.to_string();
             if !names.insert(name.clone()) {
-                return py_schema_err!("Duplicate parameter '{}'", name);
+                return py_schema_err!("Duplicate parameter '{name}'");
             }
 
             let py_mode = arg.get_as::<Bound<'_, PyString>>(intern!(py, "mode"))?;
@@ -118,28 +118,25 @@ impl BuildValidator for ArgumentsV3Validator {
                 ParameterMode::PositionalOnly => {
                     if had_positional_or_keyword || had_var_args || had_keyword_only || had_var_kwargs {
                         return py_schema_err!(
-                            "Positional only parameter '{}' cannot follow other parameter kinds",
-                            name
+                            "Positional only parameter '{name}' cannot follow other parameter kinds"
                         );
                     }
                 }
                 ParameterMode::PositionalOrKeyword => {
                     if had_var_args || had_keyword_only || had_var_kwargs {
                         return py_schema_err!(
-                            "Positional or keyword parameter '{}' cannot follow variadic or keyword only parameters",
-                            name
+                            "Positional or keyword parameter '{name}' cannot follow variadic or keyword only parameters"
                         );
                     }
                     had_positional_or_keyword = true;
                 }
                 ParameterMode::VarArgs => {
                     if had_var_args {
-                        return py_schema_err!("Duplicate variadic positional parameter '{}'", name);
+                        return py_schema_err!("Duplicate variadic positional parameter '{name}'");
                     }
                     if had_keyword_only || had_var_kwargs {
                         return py_schema_err!(
-                            "Variadic positional parameter '{}' cannot follow variadic or keyword only parameters",
-                            name
+                            "Variadic positional parameter '{name}' cannot follow variadic or keyword only parameters"
                         );
                     }
                     had_var_args = true;
@@ -147,15 +144,14 @@ impl BuildValidator for ArgumentsV3Validator {
                 ParameterMode::KeywordOnly => {
                     if had_var_kwargs {
                         return py_schema_err!(
-                            "Keyword only parameter '{}' cannot follow variadic keyword only parameter",
-                            name
+                            "Keyword only parameter '{name}' cannot follow variadic keyword only parameter"
                         );
                     }
                     had_keyword_only = true;
                 }
                 ParameterMode::VarKwargsUniform | ParameterMode::VarKwargsUnpackedTypedDict => {
                     if had_var_kwargs {
-                        return py_schema_err!("Duplicate variadic keyword parameter '{}'", name);
+                        return py_schema_err!("Duplicate variadic keyword parameter '{name}'");
                     }
                     had_var_kwargs = true;
                 }
@@ -165,13 +161,13 @@ impl BuildValidator for ArgumentsV3Validator {
 
             let validator = match build_validator(&schema, config, definitions) {
                 Ok(v) => v,
-                Err(err) => return py_schema_err!("Parameter '{}':\n  {}", name, err),
+                Err(err) => return py_schema_err!("Parameter '{name}':\n  {err}"),
             };
 
             let has_default = match validator.as_ref() {
                 CombinedValidator::WithDefault(v) => {
                     if v.omit_on_error() {
-                        return py_schema_err!("Parameter '{}': omit_on_error cannot be used with arguments", name);
+                        return py_schema_err!("Parameter '{name}': omit_on_error cannot be used with arguments");
                     }
                     v.has_default()
                 }
@@ -179,7 +175,7 @@ impl BuildValidator for ArgumentsV3Validator {
             };
 
             if had_default_arg && !has_default && !had_keyword_only {
-                return py_schema_err!("Required parameter '{}' follows parameter with default", name);
+                return py_schema_err!("Required parameter '{name}' follows parameter with default");
             } else if has_default {
                 had_default_arg = true;
             }

--- a/pydantic-core/src/validators/config.rs
+++ b/pydantic-core/src/validators/config.rs
@@ -40,8 +40,7 @@ impl FromStr for TemporalUnitMode {
             "infer" => Ok(Self::Infer),
 
             s => py_schema_err!(
-                "Invalid temporal_unit_mode serialization mode: `{}`, expected seconds, milliseconds or infer",
-                s
+                "Invalid temporal_unit_mode serialization mode: `{s}`, expected seconds, milliseconds or infer"
             ),
         }
     }

--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -81,13 +81,13 @@ impl BuildValidator for DataclassArgsValidator {
 
             let validator = match build_validator(&schema, config, definitions) {
                 Ok(v) => v,
-                Err(err) => return py_schema_err!("Field '{}':\n  {}", name, err),
+                Err(err) => return py_schema_err!("Field '{name}':\n  {err}"),
             };
 
             if let CombinedValidator::WithDefault(v) = validator.as_ref()
                 && v.omit_on_error()
             {
-                return py_schema_err!("Field `{}`: omit_on_error cannot be used with arguments", name);
+                return py_schema_err!("Field `{name}`: omit_on_error cannot be used with arguments");
             }
 
             let kw_only = field.get_as(intern!(py, "kw_only"))?.unwrap_or(true);

--- a/pydantic-core/src/validators/datetime.rs
+++ b/pydantic-core/src/validators/datetime.rs
@@ -247,7 +247,7 @@ impl NowOp {
         match s {
             "past" => Ok(NowOp::Past),
             "future" => Ok(NowOp::Future),
-            _ => py_schema_err!("Invalid now_op {:?}", s),
+            _ => py_schema_err!("Invalid now_op {s:?}"),
         }
     }
 }
@@ -296,7 +296,7 @@ impl TZConstraint {
         match s {
             "naive" => Ok(TZConstraint::Naive),
             "aware" => Ok(TZConstraint::Aware(None)),
-            _ => py_schema_err!("Invalid tz_constraint {:?}", s),
+            _ => py_schema_err!("Invalid tz_constraint {s:?}"),
         }
     }
 

--- a/pydantic-core/src/validators/literal.rs
+++ b/pydantic-core/src/validators/literal.rs
@@ -77,7 +77,7 @@ impl<T: Debug> LiteralLookup<T> {
             } else if let Ok(either_str) = k.exact_str() {
                 let str = either_str
                     .as_cow()
-                    .map_err(|_| py_schema_error_type!("error extracting str {:?}", k))?;
+                    .map_err(|_| py_schema_error_type!("error extracting str {k:?}"))?;
                 expected_str.insert(str.to_string(), id);
                 expected_py_primitives.set_item(&k, id)?;
             } else if expected_py_dict.set_item(&k, id).is_err() {

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -656,7 +656,7 @@ fn build_validator_inner(
 
 #[cold]
 fn failed_to_build_validator(val_type: &str, err: PyErr) -> PyErr {
-    py_schema_error_type!("Error building \"{}\" validator:\n  {}", val_type, err)
+    py_schema_error_type!("Error building \"{val_type}\" validator:\n  {err}")
 }
 
 #[cold]
@@ -666,7 +666,7 @@ fn invalid_schema_type() -> PyErr {
 
 #[cold]
 fn unknown_schema_type(val_type: &str) -> PyErr {
-    py_schema_error_type!("Unknown schema type: \"{}\"", val_type)
+    py_schema_error_type!("Unknown schema type: \"{val_type}\"")
 }
 
 /// More (mostly immutable) data to pass between validators, should probably be class `Context`,

--- a/pydantic-core/src/validators/model.rs
+++ b/pydantic-core/src/validators/model.rs
@@ -37,7 +37,7 @@ impl Revalidate {
             Some("always") => Ok(Self::Always),
             Some("never") | None => Ok(Self::Never),
             Some("subclass-instances") => Ok(Self::SubclassInstances),
-            Some(s) => py_schema_err!("Invalid revalidate_instances value: {}", s),
+            Some(s) => py_schema_err!("Invalid revalidate_instances value: {s}"),
         }
     }
 

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -86,7 +86,7 @@ impl BuildValidator for ModelFieldsValidator {
 
             let validator = match build_validator(&schema, config, definitions) {
                 Ok(v) => v,
-                Err(err) => return py_schema_err!("Field \"{}\":\n  {}", field_name, err),
+                Err(err) => return py_schema_err!("Field \"{field_name}\":\n  {err}"),
             };
 
             let validation_alias = field_info.get_item(intern!(py, "validation_alias"))?;

--- a/pydantic-core/src/validators/string.rs
+++ b/pydantic-core/src/validators/string.rs
@@ -277,7 +277,7 @@ impl Pattern {
             pattern
                 .getattr("pattern")
                 .and_then(|attr| attr.extract::<String>())
-                .map_err(|_| py_schema_error_type!("Invalid pattern, must be str or re.Pattern: {}", pattern))
+                .map_err(|_| py_schema_error_type!("Invalid pattern, must be str or re.Pattern: {pattern}"))
         }
     }
 
@@ -313,7 +313,7 @@ impl Pattern {
                     RegexEngine::RustRegex(re_pattern)
                 }
                 RegexEngine::PYTHON_RE => RegexEngine::PythonRe(re_compile.call1((pattern,))?.into()),
-                _ => return Err(py_schema_error_type!("Invalid regex engine: {}", engine)),
+                _ => return Err(py_schema_error_type!("Invalid regex engine: {engine}")),
             };
 
             Ok(Self {

--- a/pydantic-core/src/validators/typed_dict.rs
+++ b/pydantic-core/src/validators/typed_dict.rs
@@ -89,7 +89,7 @@ impl BuildValidator for TypedDictValidator {
 
             let validator = match build_validator(&schema, config, definitions) {
                 Ok(v) => v,
-                Err(err) => return py_schema_err!("Field \"{}\":\n  {}", field_name, err),
+                Err(err) => return py_schema_err!("Field \"{field_name}\":\n  {err}"),
             };
 
             let required = match field_info.get_as::<bool>(intern!(py, "required"))? {
@@ -98,7 +98,7 @@ impl BuildValidator for TypedDictValidator {
                         && let CombinedValidator::WithDefault(val) = validator.as_ref()
                         && val.has_default()
                     {
-                        return py_schema_err!("Field '{}': a required field cannot have a default value", field_name);
+                        return py_schema_err!("Field '{field_name}': a required field cannot have a default value");
                     }
                     required
                 }
@@ -109,10 +109,7 @@ impl BuildValidator for TypedDictValidator {
                 && let CombinedValidator::WithDefault(val) = validator.as_ref()
                 && val.omit_on_error()
             {
-                return py_schema_err!(
-                    "Field '{}': 'on_error = omit' cannot be set for required fields",
-                    field_name
-                );
+                return py_schema_err!("Field '{field_name}': 'on_error = omit' cannot be set for required fields");
             }
 
             let validation_alias = field_info.get_item(intern!(py, "validation_alias"))?;

--- a/pydantic-core/src/validators/union.rs
+++ b/pydantic-core/src/validators/union.rs
@@ -34,7 +34,7 @@ impl FromStr for UnionMode {
         match s {
             "smart" => Ok(Self::Smart),
             "left_to_right" => Ok(Self::LeftToRight),
-            s => py_schema_err!("Invalid union mode: `{}`, expected `smart` or `left_to_right`", s),
+            s => py_schema_err!("Invalid union mode: `{s}`, expected `smart` or `left_to_right`"),
         }
     }
 }


### PR DESCRIPTION
## Change Summary

This is two improvements to the Rust code in one:
  - A code cleanup to allow using format arguments by-name inside format strings in some error-producing macros (like the `format!()` macro and friends can)
  - Change those same macros so that for constant messages (without formatting arguments) they will no longer allocate a temporary string.

This amounts to making the code slightly easier to read, and slightly more efficient.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
