### PR TITLE
Remove lifetime from serialization `Extra`

### DIFF
--- a/pydantic-core/src/errors/validation_exception.rs
+++ b/pydantic-core/src/errors/validation_exception.rs
@@ -341,10 +341,10 @@ impl ValidationError {
         include_context: bool,
         include_input: bool,
     ) -> PyResult<Bound<'py, PyString>> {
-        let config = SerializationConfig::from_args("iso8601", "iso8601", "utf8", "constants")?;
+        let config = SerializationConfig::default();
         let extra = Extra::new(
             py,
-            &SerMode::Json,
+            SerMode::Json,
             None,
             false,
             false,
@@ -574,17 +574,17 @@ where
     S::Error::custom(error.to_string())
 }
 
-struct ValidationErrorSerializer<'slf, 'a, 'py> {
+struct ValidationErrorSerializer<'slf, 'py> {
     py: Python<'py>,
     line_errors: &'py [PyLineError],
     url_prefix: Option<&'py str>,
     include_context: bool,
     include_input: bool,
-    state: &'slf mut SerializationState<'a, 'py>,
+    state: &'slf mut SerializationState<'py>,
     input_type: &'py InputType,
 }
 
-impl ValidationErrorSerializer<'_, '_, '_> {
+impl ValidationErrorSerializer<'_, '_> {
     fn serialize<S>(&mut self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -606,17 +606,17 @@ impl ValidationErrorSerializer<'_, '_, '_> {
     }
 }
 
-struct PyLineErrorSerializer<'slf, 'a, 'py> {
+struct PyLineErrorSerializer<'slf, 'py> {
     py: Python<'py>,
     line_error: &'py PyLineError,
     url_prefix: Option<&'py str>,
     include_context: bool,
     include_input: bool,
-    state: RefCell<&'slf mut SerializationState<'a, 'py>>,
+    state: RefCell<&'slf mut SerializationState<'py>>,
     input_type: &'py InputType,
 }
 
-impl Serialize for PyLineErrorSerializer<'_, '_, '_> {
+impl Serialize for PyLineErrorSerializer<'_, '_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/pydantic-core/src/serializers/computed_fields.rs
+++ b/pydantic-core/src/serializers/computed_fields.rs
@@ -47,7 +47,7 @@ impl ComputedFields {
         model: &Bound<'py, PyAny>,
         output_dict: &Bound<'py, PyDict>,
         filter: &SchemaFilter<isize>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<()> {
         self.serialize_fields(
             model,
@@ -74,7 +74,7 @@ impl ComputedFields {
         model: &Bound<'py, PyAny>,
         map: &mut S::SerializeMap,
         filter: &SchemaFilter<isize>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<(), S::Error> {
         self.serialize_fields(
             model,
@@ -102,9 +102,9 @@ impl ComputedFields {
         &self,
         model: &Bound<'py, PyAny>,
         filter: &SchemaFilter<isize>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
         convert_error: impl FnOnce(PyErr) -> E,
-        mut serialize: impl for<'slf, 'a> FnMut(ComputedFieldToSerialize<'slf, 'a, 'py>) -> Result<(), E>,
+        mut serialize: impl for<'slf, 'a> FnMut(ComputedFieldToSerialize<'slf, 'py>) -> Result<(), E>,
     ) -> Result<(), E> {
         // In round trip mode, exclude computed fields:
         if state.extra.round_trip || state.extra.exclude_computed_fields {
@@ -146,10 +146,10 @@ impl ComputedFields {
     }
 }
 
-struct ComputedFieldToSerialize<'slf, 'a, 'py> {
+struct ComputedFieldToSerialize<'slf, 'py> {
     computed_field: &'slf ComputedField,
     value: Bound<'py, PyAny>,
-    state: &'slf mut SerializationState<'a, 'py>,
+    state: &'slf mut SerializationState<'py>,
 }
 
 #[derive(Debug)]

--- a/pydantic-core/src/serializers/config.rs
+++ b/pydantic-core/src/serializers/config.rs
@@ -26,6 +26,16 @@ pub(crate) struct SerializationConfig {
     pub inf_nan_mode: InfNanMode,
 }
 
+impl Default for SerializationConfig {
+    fn default() -> Self {
+        Self {
+            temporal_mode: TemporalMode::default(),
+            bytes_mode: BytesMode::default(),
+            inf_nan_mode: InfNanMode::Constants,
+        }
+    }
+}
+
 impl SerializationConfig {
     pub fn from_config(config: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
         let temporal_set = config

--- a/pydantic-core/src/serializers/filter.rs
+++ b/pydantic-core/src/serializers/filter.rs
@@ -95,7 +95,7 @@ impl SchemaFilter<usize> {
     pub fn index_filter<'py>(
         &self,
         index: usize,
-        state: &SerializationState<'_, 'py>,
+        state: &SerializationState<'py>,
         len: Option<usize>,
     ) -> PyResult<NextFilters<'py>> {
         let include = state.include().map(|v| map_negative_indices(v, len)).transpose()?;
@@ -133,7 +133,7 @@ impl SchemaFilter<isize> {
     pub fn key_filter<'py>(
         &self,
         key: &Bound<'py, PyAny>,
-        state: &SerializationState<'_, 'py>,
+        state: &SerializationState<'py>,
     ) -> PyResult<NextFilters<'py>> {
         let hash = key.hash()?;
         self.filter(key, hash, state.include(), state.exclude())
@@ -266,7 +266,7 @@ impl AnyFilter {
     pub fn key_filter<'py>(
         &self,
         key: &Bound<'py, PyAny>,
-        state: &SerializationState<'_, 'py>,
+        state: &SerializationState<'py>,
     ) -> PyResult<NextFilters<'py>> {
         // just use 0 for the int_key, it's always ignored in the implementation here
         self.filter(key, 0, state.include(), state.exclude())
@@ -275,7 +275,7 @@ impl AnyFilter {
     pub fn index_filter<'py>(
         &self,
         index: usize,
-        state: &SerializationState<'_, 'py>,
+        state: &SerializationState<'py>,
         len: Option<usize>,
     ) -> PyResult<NextFilters<'py>> {
         let include = state.include().map(|v| map_negative_indices(v, len)).transpose()?;

--- a/pydantic-core/src/serializers/infer.rs
+++ b/pydantic-core/src/serializers/infer.rs
@@ -31,7 +31,7 @@ use super::shared::any_dataclass_iter;
 
 pub(crate) fn infer_to_python<'py>(
     value: &Bound<'py, PyAny>,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
 ) -> PyResult<Py<PyAny>> {
     infer_to_python_known(state.extra.ob_type_lookup.get_type(value), value, state)
 }
@@ -43,18 +43,19 @@ const INFER_DEF_REF_ID: usize = usize::MAX;
 pub(crate) fn infer_to_python_known<'py>(
     ob_type: ObType,
     value: &Bound<'py, PyAny>,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
 ) -> PyResult<Py<PyAny>> {
     let py = value.py();
 
-    let mode = state.extra.mode;
+    let is_json = matches!(state.extra.mode, SerMode::Json);
     let mut guard = match state.recursion_guard(value, INFER_DEF_REF_ID) {
         Ok(v) => v,
         Err(e) => {
-            return match mode {
-                SerMode::Json => Err(e),
+            return if is_json {
+                Err(e)
+            } else {
                 // if recursion is detected by we're serializing to python, we just return the value
-                _ => Ok(value.clone().unbind()),
+                Ok(value.clone().unbind())
             };
         }
     };
@@ -205,7 +206,7 @@ pub(crate) fn infer_to_python_known<'py>(
             }
             ObType::Pattern => serialize_pattern(value, serialize_to_python())?,
             ObType::Unknown => {
-                if let Some(fallback) = state.extra.fallback {
+                if let Some(fallback) = &state.extra.fallback {
                     let next_value = fallback.call1((value,))?;
                     let next_result = infer_to_python(&next_value, state);
                     return next_result;
@@ -253,7 +254,7 @@ pub(crate) fn infer_to_python_known<'py>(
                 v.into_py_any(py)?
             }
             ObType::Unknown => {
-                if let Some(fallback) = state.extra.fallback {
+                if let Some(fallback) = &state.extra.fallback {
                     let next_value = fallback.call1((value,))?;
                     let next_result = infer_to_python(&next_value, state);
                     return next_result;
@@ -266,13 +267,13 @@ pub(crate) fn infer_to_python_known<'py>(
     Ok(value)
 }
 
-pub(crate) struct SerializeInfer<'slf, 'a, 'py> {
+pub(crate) struct SerializeInfer<'slf, 'py> {
     value: &'slf Bound<'py, PyAny>,
-    state: RefCell<&'slf mut SerializationState<'a, 'py>>,
+    state: RefCell<&'slf mut SerializationState<'py>>,
 }
 
-impl<'slf, 'a, 'py> SerializeInfer<'slf, 'a, 'py> {
-    pub(crate) fn new(value: &'slf Bound<'py, PyAny>, state: &'slf mut SerializationState<'a, 'py>) -> Self {
+impl<'slf, 'py> SerializeInfer<'slf, 'py> {
+    pub(crate) fn new(value: &'slf Bound<'py, PyAny>, state: &'slf mut SerializationState<'py>) -> Self {
         Self {
             value,
             state: RefCell::new(state),
@@ -280,7 +281,7 @@ impl<'slf, 'a, 'py> SerializeInfer<'slf, 'a, 'py> {
     }
 }
 
-impl Serialize for SerializeInfer<'_, '_, '_> {
+impl Serialize for SerializeInfer<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let state = &mut self.state.borrow_mut();
         let ob_type = state.extra.ob_type_lookup.get_type(self.value);
@@ -291,7 +292,7 @@ impl Serialize for SerializeInfer<'_, '_, '_> {
 pub(crate) fn infer_serialize<'py, S: Serializer>(
     value: &Bound<'py, PyAny>,
     serializer: S,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
 ) -> Result<S::Ok, S::Error> {
     infer_serialize_known(state.extra.ob_type_lookup.get_type(value), value, serializer, state)
 }
@@ -300,7 +301,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
     ob_type: ObType,
     value: &Bound<'py, PyAny>,
     serializer: S,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
 ) -> Result<S::Ok, S::Error> {
     let extra_serialize_unknown = state.extra.serialize_unknown;
     let mut guard = match state.recursion_guard(value, INFER_DEF_REF_ID) {
@@ -454,7 +455,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
         }
         ObType::Pattern => serialize_pattern(value, serialize_to_json(serializer)).map_err(unwrap_ser_error),
         ObType::Unknown => {
-            if let Some(fallback) = state.extra.fallback {
+            if let Some(fallback) = &state.extra.fallback {
                 let next_value = fallback.call1((value,)).map_err(py_err_se_err)?;
                 infer_serialize(&next_value, serializer, state)
             } else if state.extra.serialize_unknown {
@@ -498,7 +499,7 @@ fn serialize_unknown<'py>(value: &Bound<'py, PyAny>) -> Cow<'py, str> {
 
 pub(crate) fn infer_json_key<'a, 'py>(
     key: &'a Bound<'py, PyAny>,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
 ) -> PyResult<Cow<'a, str>> {
     let ob_type = state.extra.ob_type_lookup.get_type(key);
     infer_json_key_known(ob_type, key, state)
@@ -507,7 +508,7 @@ pub(crate) fn infer_json_key<'a, 'py>(
 pub(crate) fn infer_json_key_known<'a, 'py>(
     ob_type: ObType,
     key: &'a Bound<'py, PyAny>,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
 ) -> PyResult<Cow<'a, str>> {
     match ob_type {
         ObType::None => super::type_serializers::simple::none_json_key(),
@@ -591,7 +592,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
                 .into_owned(),
         )),
         ObType::Unknown => {
-            if let Some(fallback) = state.extra.fallback {
+            if let Some(fallback) = &state.extra.fallback {
                 let next_key = fallback.call1((key,))?;
                 infer_json_key(&next_key, state).map(|cow| Cow::Owned(cow.into_owned()))
             } else if state.extra.serialize_unknown {
@@ -608,7 +609,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
 /// `do_serialize` should be a closure which performs serialization without type inference
 pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
     value: &Bound<'py, PyAny>,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
     do_serialize: impl DoSerialize<'py, T, E>,
 ) -> Result<T, E> {
     let py = value.py();
@@ -633,8 +634,8 @@ pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
 fn serialize_pairs_python<'py>(
     py: Python,
     pairs_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
-    state: &mut SerializationState<'_, 'py>,
-    key_transform: impl Fn(Bound<'py, PyAny>, &mut SerializationState<'_, 'py>) -> PyResult<Bound<'py, PyAny>>,
+    state: &mut SerializationState<'py>,
+    key_transform: impl Fn(Bound<'py, PyAny>, &mut SerializationState<'py>) -> PyResult<Bound<'py, PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     let new_dict = PyDict::new(py);
     let filter = AnyFilter::new();
@@ -656,7 +657,7 @@ fn serialize_pairs_json<'py, S: Serializer>(
     pairs_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
     iter_size: usize,
     serializer: S,
-    state: &mut SerializationState<'_, 'py>,
+    state: &mut SerializationState<'py>,
 ) -> Result<S::Ok, S::Error> {
     let mut map = serializer.serialize_map(Some(iter_size))?;
     let filter = AnyFilter::new();

--- a/pydantic-core/src/serializers/mod.rs
+++ b/pydantic-core/src/serializers/mod.rs
@@ -93,9 +93,9 @@ impl SchemaSerializer {
         exclude_computed_fields: bool,
         round_trip: bool,
         warnings: WarningsArg,
-        fallback: Option<&Bound<'_, PyAny>>,
+        fallback: Option<Bound<'_, PyAny>>,
         serialize_as_any: bool,
-        context: Option<&Bound<'_, PyAny>>,
+        context: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Py<PyAny>> {
         let mode: SerMode = mode.into();
         let warnings_mode = match warnings {
@@ -104,7 +104,7 @@ impl SchemaSerializer {
         };
         let extra = Extra::new(
             py,
-            &mode,
+            mode,
             by_alias,
             exclude_unset,
             exclude_defaults,
@@ -141,9 +141,9 @@ impl SchemaSerializer {
         exclude_computed_fields: bool,
         round_trip: bool,
         warnings: WarningsArg,
-        fallback: Option<&Bound<'_, PyAny>>,
+        fallback: Option<Bound<'_, PyAny>>,
         serialize_as_any: bool,
-        context: Option<&Bound<'_, PyAny>>,
+        context: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Py<PyAny>> {
         let warnings_mode = match warnings {
             WarningsArg::Bool(b) => b.into(),
@@ -151,7 +151,7 @@ impl SchemaSerializer {
         };
         let extra = Extra::new(
             py,
-            &SerMode::Json,
+            SerMode::Json,
             by_alias,
             exclude_unset,
             exclude_defaults,
@@ -218,14 +218,14 @@ pub fn to_json(
     bytes_mode: &str,
     inf_nan_mode: &str,
     serialize_unknown: bool,
-    fallback: Option<&Bound<'_, PyAny>>,
+    fallback: Option<Bound<'_, PyAny>>,
     serialize_as_any: bool,
-    context: Option<&Bound<'_, PyAny>>,
+    context: Option<Bound<'_, PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     let config = SerializationConfig::from_args(timedelta_mode, temporal_mode, bytes_mode, inf_nan_mode)?;
     let extra = Extra::new(
         py,
-        &SerMode::Json,
+        SerMode::Json,
         Some(by_alias),
         false,
         false,
@@ -269,14 +269,14 @@ pub fn to_jsonable_python(
     bytes_mode: &str,
     inf_nan_mode: &str,
     serialize_unknown: bool,
-    fallback: Option<&Bound<'_, PyAny>>,
+    fallback: Option<Bound<'_, PyAny>>,
     serialize_as_any: bool,
-    context: Option<&Bound<'_, PyAny>>,
+    context: Option<Bound<'_, PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     let config = SerializationConfig::from_args(timedelta_mode, temporal_mode, bytes_mode, inf_nan_mode)?;
     let extra = Extra::new(
         py,
-        &SerMode::Json,
+        SerMode::Json,
         Some(by_alias),
         false,
         false,

--- a/pydantic-core/src/serializers/ob_type.rs
+++ b/pydantic-core/src/serializers/ob_type.rs
@@ -101,7 +101,7 @@ impl ObTypeLookup {
         }
     }
 
-    pub fn cached(py: Python<'_>) -> &Self {
+    pub fn cached(py: Python<'_>) -> &'static Self {
         TYPE_LOOKUP.get_or_init(py, || Self::new(py))
     }
 

--- a/pydantic-core/src/serializers/prebuilt.rs
+++ b/pydantic-core/src/serializers/prebuilt.rs
@@ -32,18 +32,14 @@ impl PrebuiltSerializer {
 impl_py_gc_traverse!(PrebuiltSerializer { schema_serializer });
 
 impl TypeSerializer for PrebuiltSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.schema_serializer.get().serializer.to_python_no_infer(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.schema_serializer.get().serializer.json_key_no_infer(key, state)
     }
@@ -52,7 +48,7 @@ impl TypeSerializer for PrebuiltSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         self.schema_serializer
             .get()

--- a/pydantic-core/src/serializers/type_serializers/any.rs
+++ b/pydantic-core/src/serializers/type_serializers/any.rs
@@ -37,18 +37,14 @@ impl BuildSerializer for AnySerializer {
 impl_py_gc_traverse!(AnySerializer {});
 
 impl TypeSerializer for AnySerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         infer_to_python(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         infer_json_key(key, state)
     }
@@ -57,7 +53,7 @@ impl TypeSerializer for AnySerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         infer_serialize(value, serializer, state)
     }

--- a/pydantic-core/src/serializers/type_serializers/bytes.rs
+++ b/pydantic-core/src/serializers/type_serializers/bytes.rs
@@ -65,11 +65,7 @@ impl BuildSerializer for BytesSerializer {
 impl_py_gc_traverse!(BytesSerializer {});
 
 impl TypeSerializer for BytesSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match value.cast::<PyBytes>() {
             Ok(py_bytes) => match state.extra.mode {
@@ -89,7 +85,7 @@ impl TypeSerializer for BytesSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match key.cast::<PyBytes>() {
             Ok(py_bytes) => self.bytes_mode.bytes_to_string(key.py(), py_bytes.as_bytes()),
@@ -104,7 +100,7 @@ impl TypeSerializer for BytesSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.cast::<PyBytes>() {
             Ok(py_bytes) => self.bytes_mode.serialize_bytes(py_bytes.as_bytes(), serializer),

--- a/pydantic-core/src/serializers/type_serializers/complex.rs
+++ b/pydantic-core/src/serializers/type_serializers/complex.rs
@@ -29,11 +29,7 @@ impl BuildSerializer for ComplexSerializer {
 impl_py_gc_traverse!(ComplexSerializer {});
 
 impl TypeSerializer for ComplexSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match value.cast::<PyComplex>() {
             Ok(py_complex) => match state.extra.mode {
@@ -50,7 +46,7 @@ impl TypeSerializer for ComplexSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.invalid_as_json_key(key, state, "complex")
     }
@@ -59,7 +55,7 @@ impl TypeSerializer for ComplexSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.cast::<PyComplex>() {
             Ok(py_complex) => {

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -121,7 +121,7 @@ impl BuildSerializer for DataclassSerializer {
 }
 
 impl DataclassSerializer {
-    fn allow_value(&self, value: &Bound<'_, PyAny>, state: &SerializationState<'_, '_>) -> PyResult<bool> {
+    fn allow_value(&self, value: &Bound<'_, PyAny>, state: &SerializationState<'_>) -> PyResult<bool> {
         match state.check {
             SerCheck::Strict => Ok(value.get_type().is(self.class.bind(value.py()))),
             SerCheck::Lax => value.is_instance(self.class.bind(value.py())),
@@ -144,11 +144,7 @@ impl DataclassSerializer {
 impl_py_gc_traverse!(DataclassSerializer { class, serializer });
 
 impl TypeSerializer for DataclassSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         if self.allow_value(value, state)? {
             let model = value;
             let state = &mut state.scoped_set(|s| &mut s.model, Some(value.clone()));
@@ -172,7 +168,7 @@ impl TypeSerializer for DataclassSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         if self.allow_value(key, state)? {
             infer_json_key_known(ObType::Dataclass, key, state)
@@ -186,7 +182,7 @@ impl TypeSerializer for DataclassSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         if self.allow_value(value, state).map_err(py_err_se_err)? {
             let state = &mut state.scoped_set(|s| &mut s.model, Some(value.clone()));

--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -115,7 +115,7 @@ macro_rules! build_temporal_serializer {
             fn to_python<'py>(
                 &self,
                 value: &Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Py<PyAny>> {
                 match $downcast(value) {
                     Ok(py_value) => match state.extra.mode {
@@ -132,7 +132,7 @@ macro_rules! build_temporal_serializer {
             fn json_key<'a, 'py>(
                 &self,
                 key: &'a Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Cow<'a, str>> {
                 match $downcast(key) {
                     Ok(py_value) => Ok(self.temporal_mode.$json_key_fn(py_value)?),
@@ -147,7 +147,7 @@ macro_rules! build_temporal_serializer {
                 &self,
                 value: &Bound<'py, PyAny>,
                 serializer: S,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> Result<S::Ok, S::Error> {
                 match $downcast(value) {
                     Ok(py_value) => self.temporal_mode.$serialize_fn(py_value, serializer),

--- a/pydantic-core/src/serializers/type_serializers/decimal.rs
+++ b/pydantic-core/src/serializers/type_serializers/decimal.rs
@@ -32,11 +32,7 @@ impl BuildSerializer for DecimalSerializer {
 impl_py_gc_traverse!(DecimalSerializer {});
 
 impl TypeSerializer for DecimalSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let _py = value.py();
         match state.extra.ob_type_lookup.is_type(value, ObType::Decimal) {
             IsType::Exact | IsType::Subclass => infer_to_python_known(ObType::Decimal, value, state),
@@ -50,7 +46,7 @@ impl TypeSerializer for DecimalSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match state.extra.ob_type_lookup.is_type(key, ObType::Decimal) {
             IsType::Exact | IsType::Subclass => infer_json_key_known(ObType::Decimal, key, state),
@@ -65,7 +61,7 @@ impl TypeSerializer for DecimalSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match state.extra.ob_type_lookup.is_type(value, ObType::Decimal) {
             IsType::Exact | IsType::Subclass => infer_serialize_known(ObType::Decimal, value, serializer, state),

--- a/pydantic-core/src/serializers/type_serializers/definitions.rs
+++ b/pydantic-core/src/serializers/type_serializers/definitions.rs
@@ -76,11 +76,7 @@ impl BuildSerializer for DefinitionRefSerializer {
 impl_py_gc_traverse!(DefinitionRefSerializer {});
 
 impl TypeSerializer for DefinitionRefSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.definition.read(|comb_serializer| {
             let comb_serializer = comb_serializer.unwrap();
             let mut guard = state.recursion_guard(value, self.definition.id())?;
@@ -91,7 +87,7 @@ impl TypeSerializer for DefinitionRefSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.definition.read(|s| s.unwrap().json_key_no_infer(key, state))
     }
@@ -100,7 +96,7 @@ impl TypeSerializer for DefinitionRefSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         self.definition.read(|comb_serializer| {
             let comb_serializer = comb_serializer.unwrap();

--- a/pydantic-core/src/serializers/type_serializers/dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/dict.rs
@@ -74,11 +74,7 @@ impl_py_gc_traverse!(DictSerializer {
 });
 
 impl TypeSerializer for DictSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match value.cast::<PyDict>() {
             Ok(py_dict) => {
@@ -113,7 +109,7 @@ impl TypeSerializer for DictSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.invalid_as_json_key(key, state, Self::EXPECTED_TYPE)
     }
@@ -122,7 +118,7 @@ impl TypeSerializer for DictSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.cast::<PyDict>() {
             Ok(py_dict) => {

--- a/pydantic-core/src/serializers/type_serializers/enum_.rs
+++ b/pydantic-core/src/serializers/type_serializers/enum_.rs
@@ -51,11 +51,7 @@ impl BuildSerializer for EnumSerializer {
 impl_py_gc_traverse!(EnumSerializer { serializer });
 
 impl TypeSerializer for EnumSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         if value.is_exact_instance(self.class.bind(py)) {
             // if we're in JSON mode, we need to get the value attribute and serialize that
@@ -78,7 +74,7 @@ impl TypeSerializer for EnumSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         let py = key.py();
         if key.is_exact_instance(self.class.bind(py)) {
@@ -100,7 +96,7 @@ impl TypeSerializer for EnumSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         if value.is_exact_instance(self.class.bind(value.py())) {
             let dot_value = value.getattr(intern!(value.py(), "value")).map_err(py_err_se_err)?;

--- a/pydantic-core/src/serializers/type_serializers/float.rs
+++ b/pydantic-core/src/serializers/type_serializers/float.rs
@@ -90,11 +90,7 @@ impl BuildSerializer for FloatSerializer {
 impl_py_gc_traverse!(FloatSerializer {});
 
 impl TypeSerializer for FloatSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match state.extra.ob_type_lookup.is_type(value, ObType::Float) {
             IsType::Exact => Ok(value.clone().unbind()),
@@ -115,7 +111,7 @@ impl TypeSerializer for FloatSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match state.extra.ob_type_lookup.is_type(key, ObType::Float) {
             IsType::Exact | IsType::Subclass => to_str_json_key(key),
@@ -130,7 +126,7 @@ impl TypeSerializer for FloatSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.extract::<f64>() {
             Ok(v) => serialize_f64(v, serializer, self.inf_nan_mode),

--- a/pydantic-core/src/serializers/type_serializers/format.rs
+++ b/pydantic-core/src/serializers/type_serializers/format.rs
@@ -112,7 +112,7 @@ impl FormatSerializer {
 impl_py_gc_traverse!(FormatSerializer { format_func });
 
 impl TypeSerializer for FormatSerializer {
-    fn to_python(&self, value: &Bound<'_, PyAny>, state: &mut SerializationState<'_, '_>) -> PyResult<Py<PyAny>> {
+    fn to_python(&self, value: &Bound<'_, PyAny>, state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {
         if self.when_used.should_use(value, &state.extra) {
             self.call(value).map_err(PydanticSerializationError::new_err)
         } else {
@@ -120,11 +120,7 @@ impl TypeSerializer for FormatSerializer {
         }
     }
 
-    fn json_key<'a>(
-        &self,
-        key: &'a Bound<'_, PyAny>,
-        _state: &mut SerializationState<'_, '_>,
-    ) -> PyResult<Cow<'a, str>> {
+    fn json_key<'a>(&self, key: &'a Bound<'_, PyAny>, _state: &mut SerializationState<'_>) -> PyResult<Cow<'a, str>> {
         if self.when_used.should_use_json(key) {
             let py_str = self
                 .call(key)
@@ -141,7 +137,7 @@ impl TypeSerializer for FormatSerializer {
         &self,
         value: &Bound<'_, PyAny>,
         serializer: S,
-        _state: &mut SerializationState<'_, '_>,
+        _state: &mut SerializationState<'_>,
     ) -> Result<S::Ok, S::Error> {
         if self.when_used.should_use_json(value) {
             match self.call(value) {
@@ -186,7 +182,7 @@ impl BuildSerializer for ToStringSerializer {
 impl_py_gc_traverse!(ToStringSerializer {});
 
 impl TypeSerializer for ToStringSerializer {
-    fn to_python(&self, value: &Bound<'_, PyAny>, state: &mut SerializationState<'_, '_>) -> PyResult<Py<PyAny>> {
+    fn to_python(&self, value: &Bound<'_, PyAny>, state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {
         if self.when_used.should_use(value, &state.extra) {
             serialize_via_str(value, serialize_to_python())
         } else {
@@ -197,7 +193,7 @@ impl TypeSerializer for ToStringSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        _state: &mut SerializationState<'_, 'py>,
+        _state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         if self.when_used.should_use_json(key) {
             Ok(Cow::Owned(key.str()?.to_string_lossy().into_owned()))
@@ -210,7 +206,7 @@ impl TypeSerializer for ToStringSerializer {
         &self,
         value: &Bound<'_, PyAny>,
         serializer: S,
-        _state: &mut SerializationState<'_, '_>,
+        _state: &mut SerializationState<'_>,
     ) -> Result<S::Ok, S::Error> {
         if self.when_used.should_use_json(value) {
             serialize_via_str(value, serialize_to_json(serializer)).map_err(|e| e.0)

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -143,11 +143,7 @@ impl BuildSerializer for FunctionPlainSerializer {
 }
 
 impl FunctionPlainSerializer {
-    fn call<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<(bool, Py<PyAny>)> {
+    fn call<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<(bool, Py<PyAny>)> {
         let py = value.py();
         if self.when_used.should_use(value, &state.extra) {
             let v = if self.is_field_serializer {
@@ -190,7 +186,7 @@ impl FunctionPlainSerializer {
     }
 }
 
-fn on_error(py: Python, err: PyErr, function_name: &str, state: &mut SerializationState<'_, '_>) -> PyResult<()> {
+fn on_error(py: Python, err: PyErr, function_name: &str, state: &mut SerializationState<'_>) -> PyResult<()> {
     let exception = err.value(py);
     if let Ok(ser_err) = exception.extract::<PydanticSerializationUnexpectedValue>() {
         if state.check.enabled() {
@@ -216,7 +212,7 @@ macro_rules! function_type_serializer {
             fn to_python<'py>(
                 &self,
                 value: &Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Py<PyAny>> {
                 let py = value.py();
                 let (ret_serializer, v) = match self.call(value, state) {
@@ -235,7 +231,7 @@ macro_rules! function_type_serializer {
             fn json_key<'a, 'py>(
                 &self,
                 key: &'a Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Cow<'a, str>> {
                 let py = key.py();
                 let state = &mut state.scoped_include_exclude(None, None);
@@ -259,7 +255,7 @@ macro_rules! function_type_serializer {
                 &self,
                 value: &Bound<'py, PyAny>,
                 serializer: S,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> Result<S::Ok, S::Error> {
                 let py = value.py();
                 let (ret_serializer, v) = match self.call(value, state) {
@@ -384,11 +380,7 @@ impl BuildSerializer for FunctionWrapSerializer {
 }
 
 impl FunctionWrapSerializer {
-    fn call<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<(bool, Py<PyAny>)> {
+    fn call<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<(bool, Py<PyAny>)> {
         let py = value.py();
         if self.when_used.should_use(value, &state.extra) {
             let serialize = SerializationCallable::new(&self.serializer, state);
@@ -448,7 +440,7 @@ impl_py_gc_traverse!(SerializationCallable {
 });
 
 impl SerializationCallable {
-    pub fn new(serializer: &Arc<CombinedSerializer>, state: &SerializationState<'_, '_>) -> Self {
+    pub fn new(serializer: &Arc<CombinedSerializer>, state: &SerializationState<'_>) -> Self {
         Self {
             serializer: serializer.clone(),
             extra_owned: ExtraOwned::new(state),
@@ -550,14 +542,14 @@ impl_py_gc_traverse!(SerializationInfo {
 });
 
 impl SerializationInfo {
-    fn new(state: &SerializationState<'_, '_>, is_field_serializer: bool) -> PyResult<Self> {
+    fn new(state: &SerializationState<'_>, is_field_serializer: bool) -> PyResult<Self> {
         let extra = &state.extra;
         if is_field_serializer {
             match state.field_name.as_ref() {
                 Some(field_name) => Ok(Self {
                     include: state.include().map(|i| i.clone().unbind()),
                     exclude: state.exclude().map(|e| e.clone().unbind()),
-                    context: extra.context.map(|c| c.clone().unbind()),
+                    context: extra.context.clone().map(Bound::unbind),
                     _mode: extra.mode.clone(),
                     by_alias: extra.by_alias,
                     exclude_unset: extra.exclude_unset,
@@ -576,7 +568,7 @@ impl SerializationInfo {
             Ok(Self {
                 include: state.include().map(|i| i.clone().unbind()),
                 exclude: state.exclude().map(|e| e.clone().unbind()),
-                context: extra.context.map(|c| c.clone().unbind()),
+                context: extra.context.clone().map(Bound::unbind),
                 _mode: extra.mode.clone(),
                 by_alias: extra.by_alias,
                 exclude_unset: extra.exclude_unset,

--- a/pydantic-core/src/serializers/type_serializers/generator.rs
+++ b/pydantic-core/src/serializers/type_serializers/generator.rs
@@ -51,11 +51,7 @@ impl BuildSerializer for GeneratorSerializer {
 impl_py_gc_traverse!(GeneratorSerializer { item_serializer });
 
 impl TypeSerializer for GeneratorSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         match value.cast::<PyIterator>() {
             Ok(py_iter) => {
                 let py = value.py();
@@ -94,7 +90,7 @@ impl TypeSerializer for GeneratorSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.invalid_as_json_key(key, state, Self::EXPECTED_TYPE)
     }
@@ -103,7 +99,7 @@ impl TypeSerializer for GeneratorSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.cast::<PyIterator>() {
             Ok(py_iter) => {
@@ -156,7 +152,7 @@ impl SerializationIterator {
         py_iter: &Bound<'_, PyIterator>,
         item_serializer: &Arc<CombinedSerializer>,
         filter: SchemaFilter<usize>,
-        state: &mut SerializationState<'_, '_>,
+        state: &mut SerializationState<'_>,
     ) -> Self {
         Self {
             iterator: py_iter.clone().into(),

--- a/pydantic-core/src/serializers/type_serializers/json.rs
+++ b/pydantic-core/src/serializers/type_serializers/json.rs
@@ -44,11 +44,7 @@ impl BuildSerializer for JsonSerializer {
 impl_py_gc_traverse!(JsonSerializer { serializer });
 
 impl TypeSerializer for JsonSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         if state.extra.round_trip {
             let bytes = to_json_bytes(value, &self.serializer, state, None, false, 0)?;
             let py = value.py();
@@ -62,7 +58,7 @@ impl TypeSerializer for JsonSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         if state.extra.round_trip {
             let bytes = to_json_bytes(key, &self.serializer, state, None, false, 0)?;
@@ -78,7 +74,7 @@ impl TypeSerializer for JsonSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         if state.extra.round_trip {
             let bytes = to_json_bytes(value, &self.serializer, state, None, false, 0).map_err(py_err_se_err)?;

--- a/pydantic-core/src/serializers/type_serializers/json_or_python.rs
+++ b/pydantic-core/src/serializers/type_serializers/json_or_python.rs
@@ -45,18 +45,14 @@ impl BuildSerializer for JsonOrPythonSerializer {
 impl_py_gc_traverse!(JsonOrPythonSerializer { json, python });
 
 impl TypeSerializer for JsonOrPythonSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.python.to_python(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.json.json_key(key, state)
     }
@@ -65,7 +61,7 @@ impl TypeSerializer for JsonOrPythonSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         self.json.serde_serialize(value, serializer, state)
     }

--- a/pydantic-core/src/serializers/type_serializers/list.rs
+++ b/pydantic-core/src/serializers/type_serializers/list.rs
@@ -53,11 +53,7 @@ impl BuildSerializer for ListSerializer {
 impl_py_gc_traverse!(ListSerializer { item_serializer });
 
 impl TypeSerializer for ListSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         match value.cast::<PyList>() {
             Ok(py_list) => {
                 let py = value.py();
@@ -83,7 +79,7 @@ impl TypeSerializer for ListSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.invalid_as_json_key(key, state, Self::EXPECTED_TYPE)
     }
@@ -92,7 +88,7 @@ impl TypeSerializer for ListSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.cast::<PyList>() {
             Ok(py_list) => {

--- a/pydantic-core/src/serializers/type_serializers/literal.rs
+++ b/pydantic-core/src/serializers/type_serializers/literal.rs
@@ -81,7 +81,7 @@ enum OutputValue<'py> {
 }
 
 impl LiteralSerializer {
-    fn check<'py>(&self, value: &Bound<'py, PyAny>, state: &SerializationState<'_, 'py>) -> PyResult<OutputValue<'py>> {
+    fn check<'py>(&self, value: &Bound<'py, PyAny>, state: &SerializationState<'py>) -> PyResult<OutputValue<'py>> {
         if state.check.enabled() {
             if !self.expected_int.is_empty()
                 && !value.is_instance_of::<PyBool>()
@@ -114,11 +114,7 @@ impl LiteralSerializer {
 impl_py_gc_traverse!(LiteralSerializer { expected_py });
 
 impl TypeSerializer for LiteralSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match self.check(value, state)? {
             OutputValue::OkInt(int) => match state.extra.mode {
@@ -140,7 +136,7 @@ impl TypeSerializer for LiteralSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match self.check(key, state)? {
             OutputValue::OkInt(int) => Ok(Cow::Owned(int.to_string())),
@@ -157,7 +153,7 @@ impl TypeSerializer for LiteralSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match self.check(value, state).map_err(py_err_se_err)? {
             OutputValue::OkInt(int) => int.serialize(serializer),

--- a/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
+++ b/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
@@ -40,7 +40,7 @@ impl BuildSerializer for MissingSentinelSerializer {
 impl_py_gc_traverse!(MissingSentinelSerializer {});
 
 impl TypeSerializer for MissingSentinelSerializer {
-    fn to_python(&self, value: &Bound<'_, PyAny>, _state: &mut SerializationState<'_, '_>) -> PyResult<Py<PyAny>> {
+    fn to_python(&self, value: &Bound<'_, PyAny>, _state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {
         let missing_sentinel = get_missing_sentinel_object(value.py());
 
         if value.is(missing_sentinel) {
@@ -56,7 +56,7 @@ impl TypeSerializer for MissingSentinelSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.invalid_as_json_key(key, state, Self::EXPECTED_TYPE)
     }
@@ -65,7 +65,7 @@ impl TypeSerializer for MissingSentinelSerializer {
         &self,
         _value: &Bound<'_, PyAny>,
         _serializer: S,
-        _state: &mut SerializationState<'_, '_>,
+        _state: &mut SerializationState<'_>,
     ) -> Result<S::Ok, S::Error> {
         Err(Error::custom("'MISSING' can't be serialized to JSON".to_string()))
     }

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -169,7 +169,7 @@ impl ModelSerializer {
     fn serialize<'py, T, E: From<PyErr>>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
         do_serialize: impl DoSerialize<'py, T, E>,
     ) -> Result<T, E> {
         if self.root_model {
@@ -189,7 +189,7 @@ impl ModelSerializer {
     fn serialize_root_model<'py, T, E: From<PyErr>>(
         &self,
         value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
         do_serialize: impl DoSerialize<'py, T, E>,
     ) -> Result<T, E> {
         if !self.allow_value_root_model(value, state.check)? {
@@ -250,18 +250,14 @@ impl ModelSerializer {
 impl_py_gc_traverse!(ModelSerializer { class, serializer });
 
 impl TypeSerializer for ModelSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.serialize(value, state, serialize_to_python())
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         // FIXME: root model in json key position should serialize as inner value?
         if self.allow_value(key, state.check)? {
@@ -276,7 +272,7 @@ impl TypeSerializer for ModelSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         self.serialize(value, state, serialize_to_json(serializer))
             .map_err(|e| e.0)

--- a/pydantic-core/src/serializers/type_serializers/nullable.rs
+++ b/pydantic-core/src/serializers/type_serializers/nullable.rs
@@ -35,11 +35,7 @@ impl BuildSerializer for NullableSerializer {
 impl_py_gc_traverse!(NullableSerializer { serializer });
 
 impl TypeSerializer for NullableSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match state.extra.ob_type_lookup.is_type(value, ObType::None) {
             IsType::Exact => Ok(py.None()),
@@ -51,7 +47,7 @@ impl TypeSerializer for NullableSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match state.extra.ob_type_lookup.is_type(key, ObType::None) {
             IsType::Exact => infer_json_key_known(ObType::None, key, state),
@@ -63,7 +59,7 @@ impl TypeSerializer for NullableSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match state.extra.ob_type_lookup.is_type(value, ObType::None) {
             IsType::Exact => serializer.serialize_none(),

--- a/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
+++ b/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
@@ -54,7 +54,7 @@ macro_rules! build_serializer {
             fn to_python<'py>(
                 &self,
                 value: &Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Py<PyAny>> {
                 let py = value.py();
                 match value.cast::<$py_type>() {
@@ -80,7 +80,7 @@ macro_rules! build_serializer {
             fn json_key<'a, 'py>(
                 &self,
                 key: &'a Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Cow<'a, str>> {
                 self.invalid_as_json_key(key, state, Self::EXPECTED_TYPE)
             }
@@ -89,7 +89,7 @@ macro_rules! build_serializer {
                 &self,
                 value: &Bound<'py, PyAny>,
                 serializer: S,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> Result<S::Ok, S::Error> {
                 match value.cast::<$py_type>() {
                     Ok(py_set) => {

--- a/pydantic-core/src/serializers/type_serializers/simple.rs
+++ b/pydantic-core/src/serializers/type_serializers/simple.rs
@@ -42,11 +42,7 @@ pub(crate) fn none_json_key() -> PyResult<Cow<'static, str>> {
 impl_py_gc_traverse!(NoneSerializer {});
 
 impl TypeSerializer for NoneSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match state.extra.ob_type_lookup.is_type(value, ObType::None) {
             IsType::Exact => Ok(py.None()),
@@ -61,7 +57,7 @@ impl TypeSerializer for NoneSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match state.extra.ob_type_lookup.is_type(key, ObType::None) {
             IsType::Exact => none_json_key(),
@@ -76,7 +72,7 @@ impl TypeSerializer for NoneSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match state.extra.ob_type_lookup.is_type(value, ObType::None) {
             IsType::Exact => serializer.serialize_none(),
@@ -123,7 +119,7 @@ macro_rules! build_simple_serializer {
             fn to_python<'py>(
                 &self,
                 value: &Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Py<PyAny>> {
                 let py = value.py();
                 match state.extra.ob_type_lookup.is_type(value, $ob_type) {
@@ -145,7 +141,7 @@ macro_rules! build_simple_serializer {
             fn json_key<'a, 'py>(
                 &self,
                 key: &'a Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Cow<'a, str>> {
                 match state.extra.ob_type_lookup.is_type(key, $ob_type) {
                     IsType::Exact | IsType::Subclass => $key_method(key),
@@ -160,7 +156,7 @@ macro_rules! build_simple_serializer {
                 &self,
                 value: &Bound<'py, PyAny>,
                 serializer: S,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> Result<S::Ok, S::Error> {
                 match value.extract::<$rust_type>() {
                     Ok(v) => v.serialize(serializer),

--- a/pydantic-core/src/serializers/type_serializers/string.rs
+++ b/pydantic-core/src/serializers/type_serializers/string.rs
@@ -41,11 +41,7 @@ impl BuildSerializer for StrSerializer {
 impl_py_gc_traverse!(StrSerializer {});
 
 impl TypeSerializer for StrSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match state.extra.ob_type_lookup.is_type(value, ObType::Str) {
             IsType::Exact => Ok(value.clone().unbind()),
@@ -63,7 +59,7 @@ impl TypeSerializer for StrSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         if let Ok(py_str) = key.cast::<PyString>() {
             // FIXME py cow to avoid the copy
@@ -78,7 +74,7 @@ impl TypeSerializer for StrSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.cast::<PyString>() {
             Ok(py_str) => serialize_to_json(serializer)

--- a/pydantic-core/src/serializers/type_serializers/timedelta.rs
+++ b/pydantic-core/src/serializers/type_serializers/timedelta.rs
@@ -43,11 +43,7 @@ impl BuildSerializer for TimeDeltaSerializer {
 impl_py_gc_traverse!(TimeDeltaSerializer {});
 
 impl TypeSerializer for TimeDeltaSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         match EitherTimedelta::try_from(value) {
             Ok(either_timedelta) => match state.extra.mode {
                 SerMode::Json => Ok(self.temporal_mode.timedelta_to_json(value.py(), either_timedelta)?),
@@ -63,7 +59,7 @@ impl TypeSerializer for TimeDeltaSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match EitherTimedelta::try_from(key) {
             Ok(either_timedelta) => self.temporal_mode.timedelta_json_key(&either_timedelta),
@@ -78,7 +74,7 @@ impl TypeSerializer for TimeDeltaSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match EitherTimedelta::try_from(value) {
             Ok(either_timedelta) => self.temporal_mode.timedelta_serialize(either_timedelta, serializer),

--- a/pydantic-core/src/serializers/type_serializers/tuple.rs
+++ b/pydantic-core/src/serializers/type_serializers/tuple.rs
@@ -62,11 +62,7 @@ impl BuildSerializer for TupleSerializer {
 impl_py_gc_traverse!(TupleSerializer { serializers });
 
 impl TypeSerializer for TupleSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         match value.cast::<PyTuple>() {
             Ok(py_tuple) => {
                 let py = value.py();
@@ -96,7 +92,7 @@ impl TypeSerializer for TupleSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match key.cast::<PyTuple>() {
             Ok(py_tuple) => {
@@ -123,7 +119,7 @@ impl TypeSerializer for TupleSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match value.cast::<PyTuple>() {
             Ok(py_tuple) => {
@@ -155,10 +151,10 @@ impl TypeSerializer for TupleSerializer {
     }
 }
 
-struct TupleSerializerEntry<'a, 'b, 'py> {
+struct TupleSerializerEntry<'a, 'py> {
     item: Bound<'py, PyAny>,
     serializer: &'a CombinedSerializer,
-    state: &'a mut SerializationState<'b, 'py>,
+    state: &'a mut SerializationState<'py>,
 }
 
 impl TupleSerializer {
@@ -171,8 +167,8 @@ impl TupleSerializer {
     fn for_each_tuple_item_and_serializer<'py, E>(
         &self,
         tuple: &Bound<'py, PyTuple>,
-        state: &mut SerializationState<'_, 'py>,
-        mut f: impl for<'a, 'b> FnMut(TupleSerializerEntry<'a, 'b, 'py>) -> Result<(), E>,
+        state: &mut SerializationState<'py>,
+        mut f: impl for<'a> FnMut(TupleSerializerEntry<'a, 'py>) -> Result<(), E>,
     ) -> PyResult<Result<(), E>> {
         let n_items = tuple.len();
         let mut py_tuple_iter = tuple.iter();

--- a/pydantic-core/src/serializers/type_serializers/typed_dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/typed_dict.rs
@@ -103,11 +103,7 @@ impl BuildSerializer for TypedDictSerializer {
 }
 
 impl TypeSerializer for TypedDictSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.serializer
             .to_python(value, &mut state.scoped_set(|s| &mut s.model, Some(value.clone())))
     }
@@ -115,7 +111,7 @@ impl TypeSerializer for TypedDictSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.invalid_as_json_key(key, state, "typed-dict")
     }
@@ -124,7 +120,7 @@ impl TypeSerializer for TypedDictSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         self.serializer.serde_serialize(
             value,

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -71,8 +71,8 @@ fn union_serialize<'py, S>(
     // if this returns `Ok(Some(v))`, we picked a union variant to serialize,
     // Or `Ok(None)` if we couldn't find a suitable variant to serialize
     // Finally, `Err(err)` if we encountered errors while trying to serialize
-    mut selector: impl FnMut(&CombinedSerializer, &mut SerializationState<'_, 'py>) -> PyResult<S>,
-    state: &mut SerializationState<'_, 'py>,
+    mut selector: impl FnMut(&CombinedSerializer, &mut SerializationState<'py>) -> PyResult<S>,
+    state: &mut SerializationState<'py>,
     choices: &[Arc<CombinedSerializer>],
     retry_with_lax_check: bool,
     py: Python<'_>,
@@ -126,11 +126,7 @@ fn union_serialize<'py, S>(
 }
 
 impl TypeSerializer for UnionSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         union_serialize(
             |comb_serializer, state| comb_serializer.to_python(value, state),
             state,
@@ -144,7 +140,7 @@ impl TypeSerializer for UnionSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         union_serialize(
             |comb_serializer, state| comb_serializer.json_key(key, state),
@@ -160,7 +156,7 @@ impl TypeSerializer for UnionSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match union_serialize(
             |comb_serializer, state| comb_serializer.to_python(value, state),
@@ -232,11 +228,7 @@ impl BuildSerializer for TaggedUnionSerializer {
 impl_py_gc_traverse!(TaggedUnionSerializer { discriminator, choices });
 
 impl TypeSerializer for TaggedUnionSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.tagged_union_serialize(
             value,
             |comb_serializer, state| comb_serializer.to_python(value, state),
@@ -248,7 +240,7 @@ impl TypeSerializer for TaggedUnionSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.tagged_union_serialize(
             key,
@@ -262,7 +254,7 @@ impl TypeSerializer for TaggedUnionSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match self.tagged_union_serialize(
             value,
@@ -311,8 +303,8 @@ impl TaggedUnionSerializer {
         value: &Bound<'py, PyAny>,
         // if this returns `Ok(v)`, we picked a union variant to serialize, where
         // `S` is intermediate state which can be passed on to the finalizer
-        mut selector: impl FnMut(&CombinedSerializer, &mut SerializationState<'_, 'py>) -> PyResult<S>,
-        state: &mut SerializationState<'_, 'py>,
+        mut selector: impl FnMut(&CombinedSerializer, &mut SerializationState<'py>) -> PyResult<S>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Option<S>> {
         if let Some(tag) = self.get_discriminator_value(value) {
             let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::Strict);

--- a/pydantic-core/src/serializers/type_serializers/url.rs
+++ b/pydantic-core/src/serializers/type_serializers/url.rs
@@ -39,7 +39,7 @@ macro_rules! build_serializer {
             fn to_python<'py>(
                 &self,
                 value: &Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Py<PyAny>> {
                 let py = value.py();
                 match value.extract::<$extract>() {
@@ -57,7 +57,7 @@ macro_rules! build_serializer {
             fn json_key<'a, 'py>(
                 &self,
                 key: &'a Bound<'py, PyAny>,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> PyResult<Cow<'a, str>> {
                 match key.extract::<$extract>() {
                     Ok(py_url) => Ok(Cow::Owned(py_url.__str__(key.py()).to_string())),
@@ -72,7 +72,7 @@ macro_rules! build_serializer {
                 &self,
                 value: &Bound<'py, PyAny>,
                 serializer: S,
-                state: &mut SerializationState<'_, 'py>,
+                state: &mut SerializationState<'py>,
             ) -> Result<S::Ok, S::Error> {
                 match value.extract::<$extract>() {
                     Ok(py_url) => serializer.serialize_str(&py_url.__str__(value.py())),

--- a/pydantic-core/src/serializers/type_serializers/uuid.rs
+++ b/pydantic-core/src/serializers/type_serializers/uuid.rs
@@ -42,11 +42,7 @@ impl BuildSerializer for UuidSerializer {
 }
 
 impl TypeSerializer for UuidSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         match state.extra.ob_type_lookup.is_type(value, ObType::Uuid) {
             IsType::Exact | IsType::Subclass => match state.extra.mode {
@@ -63,7 +59,7 @@ impl TypeSerializer for UuidSerializer {
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         match state.extra.ob_type_lookup.is_type(key, ObType::Uuid) {
             IsType::Exact | IsType::Subclass => {
@@ -81,7 +77,7 @@ impl TypeSerializer for UuidSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         match state.extra.ob_type_lookup.is_type(value, ObType::Uuid) {
             IsType::Exact | IsType::Subclass => {

--- a/pydantic-core/src/serializers/type_serializers/with_default.rs
+++ b/pydantic-core/src/serializers/type_serializers/with_default.rs
@@ -39,18 +39,14 @@ impl BuildSerializer for WithDefaultSerializer {
 impl_py_gc_traverse!(WithDefaultSerializer { default, serializer });
 
 impl TypeSerializer for WithDefaultSerializer {
-    fn to_python<'py>(
-        &self,
-        value: &Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
-    ) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.serializer.to_python(value, state)
     }
 
     fn json_key<'a, 'py>(
         &self,
         key: &'a Bound<'py, PyAny>,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.serializer.json_key(key, state)
     }
@@ -59,7 +55,7 @@ impl TypeSerializer for WithDefaultSerializer {
         &self,
         value: &Bound<'py, PyAny>,
         serializer: S,
-        state: &mut SerializationState<'_, 'py>,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
         self.serializer.serde_serialize(value, serializer, state)
     }


### PR DESCRIPTION
## Change Summary

Heading towards resolving #12592, this makes `Extra` in serialization state take ownership of a few values rather than borrow them. This is a minor perf cost, but `Extra` is typically only created once per serialization process.

On the upside, this allows us to remove `'a` lifetime from a lot of serialization code, making things read a lot nicer!

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
