### PR TITLE
Add deprecation warning test for schema function

### DIFF
--- a/pydantic-core/tests/test_schema_functions.py
+++ b/pydantic-core/tests/test_schema_functions.py
@@ -384,3 +384,10 @@ def test_expected_serialization_types(return_schema):
 def test_err_on_invalid() -> None:
     with pytest.raises(SchemaError, match='Cannot construct schema with `InvalidSchema` member.'):
         SchemaValidator(core_schema.invalid_schema())
+
+
+def test_deprecation_warning() -> None:
+    with pytest.deprecated_call(
+        match='The `field_name` argument on `with_info_before_validator_function` is deprecated'
+    ):
+        core_schema.with_info_before_validator_function(val_function, schema={'type': 'int'}, field_name='foo')


### PR DESCRIPTION
## Change Summary

Add a test for a deprecation warning to increase test coverage. Tests a deprecation warning is raised if a field name is provided in `with_info_before_validator_function`

## Related issue number

Contributes to https://github.com/pydantic/pydantic/issues/7656

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
