### PR TITLE
Remove `xfail` marker on a PEP 649 related test

### DIFF
--- a/tests/test_deferred_annotations.py
+++ b/tests/test_deferred_annotations.py
@@ -36,12 +36,6 @@ def test_deferred_annotations_model() -> None:
     assert inst.b == 'test'
 
 
-@pytest.mark.xfail(
-    reason=(
-        'When rebuilding model fields, we individually re-evaluate all fields (using `_eval_type()`) '
-        "and as such we don't benefit from PEP 649's capabilities."
-    ),
-)
 def test_deferred_annotations_nested_model() -> None:
     def outer():
         def inner():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Thanks to https://github.com/python/cpython/pull/138164 (included in 3.14.1), Python is now able to preserve references when building the forward ref object, and so calling `_eval_type()` on the individual annotations works as expected.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
