### PR TITLE
Add tests to improve coverage

### DIFF
--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7217,3 +7217,33 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_deprecated_tuple_positional_schema() -> None:
+    """Test that tuple_positional_schema raises a deprecation warning and calls tuple_schema."""
+    from pydantic.warnings import PydanticDeprecatedSince26
+
+    gen_js = GenerateJsonSchema()
+    schema = core_schema.tuple_schema([core_schema.int_schema(), core_schema.str_schema()])
+
+    with pytest.warns(PydanticDeprecatedSince26, match='`tuple_positional_schema` is deprecated'):
+        result = gen_js.tuple_positional_schema(schema)
+
+    # Verify it returns the same result as tuple_schema
+    expected = gen_js.tuple_schema(schema)
+    assert result == expected
+
+
+def test_deprecated_tuple_variable_schema() -> None:
+    """Test that tuple_variable_schema raises a deprecation warning and calls tuple_schema."""
+    from pydantic.warnings import PydanticDeprecatedSince26
+
+    gen_js = GenerateJsonSchema()
+    schema = core_schema.tuple_schema([core_schema.int_schema()], variadic_item_index=0)
+
+    with pytest.warns(PydanticDeprecatedSince26, match='`tuple_variable_schema` is deprecated'):
+        result = gen_js.tuple_variable_schema(schema)
+
+    # Verify it returns the same result as tuple_schema
+    expected = gen_js.tuple_schema(schema)
+    assert result == expected

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,7 +4,7 @@ import pytest
 from packaging.version import parse as parse_version
 
 import pydantic
-from pydantic.version import check_pydantic_core_version, version_info, version_short
+from pydantic.version import check_pydantic_core_version, parse_mypy_version, version_info, version_short
 
 
 def test_version_info():
@@ -45,3 +45,18 @@ def test_check_pydantic_core_version() -> None:
 def test_version_short(version, expected):
     with patch('pydantic.version.VERSION', version):
         assert version_short() == expected
+
+
+@pytest.mark.parametrize(
+    'version,expected',
+    [
+        ('1.11.0', (1, 11, 0)),
+        ('1.0.0', (1, 0, 0)),
+        ('2.5.1', (2, 5, 1)),
+        ('1.11.0+dev.d6d9d8cd4f27c52edac1f537e236ec48a01e54cb.dirty', (1, 11, 0)),
+        ('1.0.0+something', (1, 0, 0)),
+    ],
+)
+def test_parse_mypy_version(version: str, expected: tuple[int, int, int]) -> None:
+    """Test that mypy version strings are correctly parsed to 3-tuples of ints."""
+    assert parse_mypy_version(version) == expected


### PR DESCRIPTION
## Summary

This PR adds tests to improve test coverage as tracked in #7656.

## Changes

1. **tests/test_json_schema.py**: Added tests for deprecated `tuple_positional_schema` and `tuple_variable_schema` methods
   - These tests cover the `PydanticDeprecatedSince26` warning that was previously untested
   - Verifies that the deprecated methods correctly call `tuple_schema` and raise the appropriate deprecation warning

2. **tests/test_version.py**: Added tests for `parse_mypy_version` function
   - Covers various version string formats including normal versions (e.g., `1.11.0`) and versions with extra info (e.g., `1.11.0+dev.xxx`)
   - Previously line 113 in `version.py` was uncovered

## Test plan

- [x] All new tests pass locally
- [x] Existing tests still pass