### PR TITLE
Optimize datetime formatting code

### DIFF
--- a/pydantic-core/src/input/datetime.rs
+++ b/pydantic-core/src/input/datetime.rs
@@ -4,7 +4,10 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::pyclass::CompareOp;
+use pyo3::types::PyDateAccess;
+use pyo3::types::PyTimeAccess;
 use pyo3::types::PyTuple;
+use pyo3::types::PyTzInfoAccess;
 use pyo3::types::{PyDate, PyDateTime, PyDelta, PyDeltaAccess, PyDict, PyTime, PyTzInfo};
 use speedate::DateConfig;
 use speedate::{
@@ -43,6 +46,25 @@ impl<'py> From<Bound<'py, PyDate>> for EitherDate<'py> {
 }
 
 pub fn pydate_as_date(py_date: &Bound<'_, PyAny>) -> PyResult<Date> {
+    if let Ok(py_date) = py_date.cast_exact::<PyDate>() {
+        return pydateaccess_as_date(py_date);
+    }
+    py_any_date_as_date(py_date)
+}
+
+/// Fast path for reading date information from `datetime.date` and `datetime.datetime` objects
+#[inline]
+fn pydateaccess_as_date(py_date: &impl PyDateAccess) -> PyResult<Date> {
+    Ok(Date {
+        year: py_date.get_year().try_into()?,
+        month: py_date.get_month(),
+        day: py_date.get_day(),
+    })
+}
+
+/// Slow path for reading date information from subclasses of the builtin datetime types
+#[cold]
+fn py_any_date_as_date(py_date: &Bound<'_, PyAny>) -> PyResult<Date> {
     let py = py_date.py();
     Ok(Date {
         year: py_date.getattr(intern!(py, "year"))?.extract()?,
@@ -284,21 +306,47 @@ pub fn duration_as_pytimedelta<'py>(py: Python<'py>, duration: &Duration) -> PyR
     )
 }
 
-pub fn pytime_as_time(py_time: &Bound<'_, PyAny>, py_dt: Option<&Bound<'_, PyAny>>) -> PyResult<Time> {
+pub fn pytime_as_time(py_time: &Bound<'_, PyAny>) -> PyResult<Time> {
+    if let Ok(py_time) = py_time.cast_exact::<PyTime>() {
+        return pytimeaccess_as_time(py_time, None);
+    }
+
+    py_any_time_as_time(py_time, None)
+}
+
+trait PyTimeAndTzAccess<'py>: PyTimeAccess + PyTzInfoAccess<'py> {}
+impl<'py, T: PyTimeAccess + PyTzInfoAccess<'py>> PyTimeAndTzAccess<'py> for T {}
+
+/// Fast path for reading time information from exact `dt.time` and `dt.datetime` instances
+#[inline]
+fn pytimeaccess_as_time<'py>(
+    py_time: &impl PyTimeAndTzAccess<'py>,
+    py_dt: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Time> {
+    let tz_offset = py_time
+        .get_tzinfo()
+        .and_then(|tzinfo| tz_offset_from_tzinfo(&tzinfo, py_dt).transpose())
+        .transpose()?;
+
+    Ok(Time {
+        hour: py_time.get_hour(),
+        minute: py_time.get_minute(),
+        second: py_time.get_second(),
+        microsecond: py_time.get_microsecond(),
+        tz_offset,
+    })
+}
+
+/// Slow path for reading time information from subclasses of `dt.time` and `dt.datetime`
+#[cold]
+pub fn py_any_time_as_time(py_time: &Bound<'_, PyAny>, py_dt: Option<&Bound<'_, PyAny>>) -> PyResult<Time> {
     let py = py_time.py();
 
     let tzinfo = py_time.getattr(intern!(py, "tzinfo"))?;
-    let tz_offset: Option<i32> = if PyAnyMethods::is_none(&tzinfo) {
+    let tz_offset = if PyAnyMethods::is_none(&tzinfo) {
         None
     } else {
-        let offset_delta = tzinfo.call_method1(intern!(py, "utcoffset"), (py_dt,))?;
-        // as per the docs, utcoffset() can return None
-        if PyAnyMethods::is_none(&offset_delta) {
-            None
-        } else {
-            let offset_seconds: f64 = offset_delta.call_method0(intern!(py, "total_seconds"))?.extract()?;
-            Some(offset_seconds.round() as i32)
-        }
+        tz_offset_from_tzinfo(&tzinfo, py_dt)?
     };
 
     Ok(Time {
@@ -308,6 +356,18 @@ pub fn pytime_as_time(py_time: &Bound<'_, PyAny>, py_dt: Option<&Bound<'_, PyAny
         microsecond: py_time.getattr(intern!(py, "microsecond"))?.extract()?,
         tz_offset,
     })
+}
+
+fn tz_offset_from_tzinfo(tzinfo: &Bound<'_, PyAny>, py_dt: Option<&Bound<'_, PyAny>>) -> PyResult<Option<i32>> {
+    let py = tzinfo.py();
+    let offset_delta = tzinfo.call_method1(intern!(py, "utcoffset"), (py_dt,))?;
+    // as per the docs, utcoffset() can return None
+    if PyAnyMethods::is_none(&offset_delta) {
+        return Ok(None);
+    }
+
+    let offset_seconds: f64 = offset_delta.call_method0(intern!(py, "total_seconds"))?.extract()?;
+    Ok(Some(offset_seconds.round() as i32))
 }
 
 impl<'py> IntoPyObject<'py> for EitherTime<'py> {
@@ -334,7 +394,7 @@ impl EitherTime<'_> {
     pub fn as_raw(&self) -> PyResult<Time> {
         match self {
             Self::Raw(time) => Ok(*time),
-            Self::Py(py_time) => pytime_as_time(py_time, None),
+            Self::Py(py_time) => pytime_as_time(py_time),
         }
     }
 }
@@ -368,9 +428,16 @@ impl<'a> From<Bound<'a, PyDateTime>> for EitherDateTime<'a> {
 }
 
 pub fn pydatetime_as_datetime(py_dt: &Bound<'_, PyAny>) -> PyResult<DateTime> {
+    if let Ok(py_dt) = py_dt.cast_exact::<PyDateTime>() {
+        return Ok(DateTime {
+            date: pydateaccess_as_date(py_dt)?,
+            time: pytimeaccess_as_time(py_dt, Some(py_dt))?,
+        });
+    }
+
     Ok(DateTime {
-        date: pydate_as_date(py_dt)?,
-        time: pytime_as_time(py_dt, Some(py_dt))?,
+        date: py_any_date_as_date(py_dt)?,
+        time: py_any_time_as_time(py_dt, Some(py_dt))?,
     })
 }
 

--- a/pydantic-core/src/serializers/config.rs
+++ b/pydantic-core/src/serializers/config.rs
@@ -9,10 +9,10 @@ use pyo3::{IntoPyObjectExt, intern};
 use serde::ser::Error;
 
 use crate::build_tools::py_schema_err;
-use crate::input::EitherTimedelta;
+use crate::input::{EitherTimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time};
 use crate::serializers::type_serializers::datetime_etc::{
-    date_to_milliseconds, date_to_seconds, date_to_string, datetime_to_milliseconds, datetime_to_seconds,
-    datetime_to_string, time_to_milliseconds, time_to_seconds, time_to_string,
+    date_to_milliseconds, date_to_seconds, datetime_to_milliseconds, datetime_to_seconds, time_to_milliseconds,
+    time_to_seconds,
 };
 use crate::tools::SchemaDict;
 
@@ -159,26 +159,29 @@ impl From<TimedeltaMode> for TemporalMode {
 
 impl TemporalMode {
     pub fn datetime_to_json(self, py: Python, datetime: &Bound<'_, PyDateTime>) -> PyResult<Py<PyAny>> {
+        let dt = pydatetime_as_datetime(datetime)?;
         match self {
-            Self::Iso8601 => datetime_to_string(datetime)?.into_py_any(py),
-            Self::Seconds => datetime_to_seconds(datetime)?.into_py_any(py),
-            Self::Milliseconds => datetime_to_milliseconds(datetime)?.into_py_any(py),
+            Self::Iso8601 => dt.to_string().into_py_any(py),
+            Self::Seconds => datetime_to_seconds(dt).into_py_any(py),
+            Self::Milliseconds => datetime_to_milliseconds(dt).into_py_any(py),
         }
     }
 
     pub fn date_to_json(self, py: Python, date: &Bound<'_, PyDate>) -> PyResult<Py<PyAny>> {
+        let date = pydate_as_date(date)?;
         match self {
-            Self::Iso8601 => date_to_string(date)?.into_py_any(py),
-            Self::Seconds => date_to_seconds(date)?.into_py_any(py),
-            Self::Milliseconds => date_to_milliseconds(date)?.into_py_any(py),
+            Self::Iso8601 => date.to_string().into_py_any(py),
+            Self::Seconds => date_to_seconds(date).into_py_any(py),
+            Self::Milliseconds => date_to_milliseconds(date).into_py_any(py),
         }
     }
 
     pub fn time_to_json(self, py: Python, time: &Bound<'_, PyTime>) -> PyResult<Py<PyAny>> {
+        let time = pytime_as_time(time)?;
         match self {
-            Self::Iso8601 => time_to_string(time)?.into_py_any(py),
-            Self::Seconds => time_to_seconds(time)?.into_py_any(py),
-            Self::Milliseconds => time_to_milliseconds(time)?.into_py_any(py),
+            Self::Iso8601 => time.to_string().into_py_any(py),
+            Self::Seconds => time_to_seconds(time).into_py_any(py),
+            Self::Milliseconds => time_to_milliseconds(time).into_py_any(py),
         }
     }
 
@@ -200,26 +203,29 @@ impl TemporalMode {
     }
 
     pub fn datetime_json_key<'py>(self, datetime: &Bound<'_, PyDateTime>) -> PyResult<Cow<'py, str>> {
+        let dt = pydatetime_as_datetime(datetime)?;
         match self {
-            Self::Iso8601 => Ok(datetime_to_string(datetime)?.into()),
-            Self::Seconds => Ok(datetime_to_seconds(datetime)?.to_string().into()),
-            Self::Milliseconds => Ok(datetime_to_milliseconds(datetime)?.to_string().into()),
+            Self::Iso8601 => Ok(dt.to_string().into()),
+            Self::Seconds => Ok(datetime_to_seconds(dt).to_string().into()),
+            Self::Milliseconds => Ok(datetime_to_milliseconds(dt).to_string().into()),
         }
     }
 
     pub fn date_json_key<'py>(self, date: &Bound<'_, PyDate>) -> PyResult<Cow<'py, str>> {
+        let date = pydate_as_date(date)?;
         match self {
-            Self::Iso8601 => Ok(date_to_string(date)?.into()),
-            Self::Seconds => Ok(date_to_seconds(date)?.to_string().into()),
-            Self::Milliseconds => Ok(date_to_milliseconds(date)?.to_string().into()),
+            Self::Iso8601 => Ok(date.to_string().into()),
+            Self::Seconds => Ok(date_to_seconds(date).to_string().into()),
+            Self::Milliseconds => Ok(date_to_milliseconds(date).to_string().into()),
         }
     }
 
     pub fn time_json_key<'py>(self, time: &Bound<'_, PyTime>) -> PyResult<Cow<'py, str>> {
+        let time = pytime_as_time(time)?;
         match self {
-            Self::Iso8601 => Ok(time_to_string(time)?.into()),
-            Self::Seconds => Ok(time_to_seconds(time)?.to_string().into()),
-            Self::Milliseconds => Ok(time_to_milliseconds(time)?.to_string().into()),
+            Self::Iso8601 => Ok(time.to_string().into()),
+            Self::Seconds => Ok(time_to_seconds(time).to_string().into()),
+            Self::Milliseconds => Ok(time_to_milliseconds(time).to_string().into()),
         }
     }
 
@@ -245,19 +251,11 @@ impl TemporalMode {
         datetime: &Bound<'_, PyDateTime>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
+        let dt = pydatetime_as_datetime(datetime).map_err(py_err_se_err)?;
         match self {
-            Self::Iso8601 => {
-                let s = datetime_to_string(datetime).map_err(py_err_se_err)?;
-                serializer.serialize_str(&s)
-            }
-            Self::Seconds => {
-                let s = datetime_to_seconds(datetime).map_err(py_err_se_err)?;
-                serializer.serialize_f64(s)
-            }
-            Self::Milliseconds => {
-                let s = datetime_to_milliseconds(datetime).map_err(py_err_se_err)?;
-                serializer.serialize_f64(s)
-            }
+            Self::Iso8601 => serializer.collect_str(&dt),
+            Self::Seconds => serializer.serialize_f64(datetime_to_seconds(dt)),
+            Self::Milliseconds => serializer.serialize_f64(datetime_to_milliseconds(dt)),
         }
     }
 
@@ -266,19 +264,11 @@ impl TemporalMode {
         date: &Bound<'_, PyDate>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
+        let date = pydate_as_date(date).map_err(py_err_se_err)?;
         match self {
-            Self::Iso8601 => {
-                let s = date_to_string(date).map_err(py_err_se_err)?;
-                serializer.serialize_str(&s)
-            }
-            Self::Seconds => {
-                let s = date_to_seconds(date).map_err(py_err_se_err)?;
-                serializer.serialize_f64(s)
-            }
-            Self::Milliseconds => {
-                let s = date_to_milliseconds(date).map_err(py_err_se_err)?;
-                serializer.serialize_f64(s)
-            }
+            Self::Iso8601 => serializer.collect_str(&date),
+            Self::Seconds => serializer.serialize_f64(date_to_seconds(date)),
+            Self::Milliseconds => serializer.serialize_f64(date_to_milliseconds(date)),
         }
     }
 
@@ -287,19 +277,11 @@ impl TemporalMode {
         time: &Bound<'_, PyTime>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
+        let time = pytime_as_time(time).map_err(py_err_se_err)?;
         match self {
-            Self::Iso8601 => {
-                let s = time_to_string(time).map_err(py_err_se_err)?;
-                serializer.serialize_str(&s)
-            }
-            Self::Seconds => {
-                let s = time_to_seconds(time).map_err(py_err_se_err)?;
-                serializer.serialize_f64(s)
-            }
-            Self::Milliseconds => {
-                let s = time_to_milliseconds(time).map_err(py_err_se_err)?;
-                serializer.serialize_f64(s)
-            }
+            Self::Iso8601 => serializer.collect_str(&time),
+            Self::Seconds => serializer.serialize_f64(time_to_seconds(time)),
+            Self::Milliseconds => serializer.serialize_f64(time_to_milliseconds(time)),
         }
     }
 
@@ -311,7 +293,7 @@ impl TemporalMode {
         match self {
             Self::Iso8601 => {
                 let d = either_delta.to_duration().map_err(py_err_se_err)?;
-                serializer.serialize_str(&d.to_string())
+                serializer.collect_str(&d)
             }
             Self::Seconds => {
                 let seconds: f64 = either_delta.total_seconds().map_err(py_err_se_err)?;


### PR DESCRIPTION
## Change Summary

I was looking at cleaning up the `json_key` methods a bit (they create a lot of temporary `String` allocations). I found that these datetime methods needed particular work to clean up, so I'm pushing this first and separately:

- Use `serializer.collect_str(s)` instead of `serializer.serialize_str(&s.to_string())`
- Add fast paths for converting exact datetime types to `speedate` types without having to go through Python attributes.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
