### PR TITLE
Fix `@validate_call` deferred annotations support for Python 3.14

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -55,6 +55,9 @@ from typing_extensions import TypeAlias, TypeAliasType, get_args, get_origin, is
 from typing_inspection import typing_objects
 from typing_inspection.introspection import AnnotationSource, get_literal_values, is_union_origin
 
+if sys.version_info >= (3, 14):
+    import annotationlib
+
 from ..aliases import AliasChoices, AliasPath
 from ..annotated_handlers import GetCoreSchemaHandler, GetJsonSchemaHandler
 from ..config import ConfigDict, JsonDict, JsonEncoder, JsonSchemaExtraCallable
@@ -1962,7 +1965,11 @@ class GenerateSchema:
             Parameter.KEYWORD_ONLY: 'keyword_only',
         }
 
-        sig = signature(function)
+        if sys.version_info >= (3, 14):
+            # Use FORWARDREF format to avoid evaluating deferred annotations
+            sig = signature(function, annotation_format=annotationlib.Format.FORWARDREF)
+        else:
+            sig = signature(function)
         globalns, localns = self._types_namespace
         type_hints = _typing_extra.get_function_type_hints(function, globalns=globalns, localns=localns)
 

--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -567,11 +567,13 @@ def get_function_type_hints(
     - Do not wrap type annotation of a parameter with `Optional` if it has a default value of `None`
       (related bug: https://github.com/python/cpython/issues/90353, only fixed in 3.11+).
     """
+    func = function.func if isinstance(function, partial) else function
+
     try:
-        if isinstance(function, partial):
-            annotations = function.func.__annotations__
+        if sys.version_info >= (3, 14):
+            annotations = annotationlib.get_annotations(func, format=annotationlib.Format.FORWARDREF)
         else:
-            annotations = function.__annotations__
+            annotations = func.__annotations__
     except AttributeError:
         # Some functions (e.g. builtins) don't have annotations:
         return {}


### PR DESCRIPTION
## Summary

Fixes #12620

In Python 3.14, `functools.update_wrapper` copies `__annotate__` instead of `__annotations__` (per PEP 649/749). This caused `get_function_type_hints()` to return an empty dict for wrapped functions, breaking `@validate_call` when used with decorators like `sync_to_async`.

This was reported in pydantic-ai as [issue #3685](https://github.com/pydantic/pydantic-ai/issues/3685).

## Changes

- Use `annotationlib.get_annotations()` in `get_function_type_hints()` for Python 3.14+ to properly handle both `__annotations__` and `__annotate__`
- Use `annotation_format=Format.FORWARDREF` in `inspect.signature()` calls to avoid evaluating deferred annotations prematurely
- Add test for wrapped functions with `@validate_call`

## Test plan

- [x] Added test `test_deferred_annotations_validate_call_wrapped_function` that verifies `@validate_call` works with `functools.wraps` decorated functions
- [x] All existing `test_deferred_annotations.py` tests pass on Python 3.14.2
- [x] Backward compatibility verified on Python 3.13.7