### PR TITLE
Update AliasPath to support object attribute access in addition to dict access

### DIFF
--- a/docs/concepts/alias.md
+++ b/docs/concepts/alias.md
@@ -47,6 +47,49 @@ print(user)
 In the `'first_name'` field, we are using the alias `'names'` and the index `0` to specify the path to the first name.
 In the `'last_name'` field, we are using the alias `'names'` and the index `1` to specify the path to the last name.
 
+### `AliasPath` with `model_construct`
+
+When using `model_construct`, `AliasPath` supports both dictionary-like access (using keys/indices) and attribute access on objects. This is particularly useful when working with nested objects or Pydantic models:
+
+```python {lint="skip"}
+from pydantic import BaseModel, Field, AliasPath
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+
+
+class ContactInfo(BaseModel):
+    address: Address
+
+
+class User(BaseModel):
+    name: str = Field(validation_alias=AliasPath('contact', 'address', 'city'))
+
+
+# The AliasPath can traverse through object attributes with model_construct
+contact_data = {
+    'contact': ContactInfo(
+        address=Address(street='221B Baker St', city='London')
+    )
+}
+
+user = User.model_construct(**contact_data)
+print(user)
+#> name='London'
+```
+
+In this example, `AliasPath('contact', 'address', 'city')` traverses:
+
+1. The dictionary key `'contact'` (returns a `ContactInfo` object)
+2. The attribute `address` on the `ContactInfo` object (returns an `Address` object)
+3. The attribute `city` on the `Address` object (returns the string `'London'`)
+
+The path resolution tries dictionary/index access first, then falls back to attribute access if the key is a string.
+
+### `AliasChoices`
+
 `AliasChoices` is used to specify a choice of aliases. For example:
 
 ```python {lint="skip"}

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -352,7 +352,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                         fields_set.add(name)
                         break
                     elif isinstance(alias, AliasPath):
-                        value = alias.search_dict_for_path(values)
+                        value = alias.resolve_path(values)
                         if value is not PydanticUndefined:
                             fields_values[name] = value
                             fields_set.add(name)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Updated the AliasPath class to include a new method `resolve_path` that can traverse both dictionaries and objects using attribute access. This enhancement allows for more flexible data retrieval in nested structures, accommodating both dict-like and object-like access patterns.

Also updated the test suite to include comprehensive tests for the new functionality, ensuring that both dict and object access methods are thoroughly validated.

## Related issue number

Fixes issue #10851

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
