### PR TITLE
Refactor dataclass serialization to re-use logic better

### DIFF
--- a/pydantic-core/src/serializers/computed_fields.rs
+++ b/pydantic-core/src/serializers/computed_fields.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyString};
+use pyo3::pybacked::PyBackedStr;
+use pyo3::types::{PyDict, PyList};
 use pyo3::{PyTraverseError, PyVisit, intern};
-use serde::ser::SerializeMap;
 
 use crate::build_tools::py_schema_error_type;
 use crate::common::missing_sentinel::get_missing_sentinel_object;
@@ -12,10 +12,8 @@ use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::extra::FieldName;
 use crate::serializers::filter::SchemaFilter;
-use crate::serializers::shared::{BuildSerializer, CombinedSerializer, PydanticSerializer};
-use crate::tools::SchemaDict;
-
-use super::errors::py_err_se_err;
+use crate::serializers::shared::{BuildSerializer, CombinedSerializer, SerializeMap};
+use crate::tools::{SchemaDict, pybackedstr_to_pystring};
 
 #[derive(Debug)]
 pub(super) struct ComputedFields(Vec<ComputedField>);
@@ -38,93 +36,25 @@ impl ComputedFields {
         }
     }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn to_python<'py>(
+    pub fn serialize<'py, M: SerializeMap>(
         &self,
         model: &Bound<'py, PyAny>,
-        output_dict: &Bound<'py, PyDict>,
+        map: &mut M,
         filter: &SchemaFilter<isize>,
         state: &mut SerializationState<'py>,
-    ) -> PyResult<()> {
-        self.serialize_fields(
-            model,
-            filter,
-            state,
-            |e| e,
-            |ComputedFieldToSerialize {
-                 computed_field,
-                 value,
-                 state,
-             }| {
-                let key = match state.extra.serialize_by_alias_or(computed_field.serialize_by_alias) {
-                    true => computed_field.alias_py.bind(model.py()),
-                    false => computed_field.property_name_py.bind(model.py()),
-                };
-                let value = computed_field.serializer.to_python(&value, state)?;
-                output_dict.set_item(key, value)
-            },
-        )
-    }
-
-    pub fn serde_serialize<'py, S: serde::ser::Serializer>(
-        &self,
-        model: &Bound<'py, PyAny>,
-        map: &mut S::SerializeMap,
-        filter: &SchemaFilter<isize>,
-        state: &mut SerializationState<'py>,
-    ) -> Result<(), S::Error> {
-        self.serialize_fields(
-            model,
-            filter,
-            state,
-            py_err_se_err,
-            |ComputedFieldToSerialize {
-                 computed_field,
-                 value,
-                 state,
-             }| {
-                let key = match state.extra.serialize_by_alias_or(computed_field.serialize_by_alias) {
-                    true => &computed_field.alias,
-                    false => &computed_field.property_name,
-                };
-                let s = PydanticSerializer::new(&value, &computed_field.serializer, state);
-                map.serialize_entry(key, &s)
-            },
-        )
-    }
-
-    /// Iterate each field for serialization, filtering on
-    /// `include` and `exclude` if provided.
-    fn serialize_fields<'py, E>(
-        &self,
-        model: &Bound<'py, PyAny>,
-        filter: &SchemaFilter<isize>,
-        state: &mut SerializationState<'py>,
-        convert_error: impl FnOnce(PyErr) -> E,
-        mut serialize: impl for<'slf, 'a> FnMut(ComputedFieldToSerialize<'slf, 'py>) -> Result<(), E>,
-    ) -> Result<(), E> {
+    ) -> Result<(), M::Error> {
         // In round trip mode, exclude computed fields:
         if state.extra.round_trip || state.extra.exclude_computed_fields {
             return Ok(());
         }
 
         for computed_field in &self.0 {
-            let property_name_py = computed_field.property_name_py.bind(model.py());
-            let (next_include, next_exclude) = match filter.key_filter(property_name_py, state) {
-                Ok(Some((next_include, next_exclude))) => (next_include, next_exclude),
-                Ok(None) => continue,
-                Err(e) => return Err(convert_error(e)),
+            let property_name_py = pybackedstr_to_pystring(model.py(), &computed_field.property_name);
+            let Some((next_include, next_exclude)) = filter.key_filter(&property_name_py, state)? else {
+                continue;
             };
 
-            let value = match model.getattr(property_name_py) {
-                Ok(field_value) => field_value,
-                Err(e) => {
-                    return Err(convert_error(e));
-                }
-            };
+            let value = model.getattr(&property_name_py)?;
             if state.extra.exclude_none && value.is_none() {
                 continue;
             }
@@ -133,32 +63,24 @@ impl ComputedFields {
                 continue;
             }
 
-            let field_name = FieldName::from(computed_field.property_name_py.bind(model.py()).clone());
+            let field_name = FieldName::from(property_name_py);
             let state = &mut state.scoped_set(|s| &mut s.field_name, Some(field_name));
             let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-            serialize(ComputedFieldToSerialize {
-                computed_field,
-                value,
-                state,
-            })?;
+            let key = match state.extra.serialize_by_alias_or(computed_field.serialize_by_alias) {
+                true => &computed_field.alias,
+                false => &computed_field.property_name,
+            };
+            map.serialize_entry_string_key(key, &value, &computed_field.serializer, state)?;
         }
         Ok(())
     }
 }
 
-struct ComputedFieldToSerialize<'slf, 'py> {
-    computed_field: &'slf ComputedField,
-    value: Bound<'py, PyAny>,
-    state: &'slf mut SerializationState<'py>,
-}
-
 #[derive(Debug)]
 struct ComputedField {
-    property_name: String,
-    property_name_py: Py<PyString>,
+    property_name: PyBackedStr,
     serializer: Arc<CombinedSerializer>,
-    alias: String,
-    alias_py: Py<PyString>,
+    alias: PyBackedStr,
     serialize_by_alias: Option<bool>,
 }
 
@@ -170,19 +92,17 @@ impl ComputedField {
     ) -> PyResult<Self> {
         let py = schema.py();
         let schema: &Bound<'_, PyDict> = schema.cast()?;
-        let property_name: Bound<'_, PyString> = schema.get_as_req(intern!(py, "property_name"))?;
+        let property_name: PyBackedStr = schema.get_as_req(intern!(py, "property_name"))?;
         let return_schema = schema.get_as_req(intern!(py, "return_schema"))?;
         let serializer = CombinedSerializer::build(&return_schema, config, definitions)
             .map_err(|e| py_schema_error_type!("Computed field `{property_name}`:\n  {e}"))?;
-        let alias_py = schema
+        let alias = schema
             .get_as(intern!(py, "alias"))?
             .unwrap_or_else(|| property_name.clone());
         Ok(Self {
-            property_name: property_name.extract()?,
-            property_name_py: property_name.into(),
+            property_name,
             serializer,
-            alias: alias_py.extract()?,
-            alias_py: alias_py.into(),
+            alias,
             serialize_by_alias: config.get_as(intern!(py, "serialize_by_alias"))?,
         })
     }

--- a/pydantic-core/src/serializers/errors.rs
+++ b/pydantic-core/src/serializers/errors.rs
@@ -19,7 +19,7 @@ pub(super) fn py_err_se_err<T: ser::Error, E: fmt::Display>(py_error: E) -> T {
 }
 
 /// Wrapper type which allows convenient conversion between `PyErr` and `ser::Error` in `?` expressions.
-pub(super) struct WrappedSerError<T: ser::Error>(pub T);
+pub(crate) struct WrappedSerError<T: ser::Error>(pub T);
 
 pub fn unwrap_ser_error<T: ser::Error>(wrapped: WrappedSerError<T>) -> T {
     wrapped.0

--- a/pydantic-core/src/serializers/fields.rs
+++ b/pydantic-core/src/serializers/fields.rs
@@ -3,32 +3,31 @@ use std::string::ToString;
 use std::sync::Arc;
 
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyString};
 
 use ahash::AHashMap;
-use serde::ser::SerializeMap;
 use smallvec::SmallVec;
 
 use crate::PydanticSerializationUnexpectedValue;
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::serializers::SerializationState;
+use crate::serializers::errors::unwrap_ser_error;
 use crate::serializers::extra::{FieldName, SerCheck};
+use crate::serializers::shared::{DoSerialize, SerializeMap, serialize_to_json, serialize_to_python};
 use crate::serializers::type_serializers::any::AnySerializer;
 use crate::serializers::type_serializers::function::{FunctionPlainSerializer, FunctionWrapSerializer};
 
 use super::computed_fields::ComputedFields;
-use super::errors::py_err_se_err;
 use super::extra::Extra;
 use super::filter::SchemaFilter;
-use super::infer::{SerializeInfer, infer_json_key, infer_serialize, infer_to_python};
-use super::shared::{CombinedSerializer, PydanticSerializer, TypeSerializer};
+use super::shared::{CombinedSerializer, TypeSerializer};
 
 /// representation of a field for serialization
 #[derive(Debug)]
 pub(super) struct SerField {
-    pub key_py: Py<PyString>,
-    pub alias: Option<String>,
-    pub alias_py: Option<Py<PyString>>,
+    pub key: PyBackedStr,
+    pub alias: Option<PyBackedStr>,
     // None serializer means exclude
     pub serializer: Option<Arc<CombinedSerializer>>,
     pub required: bool,
@@ -40,19 +39,16 @@ impl_py_gc_traverse!(SerField { serializer });
 
 impl SerField {
     pub fn new(
-        py: Python,
-        key_py: Py<PyString>,
-        alias: Option<String>,
+        key: PyBackedStr,
+        alias: Option<PyBackedStr>,
         serializer: Option<Arc<CombinedSerializer>>,
         required: bool,
         serialize_by_alias: Option<bool>,
         serialization_exclude_if: Option<Py<PyAny>>,
     ) -> Self {
-        let alias_py = alias.as_ref().map(|alias| PyString::new(py, alias.as_str()).into());
         Self {
-            key_py,
+            key,
             alias,
-            alias_py,
             serializer,
             required,
             serialize_by_alias,
@@ -60,22 +56,13 @@ impl SerField {
         }
     }
 
-    pub fn get_key_py<'py>(&self, py: Python<'py>, extra: &Extra) -> &Bound<'py, PyAny> {
-        if extra.serialize_by_alias_or(self.serialize_by_alias) {
-            if let Some(ref alias_py) = self.alias_py {
-                return alias_py.bind(py);
-            }
+    pub fn get_key(&self, extra: &Extra) -> &PyBackedStr {
+        if extra.serialize_by_alias_or(self.serialize_by_alias)
+            && let Some(alias) = &self.alias
+        {
+            return alias;
         }
-        self.key_py.bind(py)
-    }
-
-    pub fn get_key_json<'a>(&'a self, key_str: &'a str, extra: &Extra) -> Cow<'a, str> {
-        if extra.serialize_by_alias_or(self.serialize_by_alias) {
-            if let Some(ref alias) = self.alias {
-                return Cow::Borrowed(alias.as_str());
-            }
-        }
-        Cow::Borrowed(key_str)
+        &self.key
     }
 }
 
@@ -127,15 +114,6 @@ pub struct GeneralFieldsSerializer {
     required_fields: usize,
 }
 
-macro_rules! option_length {
-    ($op_has_len:expr) => {
-        match $op_has_len {
-            Some(ref has_len) => has_len.len(),
-            None => 0,
-        }
-    };
-}
-
 impl GeneralFieldsSerializer {
     pub(super) fn new(
         fields: AHashMap<String, SerField>,
@@ -167,14 +145,57 @@ impl GeneralFieldsSerializer {
         }
     }
 
-    pub(crate) fn main_to_python<'py>(
+    fn serialize<'py, S: DoSerialize>(
+        &self,
+        value: &Bound<'py, PyAny>,
+        state: &mut SerializationState<'py>,
+        do_serialize: S,
+    ) -> Result<S::Ok, S::Error> {
+        let py = value.py();
+
+        let Some((main_dict, extra_dict)) = self.extract_dicts(value) else {
+            return do_serialize.serialize_fallback(self.get_name(), value, state);
+        };
+
+        let missing_sentinel = get_missing_sentinel_object(py);
+        let model = get_model(state)?;
+
+        let mut map = self.serialize_main(py, &model, dict_items(&main_dict), state, do_serialize)?;
+
+        // this is used to include `__pydantic_extra__` in serialization on models
+        if let Some(extra_dict) = extra_dict {
+            for (key, value) in extra_dict {
+                if state.extra.exclude_none && value.is_none() {
+                    continue;
+                }
+                if value.is(missing_sentinel) {
+                    continue;
+                }
+                if let Some((next_include, next_exclude)) = self.filter.key_filter(&key, state)? {
+                    let state = &mut state.scoped_include_exclude(next_include, next_exclude);
+                    map.serialize_entry(
+                        &key,
+                        AnySerializer::get(),
+                        &value,
+                        self.extra_serializer.as_ref().unwrap_or(AnySerializer::get()),
+                        state,
+                    )?;
+                }
+            }
+        }
+        self.add_computed_fields(&model, &mut map, state)?;
+        map.end()
+    }
+
+    pub(crate) fn serialize_main<'py, S: DoSerialize>(
         &self,
         py: Python<'py>,
         model: &Bound<'py, PyAny>,
         main_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
         state: &mut SerializationState<'py>,
-    ) -> PyResult<Bound<'py, PyDict>> {
-        let output_dict = PyDict::new(py);
+        do_serialize: S,
+    ) -> Result<S::Map, S::Error> {
+        let mut map = do_serialize.serialize_map()?;
         let mut used_req_fields: usize = 0;
         let missing_sentinel = get_missing_sentinel_object(py);
 
@@ -190,11 +211,11 @@ impl GeneralFieldsSerializer {
                 continue;
             }
 
-            let field_name = FieldName::from(key.clone().cast_into()?);
+            let field_name = FieldName::from(key.clone().cast_into().map_err(PyErr::from)?);
             let state = &mut state.scoped_set(|s| &mut s.field_name, Some(field_name));
             if let Some((next_include, next_exclude)) = self.filter.key_filter(&key, state)? {
                 let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                let (key, serializer) = if let Some(field) = op_field {
+                if let Some(field) = op_field {
                     let serializer = Self::prepare_value(&value, field, &state.extra)?;
 
                     if field.required {
@@ -202,10 +223,11 @@ impl GeneralFieldsSerializer {
                     }
 
                     let Some(serializer) = serializer else {
+                        // field is excluded
                         continue;
                     };
 
-                    (field.get_key_py(output_dict.py(), &state.extra), serializer)
+                    map.serialize_entry_string_key(field.get_key(&state.extra), &value, serializer, state)?;
                 } else if self.mode == FieldsMode::TypedDictAllow {
                     let serializer = self
                         .extra_serializer
@@ -213,7 +235,7 @@ impl GeneralFieldsSerializer {
                         // If using `serialize_as_any`, extras are always inferred
                         .filter(|_| !state.extra.serialize_as_any)
                         .unwrap_or_else(|| AnySerializer::get());
-                    (&key, serializer)
+                    map.serialize_entry(&key, AnySerializer::get(), &value, serializer, state)?;
                 } else if state.check == SerCheck::Strict {
                     return Err(PydanticSerializationUnexpectedValue::new(
                         Some(format!("Unexpected field `{key}`")),
@@ -221,14 +243,9 @@ impl GeneralFieldsSerializer {
                         model_type_name(model),
                         None,
                     )
-                    .to_py_err());
-                } else {
-                    continue;
-                };
-
-                // Use `no_infer` here because the `serialize_as_any` logic has been handled in `prepare_value`
-                let value = serializer.to_python_no_infer(&value, state)?;
-                output_dict.set_item(key, value)?;
+                    .to_py_err()
+                    .into());
+                }
             }
         }
 
@@ -247,60 +264,11 @@ impl GeneralFieldsSerializer {
                 model_type_name(model),
                 Some(model.clone().unbind()),
             )
-            .to_py_err())
+            .to_py_err()
+            .into())
         } else {
-            Ok(output_dict)
+            Ok(map)
         }
-    }
-
-    pub(crate) fn main_serde_serialize<'py, S: serde::ser::Serializer>(
-        &self,
-        main_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
-        expected_len: usize,
-        serializer: S,
-        state: &mut SerializationState<'py>,
-    ) -> Result<S::SerializeMap, S::Error> {
-        // NOTE! As above, we maintain the order of the input dict assuming that's right
-        // we don't both with `used_req_fields` here because on unions, `to_python(..., mode='json')` is used
-        let mut map = serializer.serialize_map(Some(expected_len))?;
-
-        for result in main_iter {
-            let (key, value) = result.map_err(py_err_se_err)?;
-            let missing_sentinel = get_missing_sentinel_object(value.py());
-            if state.extra.exclude_none && value.is_none() {
-                continue;
-            }
-            if value.is(missing_sentinel) {
-                continue;
-            }
-            let key_str = key_str(&key).map_err(py_err_se_err)?;
-
-            let field_name = FieldName::from(key.clone().cast_into().map_err(py_err_se_err)?);
-            let state = &mut state.scoped_set(|s| &mut s.field_name, Some(field_name));
-
-            let filter = self.filter.key_filter(&key, state).map_err(py_err_se_err)?;
-            if let Some((next_include, next_exclude)) = filter {
-                let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                if let Some(field) = self.fields.get(key_str) {
-                    let Some(serializer) = Self::prepare_value(&value, field, &state.extra).map_err(py_err_se_err)?
-                    else {
-                        continue;
-                    };
-
-                    let output_key = field.get_key_json(key_str, &state.extra);
-                    // Use `no_infer` here because the `serialize_as_any` logic has been handled in `prepare_value`
-                    let s = PydanticSerializer::new_no_infer(&value, serializer, state);
-                    map.serialize_entry(&output_key, &s)?;
-                } else if self.mode == FieldsMode::TypedDictAllow {
-                    // FIXME: why is `extra_serializer` not used here when `serialize_as_any` is not set?
-                    let output_key = infer_json_key(&key, state).map_err(py_err_se_err)?;
-                    let s = SerializeInfer::new(&value, state);
-                    map.serialize_entry(&output_key, &s)?;
-                }
-                // no error case here since unions (which need the error case) use `to_python(..., mode='json')`
-            }
-        }
-        Ok(map)
     }
 
     /// Gets the serializer to use for a field, applying `serialize_as_any` logic and applying any
@@ -346,32 +314,16 @@ impl GeneralFieldsSerializer {
         ))
     }
 
-    pub(crate) fn add_computed_fields_python<'py>(
+    pub(crate) fn add_computed_fields<'py, M: SerializeMap>(
         &self,
         model: &Bound<'py, PyAny>,
-        output_dict: &Bound<'py, PyDict>,
+        map: &mut M,
         state: &mut SerializationState<'py>,
-    ) -> PyResult<()> {
+    ) -> Result<(), M::Error> {
         if let Some(ref computed_fields) = self.computed_fields {
-            computed_fields.to_python(model, output_dict, &self.filter, state)?;
+            computed_fields.serialize(model, map, &self.filter, state)?;
         }
         Ok(())
-    }
-
-    pub(crate) fn add_computed_fields_json<'py, S: serde::ser::Serializer>(
-        &self,
-        model: &Bound<'py, PyAny>,
-        map: &mut S::SerializeMap,
-        state: &mut SerializationState<'py>,
-    ) -> Result<(), S::Error> {
-        if let Some(ref computed_fields) = self.computed_fields {
-            computed_fields.serde_serialize::<S>(model, map, &self.filter, state)?;
-        }
-        Ok(())
-    }
-
-    pub(crate) fn computed_field_count(&self) -> usize {
-        option_length!(self.computed_fields)
     }
 }
 
@@ -382,38 +334,7 @@ impl_py_gc_traverse!(GeneralFieldsSerializer {
 
 impl TypeSerializer for GeneralFieldsSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
-        let py = value.py();
-        let missing_sentinel = get_missing_sentinel_object(py);
-
-        let model = get_model(state)?;
-
-        let Some((main_dict, extra_dict)) = self.extract_dicts(value) else {
-            state.warn_fallback_py(self.get_name(), value)?;
-            return infer_to_python(value, state);
-        };
-        let output_dict = self.main_to_python(py, &model, dict_items(&main_dict), state)?;
-
-        // this is used to include `__pydantic_extra__` in serialization on models
-        if let Some(extra_dict) = extra_dict {
-            for (key, value) in extra_dict {
-                if state.extra.exclude_none && value.is_none() {
-                    continue;
-                }
-                if value.is(missing_sentinel) {
-                    continue;
-                }
-                if let Some((next_include, next_exclude)) = self.filter.key_filter(&key, state)? {
-                    let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                    let value = match &self.extra_serializer {
-                        Some(serializer) => serializer.to_python(&value, state)?,
-                        _ => infer_to_python(&value, state)?,
-                    };
-                    output_dict.set_item(key, value)?;
-                }
-            }
-        }
-        self.add_computed_fields_python(&model, &output_dict, state)?;
-        Ok(output_dict.into())
+        self.serialize(value, state, serialize_to_python(value.py()))
     }
 
     fn json_key<'a, 'py>(
@@ -430,42 +351,8 @@ impl TypeSerializer for GeneralFieldsSerializer {
         serializer: S,
         state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
-        let Some((main_dict, extra_dict)) = self.extract_dicts(value) else {
-            state.warn_fallback_ser::<S>(self.get_name(), value)?;
-            return infer_serialize(value, serializer, state);
-        };
-        let missing_sentinel = get_missing_sentinel_object(value.py());
-        let model = get_model(state).map_err(py_err_se_err)?;
-
-        let expected_len = match self.mode {
-            FieldsMode::TypedDictAllow => main_dict.len() + self.computed_field_count(),
-            _ => self.fields.len() + option_length!(extra_dict) + self.computed_field_count(),
-        };
-        // NOTE! As above, we maintain the order of the input dict assuming that's right
-        // we don't both with `used_req_fields` here because on unions, `to_python(..., mode='json')` is used
-        let mut map = self.main_serde_serialize(dict_items(&main_dict), expected_len, serializer, state)?;
-
-        // this is used to include `__pydantic_extra__` in serialization on models
-        if let Some(extra_dict) = extra_dict {
-            for (key, value) in extra_dict {
-                if state.extra.exclude_none && value.is_none() {
-                    continue;
-                }
-                if value.is(missing_sentinel) {
-                    continue;
-                }
-                let filter = self.filter.key_filter(&key, state).map_err(py_err_se_err)?;
-                if let Some((next_include, next_exclude)) = filter {
-                    let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                    let output_key = infer_json_key(&key, state).map_err(py_err_se_err)?;
-                    let s = SerializeInfer::new(&value, state);
-                    map.serialize_entry(&output_key, &s)?;
-                }
-            }
-        }
-
-        self.add_computed_fields_json::<S>(&model, &mut map, state)?;
-        map.end()
+        self.serialize(value, state, serialize_to_json(serializer))
+            .map_err(unwrap_ser_error)
     }
 
     fn get_name(&self) -> &'static str {

--- a/pydantic-core/src/serializers/infer.rs
+++ b/pydantic-core/src/serializers/infer.rs
@@ -4,19 +4,22 @@ use std::cell::RefCell;
 use pyo3::exceptions::PyTypeError;
 use pyo3::intern;
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::PyComplex;
 use pyo3::types::{PyByteArray, PyBytes, PyDict, PyFrozenSet, PyIterator, PyList, PySet, PyString, PyTuple};
 
 use pyo3::IntoPyObjectExt;
-use serde::ser::{Error, Serialize, SerializeMap, SerializeSeq, Serializer};
+use serde::ser::{Error, Serialize, SerializeSeq, Serializer};
 
 use crate::input::{EitherTimedelta, Int};
 use crate::serializers::SerializationState;
 use crate::serializers::errors::unwrap_ser_error;
 use crate::serializers::shared::DoSerialize;
+use crate::serializers::shared::SerializeMap;
 use crate::serializers::shared::serialize_to_json;
 use crate::serializers::shared::serialize_to_python;
 use crate::serializers::type_serializers;
+use crate::serializers::type_serializers::any::AnySerializer;
 use crate::serializers::type_serializers::format::serialize_via_str;
 use crate::tools::{py_err, safe_repr};
 
@@ -27,7 +30,6 @@ use super::errors::{PydanticSerializationError, py_err_se_err};
 use super::extra::SerMode;
 use super::filter::{AnyFilter, SchemaFilter};
 use super::ob_type::ObType;
-use super::shared::any_dataclass_iter;
 
 pub(crate) fn infer_to_python<'py>(
     value: &Bound<'py, PyAny>,
@@ -145,9 +147,7 @@ pub(crate) fn infer_to_python_known<'py>(
             }
             ObType::Dict => {
                 let dict = value.cast::<PyDict>()?;
-                serialize_pairs_python(py, dict.iter().map(Ok), state, |k, state| {
-                    Ok(PyString::new(py, &infer_json_key(&k, state)?).into_any())
-                })?
+                serialize_pairs(dict.iter().map(Ok), state, serialize_to_python(py))?
             }
             ObType::Datetime => {
                 let datetime = state.config.temporal_mode.datetime_to_json(value.py(), value.cast()?)?;
@@ -171,15 +171,13 @@ pub(crate) fn infer_to_python_known<'py>(
             | ObType::Ipv4Address
             | ObType::Ipv6Address
             | ObType::Ipv4Network
-            | ObType::Ipv6Network => serialize_via_str(value, serialize_to_python())?,
+            | ObType::Ipv6Network => serialize_via_str(value, serialize_to_python(py))?,
             ObType::Uuid => {
                 let uuid = super::type_serializers::uuid::uuid_to_string(value)?;
                 uuid.into_py_any(py)?
             }
-            ObType::PydanticSerializable => call_pydantic_serializer(value, state, serialize_to_python())?,
-            ObType::Dataclass => serialize_pairs_python(py, any_dataclass_iter(value)?.0, state, |k, state| {
-                Ok(PyString::new(py, &infer_json_key(&k, state)?).into_any())
-            })?,
+            ObType::PydanticSerializable => call_pydantic_serializer(value, state, serialize_to_python(py))?,
+            ObType::Dataclass => infer_serialize_dataclass(value, state, serialize_to_python(py))?,
             ObType::Enum => {
                 let v = value.getattr(intern!(py, "value"))?;
                 infer_to_python(&v, state)?
@@ -204,7 +202,7 @@ pub(crate) fn infer_to_python_known<'py>(
                 let complex_str = type_serializers::complex::complex_to_str(v);
                 complex_str.into_py_any(py)?
             }
-            ObType::Pattern => serialize_pattern(value, serialize_to_python())?,
+            ObType::Pattern => serialize_pattern(value, serialize_to_python(py))?,
             ObType::Unknown => {
                 if let Some(fallback) = &state.extra.fallback {
                     let next_value = fallback.call1((value,))?;
@@ -236,10 +234,10 @@ pub(crate) fn infer_to_python_known<'py>(
             }
             ObType::Dict => {
                 let dict = value.cast::<PyDict>()?;
-                serialize_pairs_python(py, dict.iter().map(Ok), state, |k, _| Ok(k))?
+                serialize_pairs(dict.iter().map(Ok), state, serialize_to_python(py))?
             }
-            ObType::PydanticSerializable => call_pydantic_serializer(value, state, serialize_to_python())?,
-            ObType::Dataclass => serialize_pairs_python(py, any_dataclass_iter(value)?.0, state, |k, _| Ok(k))?,
+            ObType::PydanticSerializable => call_pydantic_serializer(value, state, serialize_to_python(py))?,
+            ObType::Dataclass => infer_serialize_dataclass(value, state, serialize_to_python(py))?,
             ObType::Generator => {
                 let iter = super::type_serializers::generator::SerializationIterator::new(
                     value.cast()?,
@@ -394,7 +392,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
         }
         ObType::Dict => {
             let dict = value.cast::<PyDict>().map_err(py_err_se_err)?;
-            serialize_pairs_json(dict.iter().map(Ok), dict.len(), serializer, state)
+            serialize_pairs(dict.iter().map(Ok), state, serialize_to_json(serializer)).map_err(unwrap_ser_error)
         }
         ObType::List => serialize_seq_filter!(PyList),
         ObType::Tuple => serialize_seq_filter!(PyTuple),
@@ -427,8 +425,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
             call_pydantic_serializer(value, state, serialize_to_json(serializer)).map_err(unwrap_ser_error)
         }
         ObType::Dataclass => {
-            let (pairs_iter, fields_dict) = any_dataclass_iter(value).map_err(py_err_se_err)?;
-            serialize_pairs_json(pairs_iter, fields_dict.len(), serializer, state)
+            infer_serialize_dataclass(value, state, serialize_to_json(serializer)).map_err(unwrap_ser_error)
         }
         ObType::Uuid => {
             let uuid = super::type_serializers::uuid::uuid_to_string(value).map_err(py_err_se_err)?;
@@ -477,14 +474,6 @@ fn unknown_type_error(value: &Bound<'_, PyAny>) -> PyErr {
         "Unable to serialize unknown type: {}",
         safe_repr(&value.get_type())
     ))
-}
-
-fn serialize_pattern<'py, T, E: From<PyErr>>(
-    value: &Bound<'py, PyAny>,
-    do_serialize: impl DoSerialize<'py, T, E>,
-) -> Result<T, E> {
-    let pattern = value.getattr(intern!(value.py(), "pattern"))?;
-    serialize_via_str(&pattern, do_serialize)
 }
 
 fn serialize_unknown<'py>(value: &Bound<'py, PyAny>) -> Cow<'py, str> {
@@ -607,11 +596,11 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
 /// Serialize `value` as if it had a `__pydantic_serializer__` attribute
 ///
 /// `do_serialize` should be a closure which performs serialization without type inference
-pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
+pub(crate) fn call_pydantic_serializer<'py, S: DoSerialize>(
     value: &Bound<'py, PyAny>,
     state: &mut SerializationState<'py>,
-    do_serialize: impl DoSerialize<'py, T, E>,
-) -> Result<T, E> {
+    do_serialize: S,
+) -> Result<S::Ok, S::Error> {
     let py = value.py();
     let py_serializer = value.getattr(intern!(py, "__pydantic_serializer__"))?;
     let extracted_serializer: PyRef<SchemaSerializer> = py_serializer.extract().map_err(Into::into)?;
@@ -631,47 +620,61 @@ pub(crate) fn call_pydantic_serializer<'py, T, E: From<PyErr>>(
     do_serialize.serialize_no_infer(&extracted_serializer.serializer, value, &mut state)
 }
 
-fn serialize_pairs_python<'py>(
-    py: Python,
-    pairs_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
-    state: &mut SerializationState<'py>,
-    key_transform: impl Fn(Bound<'py, PyAny>, &mut SerializationState<'py>) -> PyResult<Bound<'py, PyAny>>,
-) -> PyResult<Py<PyAny>> {
-    let new_dict = PyDict::new(py);
-    let filter = AnyFilter::new();
-
-    for result in pairs_iter {
-        let (k, v) = result?;
-        let op_next = filter.key_filter(&k, state)?;
-        if let Some((next_include, next_exclude)) = op_next {
-            let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-            let k = key_transform(k, state)?;
-            let v = infer_to_python(&v, state)?;
-            new_dict.set_item(k, v)?;
-        }
-    }
-    Ok(new_dict.into())
+fn serialize_pattern<S: DoSerialize>(value: &Bound<'_, PyAny>, do_serialize: S) -> Result<S::Ok, S::Error> {
+    let pattern = value.getattr(intern!(value.py(), "pattern"))?;
+    serialize_via_str(&pattern, do_serialize)
 }
 
-fn serialize_pairs_json<'py, S: Serializer>(
-    pairs_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
-    iter_size: usize,
-    serializer: S,
+/// Serializes `value` as a dataclass where all fields are serialized using type inference.
+fn infer_serialize_dataclass<'py, S: DoSerialize>(
+    value: &Bound<'py, PyAny>,
     state: &mut SerializationState<'py>,
+    do_serialize: S,
 ) -> Result<S::Ok, S::Error> {
-    let mut map = serializer.serialize_map(Some(iter_size))?;
+    let py = value.py();
+    let fields = value
+        .getattr(intern!(py, "__dataclass_fields__"))?
+        .cast_into::<PyDict>()
+        .map_err(PyErr::from)?;
+    let field_type_marker = get_field_marker(py)?;
+
+    let next = move |(field_name, field): (Bound<'py, PyAny>, Bound<'py, PyAny>)| -> PyResult<Option<(Bound<'py, PyAny>, Bound<'py, PyAny>)>> {
+        let field_type = field.getattr(intern!(py, "_field_type"))?;
+        if field_type.is(field_type_marker) {
+            let value = value.getattr(field_name.cast::<PyString>()?)?;
+            Ok(Some((field_name, value)))
+        } else {
+            Ok(None)
+        }
+    };
+
+    let pairs_iter = fields.iter().filter_map(move |field| next(field).transpose());
+
+    serialize_pairs(pairs_iter, state, do_serialize)
+}
+
+/// needed to match the logic from dataclasses.fields `tuple(f for f in fields.values() if f._field_type is _FIELD)`
+fn get_field_marker(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
+    static DC_FIELD_MARKER: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+    DC_FIELD_MARKER.import(py, "dataclasses", "_FIELD")
+}
+
+fn serialize_pairs<'py, S: DoSerialize>(
+    pairs_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
+    state: &mut SerializationState<'py>,
+    do_serialize: S,
+) -> Result<S::Ok, S::Error> {
+    let mut map_serializer = do_serialize.serialize_map()?;
     let filter = AnyFilter::new();
+    let any_ser = AnySerializer::get();
 
     for result in pairs_iter {
-        let (key, value) = result.map_err(py_err_se_err)?;
-
-        let op_next = filter.key_filter(&key, state).map_err(py_err_se_err)?;
-        if let Some((next_include, next_exclude)) = op_next {
+        let (key, value) = result?;
+        if let Some((next_include, next_exclude)) = filter.key_filter(&key, state)? {
             let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-            let key = infer_json_key(&key, state).map_err(py_err_se_err)?;
-            let value_serializer = SerializeInfer::new(&value, state);
-            map.serialize_entry(&key, &value_serializer)?;
+            map_serializer.serialize_entry(&key, any_ser, &value, any_ser, state)?;
         }
     }
-    map.end()
+    map_serializer.end()
 }

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -5,12 +5,13 @@ use std::io::{self, Write};
 use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
-use pyo3::sync::PyOnceLock;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyString};
 use pyo3::{IntoPyObjectExt, prelude::*};
 use pyo3::{PyTraverseError, PyVisit, intern};
 
 use enum_dispatch::enum_dispatch;
+use serde::ser::SerializeMap as _;
 use serde::{Serialize, Serializer};
 use serde_json::ser::{Formatter, PrettyFormatter};
 
@@ -18,6 +19,7 @@ use crate::build_tools::py_schema_err;
 use crate::build_tools::py_schema_error_type;
 use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
+use crate::serializers::SerMode;
 use crate::serializers::errors::WrappedSerError;
 use crate::serializers::ser::PythonSerializer;
 use crate::serializers::type_serializers::any::AnySerializer;
@@ -576,64 +578,61 @@ pub(crate) fn to_json_bytes<'py>(
     Ok(bytes)
 }
 
-#[allow(clippy::type_complexity)]
-pub(super) fn any_dataclass_iter<'a, 'py>(
-    dataclass: &'a Bound<'py, PyAny>,
-) -> PyResult<(
-    impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>> + 'a,
-    Bound<'py, PyDict>,
-)>
-where
-    'py: 'a,
-{
-    let py = dataclass.py();
-    let fields = dataclass
-        .getattr(intern!(py, "__dataclass_fields__"))?
-        .cast_into::<PyDict>()?;
-    let field_type_marker = get_field_marker(py)?;
-
-    let next = move |(field_name, field): (Bound<'py, PyAny>, Bound<'py, PyAny>)| -> PyResult<Option<(Bound<'py, PyAny>, Bound<'py, PyAny>)>> {
-        let field_type = field.getattr(intern!(py, "_field_type"))?;
-        if field_type.is(field_type_marker) {
-            let value = dataclass.getattr(field_name.cast::<PyString>()?)?;
-            Ok(Some((field_name, value)))
-        } else {
-            Ok(None)
-        }
-    };
-
-    Ok((fields.iter().filter_map(move |field| next(field).transpose()), fields))
-}
-
-static DC_FIELD_MARKER: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
-
-/// needed to match the logic from dataclasses.fields `tuple(f for f in fields.values() if f._field_type is _FIELD)`
-fn get_field_marker(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
-    DC_FIELD_MARKER.import(py, "dataclasses", "_FIELD")
-}
-
 /// Common interface for doing serialization
-pub trait DoSerialize<'py, OutputT, ErrorT> {
-    fn serialize_no_infer(
+pub(crate) trait DoSerialize {
+    type Ok;
+    type Error: From<PyErr>;
+
+    fn serialize_no_infer<'py>(
         self,
         serializer: &CombinedSerializer,
         value: &Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
-    ) -> Result<OutputT, ErrorT>;
+    ) -> Result<Self::Ok, Self::Error>;
 
-    fn serialize_fallback(
+    fn serialize_fallback<'py>(
         self,
         name: &str,
         value: &Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
-    ) -> Result<OutputT, ErrorT>;
+    ) -> Result<Self::Ok, Self::Error>;
 
-    fn serialize_str(self, value: &Bound<'py, PyString>) -> Result<OutputT, ErrorT>;
+    fn serialize_str(self, value: &Bound<'_, PyString>) -> Result<Self::Ok, Self::Error>;
+
+    type Map: SerializeMap<Ok = Self::Ok, Error = Self::Error>;
+
+    fn serialize_map(self) -> Result<Self::Map, Self::Error>;
+}
+
+pub(crate) trait SerializeMap {
+    type Ok;
+    type Error: From<PyErr>;
+
+    /// Serialize a key-value entry into the map
+    fn serialize_entry<'py>(
+        &mut self,
+        key: &Bound<'py, PyAny>,
+        key_serializer: &CombinedSerializer,
+        value: &Bound<'py, PyAny>,
+        value_serializer: &CombinedSerializer,
+        state: &mut SerializationState<'py>,
+    ) -> Result<(), Self::Error>;
+
+    /// Serialize a string key-value entry into the map (avoids needing to "serialize" the key)
+    fn serialize_entry_string_key<'py>(
+        &mut self,
+        key: &PyBackedStr,
+        value: &Bound<'py, PyAny>,
+        value_serializer: &CombinedSerializer,
+        state: &mut SerializationState<'py>,
+    ) -> Result<(), Self::Error>;
+
+    fn end(self) -> Result<Self::Ok, Self::Error>;
 }
 
 /// Helper to create a `SerializeToPython` instance
-pub fn serialize_to_python() -> SerializeToPython {
-    SerializeToPython { _private: () }
+pub fn serialize_to_python(py: Python<'_>) -> SerializeToPython<'_> {
+    SerializeToPython(py)
 }
 
 /// Helper to create a `SerializeToJson` instance
@@ -641,12 +640,13 @@ pub fn serialize_to_json<S>(serializer: S) -> SerializeToJson<S> {
     SerializeToJson { serializer }
 }
 
-pub struct SerializeToPython {
-    _private: (),
-}
+pub struct SerializeToPython<'py>(Python<'py>);
 
-impl<'py> DoSerialize<'py, Py<PyAny>, PyErr> for SerializeToPython {
-    fn serialize_no_infer(
+impl<'s> DoSerialize for SerializeToPython<'s> {
+    type Ok = Py<PyAny>;
+    type Error = PyErr;
+
+    fn serialize_no_infer<'py>(
         self,
         serializer: &CombinedSerializer,
         value: &Bound<'py, PyAny>,
@@ -655,7 +655,7 @@ impl<'py> DoSerialize<'py, Py<PyAny>, PyErr> for SerializeToPython {
         serializer.to_python_no_infer(value, state)
     }
 
-    fn serialize_fallback(
+    fn serialize_fallback<'py>(
         self,
         name: &str,
         value: &Bound<'py, PyAny>,
@@ -665,17 +665,67 @@ impl<'py> DoSerialize<'py, Py<PyAny>, PyErr> for SerializeToPython {
         infer_to_python(value, state)
     }
 
-    fn serialize_str(self, value: &Bound<'py, PyString>) -> Result<Py<PyAny>, PyErr> {
+    fn serialize_str(self, value: &Bound<'_, PyString>) -> Result<Py<PyAny>, PyErr> {
         value.into_py_any(value.py())
+    }
+
+    type Map = Bound<'s, PyDict>;
+
+    fn serialize_map(self) -> Result<Bound<'s, PyDict>, PyErr> {
+        Ok(PyDict::new(self.0))
     }
 }
 
-pub struct SerializeToJson<S> {
+impl SerializeMap for Bound<'_, PyDict> {
+    type Ok = Py<PyAny>;
+    type Error = PyErr;
+
+    fn serialize_entry<'py>(
+        &mut self,
+        key: &Bound<'py, PyAny>,
+        key_serializer: &CombinedSerializer,
+        value: &Bound<'py, PyAny>,
+        value_serializer: &CombinedSerializer,
+        state: &mut SerializationState<'py>,
+    ) -> Result<(), Self::Error> {
+        if matches!(state.extra.mode, SerMode::Json) {
+            let key = key_serializer.json_key_no_infer(key, state)?;
+            let py_value = value_serializer.to_python_no_infer(value, state)?;
+            self.set_item(key, py_value)?;
+        } else {
+            let py_key = key_serializer.to_python_no_infer(key, state)?;
+            let py_value = value_serializer.to_python_no_infer(value, state)?;
+            self.set_item(py_key, py_value)?;
+        }
+        Ok(())
+    }
+
+    fn serialize_entry_string_key<'py>(
+        &mut self,
+        key: &PyBackedStr,
+        value: &Bound<'py, PyAny>,
+        value_serializer: &CombinedSerializer,
+        state: &mut SerializationState<'py>,
+    ) -> Result<(), Self::Error> {
+        let py_value = value_serializer.to_python_no_infer(value, state)?;
+        self.set_item(key, py_value)?;
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.into_any().unbind())
+    }
+}
+
+pub(crate) struct SerializeToJson<S> {
     serializer: S,
 }
 
-impl<'py, S: Serializer> DoSerialize<'py, S::Ok, WrappedSerError<S::Error>> for SerializeToJson<S> {
-    fn serialize_no_infer(
+impl<S: Serializer> DoSerialize for SerializeToJson<S> {
+    type Ok = S::Ok;
+    type Error = WrappedSerError<S::Error>;
+
+    fn serialize_no_infer<'py>(
         self,
         serializer: &CombinedSerializer,
         value: &Bound<'py, PyAny>,
@@ -686,7 +736,7 @@ impl<'py, S: Serializer> DoSerialize<'py, S::Ok, WrappedSerError<S::Error>> for 
             .map_err(WrappedSerError)
     }
 
-    fn serialize_fallback(
+    fn serialize_fallback<'py>(
         self,
         name: &str,
         value: &Bound<'py, PyAny>,
@@ -696,8 +746,54 @@ impl<'py, S: Serializer> DoSerialize<'py, S::Ok, WrappedSerError<S::Error>> for 
         infer_serialize(value, self.serializer, state).map_err(WrappedSerError)
     }
 
-    fn serialize_str(self, value: &Bound<'py, PyString>) -> Result<S::Ok, WrappedSerError<S::Error>> {
+    fn serialize_str(self, value: &Bound<'_, PyString>) -> Result<S::Ok, WrappedSerError<S::Error>> {
         let s = value.to_str()?;
         self.serializer.serialize_str(s).map_err(WrappedSerError)
+    }
+
+    type Map = SerdeMapSerializer<S>;
+
+    fn serialize_map(self) -> Result<SerdeMapSerializer<S>, Self::Error> {
+        Ok(SerdeMapSerializer::<S> {
+            // choice not to pass size_hint here is because JSON maps don't need a size hint
+            map: self.serializer.serialize_map(None).map_err(WrappedSerError)?,
+        })
+    }
+}
+
+pub(crate) struct SerdeMapSerializer<S: Serializer> {
+    map: S::SerializeMap,
+}
+
+impl<S: Serializer> SerializeMap for SerdeMapSerializer<S> {
+    type Ok = S::Ok;
+    type Error = WrappedSerError<S::Error>;
+
+    fn serialize_entry<'py>(
+        &mut self,
+        key: &Bound<'py, PyAny>,
+        key_serializer: &CombinedSerializer,
+        value: &Bound<'py, PyAny>,
+        value_serializer: &CombinedSerializer,
+        state: &mut SerializationState<'py>,
+    ) -> Result<(), Self::Error> {
+        let key = key_serializer.json_key_no_infer(key, state)?;
+        let value_ser = PydanticSerializer::new_no_infer(value, value_serializer, state);
+        self.map.serialize_entry(&key, &value_ser).map_err(WrappedSerError)
+    }
+
+    fn serialize_entry_string_key<'py>(
+        &mut self,
+        key: &PyBackedStr,
+        value: &Bound<'py, PyAny>,
+        value_serializer: &CombinedSerializer,
+        state: &mut SerializationState<'py>,
+    ) -> Result<(), Self::Error> {
+        let value_ser = PydanticSerializer::new_no_infer(value, value_serializer, state);
+        self.map.serialize_entry(&**key, &value_ser).map_err(WrappedSerError)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.map.end().map_err(WrappedSerError)
     }
 }

--- a/pydantic-core/src/serializers/type_serializers/format.rs
+++ b/pydantic-core/src/serializers/type_serializers/format.rs
@@ -184,7 +184,7 @@ impl_py_gc_traverse!(ToStringSerializer {});
 impl TypeSerializer for ToStringSerializer {
     fn to_python(&self, value: &Bound<'_, PyAny>, state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {
         if self.when_used.should_use(value, &state.extra) {
-            serialize_via_str(value, serialize_to_python())
+            serialize_via_str(value, serialize_to_python(value.py()))
         } else {
             Ok(value.clone().unbind())
         }
@@ -221,10 +221,7 @@ impl TypeSerializer for ToStringSerializer {
 }
 
 /// Serialize a value by calling `str()` on it
-pub fn serialize_via_str<'py, T, E: From<PyErr>>(
-    value: &Bound<'py, PyAny>,
-    do_serialize: impl DoSerialize<'py, T, E>,
-) -> Result<T, E> {
+pub fn serialize_via_str<S: DoSerialize>(value: &Bound<'_, PyAny>, do_serialize: S) -> Result<S::Ok, S::Error> {
     let s = value.str()?;
     do_serialize.serialize_str(&s)
 }

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PySet, PyString, PyType};
+use pyo3::pybacked::PyBackedStr;
+use pyo3::types::{PyDict, PySet, PyType};
 
 use ahash::AHashMap;
 use pyo3::IntoPyObjectExt;
@@ -56,19 +57,14 @@ impl BuildSerializer for ModelFieldsBuilder {
         let serialize_by_alias = config.get_as(intern!(py, "serialize_by_alias"))?;
 
         for (key, value) in fields_dict {
-            let key_py = key.cast_into::<PyString>()?;
-            let key: String = key_py.extract()?;
+            let key_py: PyBackedStr = key.extract()?;
+            let key: String = key_py.to_string();
             let field_info = value.cast()?;
 
-            let key_py: Py<PyString> = key_py.into();
-
             if field_info.get_as(intern!(py, "serialization_exclude"))? == Some(true) {
-                fields.insert(
-                    key,
-                    SerField::new(py, key_py, None, None, true, serialize_by_alias, None),
-                );
+                fields.insert(key, SerField::new(key_py, None, None, true, serialize_by_alias, None));
             } else {
-                let alias: Option<String> = field_info.get_as(intern!(py, "serialization_alias"))?;
+                let alias = field_info.get_as(intern!(py, "serialization_alias"))?;
                 let serialization_exclude_if: Option<Py<PyAny>> =
                     field_info.get_as(intern!(py, "serialization_exclude_if"))?;
                 let schema = field_info.get_as_req(intern!(py, "schema"))?;
@@ -78,7 +74,6 @@ impl BuildSerializer for ModelFieldsBuilder {
                 fields.insert(
                     key,
                     SerField::new(
-                        py,
                         key_py,
                         alias,
                         Some(serializer),
@@ -163,15 +158,12 @@ impl ModelSerializer {
     /// - compatibility checks
     /// - extracting the inner value for root models
     /// - applying `serialize_as_any` where needed
-    ///
-    /// If the value is not applicable, `do_serialize` will be called with `None` to indicate fallback
-    /// behaviour should be used.
-    fn serialize<'py, T, E: From<PyErr>>(
+    fn serialize<'py, S: DoSerialize>(
         &self,
         value: &Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
-        do_serialize: impl DoSerialize<'py, T, E>,
-    ) -> Result<T, E> {
+        do_serialize: S,
+    ) -> Result<S::Ok, S::Error> {
         if self.root_model {
             return self.serialize_root_model(value, state, do_serialize);
         }
@@ -186,12 +178,12 @@ impl ModelSerializer {
         do_serialize.serialize_no_infer(&self.serializer, &inner_value, state)
     }
 
-    fn serialize_root_model<'py, T, E: From<PyErr>>(
+    fn serialize_root_model<'py, S: DoSerialize>(
         &self,
         value: &Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
-        do_serialize: impl DoSerialize<'py, T, E>,
-    ) -> Result<T, E> {
+        do_serialize: S,
+    ) -> Result<S::Ok, S::Error> {
         if !self.allow_value_root_model(value, state.check)? {
             return do_serialize.serialize_fallback(self.get_name(), value, state);
         }
@@ -251,7 +243,7 @@ impl_py_gc_traverse!(ModelSerializer { class, serializer });
 
 impl TypeSerializer for ModelSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
-        self.serialize(value, state, serialize_to_python())
+        self.serialize(value, state, serialize_to_python(value.py()))
     }
 
     fn json_key<'a, 'py>(


### PR DESCRIPTION
## Change Summary

This reworks dataclass serialization to make use of the `DoSerialize` abstraction over python & json (similar to how model serialization was started in https://github.com/pydantic/pydantic-core/pull/1855).

The upside is a lot more DRY, so fewer bugs and less code to read 🎉 

## Related issue number

I have done this as a precursor to #12518, where I want to be able to use this to fallback to inferred serialization of stdlib dataclasses.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
