### PR TITLE
Fix serialization of typed dict unions when `exclude_none` is set

### DIFF
--- a/pydantic-core/src/serializers/computed_fields.rs
+++ b/pydantic-core/src/serializers/computed_fields.rs
@@ -6,11 +6,11 @@ use pyo3::types::{PyDict, PyList};
 use pyo3::{PyTraverseError, PyVisit, intern};
 
 use crate::build_tools::py_schema_error_type;
-use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::extra::FieldName;
+use crate::serializers::fields::exclude_field_by_value;
 use crate::serializers::filter::SchemaFilter;
 use crate::serializers::shared::{BuildSerializer, CombinedSerializer, SerializeMap};
 use crate::tools::{SchemaDict, pybackedstr_to_pystring};
@@ -42,6 +42,7 @@ impl ComputedFields {
         map: &mut M,
         filter: &SchemaFilter<isize>,
         state: &mut SerializationState<'py>,
+        missing_sentinel: &Bound<'py, PyAny>,
     ) -> Result<(), M::Error> {
         // In round trip mode, exclude computed fields:
         if state.extra.round_trip || state.extra.exclude_computed_fields {
@@ -50,22 +51,24 @@ impl ComputedFields {
 
         for computed_field in &self.0 {
             let property_name_py = pybackedstr_to_pystring(model.py(), &computed_field.property_name);
-            let Some((next_include, next_exclude)) = filter.key_filter(&property_name_py, state)? else {
+            let Some(next_include_exclude) = filter.key_filter(&property_name_py, state)? else {
                 continue;
             };
 
             let value = model.getattr(&property_name_py)?;
-            if state.extra.exclude_none && value.is_none() {
-                continue;
-            }
-            let missing_sentinel = get_missing_sentinel_object(model.py());
-            if value.is(missing_sentinel) {
+            if exclude_field_by_value(
+                &value,
+                state,
+                missing_sentinel,
+                // TODO: support exclude_if for computed fields?
+                None,
+            )? {
                 continue;
             }
 
             let field_name = FieldName::from(property_name_py);
             let state = &mut state.scoped_set(|s| &mut s.field_name, Some(field_name));
-            let state = &mut state.scoped_include_exclude(next_include, next_exclude);
+            let state = &mut state.scoped_include_exclude(next_include_exclude);
             let key = match state.extra.serialize_by_alias_or(computed_field.serialize_by_alias) {
                 true => &computed_field.alias,
                 false => &computed_field.property_name,

--- a/pydantic-core/src/serializers/fields.rs
+++ b/pydantic-core/src/serializers/fields.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
-use pyo3::types::{PyDict, PyString};
+use pyo3::types::PyDict;
 
 use ahash::AHashMap;
 use smallvec::SmallVec;
@@ -13,10 +13,11 @@ use crate::PydanticSerializationUnexpectedValue;
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::serializers::SerializationState;
 use crate::serializers::errors::unwrap_ser_error;
-use crate::serializers::extra::{FieldName, SerCheck};
+use crate::serializers::extra::{FieldName, IncludeExclude, SerCheck};
 use crate::serializers::shared::{DoSerialize, SerializeMap, serialize_to_json, serialize_to_python};
 use crate::serializers::type_serializers::any::AnySerializer;
 use crate::serializers::type_serializers::function::{FunctionPlainSerializer, FunctionWrapSerializer};
+use crate::tools::pybackedstr_to_pystring;
 
 use super::computed_fields::ComputedFields;
 use super::extra::Extra;
@@ -105,6 +106,7 @@ pub(super) enum FieldsMode {
 /// General purpose serializer for fields - used by dataclasses, models and typed_dicts
 #[derive(Debug)]
 pub struct GeneralFieldsSerializer {
+    // TODO: use PyBackedStr in the keys
     fields: AHashMap<String, SerField>,
     computed_fields: Option<ComputedFields>,
     mode: FieldsMode,
@@ -151,151 +153,121 @@ impl GeneralFieldsSerializer {
         state: &mut SerializationState<'py>,
         do_serialize: S,
     ) -> Result<S::Ok, S::Error> {
-        let py = value.py();
-
         let Some((main_dict, extra_dict)) = self.extract_dicts(value) else {
             return do_serialize.serialize_fallback(self.get_name(), value, state);
         };
 
-        let missing_sentinel = get_missing_sentinel_object(py);
-        let model = get_model(state)?;
-
-        let mut map = self.serialize_main(py, &model, dict_items(&main_dict), state, do_serialize)?;
-
-        // this is used to include `__pydantic_extra__` in serialization on models
-        if let Some(extra_dict) = extra_dict {
-            for (key, value) in extra_dict {
-                if state.extra.exclude_none && value.is_none() {
-                    continue;
-                }
-                if value.is(missing_sentinel) {
-                    continue;
-                }
-                if let Some((next_include, next_exclude)) = self.filter.key_filter(&key, state)? {
-                    let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                    map.serialize_entry(
-                        &key,
-                        AnySerializer::get(),
-                        &value,
-                        self.extra_serializer.as_ref().unwrap_or(AnySerializer::get()),
-                        state,
-                    )?;
-                }
-            }
-        }
-        self.add_computed_fields(&model, &mut map, state)?;
-        map.end()
+        self.serialize_iterators(
+            &get_model(state)?,
+            dict_items(&main_dict),
+            extra_dict.into_iter().flatten().map(Ok),
+            state,
+            do_serialize,
+        )
     }
 
-    pub(crate) fn serialize_main<'py, S: DoSerialize>(
+    /// Serialize from two iterators - one for the main fields, one for extra fields. Order of iteration is preserved.
+    ///
+    /// It is assumed that the iterators do not yield duplicate keys (the check logic will be incorrect if duplicates are present)
+    pub(crate) fn serialize_iterators<'py, S: DoSerialize>(
         &self,
-        py: Python<'py>,
         model: &Bound<'py, PyAny>,
         main_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
+        extras_iter: impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>>,
         state: &mut SerializationState<'py>,
         do_serialize: S,
-    ) -> Result<S::Map, S::Error> {
+    ) -> Result<S::Ok, S::Error> {
+        let py = model.py();
         let mut map = do_serialize.serialize_map()?;
         let mut used_req_fields: usize = 0;
         let missing_sentinel = get_missing_sentinel_object(py);
 
-        // NOTE! we maintain the order of the input dict assuming that's right
+        let extras_serializer = self
+            .extra_serializer
+            .as_ref()
+            // If using `serialize_as_any`, extras are always inferred
+            .filter(|_| !state.extra.serialize_as_any)
+            .unwrap_or_else(|| AnySerializer::get());
+
         for result in main_iter {
             let (key, value) = result?;
-            let key_str = key_str(&key)?;
-            let op_field = self.fields.get(key_str);
-            if state.extra.exclude_none && value.is_none() {
-                continue;
-            }
+            let key_str: PyBackedStr = key.extract()?;
 
             let field_name = FieldName::from(key.clone().cast_into().map_err(PyErr::from)?);
             let state = &mut state.scoped_set(|s| &mut s.field_name, Some(field_name));
-            if let Some((next_include, next_exclude)) = self.filter.key_filter(&key, state)? {
-                let state = &mut state.scoped_include_exclude(next_include, next_exclude);
-                if let Some(field) = op_field {
-                    let serializer = Self::prepare_value(&value, field, &state.extra, missing_sentinel)?;
 
-                    if field.required {
-                        used_req_fields += 1;
-                    }
-
-                    let Some(serializer) = serializer else {
-                        // field is excluded
-                        continue;
-                    };
-
-                    map.serialize_entry_string_key(field.get_key(&state.extra), &value, serializer, state)?;
-                } else if self.mode == FieldsMode::TypedDictAllow {
-                    let serializer = self
-                        .extra_serializer
-                        .as_ref()
-                        // If using `serialize_as_any`, extras are always inferred
-                        .filter(|_| !state.extra.serialize_as_any)
-                        .unwrap_or_else(|| AnySerializer::get());
-                    map.serialize_entry(&key, AnySerializer::get(), &value, serializer, state)?;
-                } else if state.check == SerCheck::Strict {
-                    return Err(PydanticSerializationUnexpectedValue::new(
-                        Some(format!("Unexpected field `{key}`")),
-                        Some(key_str.to_string()),
-                        model_type_name(model),
-                        None,
-                    )
-                    .to_py_err()
-                    .into());
+            if let Some(field) = self.fields.get(&*key_str) {
+                if field.required {
+                    used_req_fields += 1;
                 }
+
+                let Some((serializer, next_include_exclude)) =
+                    self.prepare_value(&key, &value, field, state, missing_sentinel)?
+                else {
+                    // field was excluded
+                    continue;
+                };
+
+                let state = &mut state.scoped_include_exclude(next_include_exclude);
+                map.serialize_entry_string_key(field.get_key(&state.extra), &value, serializer, state)?;
+            } else if self.mode == FieldsMode::TypedDictAllow {
+                self.serialize_extra(&key_str, &value, state, missing_sentinel, extras_serializer, &mut map)?;
+            } else if state.check == SerCheck::Strict {
+                return Err(unexpected_field(&key_str, model).into());
             }
         }
 
-        let extra = &state.extra;
-        if state.check.enabled()
-            // If any of these are true we can't count fields
-            && !(extra.exclude_defaults || extra.exclude_unset || extra.exclude_none || extra.exclude_computed_fields || state.exclude().is_some())
-            // Check for missing fields, we can't have extra fields here
-            && self.required_fields > used_req_fields
-        {
-            let required_fields = self.required_fields;
-
-            Err(PydanticSerializationUnexpectedValue::new(
-                Some(format!("Expected {required_fields} fields but got {used_req_fields}").to_string()),
-                state.field_name.as_ref().map(ToString::to_string),
-                model_type_name(model),
-                Some(model.clone().unbind()),
-            )
-            .to_py_err()
-            .into())
-        } else {
-            Ok(map)
+        if state.check.enabled() && self.required_fields > used_req_fields {
+            return Err(incorrect_field_count(self.required_fields, used_req_fields, model, state).into());
         }
+
+        for result in extras_iter {
+            let (key, value) = result?;
+            self.serialize_extra(
+                &key.extract()?,
+                &value,
+                state,
+                missing_sentinel,
+                extras_serializer,
+                &mut map,
+            )?;
+        }
+
+        if let Some(computed_fields) = &self.computed_fields {
+            computed_fields.serialize(model, &mut map, &self.filter, state, missing_sentinel)?;
+        }
+
+        map.end()
     }
 
     /// Gets the serializer to use for a field, applying `serialize_as_any` logic and applying any
     /// field-level exclusions
-    fn prepare_value<'s>(
-        value: &Bound<'_, PyAny>,
+    fn prepare_value<'s, 'py>(
+        &self,
+        key: &Bound<'py, PyAny>,
+        value: &Bound<'py, PyAny>,
         field: &'s SerField,
-        field_extra: &Extra<'_>,
-        missing_sentinel: &Bound<'_, PyAny>,
-    ) -> PyResult<Option<&'s Arc<CombinedSerializer>>> {
+        state: &SerializationState<'py>,
+        missing_sentinel: &Bound<'py, PyAny>,
+    ) -> PyResult<Option<(&'s Arc<CombinedSerializer>, IncludeExclude<'py>)>> {
+        // if field excluded at schema level, this is the cheapest exclusion
         let Some(serializer) = field.serializer.as_ref() else {
-            // field excluded at schema level
             return Ok(None);
         };
 
-        if value.is(missing_sentinel) {
+        // filtering on the keys
+        let Some(next_include_exclude) = self.filter.key_filter(key, state)? else {
+            return Ok(None);
+        };
+
+        // filtering on the value
+        if exclude_field_by_value(value, state, missing_sentinel, field.serialization_exclude_if.as_ref())?
+            || exclude_default(value, &state.extra, serializer)?
+        {
             return Ok(None);
         }
 
-        if exclude_default(value, field_extra, serializer)? {
-            return Ok(None);
-        }
-
-        // FIXME: should `exclude_if` be applied to extra fields too?
-        if serialization_exclude_if(field.serialization_exclude_if.as_ref(), value)? {
-            return Ok(None);
-        }
-
-        Ok(Some(
-            if field_extra.serialize_as_any &&
+        let serializer = if state.extra.serialize_as_any &&
             // if serialize_as_any is set, we ensure that field serializers are
             // still used, because this would match the `SerializeAsAny` annotation
             // on a field
@@ -309,24 +281,62 @@ impl GeneralFieldsSerializer {
                     ..
                 })
             ) {
-                AnySerializer::get()
-            } else {
-                serializer
-            },
-        ))
+            AnySerializer::get()
+        } else {
+            serializer
+        };
+
+        Ok(Some((serializer, next_include_exclude)))
     }
 
-    pub(crate) fn add_computed_fields<'py, M: SerializeMap>(
+    fn serialize_extra<'py, Map: SerializeMap>(
         &self,
-        model: &Bound<'py, PyAny>,
-        map: &mut M,
+        key: &PyBackedStr,
+        value: &Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
-    ) -> Result<(), M::Error> {
-        if let Some(ref computed_fields) = self.computed_fields {
-            computed_fields.serialize(model, map, &self.filter, state)?;
+        missing_sentinel: &Bound<'py, PyAny>,
+        extras_serializer: &Arc<CombinedSerializer>,
+        map: &mut Map,
+    ) -> Result<(), Map::Error> {
+        let key_py_string = pybackedstr_to_pystring(value.py(), key);
+        if let Some(next_include_exclude) = self.filter.key_filter(&key_py_string, state)?
+            && !exclude_field_by_value(
+                value,
+                state,
+                missing_sentinel,
+                // TODO: support `exclude_if` on extra_fields
+                None,
+            )?
+        {
+            let state = &mut state.scoped_include_exclude(next_include_exclude);
+            map.serialize_entry_string_key(key, value, extras_serializer, state)
+        } else {
+            // field was excluded
+            Ok(())
         }
-        Ok(())
     }
+}
+
+/// Common logic for excluding fields during serialization
+pub fn exclude_field_by_value<'py>(
+    value: &Bound<'py, PyAny>,
+    state: &SerializationState<'py>,
+    missing_sentinel: &Bound<'py, PyAny>,
+    exclude_if_callable: Option<&Py<PyAny>>,
+) -> PyResult<bool> {
+    if state.extra.exclude_none && value.is_none() {
+        return Ok(true);
+    }
+
+    if value.is(missing_sentinel) {
+        return Ok(true);
+    }
+
+    if serialization_exclude_if(exclude_if_callable, value)? {
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 impl_py_gc_traverse!(GeneralFieldsSerializer {
@@ -362,10 +372,6 @@ impl TypeSerializer for GeneralFieldsSerializer {
     }
 }
 
-fn key_str<'a>(key: &'a Bound<'_, PyAny>) -> PyResult<&'a str> {
-    key.cast::<PyString>()?.to_str()
-}
-
 fn dict_items<'py>(
     main_dict: &'_ Bound<'py, PyDict>,
 ) -> impl Iterator<Item = PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>> {
@@ -389,4 +395,31 @@ fn get_model<'py>(state: &mut SerializationState<'py>) -> PyResult<Bound<'py, Py
 
 fn model_type_name(model: &Bound<'_, PyAny>) -> Option<String> {
     model.get_type().name().ok().map(|s| s.to_string())
+}
+
+#[cold]
+fn unexpected_field(key: &PyBackedStr, model: &Bound<'_, PyAny>) -> PyErr {
+    PydanticSerializationUnexpectedValue::new(
+        Some(format!("Unexpected field `{key}`")),
+        Some(key.to_string()),
+        model_type_name(model),
+        None,
+    )
+    .to_py_err()
+}
+
+#[cold]
+fn incorrect_field_count(
+    expected_fields: usize,
+    used_fields: usize,
+    model: &Bound<'_, PyAny>,
+    state: &SerializationState<'_>,
+) -> PyErr {
+    PydanticSerializationUnexpectedValue::new(
+        Some(format!("Expected {expected_fields} fields but got {used_fields}").to_string()),
+        state.field_name.as_ref().map(ToString::to_string),
+        model_type_name(model),
+        Some(model.clone().unbind()),
+    )
+    .to_py_err()
 }

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -11,14 +11,14 @@ use crate::build_tools::{ExtraBehavior, py_schema_error_type};
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 use crate::serializers::errors::unwrap_ser_error;
-use crate::serializers::shared::SerializeMap;
+use crate::serializers::shared::DoSerialize;
 use crate::serializers::shared::serialize_to_json;
 use crate::serializers::shared::serialize_to_python;
 use crate::tools::SchemaDict;
 
 use super::{
     BuildSerializer, CombinedSerializer, ComputedFields, FieldsMode, GeneralFieldsSerializer, ObType, SerCheck,
-    SerField, TypeSerializer, infer_json_key, infer_json_key_known, infer_serialize, infer_to_python, py_err_se_err,
+    SerField, TypeSerializer, infer_json_key, infer_json_key_known,
 };
 
 pub struct DataclassArgsBuilder;
@@ -139,35 +139,39 @@ impl DataclassSerializer {
         }
         Ok(dict)
     }
+
+    fn serialize<'py, S: DoSerialize>(
+        &self,
+        value: &Bound<'py, PyAny>,
+        state: &mut SerializationState<'py>,
+        do_serialize: S,
+    ) -> Result<S::Ok, S::Error> {
+        if self.allow_value(value, state)? {
+            let state = &mut state.scoped_set(|s| &mut s.model, Some(value.clone()));
+            if let CombinedSerializer::Fields(ref fields_serializer) = *self.serializer {
+                // Fast path uses known dataclass fields to avoid needing to create a dict of field values
+                fields_serializer.serialize_iterators(
+                    value,
+                    known_dataclass_iter(&self.fields, value),
+                    std::iter::empty(),
+                    state,
+                    do_serialize,
+                )
+            } else {
+                let inner_value = self.get_inner_value(value)?;
+                do_serialize.serialize_no_infer(&self.serializer, &inner_value, state)
+            }
+        } else {
+            do_serialize.serialize_fallback(self.get_name(), value, state)
+        }
+    }
 }
 
 impl_py_gc_traverse!(DataclassSerializer { class, serializer });
 
 impl TypeSerializer for DataclassSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
-        if self.allow_value(value, state)? {
-            let model = value;
-            let state = &mut state.scoped_set(|s| &mut s.model, Some(value.clone()));
-            let py = value.py();
-            if let CombinedSerializer::Fields(ref fields_serializer) = *self.serializer {
-                let mut map = fields_serializer.serialize_main(
-                    py,
-                    model,
-                    known_dataclass_iter(&self.fields, model),
-                    state,
-                    serialize_to_python(py),
-                )?;
-
-                fields_serializer.add_computed_fields(model, &mut map, state)?;
-                Ok(map.into())
-            } else {
-                let inner_value = self.get_inner_value(value)?;
-                self.serializer.to_python(&inner_value, state)
-            }
-        } else {
-            state.warn_fallback_py(self.get_name(), value)?;
-            infer_to_python(value, state)
-        }
+        self.serialize(value, state, serialize_to_python(value.py()))
     }
 
     fn json_key<'a, 'py>(
@@ -189,30 +193,8 @@ impl TypeSerializer for DataclassSerializer {
         serializer: S,
         state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
-        if self.allow_value(value, state).map_err(py_err_se_err)? {
-            let state = &mut state.scoped_set(|s| &mut s.model, Some(value.clone()));
-            if let CombinedSerializer::Fields(ref fields_serializer) = *self.serializer {
-                let mut map = fields_serializer
-                    .serialize_main(
-                        value.py(),
-                        value,
-                        known_dataclass_iter(&self.fields, value),
-                        state,
-                        serialize_to_json(serializer),
-                    )
-                    .map_err(unwrap_ser_error)?;
-                fields_serializer
-                    .add_computed_fields(value, &mut map, state)
-                    .map_err(unwrap_ser_error)?;
-                map.end().map_err(unwrap_ser_error)
-            } else {
-                let inner_value = self.get_inner_value(value).map_err(py_err_se_err)?;
-                self.serializer.serde_serialize(&inner_value, serializer, state)
-            }
-        } else {
-            state.warn_fallback_ser::<S>(self.get_name(), value)?;
-            infer_serialize(value, serializer, state)
-        }
+        self.serialize(value, state, serialize_to_json(serializer))
+            .map_err(unwrap_ser_error)
     }
 
     fn get_name(&self) -> &str {

--- a/pydantic-core/src/serializers/type_serializers/generator.rs
+++ b/pydantic-core/src/serializers/type_serializers/generator.rs
@@ -65,9 +65,8 @@ impl TypeSerializer for GeneratorSerializer {
                         };
                         for (index, iter_result) in py_iter.clone().enumerate() {
                             let element = iter_result?;
-                            let op_next = self.filter.index_filter(index, state, None)?;
-                            if let Some((next_include, next_exclude)) = op_next {
-                                let state = &mut state.scoped_include_exclude(next_include, next_exclude);
+                            if let Some(next_include_exclude) = self.filter.index_filter(index, state, None)? {
+                                let state = &mut state.scoped_include_exclude(next_include_exclude);
                                 items.push(item_serializer.to_python(&element, state)?);
                             }
                         }
@@ -110,8 +109,8 @@ impl TypeSerializer for GeneratorSerializer {
                 for (index, iter_result) in py_iter.clone().enumerate() {
                     let element = iter_result.map_err(py_err_se_err)?;
                     let op_next = self.filter.index_filter(index, state, None).map_err(py_err_se_err)?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        let state = &mut state.scoped_include_exclude(next_include, next_exclude);
+                    if let Some(next_include_exclude) = op_next {
+                        let state = &mut state.scoped_include_exclude(next_include_exclude);
                         let item_serialize = PydanticSerializer::new(&element, item_serializer, state);
                         seq.serialize_element(&item_serialize)?;
                     }
@@ -187,8 +186,8 @@ impl SerializationIterator {
             let element = iter_result?;
             let filter = self.filter.index_filter(self.index, state, None)?;
             self.index += 1;
-            if let Some((next_include, next_exclude)) = filter {
-                let state = &mut state.scoped_include_exclude(next_include, next_exclude);
+            if let Some(next_include_exclude) = filter {
+                let state = &mut state.scoped_include_exclude(next_include_exclude);
                 let v = self.item_serializer.to_python(&element, state)?;
                 state.warnings.final_check(py)?;
                 return Ok(Some(v));

--- a/pydantic-core/src/serializers/type_serializers/list.rs
+++ b/pydantic-core/src/serializers/type_serializers/list.rs
@@ -62,8 +62,8 @@ impl TypeSerializer for ListSerializer {
                 let mut items = Vec::with_capacity(py_list.len());
                 for (index, element) in py_list.iter().enumerate() {
                     let op_next = self.filter.index_filter(index, state, value.len().ok())?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        let state = &mut state.scoped_include_exclude(next_include, next_exclude);
+                    if let Some(next_include_exclude) = op_next {
+                        let state = &mut state.scoped_include_exclude(next_include_exclude);
                         items.push(item_serializer.to_python(&element, state)?);
                     }
                 }
@@ -100,8 +100,8 @@ impl TypeSerializer for ListSerializer {
                         .filter
                         .index_filter(index, state, Some(py_list.len()))
                         .map_err(py_err_se_err)?;
-                    if let Some((next_include, next_exclude)) = op_next {
-                        let state = &mut state.scoped_include_exclude(next_include, next_exclude);
+                    if let Some(next_include_exclude) = op_next {
+                        let state = &mut state.scoped_include_exclude(next_include_exclude);
                         let item_serialize = PydanticSerializer::new(&element, item_serializer, state);
                         seq.serialize_element(&item_serialize)?;
                     }

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -11,6 +11,7 @@ use crate::common::union::{Discriminator, SMALL_UNION_THRESHOLD};
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::PydanticSerializationUnexpectedValue;
 use crate::serializers::SerializationState;
+use crate::serializers::extra::IncludeExclude;
 use crate::serializers::extra::ScopedSetState;
 use crate::tools::PyHashTable;
 use crate::tools::SchemaDict;
@@ -104,7 +105,7 @@ impl TypeSerializer for UnionSerializer {
             None,
         ) {
             Ok(Some(v)) => {
-                let state = &mut state.scoped_include_exclude(None, None);
+                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
                 infer_serialize(v.bind(value.py()), serializer, state)
             }
             Ok(None) => infer_serialize(value, serializer, state),
@@ -210,7 +211,7 @@ impl TypeSerializer for TaggedUnionSerializer {
             state,
         ) {
             Ok(Some(v)) => {
-                let state = &mut state.scoped_include_exclude(None, None);
+                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
                 infer_serialize(v.bind(value.py()), serializer, state)
             }
             Ok(None) => infer_serialize(value, serializer, state),

--- a/pydantic-core/tests/serializers/test_union.py
+++ b/pydantic-core/tests/serializers/test_union.py
@@ -224,7 +224,7 @@ def test_typed_dict_extra():
                 core_schema.typed_dict_schema(
                     dict(
                         foo=core_schema.typed_dict_field(core_schema.int_schema()),
-                        bar=core_schema.typed_dict_field(core_schema.int_schema()),
+                        bar=core_schema.typed_dict_field(core_schema.nullable_schema(core_schema.int_schema())),
                     )
                 ),
                 core_schema.typed_dict_schema(
@@ -244,6 +244,12 @@ def test_typed_dict_extra():
     assert s.to_python(dict(foo=1)) == {'foo': 1}
     assert s.to_python(dict(foo=1), mode='json') == {'foo': '0001'}
     assert s.to_json(dict(foo=1)) == b'{"foo":"0001"}'
+
+    assert s.to_python(dict(foo=1, bar=None), mode='json', exclude_none=True) == {'foo': 1}
+    assert s.to_json(dict(foo=1, bar=None), exclude_none=True) == b'{"foo":1}'
+
+    assert s.to_python(dict(foo=1), mode='json', exclude_none=True) == {'foo': '0001'}
+    assert s.to_json(dict(foo=1), exclude_none=True) == b'{"foo":"0001"}'
 
 
 def test_typed_dict_different_fields():


### PR DESCRIPTION
## Change Summary

This PR started as a precursor refactor to help #12657 merge.

The following key cleanups were intended:
- Simplify passing of `(include, exclude)` pairs around by introducing an `IncludeExclude` type.
- Clean up `GeneralFieldsSerializer` to have a single `serialize_extra` function used for all extra serialization.
- Clean up `DataclassSerializer` to have make use of generic `DoSerialize` logic

While working on that, I realised that in a case similar to #12628 it was possible to have the "used field" counting not work properly in typed dict unions with `exclude_none` set. The new cases added to `test_union.py` fail on main (select the wrong union variant). This ends up being a revert of https://github.com/pydantic/pydantic-core/pull/727

## Related issue number

Xref #12657
Xref https://github.com/pydantic/pydantic-core/pull/727

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
