### PR TITLE
Do not re-use prebuilt serializers/validators on rebuilds

### DIFF
--- a/pydantic-core/benches/main.rs
+++ b/pydantic-core/benches/main.rs
@@ -16,7 +16,7 @@ fn build_schema_validator_with_globals(
     globals: Option<&Bound<'_, PyDict>>,
 ) -> SchemaValidator {
     let schema = py.eval(code, globals, None).unwrap().extract().unwrap();
-    SchemaValidator::py_new(py, &schema, None).unwrap()
+    SchemaValidator::py_new(py, &schema, None, true).unwrap()
 }
 
 fn build_schema_validator(py: Python, code: &CStr) -> SchemaValidator {
@@ -510,7 +510,7 @@ fn complete_model(bench: &mut Bencher) {
 
         let complete_schema = py.import("complete_schema").unwrap();
         let schema = complete_schema.call_method0("schema").unwrap();
-        let validator = SchemaValidator::py_new(py, &schema, None).unwrap();
+        let validator = SchemaValidator::py_new(py, &schema, None, true).unwrap();
 
         let input = complete_schema.call_method0("input_data_lax").unwrap();
         let input = black_box(input);
@@ -533,7 +533,7 @@ fn nested_model_using_definitions(bench: &mut Bencher) {
 
         let complete_schema = py.import("nested_schema").unwrap();
         let schema = complete_schema.call_method0("schema_using_defs").unwrap();
-        let validator = SchemaValidator::py_new(py, &schema, None).unwrap();
+        let validator = SchemaValidator::py_new(py, &schema, None, true).unwrap();
 
         let input = complete_schema.call_method0("input_data_valid").unwrap();
         let input = black_box(input);
@@ -560,7 +560,7 @@ fn nested_model_inlined(bench: &mut Bencher) {
 
         let complete_schema = py.import("nested_schema").unwrap();
         let schema = complete_schema.call_method0("inlined_schema").unwrap();
-        let validator = SchemaValidator::py_new(py, &schema, None).unwrap();
+        let validator = SchemaValidator::py_new(py, &schema, None, true).unwrap();
 
         let input = complete_schema.call_method0("input_data_valid").unwrap();
         let input = black_box(input);

--- a/pydantic-core/python/pydantic_core/_pydantic_core.pyi
+++ b/pydantic-core/python/pydantic_core/_pydantic_core.pyi
@@ -73,15 +73,16 @@ class SchemaValidator:
     # note: pyo3 currently supports __new__, but not __init__, though we include __init__ stubs
     # and docstrings here (and in the following classes) for documentation purposes
 
-    def __init__(self, schema: CoreSchema, config: CoreConfig | None = None) -> None:
+    def __init__(self, schema: CoreSchema, config: CoreConfig | None = None, _use_prebuilt: bool = True) -> None:
         """Initializes the `SchemaValidator`.
 
         Arguments:
             schema: The `CoreSchema` to use for validation.
             config: Optionally a [`CoreConfig`][pydantic_core.core_schema.CoreConfig] to configure validation.
+            _use_prebuilt: Whether to use pre-built validators (False during rebuilds to avoid stale references).
         """
 
-    def __new__(cls, schema: CoreSchema, config: CoreConfig | None = None) -> Self: ...
+    def __new__(cls, schema: CoreSchema, config: CoreConfig | None = None, _use_prebuilt: bool = True) -> Self: ...
     @property
     def title(self) -> str:
         """
@@ -297,15 +298,16 @@ class SchemaSerializer:
     `CombinedSerializer` which may in turn own more `CombinedSerializer`s which make up the full schema serializer.
     """
 
-    def __init__(self, schema: CoreSchema, config: CoreConfig | None = None) -> None:
+    def __init__(self, schema: CoreSchema, config: CoreConfig | None = None, _use_prebuilt: bool = True) -> None:
         """Initializes the `SchemaSerializer`.
 
         Arguments:
             schema: The `CoreSchema` to use for serialization.
             config: Optionally a [`CoreConfig`][pydantic_core.core_schema.CoreConfig] to to configure serialization.
+            _use_prebuilt: Whether to use pre-built validators (False during rebuilds to avoid stale references).
         """
 
-    def __new__(cls, schema: CoreSchema, config: CoreConfig | None = None) -> Self: ...
+    def __new__(cls, schema: CoreSchema, config: CoreConfig | None = None, _use_prebuilt: bool = True) -> Self: ...
     def to_python(
         self,
         value: Any,

--- a/pydantic-core/src/definitions.rs
+++ b/pydantic-core/src/definitions.rs
@@ -132,13 +132,20 @@ impl<T: PyGcTraverse> PyGcTraverse for Definitions<T> {
 #[derive(Debug)]
 pub struct DefinitionsBuilder<T> {
     definitions: Definitions<T>,
+    use_prebuilt: bool,
 }
 
 impl<T: std::fmt::Debug> DefinitionsBuilder<T> {
-    pub fn new() -> Self {
+    pub fn new(use_prebuilt: bool) -> Self {
         Self {
             definitions: Definitions(AHashMap::new()),
+            use_prebuilt,
         }
+    }
+
+    /// Whether prebuilt validators/serializers should be used
+    pub fn use_prebuilt(&self) -> bool {
+        self.use_prebuilt
     }
 
     /// Get a ReferenceId for the given reference string.

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -157,16 +157,6 @@ combined_serializer! {
 }
 
 impl CombinedSerializer {
-    // Used when creating the base serializer instance, to avoid reusing the instance
-    // when unpickling:
-    pub fn build_base(
-        schema: &Bound<'_, PyDict>,
-        config: Option<&Bound<'_, PyDict>>,
-        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
-    ) -> PyResult<Arc<CombinedSerializer>> {
-        Self::_build(schema, config, definitions, false)
-    }
-
     fn _build(
         schema: &Bound<'_, PyDict>,
         config: Option<&Bound<'_, PyDict>>,
@@ -310,7 +300,10 @@ impl BuildSerializer for CombinedSerializer {
         config: Option<&Bound<'_, PyDict>>,
         definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
     ) -> PyResult<Arc<CombinedSerializer>> {
-        Self::_build(schema, config, definitions, true)
+        // Read use_prebuilt from the definitions builder - this ensures all nested
+        // serializers respect the same setting as the top-level build
+        let use_prebuilt = definitions.use_prebuilt();
+        Self::_build(schema, config, definitions, use_prebuilt)
     }
 }
 

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -132,11 +132,18 @@ impl_py_gc_traverse!(SchemaValidator {
 #[pymethods]
 impl SchemaValidator {
     #[new]
-    #[pyo3(signature = (schema, config=None))]
-    pub fn py_new(py: Python, schema: &Bound<'_, PyAny>, config: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
-        let mut definitions_builder = DefinitionsBuilder::new();
+    #[pyo3(signature = (schema, config=None, _use_prebuilt=true))]
+    pub fn py_new(
+        py: Python,
+        schema: &Bound<'_, PyAny>,
+        config: Option<&Bound<'_, PyDict>>,
+        _use_prebuilt: bool,
+    ) -> PyResult<Self> {
+        // _use_prebuilt=true by default, but false during rebuilds to avoid stale references
+        // to old validators (see pydantic-core issue #1894)
+        let mut definitions_builder = DefinitionsBuilder::new(_use_prebuilt);
 
-        let validator = build_validator_base(schema, config, &mut definitions_builder)?;
+        let validator = build_validator(schema, config, &mut definitions_builder)?;
         let definitions = definitions_builder.finish()?;
         let py_schema = schema.clone().unbind();
         let py_config = match config {
@@ -392,7 +399,8 @@ impl SchemaValidator {
     }
 
     pub fn __reduce__<'py>(slf: &Bound<'py, Self>) -> PyResult<(Bound<'py, PyType>, Bound<'py, PyTuple>)> {
-        let init_args = (&slf.get().py_schema, &slf.get().py_config).into_pyobject(slf.py())?;
+        // Passing _use_prebuilt=false avoids reusing prebuilt serializers when unpickling
+        let init_args = (&slf.get().py_schema, &slf.get().py_config, false).into_pyobject(slf.py())?;
         Ok((slf.get_type(), init_args))
     }
 
@@ -507,22 +515,15 @@ pub trait BuildValidator: Sized {
     ) -> PyResult<Arc<CombinedValidator>>;
 }
 
-// Used when creating the base validator instance, to avoid reusing the instance
-// when unpickling:
-pub fn build_validator_base(
-    schema: &Bound<'_, PyAny>,
-    config: Option<&Bound<'_, PyDict>>,
-    definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
-) -> PyResult<Arc<CombinedValidator>> {
-    build_validator_inner(schema, config, definitions, false)
-}
-
 pub fn build_validator(
     schema: &Bound<'_, PyAny>,
     config: Option<&Bound<'_, PyDict>>,
     definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
 ) -> PyResult<Arc<CombinedValidator>> {
-    build_validator_inner(schema, config, definitions, true)
+    // Read use_prebuilt from the definitions builder - this ensures all nested
+    // validators respect the same setting as the top-level build
+    let use_prebuilt = definitions.use_prebuilt();
+    build_validator_inner(schema, config, definitions, use_prebuilt)
 }
 
 fn build_validator_inner(

--- a/pydantic-core/tests/serializers/test_simple.py
+++ b/pydantic-core/tests/serializers/test_simple.py
@@ -169,3 +169,8 @@ def test_float_inf_and_nan_serializers(value, expected_json, config):
 
     # Serialized JSON value respects the ser_json_inf_nan setting
     assert s.to_json(value).decode() == expected_json
+
+
+def test_schema_serializer_use_prebuilt_false():
+    """Test that SchemaSerializer can be constructed with _use_prebuilt=False."""
+    SchemaSerializer({'type': 'str'}, None, _use_prebuilt=False)

--- a/pydantic-core/tests/test.rs
+++ b/pydantic-core/tests/test.rs
@@ -49,7 +49,7 @@ mod tests {
             }"
             );
             let schema: Bound<'_, PyDict> = py.eval(code, None, None).unwrap().extract().unwrap();
-            SchemaSerializer::py_new(schema, None).unwrap();
+            SchemaSerializer::py_new(schema, None, true).unwrap();
         });
     }
 
@@ -76,7 +76,7 @@ json_input = '{"a": "something"}'
             py.run(code, None, Some(&locals)).unwrap();
             let schema = locals.get_item("schema").unwrap().unwrap();
             let json_input = locals.get_item("json_input").unwrap().unwrap();
-            let binding = SchemaValidator::py_new(py, &schema, None)
+            let binding = SchemaValidator::py_new(py, &schema, None, true)
                 .unwrap()
                 .validate_json(py, &json_input, None, None, None, None, false.into(), None, None)
                 .unwrap();
@@ -137,7 +137,7 @@ dump_json_input_2 = {'a': 'something'}
                 .unwrap();
             let dump_json_input_1 = locals.get_item("dump_json_input_1").unwrap().unwrap();
             let dump_json_input_2 = locals.get_item("dump_json_input_2").unwrap().unwrap();
-            let serializer = SchemaSerializer::py_new(schema, None).unwrap();
+            let serializer = SchemaSerializer::py_new(schema, None, true).unwrap();
             let serialization_result = serializer
                 .to_json(
                     py,

--- a/pydantic-core/tests/test_build.py
+++ b/pydantic-core/tests/test_build.py
@@ -76,3 +76,8 @@ def test_build_recursive_schema_from_defs() -> None:
     )
 
     SchemaValidator(s)
+
+
+def test_schema_validator_use_prebuilt_false():
+    """Test that SchemaValidator can be constructed with _use_prebuilt=False."""
+    SchemaValidator({'type': 'str'}, None, _use_prebuilt=False)

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -599,7 +599,7 @@ def complete_model_class(
     raise_errors: bool = True,
     call_on_complete_hook: bool = True,
     create_model_module: str | None = None,
-    rebuild: bool = False,
+    is_force_rebuild: bool = False,
 ) -> bool:
     """Finish building a model class.
 
@@ -613,6 +613,8 @@ def complete_model_class(
         raise_errors: Whether to raise errors.
         call_on_complete_hook: Whether to call the `__pydantic_on_complete__` hook.
         create_model_module: The module of the class to be created, if created by `create_model`.
+        is_force_rebuild: Whether the model is being force-rebuilt (if True, pre-built serializers and
+                          validators are not used, to avoid stale references).
 
     Returns:
         `True` if the model is successfully completed, else `False`.
@@ -687,9 +689,9 @@ def complete_model_class(
         'create_model' if create_model_module else 'BaseModel',
         core_config,
         config_wrapper.plugin_settings,
-        rebuild=rebuild,
+        _use_prebuilt=not is_force_rebuild,
     )
-    cls.__pydantic_serializer__ = SchemaSerializer(schema, core_config, rebuild=rebuild)
+    cls.__pydantic_serializer__ = SchemaSerializer(schema, core_config, _use_prebuilt=not is_force_rebuild)
 
     # set __signature__ attr only for model class, but not for its instances
     # (because instances can define `__call__`, and `inspect.signature` shouldn't

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -679,7 +679,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             raise_errors=raise_errors,
             # If the model was already complete, we don't need to call the hook again.
             call_on_complete_hook=not already_complete,
-            rebuild=force,
+            is_force_rebuild=force,
         )
 
     @classmethod

--- a/pydantic/plugin/_schema_validator.py
+++ b/pydantic/plugin/_schema_validator.py
@@ -27,7 +27,7 @@ def create_schema_validator(
     schema_kind: SchemaKind,
     config: CoreConfig | None = None,
     plugin_settings: dict[str, Any] | None = None,
-    rebuild: bool = False,
+    _use_prebuilt: bool = True,
 ) -> SchemaValidator | PluggableSchemaValidator:
     """Create a `SchemaValidator` or `PluggableSchemaValidator` if plugins are installed.
 
@@ -47,10 +47,10 @@ def create_schema_validator(
             config,
             plugins,
             plugin_settings or {},
-            rebuild=rebuild,
+            _use_prebuilt=_use_prebuilt,
         )
     else:
-        return SchemaValidator(schema, config, rebuild=rebuild)
+        return SchemaValidator(schema, config, _use_prebuilt=_use_prebuilt)
 
 
 class PluggableSchemaValidator:
@@ -67,9 +67,9 @@ class PluggableSchemaValidator:
         config: CoreConfig | None,
         plugins: Iterable[PydanticPluginProtocol],
         plugin_settings: dict[str, Any],
-        rebuild: bool = False,
+        _use_prebuilt: bool = True,
     ) -> None:
-        self._schema_validator = SchemaValidator(schema, config, rebuild=rebuild)
+        self._schema_validator = SchemaValidator(schema, config, _use_prebuilt=_use_prebuilt)
 
         python_event_handlers: list[BaseValidateHandlerProtocol] = []
         json_event_handlers: list[BaseValidateHandlerProtocol] = []


### PR DESCRIPTION
## Change Summary

- Adds a `_use_prebuilt` keyword argument to `SchemaValidator` and `SchemaSerializer` (from pydantic-core: https://github.com/pydantic/pydantic-core/pull/1895)
- Defaults to `True` so existing behavior is preserved (prebuilt optimization is used)
- Only disables prebuilt when `_use_prebuilt=False` which happens only during `model_rebuild(force=True)`
- Threads the flag through pydantic's `create_schema_validator` ⇒ `complete_model_class` ⇒ `model_rebuild`

The existing prebuilt tests should pass because normal schema creation uses `_use_prebuilt=True` by default, but the GC bug in #12446 is fixed (confirmed in local testing with both PRs) because `model_rebuild(force=True)` passes `_use_prebuilt=False`.

## Related issue number

- Closes #12446.
- ~~Requires upstream work in pydantic-core~~ **merged** with PR at https://github.com/pydantic/pydantic-core/pull/1895

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


---

Further details from old PR:

### Change Summary

This PR adds a `_use_prebuilt: bool = True` parameter to `SchemaValidator.__init__` and `SchemaSerializer.__init__` to fix the memory leak described in #1894.

### Problem

PR #1616 introduced `PrebuiltValidator`/`PrebuiltSerializer` as a memory optimization that reuses existing validators/serializers from model classes. However, when `model_rebuild(force=True)` is called on recursive models:

1. `Collection.model_rebuild()` creates a new validator
2. When building, it encounters `BlockGroup` and `PredictiveModel` in a union
3. Since those models have `__pydantic_complete__=True`, their existing validators are wrapped in `PrebuiltValidator` (a strong `Py<SchemaValidator>` reference)
4. Later, when `BlockGroup` and `PredictiveModel` are rebuilt, they get NEW validators
5. But `Collection`'s validator still holds references to the OLD validators via `PrebuiltValidator`
6. The old validators can never be garbage collected

This causes unbounded RSS growth (~50MB per 1000 rebuild cycles).

### Solution

- Add `_use_prebuilt: bool = True` parameter to `SchemaValidator::py_new` and `SchemaSerializer::py_new`
- When `_use_prebuilt=False`, set `use_prebuilt=false` in `DefinitionsBuilder`, which skips the prebuilt optimization
- Thread `use_prebuilt` through `DefinitionsBuilder` so nested builds respect the same setting
- Pass `_use_prebuilt=False` from `__reduce__` to maintain correct unpickling behavior (avoiding prebuilt during reconstruction)

### Unchanged

- Normal model creation still uses the prebuilt optimization (`_use_prebuilt=True` by default)
- Existing behavior is preserved for all non-rebuild scenarios

## Related Issues

- Fixes https://github.com/pydantic/pydantic-core/issues/1894 (RSS growth on model rebuild)
- Should also resolve https://github.com/pydantic/pydantic-core/issues/1893 (stale referents on rebuild)
- Also (incidentally) solves https://github.com/pydantic/pydantic/issues/12696