### PR TITLE
Add regression test for pickling objects with `@validate_call`

### DIFF
--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import pickle
 import re
 import sys
 from collections import UserDict
@@ -1346,31 +1347,20 @@ def test_validate_call_defer_build() -> None:
 
 
 class _PickleTestModel(BaseModel):
-    """Model used for pickle test - must be at module level to be importable."""
-
     number: float
 
 
 class _PickleTestDict(UserDict[int, _PickleTestModel]):
-    """UserDict with validate_call - must be at module level to be importable."""
-
     @validate_call
     def __setitem__(self, key: int, value: _PickleTestModel):
         super().__setitem__(key, value)
 
 
-def test_pickle_validate_call_with_basemodel():
-    """Test that objects using validate_call with BaseModel can be pickled.
-
-    Regression test for https://github.com/pydantic/pydantic/issues/7846
-    """
-    import pickle
-
+def test_pickle_validate_call_with_basemodel() -> None:
+    """https://github.com/pydantic/pydantic/issues/7846."""
     my_dict = _PickleTestDict({1: _PickleTestModel(number=1.0)})
 
-    # This should not raise: "Can't pickle local object"
-    pickled = pickle.dumps(my_dict)
-    unpickled = pickle.loads(pickled)
+    unpickled = pickle.loads(pickle.dumps(my_dict))
 
     assert unpickled == {1: _PickleTestModel(number=1.0)}
     assert unpickled[1].number == 1.0


### PR DESCRIPTION
## Summary

This PR adds a regression test to ensure that objects with methods decorated with \@validate_call\ can be properly pickled when the classes are defined at module level.

## Issue Reference

Closes #7846

## Details

The issue reported that pickling a \UserDict\ subclass with a \@validate_call\ decorated \__setitem__\ method would fail with:
\\\
AttributeError: Can't pickle local object 'GenerateSchema._common_field_schema.<locals>.json_schema_update_func'
\\\

Based on the comments in #7846, this issue appears to have been fixed in a previous pydantic-core update. This PR adds a regression test to ensure the fix remains in place.

## Test

The test creates:
- A simple \BaseModel\ subclass (\_PickleTestModel\)
- A \UserDict\ subclass with \@validate_call\ on \__setitem__\ (\_PickleTestDict\)

It then verifies that instances can be pickled and unpickled without errors.

## Notes

The test classes must be defined at module level to be importable/picklable - this matches the real-world use case described in the original issue.