### PR TITLE
Unify `field_name` in state between validation and serialization

### DIFF
--- a/pydantic-core/src/serializers/computed_fields.rs
+++ b/pydantic-core/src/serializers/computed_fields.rs
@@ -9,7 +9,6 @@ use crate::build_tools::py_schema_error_type;
 use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
-use crate::serializers::extra::FieldName;
 use crate::serializers::fields::exclude_field_by_value;
 use crate::serializers::filter::SchemaFilter;
 use crate::serializers::shared::{BuildSerializer, CombinedSerializer, SerializeMap};
@@ -66,8 +65,7 @@ impl ComputedFields {
                 continue;
             }
 
-            let field_name = FieldName::from(property_name_py);
-            let state = &mut state.scoped_set(|s| &mut s.field_name, Some(field_name));
+            let state = &mut state.scoped_set(|s| &mut s.field_name, Some(property_name_py));
             let state = &mut state.scoped_include_exclude(next_include_exclude);
             let key = match state.extra.serialize_by_alias_or(computed_field.serialize_by_alias) {
                 true => &computed_field.alias,

--- a/pydantic-core/src/serializers/errors.rs
+++ b/pydantic-core/src/serializers/errors.rs
@@ -112,7 +112,7 @@ impl PydanticSerializationError {
 #[derive(Debug, Clone)]
 pub struct PydanticSerializationUnexpectedValue {
     message: Option<String>,
-    field_name: Option<String>,
+    field_name: Option<Py<PyString>>,
     field_type: Option<String>,
     input_value: Option<Py<PyAny>>,
 }
@@ -128,7 +128,7 @@ impl PydanticSerializationUnexpectedValue {
     }
 
     pub fn new_from_parts(
-        field_name: Option<String>,
+        field_name: Option<Py<PyString>>,
         field_type: Option<String>,
         input_value: Option<Py<PyAny>>,
     ) -> Self {
@@ -142,7 +142,7 @@ impl PydanticSerializationUnexpectedValue {
 
     pub fn new(
         message: Option<String>,
-        field_name: Option<String>,
+        field_name: Option<Py<PyString>>,
         field_type: Option<String>,
         input_value: Option<Py<PyAny>>,
     ) -> Self {
@@ -155,7 +155,7 @@ impl PydanticSerializationUnexpectedValue {
     }
 
     pub fn to_py_err(&self) -> PyErr {
-        PyErr::new::<Self, (Option<String>, Option<String>, Option<String>, Option<Py<PyAny>>)>((
+        PyErr::new::<Self, _>((
             self.message.clone(),
             self.field_name.clone(),
             self.field_type.clone(),
@@ -170,7 +170,7 @@ impl PydanticSerializationUnexpectedValue {
     #[pyo3(signature = (message=None, field_name=None, field_type=None, input_value=None, /))]
     fn py_new(
         message: Option<String>,
-        field_name: Option<String>,
+        field_name: Option<Py<PyString>>,
         field_type: Option<String>,
         input_value: Option<Py<PyAny>>,
     ) -> Self {

--- a/pydantic-core/src/tools.rs
+++ b/pydantic-core/src/tools.rs
@@ -327,3 +327,9 @@ pub fn pybackedstr_to_pystring<'py>(py: Python<'py>, s: &PyBackedStr) -> Bound<'
     // need this cast
     unsafe { out.cast_into_unchecked() }
 }
+
+pub const ROOT_FIELD: &str = "root";
+
+pub fn root_field_py_str(py: Python<'_>) -> &'_ Bound<'_, PyString> {
+    intern!(py, ROOT_FIELD)
+}

--- a/pydantic-core/src/url.rs
+++ b/pydantic-core/src/url.rs
@@ -94,6 +94,7 @@ impl PyUrl {
                     ),
                     &mut RecursionState::default(),
                     PartialMode::Off,
+                    None,
                 ),
             )
             .map_err(|e| {
@@ -323,6 +324,7 @@ impl PyMultiHostUrl {
                     ),
                     &mut RecursionState::default(),
                     PartialMode::Off,
+                    None,
                 ),
             )
             .map_err(|e| {

--- a/pydantic-core/src/validators/arguments.rs
+++ b/pydantic-core/src/validators/arguments.rs
@@ -228,8 +228,7 @@ impl Validator for ArgumentsValidator {
                 kw_value = Some((lookup_path, value));
             }
 
-            let state =
-                &mut state.rebind_extra(|extra| extra.field_name = Some(pybackedstr_to_pystring(py, &parameter.name)));
+            let state = &mut state.scoped_set_field_name(Some(pybackedstr_to_pystring(py, &parameter.name)));
 
             match (pos_value, kw_value) {
                 (Some(_), Some((_, kw_value))) => {

--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -218,8 +218,7 @@ impl Validator for DataclassArgsValidator {
             }
             let kw_value = kw_value.as_ref().map(|(path, value)| (path, value.borrow_input()));
 
-            let state =
-                &mut state.rebind_extra(|extra| extra.field_name = Some(pybackedstr_to_pystring(py, &field.name)));
+            let state = &mut state.scoped_set_field_name(Some(pybackedstr_to_pystring(py, &field.name)));
 
             match (pos_value, kw_value) {
                 // found both positional and keyword arguments, error
@@ -411,8 +410,8 @@ impl Validator for DataclassArgsValidator {
 
             let state = &mut state.rebind_extra(|extra| {
                 extra.data = Some(data_dict.clone());
-                extra.field_name = Some(pybackedstr_to_pystring(py, &field.name));
             });
+            let state = &mut state.scoped_set_field_name(Some(pybackedstr_to_pystring(py, &field.name)));
 
             match field.validator.validate(py, field_value, state) {
                 Ok(output) => ok(output),

--- a/pydantic-core/src/validators/function.rs
+++ b/pydantic-core/src/validators/function.rs
@@ -104,9 +104,8 @@ impl FunctionBeforeValidator {
     ) -> ValResult<Py<PyAny>> {
         let r = if self.info_arg {
             let field_name = state
-                .extra()
-                .field_name
-                .clone()
+                .field_name()
+                .cloned()
                 .map(Bound::unbind)
                 .or_else(|| self.field_name.clone());
             let info = ValidationInfo::new(py, state.extra(), &self.config, field_name);
@@ -179,9 +178,8 @@ impl FunctionAfterValidator {
         let v = call(input, state)?;
         let r = if self.info_arg {
             let field_name = state
-                .extra()
-                .field_name
-                .clone()
+                .field_name()
+                .cloned()
                 .map(Bound::unbind)
                 .or_else(|| self.field_name.clone());
             let info = ValidationInfo::new(py, state.extra(), &self.config, field_name);
@@ -274,9 +272,8 @@ impl Validator for FunctionPlainValidator {
     ) -> ValResult<Py<PyAny>> {
         let r = if self.info_arg {
             let field_name = state
-                .extra()
-                .field_name
-                .clone()
+                .field_name()
+                .cloned()
                 .map(Bound::unbind)
                 .or_else(|| self.field_name.clone());
             let info = ValidationInfo::new(py, state.extra(), &self.config, field_name);
@@ -344,9 +341,8 @@ impl FunctionWrapValidator {
     ) -> ValResult<Py<PyAny>> {
         let r = if self.info_arg {
             let field_name = state
-                .extra()
-                .field_name
-                .clone()
+                .field_name()
+                .cloned()
                 .map(Bound::unbind)
                 .or_else(|| self.field_name.clone());
             let info = ValidationInfo::new(py, state.extra(), &self.config, field_name);

--- a/pydantic-core/src/validators/generator.rs
+++ b/pydantic-core/src/validators/generator.rs
@@ -259,7 +259,7 @@ impl InternalValidator {
             extra_behavior: extra.extra_behavior,
             from_attributes: extra.from_attributes,
             context: extra.context.map(|d| d.clone().unbind()),
-            field_name: extra.field_name.as_ref().map(|d| d.clone().unbind()),
+            field_name: state.field_name().map(|d| d.clone().unbind()),
             self_instance: extra.self_instance.map(|d| d.clone().unbind()),
             recursion_guard: state.recursion_guard.clone(),
             exactness: state.exactness,
@@ -285,14 +285,18 @@ impl InternalValidator {
             strict: self.strict,
             extra_behavior: self.extra_behavior,
             from_attributes: self.from_attributes,
-            field_name: Some(pybackedstr_to_pystring(py, field_name)),
             context: self.context.as_ref().map(|data| data.bind(py)),
             self_instance: self.self_instance.as_ref().map(|data| data.bind(py)),
             cache_str: self.cache_str,
             by_alias: None,
             by_name: None,
         };
-        let mut state = ValidationState::new(extra, &mut self.recursion_guard, false.into());
+        let mut state = ValidationState::new(
+            extra,
+            &mut self.recursion_guard,
+            false.into(),
+            Some(pybackedstr_to_pystring(py, field_name)),
+        );
         state.exactness = self.exactness;
         let result = self
             .validator
@@ -324,14 +328,18 @@ impl InternalValidator {
             strict: self.strict,
             extra_behavior: self.extra_behavior,
             from_attributes: self.from_attributes,
-            field_name: self.field_name.as_ref().map(|name| name.bind(py).clone()),
             context: self.context.as_ref().map(|data| data.bind(py)),
             self_instance: self.self_instance.as_ref().map(|data| data.bind(py)),
             cache_str: self.cache_str,
             by_alias: None,
             by_name: None,
         };
-        let mut state = ValidationState::new(extra, &mut self.recursion_guard, false.into());
+        let mut state = ValidationState::new(
+            extra,
+            &mut self.recursion_guard,
+            false.into(),
+            self.field_name.as_ref().map(|name| name.bind(py).clone()),
+        );
         state.exactness = self.exactness;
         state.fields_set_count = self.fields_set_count;
         let result = self.validator.validate(py, input, &mut state).map_err(|e| {

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -352,7 +352,6 @@ impl SchemaValidator {
             strict,
             extra_behavior,
             from_attributes,
-            field_name: Some(pybackedstr_to_pystring(py, &field_name)),
             context,
             self_instance: None,
             cache_str: self.cache_str,
@@ -361,7 +360,12 @@ impl SchemaValidator {
         };
 
         let guard = &mut RecursionState::default();
-        let mut state = ValidationState::new(extra, guard, false.into());
+        let mut state = ValidationState::new(
+            extra,
+            guard,
+            false.into(),
+            Some(pybackedstr_to_pystring(py, &field_name)),
+        );
         self.validator
             .validate_assignment(py, &obj, &field_name, &field_value, &mut state)
             .map_err(|e| self.prepare_validation_err(py, e, InputType::Python))
@@ -380,7 +384,6 @@ impl SchemaValidator {
             strict,
             extra_behavior: None,
             from_attributes: None,
-            field_name: None,
             context,
             self_instance: None,
             cache_str: self.cache_str,
@@ -388,7 +391,7 @@ impl SchemaValidator {
             by_name: None,
         };
         let recursion_guard = &mut RecursionState::default();
-        let mut state = ValidationState::new(extra, recursion_guard, false.into());
+        let mut state = ValidationState::new(extra, recursion_guard, false.into(), None);
         let r = self.validator.default_value(py, None::<i64>, &mut state);
         match r {
             Ok(maybe_default) => match maybe_default {
@@ -455,6 +458,7 @@ impl SchemaValidator {
             ),
             &mut recursion_guard,
             allow_partial,
+            None,
         );
         self.validator.validate(py, input, &mut state)
     }
@@ -689,8 +693,6 @@ pub struct Extra<'a, 'py> {
     pub from_attributes: Option<bool>,
     /// context used in validator functions
     pub context: Option<&'a Bound<'py, PyAny>>,
-    /// The name of the field being validated, if applicable
-    pub field_name: Option<Bound<'py, PyString>>,
     /// This is an instance of the model or dataclass being validated, when validation is performed from `__init__`
     self_instance: Option<&'a Bound<'py, PyAny>>,
     /// Whether to use a cache of short strings to accelerate python string construction
@@ -720,7 +722,6 @@ impl<'a, 'py> Extra<'a, 'py> {
             strict,
             extra_behavior,
             from_attributes,
-            field_name: None,
             context,
             self_instance,
             cache_str,
@@ -738,7 +739,6 @@ impl Extra<'_, '_> {
             strict: Some(true),
             extra_behavior: self.extra_behavior,
             from_attributes: self.from_attributes,
-            field_name: self.field_name.clone(),
             context: self.context,
             self_instance: self.self_instance,
             cache_str: self.cache_str,

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -240,8 +240,7 @@ impl Validator for ModelFieldsValidator {
                     ));
                 }
 
-                let state =
-                    &mut state.rebind_extra(|extra| extra.field_name = Some(pybackedstr_to_pystring(py, &field.name)));
+                let state = &mut state.scoped_set_field_name(Some(pybackedstr_to_pystring(py, &field.name)));
 
                 prepare_result(field.validator.validate(py, field_value, state))?
             } else {
@@ -334,8 +333,7 @@ impl ModelFieldsValidator {
             let state = &mut state.scoped_set(|state| &mut state.has_field_error, false);
 
             for field in &self.fields {
-                let state =
-                    &mut state.rebind_extra(|extra| extra.field_name = Some(pybackedstr_to_pystring(py, &field.name)));
+                let state = &mut state.scoped_set_field_name(Some(pybackedstr_to_pystring(py, &field.name)));
 
                 if let Some((lookup_path, lookup_result)) = field
                     .lookup_path_collection

--- a/pydantic-core/src/validators/typed_dict.rs
+++ b/pydantic-core/src/validators/typed_dict.rs
@@ -219,8 +219,7 @@ impl Validator for TypedDictValidator {
                     };
 
                     // FIXME: for model and dataclass, `default_value` is called with field name set in extra, does that matter?
-                    let state = &mut state
-                        .rebind_extra(|extra| extra.field_name = Some(pybackedstr_to_pystring(py, &field.name)));
+                    let state = &mut state.scoped_set_field_name(Some(pybackedstr_to_pystring(py, &field.name)));
 
                     match field.validator.validate(py, value.borrow_input(), state) {
                         Ok(value) => {


### PR DESCRIPTION
## Change Summary

Reducing cognitive load, and I have a hunch that `state.rebind_extra` is slightly bad for performance due to needing to copy the full `Extra` type.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
