### PR TITLE
Add riscv64 build target for manylinux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
             interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: linux
             manylinux: auto
+            target: riscv64gc-unknown-linux-gnu
+            interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 3.14t
+          - os: linux
+            manylinux: auto
             target: s390x
             interpreter: 3.9 3.10 3.11 3.12 3.13 3.14 3.14t
           - os: linux


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR adds support for building and publishing a wheel built for riscv64 on Linux systems using libc (musl doesn't seem to build as of yet). I tried this on my fork of [pydantic-core](https://github.com/boosterl/pydantic-core/actions/runs/20963198023/job/60245951764), which seemed to work without an issue. Since pydantic-core was moved to the main pydantic mono-repo, I'm not sure how the CI-workflow will be ran, so wasn't able to test in that context.

The target option doesn't use the same alias as the other architectures. That's because no alias was present in the maturin-action for the riscv64gc-unknown-linux-gnu target. This was added in [this PR](https://github.com/PyO3/maturin-action/pull/399). Once this is included in a new release, the alias could also be used in the pydantic-core workflow.

<!-- Please give a short summary of the changes. -->

## Related issue number

fix #12722
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos