### PR TITLE
Remove test of "strict lists" which xfails incorrectly

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2668,28 +2668,6 @@ def test_model_validate_strict() -> None:
     ]
 
 
-@pytest.mark.xfail(
-    reason='strict=True in model_validate_json does not overwrite strict=False given in ConfigDict'
-    'See issue: https://github.com/pydantic/pydantic/issues/8930'
-)
-def test_model_validate_list_strict() -> None:
-    # FIXME: This change must be implemented in pydantic-core. The argument strict=True
-    # in model_validate_json method is not overwriting the one set with ConfigDict(strict=False)
-    # for sequence like types. See: https://github.com/pydantic/pydantic/issues/8930
-
-    class LaxModel(BaseModel):
-        x: list[str]
-        model_config = ConfigDict(strict=False)
-
-    assert LaxModel.model_validate_json(json.dumps({'x': ('a', 'b', 'c')}), strict=None) == LaxModel(x=('a', 'b', 'c'))
-    assert LaxModel.model_validate_json(json.dumps({'x': ('a', 'b', 'c')}), strict=False) == LaxModel(x=('a', 'b', 'c'))
-    with pytest.raises(ValidationError) as exc_info:
-        LaxModel.model_validate_json(json.dumps({'x': ('a', 'b', 'c')}), strict=True)
-    assert exc_info.value.errors(include_url=False) == [
-        {'type': 'list_type', 'loc': ('x',), 'msg': 'Input should be a valid list', 'input': ('a', 'b', 'c')}
-    ]
-
-
 def test_model_validate_json_strict() -> None:
     class LaxModel(BaseModel):
         x: int


### PR DESCRIPTION
## Change Summary

I was beginning to look at refactoring config consumption inside validator building. Thought I would start with "strict", saw this test, studied it, pretty sure there is no bug here.

The test claims that `strict=True` should change the behaviour of the validation, but because this is a validation from JSON the tuple is dumped as a JSON array, which will always be valid input to a list. I cannot see any way that the line

```python
LaxModel.model_validate_json(json.dumps({'x': ('a', 'b', 'c')}), strict=True)
```

should ever be expected to fail.

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
