### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -952,7 +952,7 @@ except ValidationError as e:
     """
 ```
 
-1. The `OuterT` model is parametrized with `int`, but the data associated with the the `T` annotations during validation is of type `str`, leading to validation errors.
+1. The `OuterT` model is parametrized with `int`, but the data associated with the `T` annotations during validation is of type `str`, leading to validation errors.
 
 !!! warning
     While it may not raise an error, we strongly advise against using parametrized generics in [`isinstance()`](https://docs.python.org/3/library/functions.html#isinstance) checks.


### PR DESCRIPTION
## Change Summary

Fixed a minor typo in the documentation/error messages where the word "the" was duplicated ("the the" -> "the").

## Related issue number

None (Trivial typo fix).

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist (N/A for typo fix)
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, please review

Selected Reviewer: @Viicos