### PR TITLE
Resolve type ignore comment in JSON Schema code

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1671,11 +1671,12 @@ class GenerateJsonSchema:
         if isinstance(json_schema_extra, dict):
             json_schema.update(json_schema_extra)
         elif callable(json_schema_extra):
-            # FIXME: why are there type ignores here? We support two signatures for json_schema_extra callables...
             if len(_typing_extra.signature_no_eval(json_schema_extra).parameters) > 1:
-                json_schema_extra(json_schema, cls)  # type: ignore
+                json_schema_extra = cast(Callable[[JsonDict, type[Any]], None], json_schema_extra)
+                json_schema_extra(json_schema, cls)
             else:
-                json_schema_extra(json_schema)  # type: ignore
+                json_schema_extra = cast(Callable[[JsonDict], None], json_schema_extra)
+                json_schema_extra(json_schema)
         elif json_schema_extra is not None:
             raise ValueError(
                 f"model_config['json_schema_extra']={json_schema_extra} should be a dict, callable, or None"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Resolves a `FIXME` in `GenerateJsonSchema.generate`: "why are there type ignores here?".
Uses `cast` to explicitly narrow the `json_schema_extra` callable type based on the runtime signature check, allowing removal of the `type: ignore` comments.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
