### PR TITLE
Increase test coverage for multiple modules

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,7 +4,7 @@ import pytest
 from packaging.version import parse as parse_version
 
 import pydantic
-from pydantic.version import check_pydantic_core_version, version_info, version_short
+from pydantic.version import check_pydantic_core_version, parse_mypy_version, version_info, version_short
 
 
 def test_version_info():
@@ -38,6 +38,19 @@ def test_version_attribute_is_a_string():
 
 def test_check_pydantic_core_version() -> None:
     assert check_pydantic_core_version()
+
+
+@pytest.mark.parametrize(
+    'version,expected',
+    [
+        ('1.11.0', (1, 11, 0)),
+        ('0.0.0', (0, 0, 0)),
+        ('1.11.0+dev.d6d9d8cd4f27c52edac1f537e236ec48a01e54cb.dirty', (1, 11, 0)),
+        ('2.0.1+dev.abc123', (2, 0, 1)),
+    ],
+)
+def test_parse_mypy_version(version, expected):
+    assert parse_mypy_version(version) == expected
 
 
 @pytest.mark.thread_unsafe(reason='Monkeypatching')


### PR DESCRIPTION
## Summary

Contributes to #7656 (Get test coverage back to 100%).

Adds tests covering previously untested code paths across 5 source files:

- **`version.py`** (96.97% → 100%): `parse_mypy_version()` with normal and `+dev` suffixed versions
- **`_core_utils.py`** (96.72% → 100%): `get_type_ref()` qualname exception fallback when `str(origin)` raises
- **`_serializers.py`** (92.59% → 100%): `PydanticOmit` handling in `serialize_sequence_via_list`
- **`errors.py`** (95.74% → 100%): `PydanticUndefinedAnnotation.from_name_error()` regex fallback path
- **`networks.py`** (92.31% → 96.39%): `unicode_host()`, `query_params()`, `__deepcopy__()`, `.build()` for both `_BaseUrl` and `_BaseMultiHostUrl`, plus DSN `host` property overrides

All changes are test-only (no production code modified). 219 lines added across 3 test files.

## Test plan

- [x] All 12,027 existing tests pass
- [x] `make format` clean (ruff check + ruff format)
- [x] 4 of 5 target files reach 100% coverage
- [x] `networks.py` coverage improved from 92.31% to 96.39%

please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)