### PR TITLE
Increase test coverage for _mock_val_ser, _repr, _docs_extraction, and _known_annotated_metadata

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,6 +102,15 @@ def test_display_as_type_310(value_gen, expected):
     assert _repr.display_as_type(value) == expected
 
 
+def test_display_as_type_parameterized_type_alias():
+    """Test display_as_type fallback for parameterized TypeAliasType (no __qualname__)."""
+    from typing_extensions import TypeAliasType, TypeVar
+
+    T = TypeVar('T')
+    MyList = TypeAliasType('MyList', list[T], type_params=(T,))
+    assert _repr.display_as_type(MyList[int]) == 'MyList[int]'
+
+
 def test_lenient_issubclass():
     class A(str):
         pass


### PR DESCRIPTION
## Summary

Continuing work on #7656 (Get test coverage back to 100%). This PR adds 10 new tests covering previously untested code paths in 4 internal modules:

| File | Before | After |
|------|--------|-------|
| `_repr.py` | 97.98% | **100%** |
| `_mock_val_ser.py` | 84.03% | **99.16%** |
| `_docs_extraction.py` | 95.00% | **97.50%** |
| `_known_annotated_metadata.py` | 91.07% | **93.75%** |

### Tests added

**`tests/test_utils.py`** (1 test):
- `test_display_as_type_parameterized_type_alias`: Covers the `AttributeError` fallback in `display_as_type` when a parameterized `TypeAliasType` lacks `__qualname__`

**`tests/test_edge_cases.py`** (9 tests):
- `test_mock_core_schema_len_and_iter`: Covers `__len__`, `__iter__`, and the cached `_built_memo` path in `MockCoreSchema`
- `test_mock_core_schema_rebuild_no_callback`: Covers `rebuild()` when `attempt_rebuild` is `None`
- `test_mock_val_ser_rebuild_success`: Covers successful `MockValSer.rebuild()`
- `test_mock_val_ser_rebuild_failure`: Covers `MockValSer.rebuild()` when rebuild returns `None`
- `test_mock_val_ser_rebuild_no_callback`: Covers `MockValSer.rebuild()` without a callback
- `test_type_adapter_mock_rebuild_returns_none`: Covers the `return None` path in `set_type_adapter_mocks` when rebuild fails
- `test_docstring_visitor_non_name_target`: Covers `DocstringVisitor` skipping docstrings for non-`ast.Name` annotation targets
- `test_apply_known_metadata_unknown_constraint`: Covers the `ValueError` for unknown constraints
- `test_check_metadata_unknown_keys`: Covers the `TypeError` for unknown metadata keys

please review