### PR TITLE
Respect `extras_schema` when only `extra_fields_behavior` is set on the config in JSON Schema generation for typed dictionaries

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1485,13 +1485,15 @@ class GenerateJsonSchema:
         # where you don't necessarily have a class.
         # At runtime, `extra_behavior` takes priority over the config
         # for validation, so follow the same for the JSON Schema:
+        if 'extras_schema' in schema and schema['extras_schema'] != core_schema.any_schema():
+            allow_additional_props = self.generate_inner(schema['extras_schema'])
+        else:
+            allow_additional_props = True
+
         if schema.get('extra_behavior') == 'forbid':
             json_schema['additionalProperties'] = False
         elif schema.get('extra_behavior') == 'allow':
-            if 'extras_schema' in schema and schema['extras_schema'] != {'type': 'any'}:
-                json_schema['additionalProperties'] = self.generate_inner(schema['extras_schema'])
-            else:
-                json_schema['additionalProperties'] = True
+            json_schema['additionalProperties'] = allow_additional_props
 
         if cls is not None:
             # `_update_class_schema()` will not override
@@ -1502,7 +1504,7 @@ class GenerateJsonSchema:
             if extra == 'forbid':
                 json_schema['additionalProperties'] = False
             elif extra == 'allow':
-                json_schema['additionalProperties'] = True
+                json_schema['additionalProperties'] = allow_additional_props
 
         return json_schema
 

--- a/tests/test_types_typeddict.py
+++ b/tests/test_types_typeddict.py
@@ -1089,3 +1089,18 @@ def test_typeddict_core_schema_no_cls_extra_config() -> None:
     )
 
     assert GenerateJsonSchema().generate(cs_allow) == {'additionalProperties': True, 'properties': {}, 'type': 'object'}
+
+
+def test_typeddict_core_schema_no_cls_extra_config_with_extas_schema() -> None:
+    cs_allow_extras_schema = core_schema.typed_dict_schema(
+        fields={},
+        cls=None,
+        extras_schema=core_schema.int_schema(),
+        config={'extra_fields_behavior': 'allow'},
+    )
+
+    assert GenerateJsonSchema().generate(cs_allow_extras_schema) == {
+        'additionalProperties': {'type': 'integer'},
+        'properties': {},
+        'type': 'object',
+    }


### PR DESCRIPTION


Fixes https://github.com/pydantic/pydantic/issues/12809.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
