### PR TITLE
Fix defaultdict default_factory from Field not respected

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -16,12 +16,11 @@ from typing import Any, TypeAlias, TypeVar, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import typing_extensions
-from pydantic_core import PydanticCustomError, PydanticKnownError, core_schema
+from pydantic_core import PydanticCustomError, PydanticKnownError, PydanticUndefined, PydanticUndefinedType, core_schema
 from typing_extensions import get_args, get_origin  # noqa: UP035
 from typing_inspection import typing_objects
 
 from pydantic._internal._import_utils import import_cached_field_info
-from pydantic.errors import PydanticSchemaGenerationError
 
 
 def sequence_validator(
@@ -406,21 +405,25 @@ def deque_validator(input_value: Any, handler: core_schema.ValidatorFunctionWrap
 
 
 def defaultdict_validator(
-    input_value: Any, handler: core_schema.ValidatorFunctionWrapHandler, default_default_factory: Callable[[], Any]
+    input_value: Any,
+    handler: core_schema.ValidatorFunctionWrapHandler,
+    default_default_factory: Callable[[], Any] | PydanticUndefinedType,
 ) -> collections.defaultdict[Any, Any]:
     if isinstance(input_value, collections.defaultdict):
         default_factory = input_value.default_factory
         return collections.defaultdict(default_factory, handler(input_value))
     else:
-        return collections.defaultdict(default_default_factory, handler(input_value))
+        if default_default_factory is PydanticUndefined:
+            return collections.defaultdict(None, handler(input_value))
+        return collections.defaultdict(cast(Callable[[], Any], default_default_factory), handler(input_value))
 
 
-def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable[[], Any]:
+def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable[[], Any] | PydanticUndefinedType:
     FieldInfo = import_cached_field_info()
 
     values_type_origin = get_origin(values_source_type)
 
-    def infer_default() -> Callable[[], Any]:
+    def infer_default() -> Callable[[], Any] | PydanticUndefinedType:
         allowed_default_types: dict[Any, Any] = {
             tuple: tuple,
             collections.abc.Sequence: tuple,
@@ -452,13 +455,7 @@ def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable
 
             return type_var_default_factory
         elif values_type not in allowed_default_types:
-            # a somewhat subjective set of types that have reasonable default values
-            allowed_msg = ', '.join([t.__name__ for t in set(allowed_default_types.values())])
-            raise PydanticSchemaGenerationError(
-                f'Unable to infer a default factory for keys of type {values_source_type}.'
-                f' Only {allowed_msg} are supported, other types require an explicit default factory'
-                ' ' + instructions
-            )
+            return PydanticUndefined
         return allowed_default_types[values_type]
 
     # Assume Annotated[..., Field(...)]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5855,13 +5855,38 @@ def test_defaultdict_unknown_default_factory() -> None:
     """
     https://github.com/pydantic/pydantic/issues/4687
     """
-    with pytest.raises(
-        PydanticSchemaGenerationError,
-        match=r'Unable to infer a default factory for keys of type collections.defaultdict\[int, int\]',
-    ):
 
-        class Model(BaseModel):
-            d: defaultdict[int, defaultdict[int, int]]
+    class Model(BaseModel):
+        d: defaultdict[int, defaultdict[int, int]]
+
+    m = Model(d={})
+    assert m.d.default_factory is None
+
+
+def test_defaultdict_default_factory_from_field() -> None:
+    """Regression test for https://github.com/pydantic/pydantic/issues/10226.
+
+    When a defaultdict value type is not in the allowed default types,
+    the default_factory from Field() should be used instead of raising.
+    """
+
+    class A(BaseModel):
+        pass
+
+    class Model(BaseModel):
+        a: defaultdict[str, A] = Field(default_factory=lambda: defaultdict(A))
+
+    m = Model()
+    assert isinstance(m.a, defaultdict)
+    assert isinstance(m.a['test'], A)
+
+    m2 = Model(a={'key': A()})
+    assert isinstance(m2.a, defaultdict)
+    assert isinstance(m2.a['key'], A)
+    # dict input doesn't pick up the field's factory, see #9060
+    assert m2.a.default_factory is None
+    with pytest.raises(KeyError):
+        m2.a['missing']
 
 
 def test_defaultdict_infer_default_factory() -> None:


### PR DESCRIPTION
## Change Summary

Return `PydanticUndefined` from `get_defaultdict_default_default_factory` instead of raising, so `Field(default_factory=...)` gets applied correctly.

## Related issue number

fix #10226

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos