### PR TITLE
docs: fix variable name in dynamic models example

### DIFF
--- a/docs/examples/dynamic_models.md
+++ b/docs/examples/dynamic_models.md
@@ -25,7 +25,7 @@ to any use case where you need to derive a new model from another (remove defaul
             )
 
         return create_model(
-            f'{type.__name__}Optional',
+            f'{model_cls.__name__}Optional',
             __base__=model_cls,  # (1)!
             **new_fields,
         )
@@ -53,7 +53,7 @@ to any use case where you need to derive a new model from another (remove defaul
             )
 
         return create_model(
-            f'{type.__name__}Optional',
+            f'{model_cls.__name__}Optional',
             __base__=model_cls,  # (1)!
             **new_fields,
         )
@@ -81,7 +81,7 @@ to any use case where you need to derive a new model from another (remove defaul
             )
 
         return create_model(
-            f'{type.__name__}Optional',
+            f'{model_cls.__name__}Optional',
             __base__=model_cls,  # (1)!
             **new_fields,
         )


### PR DESCRIPTION
## Summary
- Fix incorrect variable name in the dynamic models documentation example
- Replace `type.__name__` with `model_cls.__name__` so the generated model is named correctly (e.g. `UserOptional` instead of `typeOptional`)

Closes #12824

## Test plan
- Verified the corrected code example runs without error