### PR TITLE
Fix error location paths for callable discriminators

### DIFF
--- a/pydantic-core/tests/validators/test_tagged_union.py
+++ b/pydantic-core/tests/validators/test_tagged_union.py
@@ -309,7 +309,7 @@ def test_discriminator_path(py_and_json: PyAndJson):
                 [
                     {
                         'type': 'literal_error',
-                        'loc': ('str',),
+                        'loc': (),
                         'msg': "Input should be 'foo' or 'bar'",
                         'input': 'baz',
                         'ctx': {'expected': "'foo' or 'bar'"},

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6742,7 +6742,7 @@ def test_json_value():
     assert exc_info.value.errors() == [
         {
             'input': Ellipsis,
-            'loc': ('dict', 'a', 'dict', 'b'),
+            'loc': ('a', 'b'),
             'msg': 'input was not a valid JSON value',
             'type': 'invalid-json-value',
         }


### PR DESCRIPTION
## Summary

- Fix incorrect error location paths when using callable discriminators with `Tag` annotations
- The `Tag` value was being prepended to the error location path, causing confusing errors like `exclusive_options.option_1_tag.option_2` instead of `exclusive_options.option_2`
- Modified `TaggedUnionValidator::find_call_validator` in pydantic-core to accept a `use_tag_as_loc` parameter: string discriminators (`LookupPaths`) still include the tag in error paths, callable discriminators (`Function`) do not

Fixes #10433

## Test plan

- [x] Added regression test `test_callable_discriminator_error_loc_no_tag` directly from issue #10433
- [x] Updated `test_callable_discriminated_union_recursive` for new expected error locations
- [x] Updated `test_json_value` for `JsonValue` which uses a callable discriminator internally
- [x] Updated pydantic-core test `test_discriminator_function` expected loc
- [x] All 5535 pydantic tests pass (257 skipped, 22 xfailed)
- [x] All 73 discriminated union tests pass (3 xfailed)
- [x] String-based discriminators continue to include tag in error path (verified manually)