### PR TITLE
fix: model_validate_strings respects custom __init__

### DIFF
--- a/pydantic-core/src/input/input_string.rs
+++ b/pydantic-core/src/input/input_string.rs
@@ -76,7 +76,10 @@ impl<'py> Input<'py> for StringMapping<'py> {
     }
 
     fn as_kwargs(&self, _py: Python<'py>) -> Option<Bound<'py, PyDict>> {
-        None
+        match self {
+            Self::String(_) => None,
+            Self::Mapping(d) => Some(d.clone()),
+        }
     }
 
     type Arguments<'a>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3094,6 +3094,26 @@ def test_model_validate_strings_dict(strict):
     }
 
 
+def test_model_validate_strings_custom_init():
+    """Test that model_validate_strings respects custom __init__().
+
+    See https://github.com/pydantic/pydantic/issues/12718
+    """
+    init_called = False
+
+    class MyModel(BaseModel):
+        x: int
+
+        def __init__(self, **data):
+            nonlocal init_called
+            init_called = True
+            super().__init__(**data)
+
+    m = MyModel.model_validate_strings({"x": "1"})
+    assert m.x == 1
+    assert init_called
+
+
 def test_model_signature_annotated() -> None:
     class Model(BaseModel):
         x: Annotated[int, 123]


### PR DESCRIPTION
## Summary
- `model_validate_strings()` bypassed custom `__init__()` unlike `model_validate()`
- Root cause: `StringMapping.as_kwargs()` always returned `None` in pydantic-core, so the `custom_init` code path in `ModelValidator.validate_construct()` was never taken for string validation
- Fix: implement `as_kwargs()` for `StringMapping::Mapping` to return the underlying dict, aligning behavior with `model_validate()`

Closes #12718

## Test plan
- Added `test_model_validate_strings_custom_init` regression test verifying custom `__init__` is called
- Verified all existing `model_validate_strings` and `model_validate` tests pass (28 tests)
- Full `test_main.py` suite passes (241 passed, 26 skipped, 1 xfailed)