### PR TITLE
fix: support exclude_if for computed fields

### DIFF
--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -498,11 +498,17 @@ class ComputedField(TypedDict, total=False):
     property_name: Required[str]
     return_schema: Required[CoreSchema]
     alias: str
+    serialization_exclude_if: Callable[[Any], bool]  # default None
     metadata: dict[str, Any]
 
 
 def computed_field(
-    property_name: str, return_schema: CoreSchema, *, alias: str | None = None, metadata: dict[str, Any] | None = None
+    property_name: str,
+    return_schema: CoreSchema,
+    *,
+    alias: str | None = None,
+    serialization_exclude_if: Callable[[Any], bool] | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> ComputedField:
     """
     ComputedFields are properties of a model or dataclass that are included in serialization.
@@ -511,10 +517,16 @@ def computed_field(
         property_name: The name of the property on the model or dataclass
         return_schema: The schema used for the type returned by the computed field
         alias: The name to use in the serialized output
+        serialization_exclude_if: A callable that determines whether to exclude the field when serializing based on its value.
         metadata: Any other information you want to include with the schema, not used by pydantic-core
     """
     return _dict_not_none(
-        type='computed-field', property_name=property_name, return_schema=return_schema, alias=alias, metadata=metadata
+        type='computed-field',
+        property_name=property_name,
+        return_schema=return_schema,
+        alias=alias,
+        serialization_exclude_if=serialization_exclude_if,
+        metadata=metadata,
     )
 
 

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1506,11 +1506,17 @@ class GenerateJsonSchema:
 
         return json_schema
 
-    @staticmethod
     def _name_required_computed_fields(
+        self,
         computed_fields: list[ComputedField],
     ) -> list[tuple[str, bool, core_schema.ComputedField]]:
-        return [(field['property_name'], True, field) for field in computed_fields]
+        result = []
+        for field in computed_fields:
+            required = True
+            if self.mode == 'serialization' and field.get('serialization_exclude_if') is not None:
+                required = False
+            result.append((field['property_name'], required, field))
+        return result
 
     def _named_required_fields_schema(
         self, named_required_fields: Sequence[tuple[str, bool, CoreSchemaField]]


### PR DESCRIPTION
## Summary
- `exclude_if` parameter on computed field return types (via `Annotated[T, Field(exclude_if=...)]`) was silently ignored during serialization
- Updated pydantic-core's `ComputedField` to store and use `serialization_exclude_if` callable
- Added `serialization_exclude_if` parameter to the `computed_field()` core schema function
- Extract `exclude_if` from computed field return type annotations in pydantic's schema generation
- Updated JSON schema generation to mark computed fields with `exclude_if` as not required in serialization mode

Closes #12690

## Test plan
- Added 6 test cases covering:
  - Basic `exclude_if` on computed fields via `Annotated` return type
  - Multiple computed fields with some excluded and some not
  - Computed fields alongside regular fields with `exclude_if`
  - Computed fields without `exclude_if` (regression check)
  - `exclude_if` on pydantic dataclass computed fields
  - JSON serialization with `exclude_if` on computed fields
- Verified all existing computed field and `exclude_if` tests pass (1081 tests)