### PR TITLE
fix(docs): use model_cls.__name__ instead of type.__name__ in dynamic models example

### DIFF
--- a/docs/examples/dynamic_models.md
+++ b/docs/examples/dynamic_models.md
@@ -25,7 +25,7 @@ to any use case where you need to derive a new model from another (remove defaul
             )
 
         return create_model(
-            f'{type.__name__}Optional',
+            f'{model_cls.__name__}Optional',
             __base__=model_cls,  # (1)!
             **new_fields,
         )
@@ -53,7 +53,7 @@ to any use case where you need to derive a new model from another (remove defaul
             )
 
         return create_model(
-            f'{type.__name__}Optional',
+            f'{model_cls.__name__}Optional',
             __base__=model_cls,  # (1)!
             **new_fields,
         )
@@ -81,7 +81,7 @@ to any use case where you need to derive a new model from another (remove defaul
             )
 
         return create_model(
-            f'{type.__name__}Optional',
+            f'{model_cls.__name__}Optional',
             __base__=model_cls,  # (1)!
             **new_fields,
         )


### PR DESCRIPTION
Fixes #12824

The `make_field_optional` example in `docs/examples/dynamic_models.md` incorrectly used `type.__name__` (Python's builtin `type`) instead of `model_cls.__name__` (the function parameter). This caused the generated model to always be named `typeOptional` instead of the expected name like `UserOptional`.

Changed all 3 occurrences of `type.__name__` to `model_cls.__name__` in the example.