### PR TITLE
ci: declare explicit token permissions for scheduled/docs workflows

### DIFF
--- a/.github/workflows/dependencies-check.yml
+++ b/.github/workflows/dependencies-check.yml
@@ -5,6 +5,9 @@ on:
     - cron: '43 3 * * 6,3'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: true
 

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -7,6 +7,10 @@ on:
       - docs-update
     tags:
       - '**'
+
+permissions:
+  contents: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,9 @@ on:
     - cron: '21 3 * * 1,2,3,4,5'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   test-pydantic-settings:
     name: Test pydantic settings


### PR DESCRIPTION
## Summary\nAdd explicit token permissions to selected workflows that currently rely on implicit defaults:\n\n- `.github/workflows/dependencies-check.yml`\n- `.github/workflows/docs-update.yml`\n- `.github/workflows/integration.yml`\n\n## Permission choices\n- Read-only CI workflows: `contents: read`\n- Docs publication workflow that pushes docs updates: `contents: write`\n\n## Why\nThis makes workflow access explicit and aligns with least-privilege recommendations while preserving current behavior.\n\n## Notes\n- configuration-only changes\n- intentionally left other workflows unchanged where token/auth requirements are less obvious\n