### PR TITLE
Fix grammar in contributing docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -147,7 +147,7 @@ When your pull request is ready for review, add a comment with the message "plea
 
 ## Documentation style
 
-Documentation is written in Markdown and built using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). API documentation is build from docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
+Documentation is written in Markdown and built using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). API documentation is built from docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
 
 ### Code documentation
 


### PR DESCRIPTION
## Summary
- fix a grammar typo in 
- change "API documentation is build from docstrings" to "is built from docstrings"

## Why
- keeps contributor documentation clear and polished for first-time contributors