### PR TITLE
docs: fix grammar in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -147,7 +147,7 @@ When your pull request is ready for review, add a comment with the message "plea
 
 ## Documentation style
 
-Documentation is written in Markdown and built using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). API documentation is build from docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
+Documentation is written in Markdown and built using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). API documentation is built from docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
 
 ### Code documentation
 


### PR DESCRIPTION
## Summary
- fix a grammar typo in `docs/contributing.md` (`is build` -> `is built`)

Part of #10083

## Testing
- docs-only change; reviewed rendered sentence for correctness
