### PR TITLE
Fix extra closing parenthesis in Logfire link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Define how data should be in pure, canonical Python 3.9+; validate it with Pydan
 ## Pydantic Logfire :fire:
 
 We've launched Pydantic Logfire to help you monitor your applications.
-[Learn more](https://pydantic.dev/logfire/?utm_source=pydantic_validation))
+[Learn more](https://pydantic.dev/logfire/?utm_source=pydantic_validation)
 
 ## Pydantic V1.10 vs. V2
 


### PR DESCRIPTION
## Summary

The README has a stray closing parenthesis at the end of the Logfire "Learn more" link, which causes the link to render incorrectly in some Markdown parsers.

## Change

```diff
-[Learn more](https://pydantic.dev/logfire/?utm_source=pydantic_validation))
+[Learn more](https://pydantic.dev/logfire/?utm_source=pydantic_validation)
```

Small typo fix — the extra `)` after the closing parenthesis of the link is extraneous.