### PR TITLE
Fix duplicated words in internal schema comments

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2783,7 +2783,7 @@ class _Definitions:
             else:
                 # `ref` was encountered, at least two times (or only once, but with metadata or a serialization schema):
                 # - Do not inline the `'definition-ref'` schemas (they are not provided in the gather result anyway).
-                # - Store the the definition in the `remaining_defs`
+                # - Store the definition in the `remaining_defs`
                 remaining_defs[ref] = self._resolve_definition(ref, definitions)
 
         for cs in gather_result['deferred_discriminator_schemas']:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -158,7 +158,7 @@ class _DefinitionsRemapping:
         copied_definitions = deepcopy(definitions)
         definitions_schema = {'$defs': copied_definitions}
         for _iter in range(100):  # prevent an infinite loop in the case of a bug, 100 iterations should be enough
-            # For every possible remapped DefsRef, collect all schemas that that DefsRef might be used for:
+            # For every possible remapped DefsRef, collect all schemas that DefsRef might be used for:
             schemas_for_alternatives: dict[DefsRef, list[JsonSchemaValue]] = defaultdict(list)
             for defs_ref in copied_definitions:
                 alternatives = prioritized_choices[defs_ref]


### PR DESCRIPTION
## Change Summary
Fix duplicated words in two internal schema comments:
- `that that` -> `that`
- `the the` -> `the`

## Related issue number
None (trivial docs/comment cleanup).

## Checklist
* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos