### PR TITLE
Fix duplicated words in v1 comments

### DIFF
--- a/pydantic/v1/datetime_parse.py
+++ b/pydantic/v1/datetime_parse.py
@@ -147,7 +147,7 @@ def parse_time(value: Union[time, StrBytesIntFloat]) -> time:
     number = get_numeric(value, 'time')
     if number is not None:
         if number >= 86400:
-            # doesn't make sense since the time time loop back around to 0
+            # doesn't make sense since the time loop back around to 0
             raise errors.TimeError()
         return (datetime.min + timedelta(seconds=number)).time()
 

--- a/pydantic/v1/fields.py
+++ b/pydantic/v1/fields.py
@@ -539,7 +539,7 @@ class ModelField(Representation):
         Prepare the field but inspecting self.default, self.type_ etc.
 
         Note: this method is **not** idempotent (because _type_analysis is not idempotent),
-        e.g. calling it it multiple times may modify the field and configure it incorrectly.
+        e.g. calling it multiple times may modify the field and configure it incorrectly.
         """
         self._set_default_and_type()
         if self.type_.__class__ is ForwardRef or self.type_.__class__ is DeferredType:


### PR DESCRIPTION
## Change Summary
Fix duplicated words in two `pydantic/v1` comments:
- `time time` -> `time`
- `it it` -> `it`

## Related issue number
None (trivial comment cleanup).

## Checklist
* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos