### PR TITLE
Fix grammar in dataclass field completion docstring

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -316,7 +316,7 @@ def dataclass(
 def _pydantic_fields_complete(cls: type[PydanticDataclass]) -> bool:
     """Return whether the fields were successfully collected (i.e. type hints were successfully resolved).
 
-    This is a private property, not meant to be used outside Pydantic.
+    This is a private helper, not meant to be used outside Pydantic.
     """
     return all(field_info._complete for field_info in cls.__pydantic_fields__.values())
 


### PR DESCRIPTION
## Related issue number
N/A (trivial docstring grammar fix)

## Summary
- fix grammar in `_pydantic_fields_complete` docstring in `pydantic/dataclasses.py`
- clarify wording from "private property" to "private helper" in the same docstring block

## Guideline alignment
- guideline reference: https://github.com/pydantic/pydantic/blob/main/docs/contributing.md
- docs/docstring-only update, no behavior change

## Validation
- docstring-only change; full upstream CI runs on PR
