### PR TITLE
Remove unused `cls` parameter from `create_model` validator example

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -1347,7 +1347,7 @@ You can also add validators by passing a dictionary to the `__validators__` argu
 from pydantic import ValidationError, create_model, field_validator
 
 
-def alphanum(cls, v):
+def alphanum(v):
     assert v.isalnum(), 'must be alphanumeric'
     return v
 


### PR DESCRIPTION
## Change Summary

Remove the unused `cls` parameter from the `alphanum` validator function in the `create_model` documentation example. Since the function does not reference the model class, the `cls` parameter is unnecessary and can be confusing for readers.

## Related issue number

Fixes #11909

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**