### PR TITLE
Fix mypy plugin crash on BaseSettings with unresolvable type annotations

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -884,7 +884,9 @@ class PydanticModelTransformer:
                         if arg_name is None or arg_name.startswith('__') or not arg_name.startswith('_'):
                             continue
                         analyzed_variable_type = self._api.anal_type(func_type.arg_types[arg_idx])
-                        if analyzed_variable_type is not None and arg_name == '_cli_settings_source':
+                        if analyzed_variable_type is None:
+                            analyzed_variable_type = AnyType(TypeOfAny.from_error)
+                        if arg_name == '_cli_settings_source':
                             # _cli_settings_source is defined as CliSettingsSource[Any], and as such
                             # the Any causes issues with --disallow-any-explicit. As a workaround, change
                             # the Any type (as if CliSettingsSource was left unparameterized):


### PR DESCRIPTION
## Change Summary

Fix an internal error in the pydantic mypy plugin when processing `BaseSettings` models with `SettingsConfigDict`. The crash occurs because some `BaseSettings.__init__` arguments (e.g. `_env_file`, `_cli_settings_source`, `_cli_shortcuts`, `_secrets_dir`) can have types that `anal_type()` cannot resolve (returns `None`). The code then passes `None` as the type annotation to `add_method()`, which triggers an assertion error.

The fix falls back to `AnyType` when `anal_type()` returns `None`, preventing the crash while still including the arguments in the generated `__init__` signature.

## Related issue number

Fixes #12102

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**