### PR TITLE
Fix `version-added` directive for `polymorphic_serialization`

### DIFF
--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -609,7 +609,7 @@ print(m.model_dump())  # (1)!
 
 ### Polymorphic serialization
 
-/// version-added | v2.12
+/// version-added | v2.13
 Polymorphic serialization was added as an better alternative to the [serialize as any](#serializing-as-any) behavior, and only
 applies to Pydantic models and Pydantic dataclasses.
 ///


### PR DESCRIPTION
Updates the documentation to report [`polymorphic_serialization`](https://docs.pydantic.dev/dev/concepts/serialization/#polymorphic-serialization) as being added in v2.13.

From what I can tell this feature is not available in any 2.12 release. The last 2.12 release was in [Nov of 2025](https://github.com/pydantic/pydantic/releases/tag/v2.12.5) but the feature was [only merged a few weeks ago](https://github.com/pydantic/pydantic/pull/12518).

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos