### PR TITLE
Fix KeyError when custom JSON schema contains local $ref/$defs

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2331,9 +2331,9 @@ class GenerateJsonSchema:
                 raise self._core_defs_invalid_for_json_schema[def_ref]
             return self.definitions.get(def_ref, None)
         except KeyError:
-            if json_ref.startswith(('http://', 'https://')):
-                return None
-            raise
+            # Ref is not managed by pydantic (e.g. external URL,
+            # or local ref from custom __get_pydantic_json_schema__)
+            return None
 
     def encode_default(self, dft: Any) -> Any:
         """Encode a default value to a JSON-serializable value.
@@ -2443,8 +2443,9 @@ class GenerateJsonSchema:
                             raise self._core_defs_invalid_for_json_schema[defs_ref]
                         _add_json_refs(self.definitions[defs_ref])
                     except KeyError:
-                        if not json_ref.startswith(('http://', 'https://')):
-                            raise
+                        # Skip refs not managed by pydantic (e.g. external URLs,
+                        # or local refs from custom __get_pydantic_json_schema__)
+                        pass
 
                 for k, v in schema.items():
                     if k == 'examples' and isinstance(v, list):
@@ -2512,8 +2513,9 @@ class GenerateJsonSchema:
                 visited_defs_refs.add(next_defs_ref)
                 unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
             except KeyError:
-                if not next_json_ref.startswith(('http://', 'https://')):
-                    raise
+                # Skip refs not managed by pydantic (e.g. external URLs,
+                # or local refs from custom __get_pydantic_json_schema__)
+                pass
 
         self.definitions = {k: v for k, v in self.definitions.items() if k in visited_defs_refs}
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6880,6 +6880,61 @@ def test_arbitrary_ref_in_json_schema() -> None:
     }
 
 
+def test_custom_json_schema_with_local_defs_and_refs() -> None:
+    """See https://github.com/pydantic/pydantic/issues/12145.
+
+    Custom __get_pydantic_json_schema__ returning $defs/$ref should not crash.
+    """
+    from pydantic_core import core_schema as cs
+
+    class CarDict(dict):
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> cs.CoreSchema:
+            return cs.dict_schema(
+                keys_schema=cs.str_schema(),
+                values_schema=cs.any_schema(),
+            )
+
+        @classmethod
+        def __get_pydantic_json_schema__(cls, _cs: cs.CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+            return {
+                '$defs': {
+                    'Tire': {
+                        'properties': {'brand': {'title': 'Brand', 'type': 'string'}},
+                        'required': ['brand'],
+                        'title': 'Tire',
+                        'type': 'object',
+                    }
+                },
+                'properties': {
+                    'tires': {
+                        'items': {'$ref': '#/$defs/Tire'},
+                        'title': 'Tires',
+                        'type': 'array',
+                    }
+                },
+                'required': ['tires'],
+                'title': 'Car',
+                'type': 'object',
+            }
+
+    schema = TypeAdapter(CarDict).json_schema()
+    assert schema['$defs']['Tire']['properties']['brand'] == {'title': 'Brand', 'type': 'string'}
+    assert schema['properties']['tires']['items'] == {'$ref': '#/$defs/Tire'}
+
+    # Also works when used as a field in a model
+    class Garage(BaseModel):
+        car: CarDict
+        name: str
+
+    schema = Garage.model_json_schema()
+    assert '$defs' in schema['properties']['car']
+    assert schema['properties']['car']['$defs']['Tire']['properties']['brand'] == {
+        'title': 'Brand',
+        'type': 'string',
+    }
+
+
 def test_examples_as_property_key() -> None:
     """https://github.com/pydantic/pydantic/issues/11304.
 


### PR DESCRIPTION
## Summary

Fixes #12145.

When `__get_pydantic_json_schema__` returns a schema that includes its own `$defs` and `$ref` entries, `TypeAdapter(...).json_schema()` crashes with `KeyError` because those refs aren't tracked in pydantic's internal `json_to_defs_refs` mapping.

Three methods in `GenerateJsonSchema` had the same pattern: catch `KeyError` on ref lookup, but only skip it for `http://`/`https://` URLs. Local refs from user-provided schemas hit the re-raise path.

The fix: treat all unresolvable `$ref` the same way -- skip them, since they aren't managed by pydantic regardless of whether they're remote URLs or local anchors from custom schema output.

## Test plan

- Added `test_custom_json_schema_with_local_defs_and_refs` covering both standalone `TypeAdapter` and model field usage
- All 529 existing `test_json_schema.py` tests pass