### PR TITLE
Fix Field metadata (examples, deprecated, title) lost in RootModel JSON schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1649,7 +1649,10 @@ class GenerateJsonSchema:
                 raise TypeError(f'model_title_generator {model_title_generator} must return str, not {title.__class__}')
             json_schema.setdefault('title', title)
         if 'title' not in json_schema:
-            json_schema['title'] = cls.__name__
+            if issubclass(cls, RootModel) and (root_title := cls.__pydantic_fields__['root'].title):
+                json_schema['title'] = root_title
+            else:
+                json_schema['title'] = cls.__name__
 
         # BaseModel and dataclasses; don't use cls.__doc__ as it will contain the verbose class signature by default
         if cls is BaseModel:
@@ -1669,6 +1672,13 @@ class GenerateJsonSchema:
             json_schema.setdefault('description', inspect.cleandoc(docstring))
         elif issubclass(cls, RootModel) and (root_description := cls.__pydantic_fields__['root'].description):
             json_schema.setdefault('description', root_description)
+
+        if issubclass(cls, RootModel):
+            root_field = cls.__pydantic_fields__['root']
+            if root_field.examples is not None:
+                json_schema.setdefault('examples', to_jsonable_python(root_field.examples))
+            if root_field.deprecated:
+                json_schema['deprecated'] = True
 
         extra = config.get('extra')
         if 'additionalProperties' not in json_schema:  # This check is particularly important for `typed_dict_schema()`

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -721,3 +721,44 @@ def test_model_with_both_docstring_and_field_description() -> None:
         'type': 'integer',
         'description': 'More detailed description',
     }
+
+
+def test_model_json_schema_field_examples() -> None:
+    class AModel(RootModel):
+        root: str = Field(examples=['foo', 'bar'])
+
+    assert AModel.model_json_schema() == {'title': 'AModel', 'type': 'string', 'examples': ['foo', 'bar']}
+
+
+def test_model_json_schema_field_deprecated() -> None:
+    class AModel(RootModel):
+        root: str = Field(deprecated=True)
+
+    assert AModel.model_json_schema() == {'title': 'AModel', 'type': 'string', 'deprecated': True}
+
+
+def test_model_json_schema_field_title() -> None:
+    class AModel(RootModel):
+        root: str = Field(title='My Title')
+
+    assert AModel.model_json_schema() == {'title': 'My Title', 'type': 'string'}
+
+
+def test_model_json_schema_field_title_overridden_by_config() -> None:
+    class AModel(RootModel):
+        model_config = ConfigDict(title='Config Title')
+        root: str = Field(title='Field Title')
+
+    assert AModel.model_json_schema() == {'title': 'Config Title', 'type': 'string'}
+
+
+def test_model_json_schema_field_examples_and_deprecated_together() -> None:
+    class AModel(RootModel):
+        root: Annotated[str, Field(examples=['foo'], deprecated=True)]
+
+    assert AModel.model_json_schema() == {
+        'title': 'AModel',
+        'type': 'string',
+        'examples': ['foo'],
+        'deprecated': True,
+    }


### PR DESCRIPTION
## Summary

When a `RootModel` declares the `root` field with `Field(examples=..., deprecated=True, title=...)`, those attributes are silently dropped from the generated JSON schema. Only `description` and `json_schema_extra` were being propagated.

- Propagate `examples` from `root` field to the JSON schema output
- Propagate `deprecated` from `root` field to the JSON schema output
- Propagate `title` from `root` field as a fallback before using the class name

The fix is in `_update_class_schema` in `json_schema.py`, following the same pattern already used for `description` on line 1670.

Closes #11922

## Reproduction

```python
from typing import Annotated
from pydantic import RootModel, Field

class Foo(RootModel):
    root: Annotated[str, Field(examples=['foo', 'bar'], deprecated=True)]

print(Foo.model_json_schema())
# Before: {'title': 'Foo', 'type': 'string'}
# After:  {'deprecated': True, 'examples': ['foo', 'bar'], 'title': 'Foo', 'type': 'string'}
```

## Test plan

- `uv run python -m pytest tests/test_root_model.py tests/test_json_schema.py -x -q`
- Added 5 new targeted tests covering `examples`, `deprecated`, `title`, config title override, and combined usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)