### PR TITLE
fix: clear cached_property values in model_copy when update is provided

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -397,9 +397,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns a copy of the model.
 
         !!! note
-            The underlying instance's [`__dict__`][object.__dict__] attribute is copied. This
-            might have unexpected side effects if you store anything in it, on top of the model
-            fields (e.g. the value of [cached properties][functools.cached_property]).
+            When `update` is provided, any [cached properties][functools.cached_property] are
+            cleared so they will be recomputed on next access with the updated field values.
+            When `update` is not provided, cached property values are preserved.
 
         Args:
             update: Values to change/add in the new model. Note: the data is not validated
@@ -422,6 +422,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             else:
                 copied.__dict__.update(update)
             copied.__pydantic_fields_set__.update(update.keys())
+            # Clear cached_property values so they recompute with updated fields
+            for key in list(copied.__dict__):
+                if isinstance(getattr(type(copied), key, None), cached_property):
+                    del copied.__dict__[key]
         return copied
 
     def model_dump(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -589,6 +589,90 @@ def test_frozen_model_cached_property():
     assert m.test == 3
 
 
+def test_model_copy_clears_cached_property_on_update() -> None:
+    class MyModel(BaseModel):
+        x: int
+
+        @cached_property
+        def double(self) -> int:
+            return self.x * 2
+
+    m1 = MyModel(x=2)
+    assert m1.double == 4
+
+    m2 = m1.model_copy(update={'x': 5})
+    assert m2.double == 10
+
+
+def test_model_copy_preserves_cached_property_without_update() -> None:
+    class MyModel(BaseModel):
+        x: int
+
+        @cached_property
+        def double(self) -> int:
+            return self.x * 2
+
+    m1 = MyModel(x=3)
+    assert m1.double == 6
+
+    m2 = m1.model_copy()
+    assert m2.double == 6
+
+
+def test_model_copy_deep_clears_cached_property_on_update() -> None:
+    class MyModel(BaseModel):
+        x: int
+
+        @cached_property
+        def double(self) -> int:
+            return self.x * 2
+
+    m1 = MyModel(x=2)
+    assert m1.double == 4
+
+    m2 = m1.model_copy(update={'x': 7}, deep=True)
+    assert m2.double == 14
+
+
+def test_model_copy_frozen_cached_property_on_update() -> None:
+    class MyModel(BaseModel):
+        model_config = ConfigDict(frozen=True)
+        x: int
+
+        @cached_property
+        def double(self) -> int:
+            return self.x * 2
+
+    m1 = MyModel(x=2)
+    assert m1.double == 4
+
+    m2 = m1.model_copy(update={'x': 3})
+    assert m2.double == 6
+    assert m1.double == 4  # original unchanged
+
+
+def test_model_copy_multiple_cached_properties_on_update() -> None:
+    class MyModel(BaseModel):
+        x: int
+        y: int
+
+        @cached_property
+        def sum(self) -> int:
+            return self.x + self.y
+
+        @cached_property
+        def product(self) -> int:
+            return self.x * self.y
+
+    m1 = MyModel(x=2, y=3)
+    assert m1.sum == 5
+    assert m1.product == 6
+
+    m2 = m1.model_copy(update={'x': 10})
+    assert m2.sum == 13
+    assert m2.product == 30
+
+
 def test_frozen_field():
     class FrozenModel(BaseModel):
         a: int = Field(10, frozen=True)


### PR DESCRIPTION
Fixes #11955 (also reported as #11428 and #11542)

## The problem

When `model_copy(update={...})` is called, the new instance retains stale `cached_property` values from the original:

```python
m1 = MyModel(x=2)
m1.double  # caches 4

m2 = m1.model_copy(update={'x': 5})
m2.double  # returns 4 (wrong) -- should be 10
```

This happens because `cached_property` stores values in the instance `__dict__`, and `model_copy` copies `__dict__` wholesale without clearing these entries.

## The fix

After applying `update` in `model_copy`, clear all `cached_property` entries from the copied instance's `__dict__`. They will be lazily recomputed on next access with the correct field values.

When `update` is not provided, cached values are preserved since fields haven't changed.

## Tests

Added 5 test cases covering:
- Basic cached_property invalidation on update
- Cached values preserved without update (no regression)
- Deep copy with update
- Frozen model with update
- Multiple cached properties on same model