### PR TITLE
Handle custom $ref/$defs in __get_pydantic_json_schema__

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2325,15 +2325,12 @@ class GenerateJsonSchema:
         return json_schema
 
     def get_schema_from_definitions(self, json_ref: JsonRef) -> JsonSchemaValue | None:
-        try:
-            def_ref = self.json_to_defs_refs[json_ref]
-            if def_ref in self._core_defs_invalid_for_json_schema:
-                raise self._core_defs_invalid_for_json_schema[def_ref]
-            return self.definitions.get(def_ref, None)
-        except KeyError:
-            if json_ref.startswith(('http://', 'https://')):
-                return None
-            raise
+        if json_ref not in self.json_to_defs_refs:
+            return None
+        def_ref = self.json_to_defs_refs[json_ref]
+        if def_ref in self._core_defs_invalid_for_json_schema:
+            raise self._core_defs_invalid_for_json_schema[def_ref]
+        return self.definitions.get(def_ref, None)
 
     def encode_default(self, dft: Any) -> Any:
         """Encode a default value to a JSON-serializable value.
@@ -2437,14 +2434,11 @@ class GenerateJsonSchema:
                     json_refs[json_ref] += 1
                     if already_visited:
                         return  # prevent recursion on a definition that was already visited
-                    try:
+                    if json_ref in self.json_to_defs_refs:
                         defs_ref = self.json_to_defs_refs[json_ref]
                         if defs_ref in self._core_defs_invalid_for_json_schema:
                             raise self._core_defs_invalid_for_json_schema[defs_ref]
                         _add_json_refs(self.definitions[defs_ref])
-                    except KeyError:
-                        if not json_ref.startswith(('http://', 'https://')):
-                            raise
 
                 for k, v in schema.items():
                     if k == 'examples' and isinstance(v, list):
@@ -2505,15 +2499,13 @@ class GenerateJsonSchema:
         unvisited_json_refs = _get_all_json_refs(schema)
         while unvisited_json_refs:
             next_json_ref = unvisited_json_refs.pop()
-            try:
-                next_defs_ref = self.json_to_defs_refs[next_json_ref]
-                if next_defs_ref in visited_defs_refs:
-                    continue
-                visited_defs_refs.add(next_defs_ref)
-                unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
-            except KeyError:
-                if not next_json_ref.startswith(('http://', 'https://')):
-                    raise
+            if next_json_ref not in self.json_to_defs_refs:
+                continue
+            next_defs_ref = self.json_to_defs_refs[next_json_ref]
+            if next_defs_ref in visited_defs_refs:
+                continue
+            visited_defs_refs.add(next_defs_ref)
+            unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
 
         self.definitions = {k: v for k, v in self.definitions.items() if k in visited_defs_refs}
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7237,3 +7237,40 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_custom_json_schema_with_ref_and_defs():
+    """TypeAdapter should handle custom $ref/$defs from __get_pydantic_json_schema__."""
+
+    class CarDict(dict):
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+            return core_schema.dict_schema(
+                keys_schema=core_schema.str_schema(),
+                values_schema=core_schema.any_schema(),
+            )
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return {
+                '$defs': {
+                    'Tire': {
+                        'properties': {'brand': {'title': 'Brand', 'type': 'string'}},
+                        'required': ['brand'],
+                        'title': 'Tire',
+                        'type': 'object',
+                    }
+                },
+                'properties': {
+                    'tires': {'items': {'$ref': '#/$defs/Tire'}, 'title': 'Tires', 'type': 'array'}
+                },
+                'required': ['tires'],
+                'title': 'Car',
+                'type': 'object',
+            }
+
+    result = TypeAdapter(CarDict).json_schema()
+    assert result['$defs']['Tire']['type'] == 'object'
+    assert result['properties']['tires']['items']['$ref'] == '#/$defs/Tire'


### PR DESCRIPTION
Fixes #12145

When a custom type returns a JSON schema containing $ref and $defs from __get_pydantic_json_schema__, TypeAdapter.json_schema() raises a KeyError because get_json_ref_counts and _garbage_collect_definitions try to look up those refs in the internal json_to_defs_refs mapping where they were never registered.

The fix checks membership in json_to_defs_refs before accessing it, so custom/external $ref values are skipped rather than causing a lookup failure. This applies to get_json_ref_counts, _garbage_collect_definitions, and get_schema_from_definitions.

Added a test covering the exact scenario from the issue: a type with __get_pydantic_json_schema__ returning a schema with local $ref/$defs.