### PR TITLE
Do not include annotations that are not part of named tuple fields

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1540,11 +1540,9 @@ class GenerateSchema:
             except NameError as e:
                 raise PydanticUndefinedAnnotation.from_name_error(e) from e
 
-            # Filter annotations to only include fields that are actually in the NamedTuple,
-            # and ensure all NamedTuple fields are included in annotations (filling with Any if missing).
-            # This is to handle inheritance where subclasses might add annotations that aren't
-            # part of the NamedTuple, or where base classes (like collections.namedtuple) don't have annotations.
-            # See https://github.com/pydantic/pydantic/issues/7987
+            # Filter annotations to only include fields that are actually in the NamedTuple
+            # (as subclassing an existing NamedTuple is not supported yet - see https://github.com/python/typing/issues/427)
+            # and use `Any` if no annotation exist (i.e. when using `collections.namedtuple()`).
             annotations = {field_name: annotations.get(field_name, Any) for field_name in namedtuple_cls._fields}
 
             if typevars_map:

--- a/tests/test_types_namedtuple.py
+++ b/tests/test_types_namedtuple.py
@@ -268,9 +268,7 @@ def test_eval_type_backport():
 
 
 def test_namedtuple_inheritance_with_annotations():
-    """
-    https://github.com/pydantic/pydantic/issues/7987
-    """
+    """https://github.com/pydantic/pydantic/issues/7987."""
 
     class Foo(NamedTuple):
         test: str


### PR DESCRIPTION
## Change Summary

Fixed a TypeError during instantiation of NamedTuple subclasses by ensuring Pydantic only generates schema for fields defined in the base NamedTuple._fields attribute. This prevents extraneous annotations in subclasses from being incorrectly treated as valid constructor arguments, resolving issue #7987 

## Related issue number

fix #7987

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
