### PR TITLE
Fix pattern constraint dropped from JSON schema with Annotated BeforeValidator on Optional fields

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -217,6 +217,17 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function schema
             return schema
 
+        # For function schemas with chain_schema_constraints (e.g. pattern, strip_whitespace),
+        # try to apply the constraint to the inner schema directly. This ensures the constraint
+        # is both enforced at runtime and correctly reflected in the JSON schema, rather than
+        # being placed in a separate chain step that JSON schema generation may not inspect.
+        if schema_type in {'function-before', 'function-wrap', 'function-after'} and constraint in chain_schema_constraints:
+            inner_schema = schema['schema']  # type: ignore  # schema is function schema
+            inner_type = inner_schema['type']
+            if inner_type in allowed_schemas:
+                inner_schema[constraint] = value
+                continue
+
         # if we're allowed to apply constraint directly to the schema, like le to int, do that
         if schema_type in allowed_schemas:
             if constraint == 'union_mode' and schema_type == 'union':

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7237,3 +7237,51 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_annotated_before_validator_with_field_pattern_constraint():
+    """Test that pattern constraint from Field() is preserved in JSON schema
+    when used with Annotated type that includes a BeforeValidator,
+    including when the field is Optional.
+
+    Regression test for https://github.com/pydantic/pydantic/issues/12417
+    """
+
+    def _convert_bytes_to_str(value):
+        if isinstance(value, bytes):
+            return value.decode('utf8')
+        return value
+
+    bytes_to_str = Annotated[str, BeforeValidator(_convert_bytes_to_str)]
+    regex = r'^[\da-fA-F]{32}$'
+
+    class TestModel(BaseModel):
+        str_mandatory: str = Field(..., pattern=regex)
+        annotated_mandatory: bytes_to_str = Field(..., pattern=regex)
+        str_optional: Optional[str] = Field(None, pattern=regex)
+        annotated_optional: Optional[bytes_to_str] = Field(None, pattern=regex)
+
+    schema = TestModel.model_json_schema()
+
+    # All four fields should have the pattern constraint in their JSON schema
+    assert schema['properties']['str_mandatory'] == {
+        'pattern': regex,
+        'title': 'Str Mandatory',
+        'type': 'string',
+    }
+    assert schema['properties']['annotated_mandatory'] == {
+        'pattern': regex,
+        'title': 'Annotated Mandatory',
+        'type': 'string',
+    }
+    assert schema['properties']['str_optional'] == {
+        'anyOf': [{'pattern': regex, 'type': 'string'}, {'type': 'null'}],
+        'default': None,
+        'title': 'Str Optional',
+    }
+    # This was the bug: pattern was missing from the annotated_optional field
+    assert schema['properties']['annotated_optional'] == {
+        'anyOf': [{'pattern': regex, 'type': 'string'}, {'type': 'null'}],
+        'default': None,
+        'title': 'Annotated Optional',
+    }


### PR DESCRIPTION
## Change Summary

When a field uses an `Annotated` type with a `BeforeValidator` and a `Field()` `pattern` constraint (e.g. `Optional[Annotated[str, BeforeValidator(fn)]] = Field(None, pattern=...)`), the `pattern` was missing from the generated JSON schema.

The root cause: `apply_known_metadata` could not directly apply `chain_schema_constraints` (like `pattern`, `strip_whitespace`, etc.) to function-type schemas (`function-before`, `function-wrap`, `function-after`). Instead, it wrapped the schema in a chain with a separate validation step containing the constraint. The JSON schema generator's `chain_schema` handler only inspects `step[0]` for validation mode, so the `pattern` in `step[1]` was lost.

The fix adds a check in `apply_known_metadata`: when the schema is a function type and the constraint is a `chain_schema_constraint`, apply it directly to the inner schema if the inner schema type supports that constraint. This ensures the constraint is both enforced at runtime (by pydantic-core) and correctly reflected in the JSON schema.

**Before:**
```python
annotated_optional:
{'anyOf': [{'type': 'string'}, {'type': 'null'}],
 'default': None,
 'title': 'Annotated Optional'}
# pattern is missing!
```

**After:**
```python
annotated_optional:
{'anyOf': [{'pattern': '^[\\da-fA-F]{32}$', 'type': 'string'}, {'type': 'null'}],
 'default': None,
 'title': 'Annotated Optional'}
```

## Related issue number

fix #12417

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**