### PR TITLE
Preserve pattern metadata for Missing sentinel JSON schema

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic_core import CoreSchema, PydanticCustomError, ValidationError, to_jsonable_python
 from pydantic_core import core_schema as cs
 
+from ._core_metadata import update_core_metadata
 from ._fields import PydanticMetadata
 from ._import_utils import import_cached_field_info
 
@@ -203,6 +204,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         'ascii_only',
     }
     chain_schema_steps: list[CoreSchema] = []
+    chain_schema_js_updates: dict[str, Any] = {}
 
     for constraint, value in schema_update.items():
         if constraint not in CONSTRAINTS_TO_ALLOWED_SCHEMAS:
@@ -251,6 +253,8 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
                     _apply_constraint_with_incompatibility_info, cs.str_schema(**{constraint: value})
                 )
             )
+            if constraint == 'pattern':
+                chain_schema_js_updates['pattern'] = as_jsonable_value(value)
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
@@ -334,7 +338,11 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
 
     if chain_schema_steps:
         chain_schema_steps = [schema] + chain_schema_steps
-        return cs.chain_schema(chain_schema_steps)
+        chain_schema = cs.chain_schema(chain_schema_steps)
+        if chain_schema_js_updates:
+            core_metadata = chain_schema.setdefault('metadata', {})
+            update_core_metadata(core_metadata, pydantic_js_updates=chain_schema_js_updates)
+        return chain_schema
 
     return schema
 

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -1,10 +1,10 @@
 import pickle
-from typing import Union
+from typing import Annotated, Union
 
 import pytest
 from pydantic_core import MISSING, PydanticSerializationUnexpectedValue
 
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 
 def test_missing_sentinel_model() -> None:
@@ -69,6 +69,38 @@ def test_missing_sentinel_json_schema() -> None:
     assert Model.model_json_schema()['properties'] == {
         'f': {'title': 'F', 'type': 'integer'},
     }
+
+
+def assert_missing_sentinel_pattern_schema(model: type[BaseModel]) -> None:
+    assert model.model_json_schema()['properties'] == {
+        'a': {
+            'description': 'Something',
+            'pattern': '^[a-z]+$',
+            'title': 'title',
+            'type': 'string',
+        }
+    }
+
+
+def test_missing_sentinel_json_schema_preserves_pattern_assignment() -> None:
+    class Model(BaseModel):
+        a: str | MISSING = Field(title='title', description='Something', pattern='^[a-z]+$')
+
+    assert_missing_sentinel_pattern_schema(Model)
+
+
+def test_missing_sentinel_json_schema_preserves_pattern_annotated_in_union() -> None:
+    class Model(BaseModel):
+        a: Annotated[str, Field(title='title', description='Something', pattern='^[a-z]+$')] | MISSING
+
+    assert_missing_sentinel_pattern_schema(Model)
+
+
+def test_missing_sentinel_json_schema_preserves_pattern_annotated_union() -> None:
+    class Model(BaseModel):
+        a: Annotated[str | MISSING, Field(title='title', description='Something', pattern='^[a-z]+$')]
+
+    assert_missing_sentinel_pattern_schema(Model)
 
 
 def test_model_construct_with_missing_default_does_not_crash() -> None:


### PR DESCRIPTION
Fixes #12971.

Summary:
- Preserve `pattern` metadata when `str | MISSING` fields are wrapped in a chain schema during JSON schema generation.
- Keep runtime validation unchanged while restoring the regex in `model_json_schema()` output.

Validation:
- `python -m pytest -o addopts='' tests\test_missing_sentinel.py -q`
- `python -m ruff check pydantic\_internal\_known_annotated_metadata.py tests\test_missing_sentinel.py`
- `python -m ruff format --check pydantic\_internal\_known_annotated_metadata.py tests\test_missing_sentinel.py`

Manual risk:
- Validation passed locally, but the change still depends on the usual upstream review and CI checks for JSON schema behavior.