### PR TITLE
Box large fields in CombinedValidator/CombinedSerializer to reduce enum size

### DIFF
--- a/pydantic-core/src/serializers/filter.rs
+++ b/pydantic-core/src/serializers/filter.rs
@@ -13,8 +13,8 @@ use crate::tools::SchemaDict;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SchemaFilter<T> {
-    include: Option<AHashSet<T>>,
-    exclude: Option<AHashSet<T>>,
+    include: Option<Box<AHashSet<T>>>,
+    exclude: Option<Box<AHashSet<T>>>,
 }
 
 fn map_negative_index<'py>(value: &Bound<'py, PyAny>, len: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
@@ -74,7 +74,7 @@ impl SchemaFilter<usize> {
         }
     }
 
-    fn build_set_ints(v: Option<Bound<'_, PyAny>>) -> PyResult<Option<AHashSet<usize>>> {
+    fn build_set_ints(v: Option<Bound<'_, PyAny>>) -> PyResult<Option<Box<AHashSet<usize>>>> {
         match v {
             Some(value) => {
                 if value.is_none() {
@@ -86,7 +86,7 @@ impl SchemaFilter<usize> {
                     for item in py_set {
                         set.insert(item.extract()?);
                     }
-                    Ok(Some(set))
+                    Ok(Some(Box::new(set)))
                 }
             }
             None => Ok(None),
@@ -112,7 +112,7 @@ impl SchemaFilter<isize> {
         Ok(Self { include, exclude })
     }
 
-    fn build_set_hashes(v: Option<&Bound<'_, PyAny>>) -> PyResult<Option<AHashSet<isize>>> {
+    fn build_set_hashes(v: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Box<AHashSet<isize>>>> {
         match v {
             Some(value) => {
                 if value.is_none() {
@@ -124,7 +124,7 @@ impl SchemaFilter<isize> {
                     for item in py_set.iter() {
                         set.insert(item.hash()?);
                     }
-                    Ok(Some(set))
+                    Ok(Some(Box::new(set)))
                 }
             }
             None => Ok(None),

--- a/pydantic-core/src/serializers/type_serializers/literal.rs
+++ b/pydantic-core/src/serializers/type_serializers/literal.rs
@@ -21,8 +21,8 @@ use super::{
 
 #[derive(Debug)]
 pub struct LiteralSerializer {
-    expected_int: AHashSet<i64>,
-    expected_str: AHashSet<String>,
+    expected_int: Box<AHashSet<i64>>,
+    expected_str: Box<AHashSet<String>>,
     expected_py: Option<Py<PyList>>,
     name: String,
 }
@@ -60,8 +60,8 @@ impl BuildSerializer for LiteralSerializer {
 
         Ok(Arc::new(
             Self {
-                expected_int,
-                expected_str,
+                expected_int: Box::new(expected_int),
+                expected_str: Box::new(expected_str),
                 expected_py: match expected_py.is_empty() {
                     true => None,
                     false => Some(expected_py.into()),

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -115,7 +115,7 @@ impl TypeSerializer for UnionSerializer {
 
 #[derive(Debug)]
 pub struct TaggedUnionSerializer {
-    discriminator: Discriminator,
+    discriminator: Box<Discriminator>,
     lookup: PyHashTable<usize>,
     choices: UnionChoices,
     name: OnceLock<String>,
@@ -152,7 +152,7 @@ impl BuildSerializer for TaggedUnionSerializer {
         };
 
         Ok(CombinedSerializer::TaggedUnion(Self {
-            discriminator,
+            discriminator: Box::new(discriminator),
             lookup,
             choices,
             name: OnceLock::new(),
@@ -237,7 +237,7 @@ impl TypeSerializer for TaggedUnionSerializer {
 impl TaggedUnionSerializer {
     fn get_discriminator_value<'py>(&self, value: &Bound<'py, PyAny>) -> Option<Bound<'py, PyAny>> {
         let py = value.py();
-        match &self.discriminator {
+        match &*self.discriminator {
             Discriminator::LookupPaths(lookup_paths) => {
                 // FIXME: should we be emitting warnings for failed discriminator lookups?
 

--- a/pydantic-core/src/validators/enum_.rs
+++ b/pydantic-core/src/validators/enum_.rs
@@ -46,7 +46,7 @@ impl BuildValidator for BuildEnumValidator {
         let class: Bound<PyType> = schema.get_as_req(intern!(py, "cls"))?;
         let class_repr = class_repr(schema, &class)?;
 
-        let lookup = LiteralLookup::new(py, expected.into_iter())?;
+        let lookup = Box::new(LiteralLookup::new(py, expected.into_iter())?);
 
         macro_rules! build {
             ($vv:ty, $name_prefix:literal) => {
@@ -87,7 +87,7 @@ pub trait EnumValidateValue: std::fmt::Debug + Clone + Send + Sync {
 pub struct EnumValidator<T: EnumValidateValue> {
     phantom: PhantomData<T>,
     class: Py<PyType>,
-    lookup: LiteralLookup<Py<PyAny>>,
+    lookup: Box<LiteralLookup<Py<PyAny>>>,
     missing: Option<Py<PyAny>>,
     expected_repr: String,
     strict: bool,

--- a/pydantic-core/src/validators/literal.rs
+++ b/pydantic-core/src/validators/literal.rs
@@ -237,7 +237,7 @@ impl<T: PyGcTraverse + Debug> PyGcTraverse for LiteralLookup<T> {
 
 #[derive(Debug, Clone)]
 pub struct LiteralValidator {
-    lookup: LiteralLookup<Py<PyAny>>,
+    lookup: Box<LiteralLookup<Py<PyAny>>>,
     expected_repr: String,
     name: String,
 }
@@ -258,7 +258,10 @@ impl BuildValidator for LiteralValidator {
         let repr_args = expected.iter().map(|item| item.repr()).collect::<PyResult<Vec<_>>>()?;
         let expected_repr = expected_repr(&repr_args)?;
         let name = expected_name(&repr_args, Self::EXPECTED_TYPE)?;
-        let lookup = LiteralLookup::new(py, expected.into_iter().map(|v| (v.clone(), v.into())))?;
+        let lookup = Box::new(LiteralLookup::new(
+            py,
+            expected.into_iter().map(|v| (v.clone(), v.into())),
+        )?);
         Ok(CombinedValidator::Literal(Self {
             lookup,
             expected_repr,

--- a/pydantic-core/src/validators/union.rs
+++ b/pydantic-core/src/validators/union.rs
@@ -291,8 +291,8 @@ impl<'a> MaybeErrors<'a> {
 
 #[derive(Debug)]
 pub struct TaggedUnionValidator {
-    discriminator: Discriminator,
-    lookup: LiteralLookup<Arc<CombinedValidator>>,
+    discriminator: Box<Discriminator>,
+    lookup: Box<LiteralLookup<Arc<CombinedValidator>>>,
     from_attributes: bool,
     custom_error: Option<CustomError>,
     tags_repr: String,
@@ -333,13 +333,13 @@ impl BuildValidator for TaggedUnionValidator {
             lookup_map.push((choice_key, validator));
         }
 
-        let lookup = LiteralLookup::new(py, lookup_map.into_iter())?;
+        let lookup = Box::new(LiteralLookup::new(py, lookup_map.into_iter())?);
 
         let key = intern!(py, "from_attributes");
         let from_attributes = schema_or_config(schema, config, key, key)?.unwrap_or(true);
 
         Ok(CombinedValidator::TaggedUnion(Self {
-            discriminator,
+            discriminator: Box::new(discriminator),
             lookup,
             from_attributes,
             custom_error: CustomError::build(schema, config, definitions)?,
@@ -360,7 +360,7 @@ impl Validator for TaggedUnionValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
-        match &self.discriminator {
+        match &*self.discriminator {
             Discriminator::LookupPaths(lookup_paths) => {
                 let from_attributes = state.extra().from_attributes.unwrap_or(self.from_attributes);
                 let dict = input.validate_model_fields(state.strict_or(false), from_attributes)?;


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Box large inline fields (`LiteralLookup`, `Discriminator`, `AHashSet`) in the largest `CombinedValidator` and `CombinedSerializer` variants to reduce memory consumption.

### Why?
The hint was given in https://github.com/pydantic/pydantic/issues/12272#issuecomment-3339381316.
Rust enums are sized to their largest variant. `TaggedUnionValidator` was 448 bytes, inflating every node in the validator to 448 bytes. Models with many fields create hundreds of nodes, so this adds up. Boxing moves the large data to the heap (8-byte pointer), shrinking `CombinedValidator` from 448 → 192 bytes (57%) and `CombinedSerializer` from 248 → 136 bytes (45%).

The total memory consumption reduction is around 10%.

More details in https://github.com/pydantic/pydantic/issues/12272.

### Full comparison:
``` bash
CombinedValidator                   448 B  →     192 B  (57% reduction)
Variant                            Before      After      Delta
------------------------------ ---------- ---------- ----------
TaggedUnionValidator                448 B      176 B       -272
StrEnumValidator                    320 B      104 B       -216
PlainEnumValidator                  320 B      104 B       -216
IntEnumValidator                    320 B      104 B       -216
FloatEnumValidator                  320 B      104 B       -216
LiteralValidator                    272 B       56 B       -216
UrlValidator                        184 B      184 B          -
MultiHostUrlValidator               184 B      184 B          -
ConstrainedIntValidator             168 B      168 B          -
UnionValidator                      136 B      136 B          -
...


CombinedSerializer                  248 B  →     136 B  (45% reduction)
Variant                            Before      After      Delta
------------------------------ ---------- ---------- ----------
TypedDictSerializer                 240 B      128 B       -112
GeneralFieldsSerializer             240 B      128 B       -112
TupleSerializer                     192 B       80 B       -112
DictSerializer                      168 B       56 B       -112
LiteralSerializer                   160 B       48 B       -112
ListSerializer                      160 B       48 B       -112
TaggedUnionSerializer               152 B       96 B        -56
GeneratorSerializer                 136 B       24 B       -112
FunctionWrapSerializer               80 B       80 B          -
FunctionPlainSerializer              80 B       80 B          -
DataclassSerializer                  64 B       64 B          -
...
```

<!-- Please give a short summary of the changes. -->

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/12272

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos