### PR TITLE
fix: update pydantic-core repo links

### DIFF
--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -3,8 +3,8 @@ name = "pydantic-core"
 version = "2.44.0"
 edition = "2024"
 license = "MIT"
-homepage = "https://github.com/pydantic/pydantic-core"
-repository = "https://github.com/pydantic/pydantic-core.git"
+homepage = "https://github.com/pydantic/pydantic/tree/main/pydantic-core"
+repository = "https://github.com/pydantic/pydantic.git"
 readme = "README.md"
 include = [
     "/pyproject.toml",

--- a/pydantic-core/pyproject.toml
+++ b/pydantic-core/pyproject.toml
@@ -43,9 +43,9 @@ dependencies = ['typing-extensions>=4.14.1']
 dynamic = ['readme', 'version']
 
 [project.urls]
-Homepage = 'https://github.com/pydantic/pydantic-core'
+Homepage = 'https://github.com/pydantic/pydantic/tree/main/pydantic-core'
 Funding = 'https://github.com/sponsors/samuelcolvin'
-Source = 'https://github.com/pydantic/pydantic-core'
+Source = 'https://github.com/pydantic/pydantic/tree/main/pydantic-core'
 
 [dependency-groups]
 dev = ["maturin"]


### PR DESCRIPTION
## Summary
- point pydantic-core package metadata at the in-repo location after the repository merge
- update both the Python package URLs and Cargo metadata so published links stop sending users to the archived repo

## Validation
- parsed `pydantic-core/pyproject.toml` with Python `tomllib` to confirm the new URLs
- verified the updated Homepage and Source URLs return HTTP 200

Fixes #12987