### PR TITLE
Update the uuid dependency to 1.23.0 and adjust the expected error message for invalid UUIDs

### DIFF
--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -777,9 +777,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -44,7 +44,7 @@ idna = "1.1.0"
 base64 = "0.22.1"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-uuid = "1.21.0"
+uuid = "1.23.0"
 jiter = { version = "0.13.0", features = ["python"] }
 hex = "0.4.3"
 percent-encoding = "2.3.2"

--- a/pydantic-core/tests/validators/test_uuid.py
+++ b/pydantic-core/tests/validators/test_uuid.py
@@ -38,13 +38,7 @@ class MyStr(str): ...
         (UUID('12345678-1234-5678-1234-567812345678'), UUID('12345678-1234-5678-1234-567812345678')),
         (UUID('550e8400-e29b-41d4-a716-446655440000'), UUID('550e8400-e29b-41d4-a716-446655440000')),
         # Invalid UUIDs
-        (
-            'not-a-valid-uuid',
-            Err(
-                'Input should be a valid UUID, invalid character: expected an optional prefix of'
-                + ' `urn:uuid:` followed by [0-9a-fA-F-], found `n` at 1'
-            ),
-        ),
+        ('not-a-valid-uuid', Err('Input should be a valid UUID, invalid character: found `n` at 1')),
         (
             '12345678-1234-5678-1234-5678123456789',
             Err('Input should be a valid UUID, invalid group length in group 4: expected 12, found 13'),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
With versions of the `uuid` crate prior to 1.23.0, the existing `test_uuid` works, matching the entire error message for input `'not-a-valid-uuid'`:

https://github.com/pydantic/pydantic/blob/ac249284616890d91c746dc890fb0f6407df2843/pydantic-core/tests/validators/test_uuid.py#L40-L47

With `uuid` version 1.23.0, the error message text changes, causing the test to fail:

```
__________________________________________________________________________ test_uuid[not-a-valid-uuid-expected21] ___________________________________________________________________________

input_value = 'not-a-valid-uuid', expected = Err('Input should be a valid UUID, invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `n` at 1')

    @pytest.mark.parametrize(
        'input_value,expected',
        [
            # Valid UUIDs
[…]
        ],
    )
    def test_uuid(input_value, expected):
        v = SchemaValidator(core_schema.uuid_schema())
        if isinstance(expected, Err):
            with pytest.raises(ValidationError, match=re.escape(expected.message)):
>               result = v.validate_python(input_value)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               pydantic_core._pydantic_core.ValidationError: 1 validation error for uuid
E                 Input should be a valid UUID, invalid character: found `n` at 1 [type=uuid_parsing, input_value='not-a-valid-uuid', input_type=str]
E                   For further information visit https://errors.pydantic.dev/latest/v/uuid_parsing

tests/validators/test_uuid.py:90: ValidationError

During handling of the above exception, another exception occurred:

input_value = 'not-a-valid-uuid', expected = Err('Input should be a valid UUID, invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `n` at 1')

    @pytest.mark.parametrize(
        'input_value,expected',
        [
[…]
        ],
    )
    def test_uuid(input_value, expected):
        v = SchemaValidator(core_schema.uuid_schema())
        if isinstance(expected, Err):
>           with pytest.raises(ValidationError, match=re.escape(expected.message)):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           AssertionError: Regex pattern did not match.
E             Expected regex: 'Input\\ should\\ be\\ a\\ valid\\ UUID,\\ invalid\\ character:\\ expected\\ an\\ optional\\ prefix\\ of\\ `urn:uuid:`\\ followed\\ by\\ \\[0\\-9a\\-fA\\-F\\-\\],\\ found\\ `n`\\ at\\ 1'
E             Actual message: "1 validation error for uuid\n  Input should be a valid UUID, invalid character: found `n` at 1 [type=uuid_parsing, input_value='not-a-valid-uuid', input_type=str]\n    For further information visit https://errors.pydantic.dev/latest/v/uuid_parsing"

tests/validators/test_uuid.py:89: AssertionError
```

So instead of the following *full* error output

```
1 validation error for uuid
  Input should be a valid UUID, invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `n` at 1 [type=uuid_parsing, input_value='not-a-valid-uuid', input_type=str]
    For further information visit https://errors.pydantic.dev/latest/v/uuid_parsing
```

we now have

```
Input should be a valid UUID, invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `n` at 1
1 validation error for uuid
  Input should be a valid UUID, invalid character: found `n` at 1 [type=uuid_parsing, input_value='not-a-valid-uuid', input_type=str]
    For further information visit https://errors.pydantic.dev/latest/v/uuid_parsing
```

I considered adjusting the test to match the entire new text and updating the minimum version of `uuid` to 1.23.0 in `Cargo.toml`, and that’s still a possibility if you prefer it, but for this PR I decided instead to make the test a bit less precise and match the largest common interesting substring of the “old” and “new” error messages, `Input should be a valid UUID, invalid character:`.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
N/A

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist **The change fixes a test**
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos