### PR TITLE
fix: MongoDSN.build() TypeError with multi-host URLs containing None credentials

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -471,6 +471,11 @@ class _BaseMultiHostUrl:
         Returns:
             An instance of `MultiHostUrl`
         """
+        # pydantic-core's UrlHostParts extraction fails when a host dict contains keys
+        # mapped to None (e.g. username/password absent in multi-host URLs). Strip those
+        # None-valued entries so that pydantic-core treats them as absent, not as invalid.
+        if hosts is not None:
+            hosts = [{k: v for k, v in h.items() if v is not None} for h in hosts]
         return cls(
             _CoreMultiHostUrl.build(
                 scheme=scheme,

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -759,6 +759,27 @@ def test_mongodb_dsns():
     assert m.a.hosts() == [{'username': None, 'password': None, 'host': 'localhost', 'port': 27017}]
 
 
+def test_mongo_dsn_build_multi_host_with_credentials():
+    """Regression test for https://github.com/pydantic/pydantic/issues/13007.
+
+    MongoDSN.build() raised TypeError when reconstructing a multi-host URL whose
+    hosts() dicts contain None-valued keys (e.g. username/password absent on
+    extra hosts in a replica-set connection string).
+    """
+    raw_uri = 'mongodb://user:pass@host-1.com:27017,host-2.com:27017/db?replicaSet=xxx&authSource=admin'
+    uri = MongoDsn(raw_uri)
+    # Should not raise: TypeError: argument 'hosts': 'NoneType' object cannot be converted to 'PyString'
+    new_uri = MongoDsn.build(
+        scheme=uri.scheme,
+        hosts=uri.hosts(),
+        path=uri.path,
+        query=uri.query,
+    )
+    assert new_uri.scheme == uri.scheme
+    assert new_uri.hosts() == uri.hosts()
+    assert new_uri.query == uri.query
+
+
 @pytest.mark.parametrize(
     ('dsn', 'expected'),
     [


### PR DESCRIPTION
## Pull Request Checklist

- [x] A news fragment is added in `news/` describing what is new.
- [x] Test cases added for changed code.

## Describe what you have changed in this PR.

Closes #3756

When using `-p /other/project <command>`, PDM was always loading
`[tool.pdm.options]` from the current working directory instead of the
target project. This meant default options (e.g. `no_sync = true`) in
the target project's `pyproject.toml` were silently ignored.

**Root causes:**

1. `_get_cli_args()` called `create_project(is_global=False)` with no
   path, so it always read options from cwd regardless of `-p`.

2. `get_command()` didn't know that `-p`/`--project` consumes a value
   argument. With `pdm -p /path install`, it would find `/path` as the
   subcommand name and fail to look up `install` in the options table.

**Fix:**

- Added `_get_project_path_from_args()` — a lightweight pre-parse that
  extracts the `-p`/`--project` value from raw args before full
  argument parsing.
- `_get_cli_args()` now passes that path to `create_project()` so
  `[tool.pdm.options]` is loaded from the correct project.
- Added `"-p"` and `"--project"` to `options_with_values` in
  `get_command()` so the subcommand is identified correctly when a
  project path is given.