### PR TITLE
Fix field info not being inherited from model parent when non-model parent has same attribute

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -303,6 +303,16 @@ def collect_model_fields(  # noqa: C901
             # Then `assigned_value` would be the method, even though no default was specified:
             assigned_value = PydanticUndefined
 
+        # getattr can pick up a class attribute from a non-model parent even when a model
+        # parent already defines this field. Discard it so we copy from the parent's field info below.
+        if (
+            assigned_value is not PydanticUndefined
+            and ann_name not in cls_annotations
+            and ann_name not in cls.__dict__
+            and ann_name in parent_fields_lookup
+        ):
+            assigned_value = PydanticUndefined
+
         if not is_valid_field_name(ann_name):
             continue
         if cls.__pydantic_root_model__ and ann_name != 'root':

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3571,6 +3571,38 @@ def test_shadow_attribute_no_warn_stdlib_dataclass() -> None:
         assert len(captured_warnings) == 0
 
 
+def test_non_model_parent_does_not_override_field_info() -> None:
+    """https://github.com/pydantic/pydantic/issues/12229"""
+
+    from abc import ABCMeta
+
+    from pydantic import AliasChoices
+
+    class NumberUnit(metaclass=ABCMeta):
+        unit: str | None = None
+        quantity: int | float = 1
+
+    class QuantifiedValue(BaseModel, NumberUnit):
+        model_config = ConfigDict(arbitrary_types_allowed=True, validate_by_alias=True, validate_by_name=True)
+
+    with pytest.warns(UserWarning, match='shadows an attribute'):
+
+        class OverrideQuantifiedValue(QuantifiedValue):
+            unit: str = Field(validation_alias=AliasChoices('xxx', 'unit'))
+
+    class Sub(OverrideQuantifiedValue):
+        pass
+
+    # The parent class should work with the alias:
+    x = OverrideQuantifiedValue.model_validate(dict(quantity=10, xxx='m'))
+    assert x.unit == 'm'
+
+    # The subclass should preserve the alias from the parent model,
+    # not pick up the default from the non-model ancestor:
+    x2 = Sub.model_validate(dict(quantity=10, xxx='m'))
+    assert x2.unit == 'm'
+
+
 def test_field_name_deprecated_method_name() -> None:
     """https://github.com/pydantic/pydantic/issues/11912"""
 


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Skip the `getattr` value in `collect_model_fields` when it comes from a non-model parent and a model parent already defines the field.

## Related issue number

Fix #12229 

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos