### PR TITLE
Fix: ensure extra_fields_schema is included in model core config

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -836,6 +836,8 @@ class GenerateSchema:
                         extras_keys_schema = self.generate_schema(extra_keys_type)
                     if not typing_objects.is_any(extra_items_type):
                         extras_schema = self.generate_schema(extra_items_type)
+                        if extras_schema is not None:
+                            core_config['extra_fields_schema'] = extras_schema
 
                 generic_origin: type[BaseModel] | None = getattr(cls, '__pydantic_generic_metadata__', {}).get('origin')
 


### PR DESCRIPTION
Fixes #12385. This PR ensures that `extra_fields_schema` is correctly included in the model's core configuration when `__pydantic_extra__` is present and typed. Without this, `pydantic-core` may bypass the correct serialization logic for extra fields.