### PR TITLE
fix: aggregate wrap serializer warnings once

### DIFF
--- a/pydantic-core/src/serializers/extra.rs
+++ b/pydantic-core/src/serializers/extra.rs
@@ -340,6 +340,18 @@ impl ExtraOwned {
             extra,
         }
     }
+
+    pub fn warnings_mode(&self) -> WarningsMode {
+        self.warnings.mode
+    }
+
+    pub fn warnings(&self) -> CollectWarnings {
+        self.warnings.clone()
+    }
+
+    pub fn set_warnings(&mut self, warnings: CollectWarnings) {
+        self.warnings = warnings;
+    }
 }
 
 #[derive(Clone)]
@@ -503,6 +515,16 @@ impl CollectWarnings {
                 Some(value.clone().unbind()),
             ));
         }
+    }
+
+    pub fn extend(&mut self, warnings: impl IntoIterator<Item = PydanticSerializationUnexpectedValue>) {
+        if self.mode != WarningsMode::None {
+            self.warnings.extend(warnings);
+        }
+    }
+
+    pub fn into_warnings(self) -> Vec<PydanticSerializationUnexpectedValue> {
+        self.warnings
     }
 
     pub fn final_check(&self, py: Python) -> PyResult<()> {

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -383,14 +383,14 @@ impl FunctionWrapSerializer {
     fn call<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<(bool, Py<PyAny>)> {
         let py = value.py();
         if self.when_used.should_use(value, &state.extra) {
-            let serialize = SerializationCallable::new(&self.serializer, state);
+            let serialize = Py::new(py, SerializationCallable::new(&self.serializer, state))?;
             let v = if self.is_field_serializer {
                 if let Some(model) = state.model.as_ref() {
                     if self.info_arg {
                         let info = SerializationInfo::new(state, self.is_field_serializer)?;
-                        self.func.call1(py, (model, value, serialize, info))?
+                        self.func.call1(py, (model, value, serialize.clone_ref(py), info))?
                     } else {
-                        self.func.call1(py, (model, value, serialize))?
+                        self.func.call1(py, (model, value, serialize.clone_ref(py)))?
                     }
                 } else {
                     return Err(PyRuntimeError::new_err(
@@ -399,10 +399,15 @@ impl FunctionWrapSerializer {
                 }
             } else if self.info_arg {
                 let info = SerializationInfo::new(state, self.is_field_serializer)?;
-                self.func.call1(py, (value, serialize, info))?
+                self.func.call1(py, (value, serialize.clone_ref(py), info))?
             } else {
-                self.func.call1(py, (value, serialize))?
+                self.func.call1(py, (value, serialize.clone_ref(py)))?
             };
+            let nested_warnings = {
+                let serialize = serialize.borrow_mut(py);
+                serialize.extra_owned.warnings()
+            };
+            state.warnings.extend(nested_warnings.into_warnings());
             Ok((true, v))
         } else {
             Ok((false, value.clone().unbind()))
@@ -471,27 +476,30 @@ impl SerializationCallable {
         // so use to_python_no_infer so that type inference can't apply
         // at this layer
 
-        let state = &mut self.extra_owned.to_state(py);
+        let mut state = self.extra_owned.to_state(py);
 
-        if let Some(index_key) = index_key {
+        let result = if let Some(index_key) = index_key {
             let filter = if let Ok(index) = index_key.extract::<usize>() {
-                self.filter.index_filter(index, state, None)?
+                self.filter.index_filter(index, &mut state, None)?
             } else {
-                self.filter.key_filter(index_key, state)?
+                self.filter.key_filter(index_key, &mut state)?
             };
             if let Some(next_include_exclude) = filter {
                 let state = &mut state.scoped_include_exclude(next_include_exclude);
-                let v = self.serializer.to_python_no_infer(value, state)?;
-                state.warnings.final_check(py)?;
-                Ok(Some(v))
+                self.serializer.to_python_no_infer(value, state).map(Some)
             } else {
                 Err(PydanticOmit::new_err())
             }
         } else {
-            let v = self.serializer.to_python_no_infer(value, state)?;
+            self.serializer.to_python_no_infer(value, &mut state).map(Some)
+        };
+
+        if self.extra_owned.warnings_mode() == super::super::extra::WarningsMode::Error {
             state.warnings.final_check(py)?;
-            Ok(Some(v))
         }
+        self.extra_owned.set_warnings(state.warnings.clone());
+
+        result
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/pydantic-core/tests/serializers/test_functions.py
+++ b/pydantic-core/tests/serializers/test_functions.py
@@ -620,6 +620,35 @@ def test_wrap_return_type():
     assert s.to_json('foobar') == b'"foobar.new"'
 
 
+def test_wrap_serializer_warnings_are_aggregated_once():
+    def passthrough(value, handler):
+        return handler(value)
+
+    s = SchemaSerializer(
+        core_schema.typed_dict_schema(
+            {
+                'a': core_schema.typed_dict_field(
+                    core_schema.str_schema(
+                        serialization=core_schema.wrap_serializer_function_ser_schema(passthrough)
+                    )
+                ),
+                'b': core_schema.typed_dict_field(core_schema.str_schema()),
+                'c': core_schema.typed_dict_field(core_schema.str_schema()),
+            }
+        )
+    )
+
+    with pytest.warns(UserWarning) as warnings:
+        assert s.to_python({'a': 1, 'b': 2, 'c': 3}) == {'a': 1, 'b': 2, 'c': 3}
+
+    assert len(warnings) == 1
+    message = str(warnings[0].message)
+    assert message.count('PydanticSerializationUnexpectedValue(') == 3
+    assert "field_name='a', input_value=1, input_type=int" in message
+    assert "field_name='b', input_value=2, input_type=int" in message
+    assert "field_name='c', input_value=3, input_type=int" in message
+
+
 def test_raise_unexpected():
     def raise_unexpected(_value):
         raise PydanticSerializationUnexpectedValue('unexpected')


### PR DESCRIPTION
## Change Summary

Keep serializer warnings collected inside `WrapSerializer` handlers attached to the parent serialization state so warn-mode emits a single aggregated warning, while still preserving immediate errors for `warnings='error'`.

## Related issue number

Fixes #12995

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
