### PR TITLE
fix: skip deep-copying fields in model_copy when replaced by update

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -415,10 +415,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             # fields that cannot be deep-copied (e.g. file handles, C extensions).
             cls = type(self)
             copied = cls.__new__(cls)
-            _object_setattr(copied, '__dict__', {
-                k: (deepcopy(v, memo={}) if k not in update else v)
-                for k, v in self.__dict__.items()
-            })
+            _object_setattr(
+                copied,
+                '__dict__',
+                {k: (deepcopy(v, memo={}) if k not in update else v) for k, v in self.__dict__.items()},
+            )
             _object_setattr(copied, '__pydantic_extra__', deepcopy(self.__pydantic_extra__, memo={}))
             _object_setattr(copied, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
             if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -409,7 +409,31 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             New model instance.
         """
-        copied = self.__deepcopy__() if deep else self.__copy__()
+        if deep and update:
+            # When deep=True with update, skip deep-copying fields that will be
+            # replaced by update. This avoids unnecessary work and supports
+            # fields that cannot be deep-copied (e.g. file handles, C extensions).
+            cls = type(self)
+            copied = cls.__new__(cls)
+            _object_setattr(copied, '__dict__', {
+                k: (deepcopy(v, memo={}) if k not in update else v)
+                for k, v in self.__dict__.items()
+            })
+            _object_setattr(copied, '__pydantic_extra__', deepcopy(self.__pydantic_extra__, memo={}))
+            _object_setattr(copied, '__pydantic_fields_set__', copy(self.__pydantic_fields_set__))
+            if not hasattr(self, '__pydantic_private__') or self.__pydantic_private__ is None:
+                _object_setattr(copied, '__pydantic_private__', None)
+            else:
+                _object_setattr(
+                    copied,
+                    '__pydantic_private__',
+                    deepcopy(
+                        {k: v for k, v in self.__pydantic_private__.items() if v is not PydanticUndefined},
+                        memo={},
+                    ),
+                )
+        else:
+            copied = self.__deepcopy__() if deep else self.__copy__()
         if update:
             if self.model_config.get('extra') == 'allow':
                 for k, v in update.items():


### PR DESCRIPTION
## Summary

When `model_copy(deep=True, update=...)` is called, the current implementation deepcopies the **entire** model first, then overwrites fields from `update`. This causes two problems:

1. **Wasteful performance**: fields that will be replaced are deep-copied for nothing
2. **Fails on non-copyable fields**: if a field contains an object that cannot be deep-copied (e.g., file handles, C extensions), `model_copy(deep=True, update={...})` raises `TypeError` even though that field would be replaced

This PR changes the behavior so that when both `deep=True` and `update` are provided, fields present in `update` are shallow-copied instead of deep-copied.

Fixes #13077

## Test plan
- [x] Existing `model_copy` tests pass (4/4)
- [x] Full `test_main.py` suite passes (241/241)
- [x] Verified fix with non-copyable field example from the issue
- [x] No changes to `model_copy(deep=True)` without `update` (still deep-copies everything)
- [x] No changes to `model_copy(update=...)` without `deep` (still shallow-copies)