### PR TITLE
Fix `ValidationInfo.field_name` missing with `model_validate_json()`

### DIFF
--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -629,6 +629,8 @@ impl ModelFieldsValidator {
         // dict, and try to set defaults for any missing fields
 
         for (field, field_result) in std::iter::zip(&self.fields, field_results) {
+            let state = &mut state.scoped_set_field_name(Some(field.name.as_py_str().bind(py).clone()));
+
             let field_value = if let Some((field_info, field_json_value)) = field_result {
                 match field.validator.validate(py, field_json_value, state) {
                     Ok(value) => {

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3143,3 +3143,45 @@ def test_nested_model_validator_not_reexecuted():
     )  # Create a Sub instance without triggering validation (e.g., using model_construct)
     # Attempt to create Base with the Sub instance. This line should succeed if the bug is fixed, but currently raises ValidationError.
     Base(sub=sub)  # <-- This throws AssertionError because Sub's 'after' validator runs again.
+
+
+def test_model_validate_by_json_field_validator_with_validation_info() -> None:
+    """https://github.com/pydantic/pydantic/issues/13074"""
+
+    class Foo(BaseModel):
+        field1: int
+        field2: int
+
+        @field_validator('field2')
+        @classmethod
+        def _validate_field2(cls, v: int, info: ValidationInfo) -> int:
+            assert info.field_name in ('field1', 'field2')
+            assert info.context == 'context'
+
+            return v + info.data['field1']
+
+    f1 = Foo.model_validate({'field1': 1, 'field2': 2}, context='context')
+    f2 = Foo.model_validate_json('{"field1": 1, "field2": 2}', context='context')
+
+    assert f1.field1 == f2.field1 == 1
+    assert f1.field2 == f2.field2 == 3
+
+
+def test_model_validate_json_default_value_validator_with_validation_info() -> None:
+    """https://github.com/pydantic/pydantic/issues/13074"""
+
+    class Foo(BaseModel, validate_default=True):
+        field: int = 1
+
+        @field_validator('field')
+        @classmethod
+        def _validate_field(cls, v: int, info: ValidationInfo) -> int:
+            assert info.field_name == 'field'
+            assert info.context == 'context'
+
+            return v + 1
+
+    f1 = Foo.model_validate({'field': 1}, context='context')
+    f2 = Foo.model_validate_json('{"field1": 1}', context='context')
+
+    assert f1.field == f2.field == 2

--- a/tests/types/test_model.py
+++ b/tests/types/test_model.py
@@ -5,8 +5,6 @@ from pydantic import (
     ConfigDict,
     SerializationInfo,
     TypeAdapter,
-    ValidationInfo,
-    field_validator,
     model_serializer,
 )
 
@@ -83,22 +81,3 @@ def test_polymorphic_serialization_with_model_serializer(config: bool, runtime: 
     else:
         assert serializer.to_python(ModelB(a=123, b='test'), **kwargs) == 'ModelA'
         assert serializer.to_json(ModelB(a=123, b='test'), **kwargs) == b'"ModelA"'
-
-
-def test_model_validate_by_json_with_validation_info_data():
-    """https://github.com/pydantic/pydantic/issues/13074"""
-
-    class Foo(BaseModel):
-        field1: int
-        field2: int
-
-        @field_validator('field2')
-        @classmethod
-        def _validate_field2(cls, v: str, info: ValidationInfo) -> int:
-            return v + info.data['field1']
-
-    f1 = Foo.model_validate({'field1': 1, 'field2': 2})
-    f2 = Foo.model_validate_json('{"field1": 1, "field2": 2}')
-
-    assert f1.field1 == f2.field1 == 1
-    assert f1.field2 == f2.field2 == 3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13074#issuecomment-4256748343.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
