### PR TITLE
Only deepcopy non-updated fields in `model_copy()`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -401,10 +401,17 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             might have unexpected side effects if you store anything in it, on top of the model
             fields (e.g. the value of [cached properties][functools.cached_property]).
 
+        !!! note
+            When both `deep=True` and `update` are provided, fields present in `update` are
+            not deepcopied (their replacement values are used directly). This avoids
+            unnecessary work and allows replacing fields whose current values cannot be
+            deepcopied (e.g. native C extension objects, file handles, GPU tensors).
+
         Args:
             update: Values to change/add in the new model. Note: the data is not validated
                 before creating the new model. You should trust this data.
-            deep: Set to `True` to make a deep copy of the model.
+            deep: Set to `True` to make a deep copy of the model. Fields that are being
+                replaced via `update` are not deepcopied.
 
         Returns:
             New model instance.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -401,29 +401,25 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             might have unexpected side effects if you store anything in it, on top of the model
             fields (e.g. the value of [cached properties][functools.cached_property]).
 
-        !!! note
-            When both `deep=True` and `update` are provided, fields present in `update` are
-            not deepcopied (their replacement values are used directly). This avoids
-            unnecessary work and allows replacing fields whose current values cannot be
-            deepcopied (e.g. native C extension objects, file handles, GPU tensors).
-
         Args:
-            update: Values to change/add in the new model. Note: the data is not validated
-                before creating the new model. You should trust this data.
-            deep: Set to `True` to make a deep copy of the model. Fields that are being
-                replaced via `update` are not deepcopied.
+            update: A mapping of values to update the copied model. Updates are *not*
+                applied recursively, and no validation is performed on updated values.
+                Only the known fields are updated (if unknown keys are being passed and
+                the model has [`extra`][pydantic.ConfigDict.extra] set to `'allow'`, they
+                are added as extra data).
+            deep: Whether a [deep copy][copy.deepcopy] of the model should be performed.
 
         Returns:
             New model instance.
         """
         if deep and update:
-            # Start with a fast shallow copy to preserve structure
+            # Only deep copy the fields that won't be updated:
             copied = self.__copy__()
 
-            # A shared memo preserves object identity across fields
+            # As we make separate `deepcopy()` calls, use a shared memo:
             memo: dict[int, Any] = {}
 
-            # Selectively deepcopy fields that are not being updated
+            # Selectively deepcopy fields that are not being updated:
             for k, v in copied.__dict__.items():
                 if k not in update:
                     copied.__dict__[k] = deepcopy(v, memo)
@@ -432,23 +428,26 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                     if k not in update:
                         copied.__pydantic_extra__[k] = deepcopy(v, memo)
             if copied.__pydantic_private__ is not None:
+                # Same logic as `BaseModel.__deepcopy__()`:
                 copied.__pydantic_private__ = deepcopy(
                     {k: v for k, v in copied.__pydantic_private__.items() if v is not PydanticUndefined},
                     memo,
                 )
         else:
             copied = self.__deepcopy__() if deep else self.__copy__()
+            if update:
+                if self.model_config.get('extra') == 'allow':
+                    for k, v in update.items():
+                        if k in self.__pydantic_fields__:
+                            copied.__dict__[k] = v
+                        else:
+                            if copied.__pydantic_extra__ is None:
+                                copied.__pydantic_extra__ = {}
+                            copied.__pydantic_extra__[k] = v
+                else:
+                    copied.__dict__.update(update)
+
         if update:
-            if self.model_config.get('extra') == 'allow':
-                for k, v in update.items():
-                    if k in self.__pydantic_fields__:
-                        copied.__dict__[k] = v
-                    else:
-                        if copied.__pydantic_extra__ is None:
-                            copied.__pydantic_extra__ = {}
-                        copied.__pydantic_extra__[k] = v
-            else:
-                copied.__dict__.update(update)
             copied.__pydantic_fields_set__.update(update.keys())
         return copied
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -435,20 +435,21 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 )
         else:
             copied = self.__deepcopy__() if deep else self.__copy__()
-            if update:
-                if self.model_config.get('extra') == 'allow':
-                    for k, v in update.items():
-                        if k in self.__pydantic_fields__:
-                            copied.__dict__[k] = v
-                        else:
-                            if copied.__pydantic_extra__ is None:
-                                copied.__pydantic_extra__ = {}
-                            copied.__pydantic_extra__[k] = v
-                else:
-                    copied.__dict__.update(update)
 
         if update:
+            if self.model_config.get('extra') == 'allow':
+                for k, v in update.items():
+                    if k in self.__pydantic_fields__:
+                        copied.__dict__[k] = v
+                    else:
+                        if copied.__pydantic_extra__ is None:
+                            copied.__pydantic_extra__ = {}
+                        copied.__pydantic_extra__[k] = v
+            else:
+                copied.__dict__.update(update)
+
             copied.__pydantic_fields_set__.update(update.keys())
+
         return copied
 
     def model_dump(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -409,7 +409,28 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             New model instance.
         """
-        copied = self.__deepcopy__() if deep else self.__copy__()
+        if deep and update:
+            # Start with a fast shallow copy to preserve structure
+            copied = self.__copy__()
+
+            # A shared memo preserves object identity across fields
+            memo: dict[int, Any] = {}
+
+            # Selectively deepcopy fields that are not being updated
+            for k, v in copied.__dict__.items():
+                if k not in update:
+                    copied.__dict__[k] = deepcopy(v, memo)
+            if copied.__pydantic_extra__ is not None:
+                for k, v in copied.__pydantic_extra__.items():
+                    if k not in update:
+                        copied.__pydantic_extra__[k] = deepcopy(v, memo)
+            if copied.__pydantic_private__ is not None:
+                copied.__pydantic_private__ = deepcopy(
+                    {k: v for k, v in copied.__pydantic_private__.items() if v is not PydanticUndefined},
+                    memo,
+                )
+        else:
+            copied = self.__deepcopy__() if deep else self.__copy__()
         if update:
             if self.model_config.get('extra') == 'allow':
                 for k, v in update.items():

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -394,6 +394,22 @@ def test_model_copy_deep_update_applies_update_value():
     assert m.a == 1
 
 
+def test_model_copy_deep_update_with_private_attributes():
+    """Ensure private attributes are deepcopied when `deep=True` and `update` are provided."""
+
+    class M(BaseModel):
+        a: int
+        _private = PrivateAttr({'private'})
+
+    m = M(a=1)
+    m._private = {'modified'}
+    m2 = m.model_copy(deep=True, update={'a': 2})
+
+    assert m2.a == 2
+    assert m2._private == {'modified'}
+    assert m2._private is not m._private
+
+
 def test_copy_set_fields(ModelTwo, copy_method):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = copy_method(m)

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -325,6 +325,7 @@ class NotDeepCopyable:
     def __deepcopy__(self, memo):
         raise TypeError('This object cannot be deepcopied')
 
+
 def test_model_copy_deep_update_skips_deepcopy_of_updated_fields() -> None:
 
     class Model(BaseModel):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -321,27 +321,23 @@ def test_copy_deep_extra(copy_method):
     assert copy_method(m, deep=True).extra is not m.extra
 
 
-class NotDeepCopyable:
-    """Helper class that raises when deepcopied, simulating native C extension objects."""
+def test_model_copy_deep_update_skips_deepcopy_of_updated_fields() -> None:
 
-    def __deepcopy__(self, memo):
-        raise TypeError('This object cannot be deepcopied')
+    class NotDeepCopyable:
+        def __deepcopy__(self, memo):
+            raise TypeError('This object cannot be deepcopied')
 
-
-def test_model_copy_deep_update_skips_deepcopy_of_updated_fields():
-    """Fields present in `update` should not be deepcopied since they are replaced."""
-
-    class AppConfig(BaseModel):
+    class Model(BaseModel):
         model_config = ConfigDict(arbitrary_types_allowed=True)
         name: str = 'default'
-        engine: Any = None
+        arbitrary: Any = None
 
-    config = AppConfig(engine=NotDeepCopyable())
+    model = Model(arbitrary=NotDeepCopyable())
 
-    copied = config.model_copy(deep=True, update={'engine': None})
-    assert copied.engine is None
-    assert copied.name == 'default'
-    assert copied is not config
+    copied = model.model_copy(deep=True, update={'arbitrary': None})
+    assert model.arbitrary is None
+    assert model.name == 'default'
+    assert copied is not model
 
 
 def test_model_copy_deep_update_preserves_shared_references():

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -321,6 +321,79 @@ def test_copy_deep_extra(copy_method):
     assert copy_method(m, deep=True).extra is not m.extra
 
 
+class NotDeepCopyable:
+    """Helper class that raises when deepcopied, simulating native C extension objects."""
+
+    def __deepcopy__(self, memo):
+        raise TypeError('This object cannot be deepcopied')
+
+
+def test_model_copy_deep_update_skips_deepcopy_of_updated_fields():
+    """Fields present in `update` should not be deepcopied since they are replaced."""
+
+    class AppConfig(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        name: str = 'default'
+        engine: Any = None
+
+    config = AppConfig(engine=NotDeepCopyable())
+
+    copied = config.model_copy(deep=True, update={'engine': None})
+    assert copied.engine is None
+    assert copied.name == 'default'
+    assert copied is not config
+
+
+def test_model_copy_deep_update_preserves_shared_references():
+    """A shared memo should preserve shared references across deep-copied fields."""
+
+    class Inner(BaseModel):
+        x: int = 0
+
+    class Outer(BaseModel):
+        a: Inner
+        b: Inner
+        c: Inner
+
+    shared = Inner(x=1)
+    m = Outer(a=shared, b=shared, c=Inner(x=2))
+    m2 = m.model_copy(deep=True, update={'c': Inner(x=99)})
+
+    assert m2.a is not shared
+    assert m2.a is m2.b
+    assert m2.c.x == 99
+    assert m.a is shared
+
+
+def test_model_copy_deep_update_skips_deepcopy_of_extra_fields():
+    """Extra fields present in `update` should not be deepcopied."""
+
+    class Foo(BaseModel, extra='allow'):
+        pass
+
+    m = Foo(extra_field=NotDeepCopyable(), other=[1, 2, 3])
+
+    copied = m.model_copy(deep=True, update={'extra_field': 'replaced'})
+    assert copied.extra_field == 'replaced'
+    assert copied.other == [1, 2, 3]
+    assert copied.other is not m.other
+
+
+def test_model_copy_deep_update_applies_update_value():
+    """Ensure the update value is applied and not clobbered by the original value."""
+
+    class M(BaseModel):
+        a: int
+        b: int
+
+    m = M(a=1, b=2)
+    m2 = m.model_copy(deep=True, update={'a': 100})
+
+    assert m2.a == 100
+    assert m2.b == 2
+    assert m.a == 1
+
+
 def test_copy_set_fields(ModelTwo, copy_method):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = copy_method(m)

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -321,11 +321,11 @@ def test_copy_deep_extra(copy_method):
     assert copy_method(m, deep=True).extra is not m.extra
 
 
-def test_model_copy_deep_update_skips_deepcopy_of_updated_fields() -> None:
+class NotDeepCopyable:
+    def __deepcopy__(self, memo):
+        raise TypeError('This object cannot be deepcopied')
 
-    class NotDeepCopyable:
-        def __deepcopy__(self, memo):
-            raise TypeError('This object cannot be deepcopied')
+def test_model_copy_deep_update_skips_deepcopy_of_updated_fields() -> None:
 
     class Model(BaseModel):
         model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -340,8 +340,7 @@ def test_model_copy_deep_update_skips_deepcopy_of_updated_fields() -> None:
     assert copied is not model
 
 
-def test_model_copy_deep_update_preserves_shared_references():
-    """A shared memo should preserve shared references across deep-copied fields."""
+def test_model_copy_deep_update_preserves_shared_references() -> None:
 
     class Inner(BaseModel):
         x: int = 0
@@ -361,7 +360,7 @@ def test_model_copy_deep_update_preserves_shared_references():
     assert m.a is shared
 
 
-def test_model_copy_deep_update_skips_deepcopy_of_extra_fields():
+def test_model_copy_deep_update_skips_deepcopy_of_extra_fields() -> None:
     """Extra fields present in `update` should not be deepcopied."""
 
     class Foo(BaseModel, extra='allow'):
@@ -375,22 +374,7 @@ def test_model_copy_deep_update_skips_deepcopy_of_extra_fields():
     assert copied.other is not m.other
 
 
-def test_model_copy_deep_update_applies_update_value():
-    """Ensure the update value is applied and not clobbered by the original value."""
-
-    class M(BaseModel):
-        a: int
-        b: int
-
-    m = M(a=1, b=2)
-    m2 = m.model_copy(deep=True, update={'a': 100})
-
-    assert m2.a == 100
-    assert m2.b == 2
-    assert m.a == 1
-
-
-def test_model_copy_deep_update_with_private_attributes():
+def test_model_copy_deep_update_with_private_attributes() -> None:
     """Ensure private attributes are deepcopied when `deep=True` and `update` are provided."""
 
     class M(BaseModel):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -336,8 +336,8 @@ def test_model_copy_deep_update_skips_deepcopy_of_updated_fields() -> None:
     model = Model(arbitrary=NotDeepCopyable())
 
     copied = model.model_copy(deep=True, update={'arbitrary': None})
-    assert model.arbitrary is None
-    assert model.name == 'default'
+    assert copied.arbitrary is None
+    assert copied.name == 'default'
     assert copied is not model
 
 


### PR DESCRIPTION
## Summary

- `model_copy(deep=True, update={...})` no longer deepcopies fields that are going to be replaced by `update`.
- Fixes a crash when such fields contain objects that cannot be deepcopied (native C extensions, file handles, GPU tensors, etc.).
- Preserves shared references between fields by passing a single shared `memo` dict to every `deepcopy` call.
- `__pydantic_extra__` and `__pydantic_private__` are handled consistently with the previous `__deepcopy__` implementation.
- Document in `BaseModel.model_copy`'s docstring that, when `deep=True` and `update` are both provided, fields present in `update` are not deepcopied.
- Behavior is unchanged when `update` is not supplied or when `deep=False`.

Resolves #13077.

## Motivation

Previously, `model_copy` did a full deepcopy first and then overwrote the replaced fields, which:

1. Wasted work deepcopying values that were about to be discarded.
2. Raised errors on non-deepcopyable fields even when the user explicitly intended to replace them via `update`.

## Test plan

- Added four targeted tests in `tests/test_construction.py`:
  - `test_model_copy_deep_update_skips_deepcopy_of_updated_fields` — confirms a non-deepcopyable field can be replaced via `update`.
  - `test_model_copy_deep_update_preserves_shared_references` — confirms shared references across fields are preserved via the shared memo.
  - `test_model_copy_deep_update_skips_deepcopy_of_extra_fields` — confirms extra fields in `update` (with `extra='allow'`) are not deepcopied either.
  - `test_model_copy_deep_update_applies_update_value` — guards against regressions where the `update` value would be clobbered by the original.
- `tests/test_construction.py`, `tests/test_main.py`, and `tests/test_root_model.py` all pass with no regressions.

Selected Reviewer: @Viicos