### PR TITLE
fix: include runtime extra fields in model_dump() output (#12937)

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -472,7 +472,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A dictionary representation of the model.
         """
-        return self.__pydantic_serializer__.to_python(
+        result = self.__pydantic_serializer__.to_python(
             self,
             mode=mode,
             by_alias=by_alias,
@@ -489,6 +489,24 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             serialize_as_any=serialize_as_any,
             polymorphic_serialization=polymorphic_serialization,
         )
+
+        # When `model_validate(..., extra='allow')` is called on a model whose
+        # class-level config is *not* `extra='allow'`, extra fields are stored
+        # in `__pydantic_extra__` but the serializer (built from the class
+        # schema) does not emit them.  Merge them here so that the runtime
+        # intent is honoured.  See https://github.com/pydantic/pydantic/issues/12937
+        pydantic_extra = self.__pydantic_extra__
+        if pydantic_extra and self.model_config.get('extra') != 'allow':
+            for key, value in pydantic_extra.items():
+                if include is not None and key not in include:
+                    continue
+                if exclude is not None and key in exclude:
+                    continue
+                if exclude_none and value is None:
+                    continue
+                result[key] = value
+
+        return result
 
     def model_dump_json(
         self,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2732,6 +2732,45 @@ def test_model_validate_with_validate_fn_override() -> None:
     ]
 
 
+def test_model_dump_includes_runtime_extra_fields() -> None:
+    """model_dump() must include extra fields collected via model_validate(extra='allow')
+    even when the model's class-level config is not extra='allow'.
+    See https://github.com/pydantic/pydantic/issues/12937
+    """
+
+    class ForbidModel(BaseModel, extra='forbid'):
+        a: int
+
+    class IgnoreModel(BaseModel):
+        a: int
+
+    # extra='forbid' at class level, but runtime extra='allow'
+    m_forbid = ForbidModel.model_validate({'a': 1, 'b': 'test'}, extra='allow')
+    assert m_forbid.model_extra == {'b': 'test'}
+    assert m_forbid.model_dump() == {'a': 1, 'b': 'test'}
+
+    # extra='ignore' (default) at class level, but runtime extra='allow'
+    m_ignore = IgnoreModel.model_validate({'a': 1, 'b': 'test', 'c': None}, extra='allow')
+    assert m_ignore.model_extra == {'b': 'test', 'c': None}
+    assert m_ignore.model_dump() == {'a': 1, 'b': 'test', 'c': None}
+
+    # exclude filter applies to runtime extra fields
+    assert m_ignore.model_dump(exclude={'b'}) == {'a': 1, 'c': None}
+
+    # include filter applies to runtime extra fields
+    assert m_ignore.model_dump(include={'b'}) == {'b': 'test'}
+
+    # exclude_none applies to runtime extra fields
+    assert m_ignore.model_dump(exclude_none=True) == {'a': 1, 'b': 'test'}
+
+    # models with class-level extra='allow' are unaffected
+    class AllowModel(BaseModel, extra='allow'):
+        a: int
+
+    m_allow = AllowModel.model_validate({'a': 1, 'b': 'test'})
+    assert m_allow.model_dump() == {'a': 1, 'b': 'test'}
+
+
 def test_model_validate_json_with_validate_fn_override() -> None:
     class Model(BaseModel):
         a: float


### PR DESCRIPTION
## Summary

Fixes #12937.

When `model_validate(..., extra='allow')` is called on a model whose class-level config is **not** `extra='allow'`, pydantic-core correctly stores the extra fields in `__pydantic_extra__`. However, the serializer is built from the class schema (which has `extra_fields_behavior='forbid'` or `'ignore'`), so it does not emit those fields during `model_dump()`.

```python
from pydantic import BaseModel

class A(BaseModel, extra='forbid'):
    a: int

a = A.model_validate({'a': 1, 'b': 'test'}, extra='allow')
print(a)           # A(a=1, b='test')  ✓
print(a.model_dump())  # {'a': 1}  ✗  —  'b' is silently dropped
```

## Fix

After calling `__pydantic_serializer__.to_python()`, if `__pydantic_extra__` contains data that the serializer would not have included (i.e. the class config is not `extra='allow'`), those fields are merged into the result. The `include`, `exclude`, and `exclude_none` filters are honoured.

This is scoped to `BaseModel` only, consistent with the maintainer guidance in the issue thread.

## Changes

- **`pydantic/main.py`**: post-process `model_dump()` result to merge runtime extra fields.
- **`tests/test_main.py`**: new test `test_model_dump_includes_runtime_extra_fields` covering `extra='forbid'` and `extra='ignore'` class configs, plus `include`, `exclude`, and `exclude_none` filter interactions.

## Test

```
uv run pytest tests/test_main.py tests/test_edge_cases.py tests/test_serialize.py
523 passed, 30 skipped, 1 xfailed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)