### PR TITLE
Fix `Decimal` serialization JSON schema pattern to accept scientific notation

### DIFF
--- a/docs/concepts/json_schema.md
+++ b/docs/concepts/json_schema.md
@@ -297,7 +297,7 @@ print(Model.model_json_schema(mode='serialization'))
     'properties': {
         'a': {
             'default': '12.34',
-            'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             'title': 'A',
             'type': 'string',
         }

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -701,6 +701,11 @@ class GenerateJsonSchema:
                 r'^(?!^[-+.]*$)[+-]?0*'  # check it is not empty string and not one or sequence of ".+-" characters.
             )
 
+            # In serialization mode, `pydantic-core` calls `str()` on `Decimal` values, which can emit
+            # scientific notation (e.g. `Decimal('0.0000001')` -> `'1E-7'`). Allow an optional exponent
+            # suffix so the generated schema accepts pydantic's own serialization output.
+            exponent_suffix = r'(?:[eE][+-]?\d+)?' if self.mode == 'serialization' else ''
+
             # Case 1: Both max_digits and decimal_places are set
             if max_digits is not None and decimal_places is not None:
                 integer_places = max(0, max_digits - decimal_places)
@@ -708,9 +713,9 @@ class GenerateJsonSchema:
                     rf'(?:'
                     rf'\d{{0,{integer_places}}}'
                     rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
-                    rf')'
+                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*{exponent_suffix}$)'
+                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*'
+                    rf'){exponent_suffix}$'
                 )
 
             # Case 2: Only max_digits is set
@@ -719,18 +724,18 @@ class GenerateJsonSchema:
                     rf'(?:'
                     rf'\d{{0,{max_digits}}}'
                     rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d*\.\d*0*$'
-                    rf')'
+                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*{exponent_suffix}$)'
+                    rf'\d*\.\d*0*'
+                    rf'){exponent_suffix}$'
                 )
 
             # Case 3: Only decimal_places is set
             elif max_digits is None and decimal_places is not None:
-                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*$'
+                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*{exponent_suffix}$'
 
             # Case 4: Both are None (no restrictions)
             else:
-                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
+                pattern += rf'\d*\.?\d*{exponent_suffix}$'  # look for arbitrary integer or decimal
 
             return pattern
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -545,7 +545,7 @@ def test_decimal_json_schema():
                 'default': '12.34',
                 'title': 'B',
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         },
         'title': 'Model',
@@ -2137,7 +2137,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2145,7 +2145,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2153,7 +2153,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2161,7 +2161,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2169,7 +2169,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
     ],
@@ -5942,7 +5942,7 @@ def test_generate_definitions_for_no_ref_schemas():
         {
             ('Decimal', 'serialization'): {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
             ('Decimal', 'validation'): {
                 'anyOf': [
@@ -7141,6 +7141,65 @@ def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places
 ) -> None:
     pattern = get_decimal_pattern()
     assert re.fullmatch(pattern, invalid_decimal) is None
+
+
+def test_decimal_serialization_pattern_accepts_scientific_notation() -> None:
+    """Regression test for #13089: serialization-mode Decimal pattern must accept the
+    scientific notation that pydantic-core's ``str(Decimal)`` serializer emits
+    (e.g. ``Decimal('0.0000001')`` -> ``'1E-7'``)."""
+
+    class MyModel(BaseModel):
+        value: Decimal | None
+
+    schema = MyModel.model_json_schema(mode='serialization')
+    pattern = next(v for v in schema['properties']['value']['anyOf'] if v.get('type') == 'string')['pattern']
+    regex = re.compile(pattern)
+
+    # Round-trip: the serializer must produce something the schema accepts.
+    m = MyModel(value=Decimal('0.0000001'))
+    serialized_value = json.loads(m.model_dump_json())['value']
+    assert serialized_value == '1E-7'
+    assert regex.fullmatch(serialized_value) is not None
+
+    # Forms emitted by ``str(Decimal)`` for various magnitudes.
+    for valid in ['1E-7', '1E-12', '-1E-7', '1.5E+10', '1E+20', '0', '1', '-1.5', '0.0000123']:
+        assert regex.fullmatch(valid) is not None, f'pattern should accept {valid!r}'
+
+    # Garbage must still be rejected.
+    for invalid in ['abc', '1.2.3', '1E', '1E--5', 'foo1E-5', '1E5bar', '.', '..', '++']:
+        assert regex.fullmatch(invalid) is None, f'pattern should reject {invalid!r}'
+
+
+def test_decimal_validation_pattern_unchanged_for_scientific_notation() -> None:
+    """The validation-mode pattern is deliberately left untouched by the #13089 fix:
+    the scientific-notation suffix is only added in serialization mode."""
+
+    class MyModel(BaseModel):
+        value: Decimal | None
+
+    schema = MyModel.model_json_schema(mode='validation')
+    pattern = next(v for v in schema['properties']['value']['anyOf'] if v.get('type') == 'string')['pattern']
+    assert '[eE]' not in pattern
+
+
+@pytest.mark.parametrize(
+    ('max_digits', 'decimal_places', 'valid_value'),
+    [
+        (None, None, '1E-7'),
+        (None, 10, '1E-7'),
+        (10, None, '1E-7'),
+        (20, 10, '1.5E+5'),
+    ],
+)
+def test_decimal_serialization_pattern_scientific_notation_with_constraints(
+    max_digits, decimal_places, valid_value
+) -> None:
+    """The scientific-notation allowance must also apply under every
+    ``max_digits`` / ``decimal_places`` combination in serialization mode."""
+    adapter = TypeAdapter(Annotated[Decimal, Field(max_digits=max_digits, decimal_places=decimal_places)])
+    schema = adapter.json_schema(mode='serialization')
+    pattern = schema['anyOf'][1]['pattern'] if 'anyOf' in schema else schema['pattern']
+    assert re.fullmatch(pattern, valid_value) is not None
 
 
 def test_union_format_primitive_type_array() -> None:


### PR DESCRIPTION
## Change Summary

The serialization-mode JSON schema regex for `Decimal` fields (introduced in #11987) rejects values that `pydantic-core` itself emits. `str(Decimal)` returns scientific notation for small/large magnitudes — `Decimal('0.0000001')` becomes `'1E-7'` — but the pattern `^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$` has no `[eE]` component, so `model_dump_json()` output fails validation against its own `model_json_schema(mode='serialization')`.

This PR extends each pattern branch in `get_decimal_pattern` with an optional `(?:[eE][+-]?\d+)?` suffix, gated on `self.mode == 'serialization'`. The validation-mode pattern is left untouched (no expansion of accepted input), and no existing decimal-pattern test changes behavior. Docs and the hard-coded serialization-mode pattern assertions are updated to match.

## Related issue number

fix #13089

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Selected Reviewer: @Viicos