### PR TITLE
Fix RootModel constructor typing in the mypy plugin

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -86,6 +86,8 @@ BASEMODEL_FULLNAME = 'pydantic.main.BaseModel'
 CREATE_MODEL_FULLNAME = 'pydantic.main.create_model'
 BASESETTINGS_FULLNAME = 'pydantic_settings.main.BaseSettings'
 ROOT_MODEL_FULLNAME = 'pydantic.root_model.RootModel'
+ROOT_MODEL_INIT_FULLNAME = 'pydantic.root_model.RootModel.__init__'
+ROOT_MODEL_METACLASS_FULLNAME = 'pydantic.root_model._RootModelMetaclass'
 MODEL_METACLASS_FULLNAME = 'pydantic._internal._model_construction.ModelMetaclass'
 FIELD_FULLNAME = 'pydantic.fields.Field'
 DATACLASS_FULLNAME = 'pydantic.dataclasses.dataclass'
@@ -142,7 +144,7 @@ class PydanticPlugin(Plugin):
 
     def get_metaclass_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
         """Update Pydantic `ModelMetaclass` definition."""
-        if fullname == MODEL_METACLASS_FULLNAME:
+        if fullname in {MODEL_METACLASS_FULLNAME, ROOT_MODEL_METACLASS_FULLNAME}:
             return self._pydantic_model_metaclass_marker_callback
         return None
 
@@ -889,7 +891,13 @@ class PydanticModelTransformer:
         The added `__init__` will be annotated with types vs. all `Any` depending on the plugin settings.
         """
         if '__init__' in self._cls.info.names and not self._cls.info.names['__init__'].plugin_generated:
-            return  # Don't generate an __init__ if one already exists
+            existing_init = self._cls.info.names['__init__'].node
+            if not (
+                is_root_model
+                and isinstance(existing_init, FuncDef)
+                and existing_init.fullname == ROOT_MODEL_INIT_FULLNAME
+            ):
+                return  # Don't generate an __init__ if one already exists
 
         typed = self.plugin_config.init_typed
         model_strict = bool(config.strict)

--- a/tests/mypy/modules/root_models.py
+++ b/tests/mypy/modules/root_models.py
@@ -23,6 +23,17 @@ pets2 = Pets2(['dog', 'cat'])
 pets3 = Pets3(['dog', 'cat'])
 
 
+class FloatModel(BaseModel):
+    value: float
+
+
+float_model = FloatModel(value='1.0')
+float_root_model = RootModel[float]('1.0')
+
+assert_type(float_model.value, float)
+assert_type(float_root_model.root, float)
+
+
 class Pets4(RootModel[list[str]]):
     pets: list[str]
 

--- a/tests/mypy/outputs/mypy-default_ini/root_models.py
+++ b/tests/mypy/outputs/mypy-default_ini/root_models.py
@@ -24,6 +24,19 @@ pets2 = Pets2(['dog', 'cat'])
 pets3 = Pets3(['dog', 'cat'])
 
 
+class FloatModel(BaseModel):
+    value: float
+
+
+float_model = FloatModel(value='1.0')
+# MYPY: error: Argument "value" to "FloatModel" has incompatible type "str"; expected "float"  [arg-type]
+float_root_model = RootModel[float]('1.0')
+# MYPY: error: Argument 1 to "RootModel" has incompatible type "str"; expected "float"  [arg-type]
+
+assert_type(float_model.value, float)
+assert_type(float_root_model.root, float)
+
+
 class Pets4(RootModel[list[str]]):
     pets: list[str]
 

--- a/tests/mypy/outputs/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/mypy-plugin_ini/root_models.py
@@ -24,6 +24,17 @@ pets2 = Pets2(['dog', 'cat'])
 pets3 = Pets3(['dog', 'cat'])
 
 
+class FloatModel(BaseModel):
+    value: float
+
+
+float_model = FloatModel(value='1.0')
+float_root_model = RootModel[float]('1.0')
+
+assert_type(float_model.value, float)
+assert_type(float_root_model.root, float)
+
+
 class Pets4(RootModel[list[str]]):
     pets: list[str]
 # MYPY: error: Only `root` is allowed as a field of a `RootModel`  [pydantic-field]

--- a/tests/mypy/outputs/pyproject-default_toml/root_models.py
+++ b/tests/mypy/outputs/pyproject-default_toml/root_models.py
@@ -24,6 +24,19 @@ pets2 = Pets2(['dog', 'cat'])
 pets3 = Pets3(['dog', 'cat'])
 
 
+class FloatModel(BaseModel):
+    value: float
+
+
+float_model = FloatModel(value='1.0')
+# MYPY: error: Argument "value" to "FloatModel" has incompatible type "str"; expected "float"  [arg-type]
+float_root_model = RootModel[float]('1.0')
+# MYPY: error: Argument 1 to "RootModel" has incompatible type "str"; expected "float"  [arg-type]
+
+assert_type(float_model.value, float)
+assert_type(float_root_model.root, float)
+
+
 class Pets4(RootModel[list[str]]):
     pets: list[str]
 


### PR DESCRIPTION
## Change Summary

This PR fixes the `arg-type` false positive from #12978.

With the default mypy plugin settings, `BaseModel` constructors keep accepting coercible inputs because the plugin synthesizes an untyped `__init__`. `RootModel` constructors were bypassing that path: `_RootModelMetaclass` still kept its dataclass-transform behavior, and `RootModel.__init__` was left in place for the root model itself. As a result, `RootModel[float]('1.0')` was checked against `float` directly and errored.

This change makes the plugin treat `_RootModelMetaclass` like `ModelMetaclass`, and lets the generated initializer replace `RootModel.__init__` for root models. I also added a regression case in `tests/mypy/modules/root_models.py` that compares `BaseModel` and `RootModel` on the same coercible `float` input.

## Related issue number

Fixes #12978

## Validation

- `uv run mypy /tmp/pydantic_12978_repro_check.py --config-file tests/mypy/configs/mypy-plugin.ini --cache-dir .mypy_cache/test-repro-final --show-error-codes --show-traceback`
- `uv run coverage run -m pytest tests/mypy/test_mypy.py --test-mypy -k root_models`
- `uv run ruff check pydantic/mypy.py tests/mypy/modules/root_models.py`

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
