### PR TITLE
fix: consolidate WrapSerializer warnings into a single UserWarning

### DIFF
--- a/pydantic-core/src/serializers/extra.rs
+++ b/pydantic-core/src/serializers/extra.rs
@@ -249,7 +249,7 @@ impl SerCheck {
 #[derive(Clone)]
 pub(crate) struct ExtraOwned {
     mode: SerMode,
-    warnings: CollectWarnings,
+    pub(crate) warnings: CollectWarnings,
     by_alias: Option<bool>,
     exclude_unset: bool,
     exclude_defaults: bool,
@@ -503,6 +503,32 @@ impl CollectWarnings {
                 Some(value.clone().unbind()),
             ));
         }
+    }
+
+    pub fn len(&self) -> usize {
+        self.warnings.len()
+    }
+
+    /// Propagates warnings added after `initial_len` to `target`.
+    ///
+    /// Used by `WrapSerializer` to forward inner warnings to the outer serialization context
+    /// instead of emitting them as a separate `UserWarning`.  In error mode the new warnings
+    /// are raised immediately; in warn/none mode they are appended to `target` so the outer
+    /// `final_check` can emit a single consolidated warning.
+    pub fn propagate_new_to(&self, initial_len: usize, target: &mut CollectWarnings, py: Python) -> PyResult<()> {
+        let new_warnings = &self.warnings[initial_len..];
+        if new_warnings.is_empty() {
+            return Ok(());
+        }
+        if self.mode == WarningsMode::Error {
+            let formatted: Vec<String> = new_warnings.iter().map(|w| w.__repr__(py)).collect();
+            let message = format!("Pydantic serializer warnings:\n  {}", formatted.join("\n  "));
+            return Err(PydanticSerializationError::new_err(message));
+        }
+        if self.mode == WarningsMode::Warn {
+            target.warnings.extend(new_warnings.iter().cloned());
+        }
+        Ok(())
     }
 
     pub fn final_check(&self, py: Python) -> PyResult<()> {

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -391,7 +391,8 @@ impl FunctionWrapSerializer {
                 if let Some(model) = state.model.as_ref() {
                     if self.info_arg {
                         let info = SerializationInfo::new(state, self.is_field_serializer)?;
-                        self.func.call1(py, (model, value, serialize_callable.clone_ref(py), info))?
+                        self.func
+                            .call1(py, (model, value, serialize_callable.clone_ref(py), info))?
                     } else {
                         self.func.call1(py, (model, value, serialize_callable.clone_ref(py)))?
                     }

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -384,13 +384,16 @@ impl FunctionWrapSerializer {
         let py = value.py();
         if self.when_used.should_use(value, &state.extra) {
             let serialize = SerializationCallable::new(&self.serializer, state);
+            // Keep a Py<> reference so we can read back accumulated warnings after the call.
+            let initial_warning_count = serialize.initial_warning_count;
+            let serialize_callable = Py::new(py, serialize)?;
             let v = if self.is_field_serializer {
                 if let Some(model) = state.model.as_ref() {
                     if self.info_arg {
                         let info = SerializationInfo::new(state, self.is_field_serializer)?;
-                        self.func.call1(py, (model, value, serialize, info))?
+                        self.func.call1(py, (model, value, serialize_callable.clone_ref(py), info))?
                     } else {
-                        self.func.call1(py, (model, value, serialize))?
+                        self.func.call1(py, (model, value, serialize_callable.clone_ref(py)))?
                     }
                 } else {
                     return Err(PyRuntimeError::new_err(
@@ -399,10 +402,19 @@ impl FunctionWrapSerializer {
                 }
             } else if self.info_arg {
                 let info = SerializationInfo::new(state, self.is_field_serializer)?;
-                self.func.call1(py, (value, serialize, info))?
+                self.func.call1(py, (value, serialize_callable.clone_ref(py), info))?
             } else {
-                self.func.call1(py, (value, serialize))?
+                self.func.call1(py, (value, serialize_callable.clone_ref(py)))?
             };
+            // Merge warnings collected inside the wrap handler into the outer context so
+            // the top-level final_check emits a single consolidated UserWarning.
+            {
+                let callable = serialize_callable.borrow(py);
+                callable
+                    .extra_owned
+                    .warnings
+                    .propagate_new_to(initial_warning_count, &mut state.warnings, py)?;
+            }
             Ok((true, v))
         } else {
             Ok((false, value.clone().unbind()))
@@ -431,6 +443,9 @@ pub(crate) struct SerializationCallable {
     serializer: Arc<CombinedSerializer>,
     extra_owned: ExtraOwned,
     filter: AnyFilter,
+    /// Number of warnings already present in `extra_owned` at construction time.
+    /// Used by `FunctionWrapSerializer::call` to determine which warnings are new.
+    initial_warning_count: usize,
 }
 
 impl_py_gc_traverse!(SerializationCallable {
@@ -440,10 +455,12 @@ impl_py_gc_traverse!(SerializationCallable {
 
 impl SerializationCallable {
     pub fn new(serializer: &Arc<CombinedSerializer>, state: &SerializationState<'_>) -> Self {
+        let initial_warning_count = state.warnings.len();
         Self {
             serializer: serializer.clone(),
             extra_owned: ExtraOwned::new(state),
             filter: AnyFilter::new(),
+            initial_warning_count,
         }
     }
 
@@ -472,8 +489,10 @@ impl SerializationCallable {
         // at this layer
 
         let state = &mut self.extra_owned.to_state(py);
+        // Track how many warnings existed before this call so we only propagate new ones.
+        let initial_warning_count = state.warnings.len();
 
-        if let Some(index_key) = index_key {
+        let result = if let Some(index_key) = index_key {
             let filter = if let Ok(index) = index_key.extract::<usize>() {
                 self.filter.index_filter(index, state, None)?
             } else {
@@ -482,16 +501,24 @@ impl SerializationCallable {
             if let Some(next_include_exclude) = filter {
                 let state = &mut state.scoped_include_exclude(next_include_exclude);
                 let v = self.serializer.to_python_no_infer(value, state)?;
-                state.warnings.final_check(py)?;
                 Ok(Some(v))
             } else {
                 Err(PydanticOmit::new_err())
             }
         } else {
             let v = self.serializer.to_python_no_infer(value, state)?;
-            state.warnings.final_check(py)?;
             Ok(Some(v))
-        }
+        };
+
+        // Instead of calling final_check() here (which would emit a separate UserWarning),
+        // propagate new warnings to extra_owned so FunctionWrapSerializer::call can merge
+        // them into the outer serialization context for a single consolidated warning.
+        // In error mode, raise immediately.
+        state
+            .warnings
+            .propagate_new_to(initial_warning_count, &mut self.extra_owned.warnings, py)?;
+
+        result
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1394,3 +1394,34 @@ def test_wrap_ser_called_once() -> None:
 
     my_model = MyParentModel.model_validate({'nested': {'inner_value': 'foo'}})
     assert my_model.model_dump() == {'nested': {'inner_value': 'my_prefix:foo'}}
+
+
+def test_wrap_serializer_warnings_consolidated() -> None:
+    """WrapSerializer must not emit a separate UserWarning for its field.
+
+    All serializer warnings from a single model_dump() call should be consolidated
+    into a single UserWarning regardless of whether a field uses WrapSerializer.
+    Regression test for https://github.com/pydantic/pydantic/issues/12995.
+    """
+
+    class Model(BaseModel):
+        a: Annotated[str, WrapSerializer(lambda v, h: h(v))]
+        b: str
+        c: str
+
+    m = Model(a='t', b='t', c='t')
+    m.a = 1  # type: ignore[assignment]
+    m.b = 2  # type: ignore[assignment]
+    m.c = 3  # type: ignore[assignment]
+
+    with pytest.warns(UserWarning) as warning_list:
+        m.model_dump()
+
+    # Should be exactly ONE UserWarning containing all three fields
+    assert len(warning_list) == 1, (
+        f'Expected 1 consolidated warning, got {len(warning_list)}: {[str(w.message) for w in warning_list]}'
+    )
+    warning_msg = str(warning_list[0].message)
+    assert "field_name='a'" in warning_msg
+    assert "field_name='b'" in warning_msg
+    assert "field_name='c'" in warning_msg

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1400,3 +1400,34 @@ def test_wrap_ser_called_once() -> None:
 
     my_model = MyParentModel.model_validate({'nested': {'inner_value': 'foo'}})
     assert my_model.model_dump() == {'nested': {'inner_value': 'my_prefix:foo'}}
+
+
+def test_wrap_serializer_warnings_consolidated() -> None:
+    """WrapSerializer must not emit a separate UserWarning for its field.
+
+    All serializer warnings from a single model_dump() call should be consolidated
+    into a single UserWarning regardless of whether a field uses WrapSerializer.
+    Regression test for https://github.com/pydantic/pydantic/issues/12995.
+    """
+
+    class Model(BaseModel):
+        a: Annotated[str, WrapSerializer(lambda v, h: h(v))]
+        b: str
+        c: str
+
+    m = Model(a='t', b='t', c='t')
+    m.a = 1  # type: ignore[assignment]
+    m.b = 2  # type: ignore[assignment]
+    m.c = 3  # type: ignore[assignment]
+
+    with pytest.warns(UserWarning) as warning_list:
+        m.model_dump()
+
+    # Should be exactly ONE UserWarning containing all three fields
+    assert len(warning_list) == 1, (
+        f'Expected 1 consolidated warning, got {len(warning_list)}: {[str(w.message) for w in warning_list]}'
+    )
+    warning_msg = str(warning_list[0].message)
+    assert "field_name='a'" in warning_msg
+    assert "field_name='b'" in warning_msg
+    assert "field_name='c'" in warning_msg


### PR DESCRIPTION
## Summary

Fixes #12995

When a model has a field annotated with `WrapSerializer` **and** other fields with unexpected types during `model_dump()`, two separate `UserWarning`s were emitted instead of one consolidated warning.

### Root cause

`SerializationCallable.__call__()` (the inner handler passed to user-supplied wrap functions) called `state.warnings.final_check()` immediately after serializing the value. This triggered a premature warning emission for the WrapSerializer field before the outer serialization context had finished collecting warnings from all other model fields.

### Fix

Three targeted changes in `pydantic-core`:

1. **`CollectWarnings::propagate_new_to()`** (new method in `extra.rs`)  
   Moves only *newly-collected* warnings (those beyond a recorded baseline index) into a target `CollectWarnings`. In `error` mode it raises immediately; in `warn` mode it appends to the target for later consolidated emission.

2. **`SerializationCallable::__call__()`** (modified in `function.rs`)  
   Replaces the premature `final_check()` with `propagate_new_to()` so warnings stay in `extra_owned.warnings` rather than being emitted early.

3. **`FunctionWrapSerializer::call()`** (modified in `function.rs`)  
   Wraps the `SerializationCallable` in a `Py<>` to keep it alive after the user function returns, then propagates accumulated inner warnings into the outer `SerializationState`. The top-level `final_check()` in `mod.rs` then emits everything as one consolidated `UserWarning`.

### Test

```python
def test_wrap_serializer_warnings_consolidated() -> None:
    class Model(BaseModel):
        a: Annotated[str, WrapSerializer(lambda v, h: h(v))]
        b: str
        c: str

    m = Model(a='t', b='t', c='t')
    m.a = 1
    m.b = 2
    m.c = 3

    with pytest.warns(UserWarning) as warning_list:
        m.model_dump()

    assert len(warning_list) == 1  # single consolidated warning
    warning_msg = str(warning_list[0].message)
    assert "field_name='a'" in warning_msg
    assert "field_name='b'" in warning_msg
    assert "field_name='c'" in warning_msg
```

All existing pydantic and pydantic-core tests continue to pass.