### PR TITLE
fix: preserve field constraints in JSON schema for Optional[Annotated[T, BeforeValidator]]

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -213,7 +213,12 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         # in this recursive case with function-after or function-wrap, we should refactor
         # this is a bit challenging because we sometimes want to apply constraints to the inner schema,
         # whereas other times we want to wrap the existing schema with a new one that enforces a new constraint.
-        if schema_type in {'function-before', 'function-wrap', 'function-after'} and constraint == 'strict':
+        # Push constraints onto the inner schema so JSON Schema generation (which for chain_schema
+        # only inspects the first step) still sees str constraints like pattern; see
+        # https://github.com/pydantic/pydantic/issues/12417
+        if schema_type in {'function-before', 'function-wrap', 'function-after'} and (
+            constraint == 'strict' or constraint in chain_schema_constraints
+        ):
             schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function schema
             return schema
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6563,6 +6563,30 @@ def test_str_schema_with_pattern() -> None:
     }
 
 
+def test_optional_annotated_before_validator_preserves_field_pattern_in_json_schema() -> None:
+    """Regression for https://github.com/pydantic/pydantic/issues/12417"""
+
+    regex = r'^[\da-fA-F]{32}$'
+
+    def _convert_bytes_to_str(value: str | bytes) -> str:
+        if isinstance(value, bytes):
+            return value.decode('utf8')
+        return value
+
+    bytes_to_str = Annotated[str, BeforeValidator(_convert_bytes_to_str)]
+
+    class TestModel(BaseModel):
+        str_optional: str | None = Field(None, pattern=regex)
+        annotated_optional: bytes_to_str | None = Field(None, pattern=regex)
+
+    props = TestModel.model_json_schema()['properties']
+
+    def string_branch(prop: dict[str, Any]) -> dict[str, Any]:
+        return next(s for s in prop['anyOf'] if s.get('type') == 'string')
+
+    assert string_branch(props['str_optional']) == string_branch(props['annotated_optional'])
+
+
 def test_plain_serializer_applies_to_default() -> None:
     class Model(BaseModel):
         custom_str: Annotated[str, PlainSerializer(lambda x: f'serialized-{x}', return_type=str)] = 'foo'


### PR DESCRIPTION
## Change Summary

Fixes a bug where field-level constraints like `pattern` were silently dropped from the generated JSON Schema when a field was typed as `Optional[Annotated[str, BeforeValidator(...)]]`.

The root cause was in `apply_known_metadata` in `pydantic/_internal/_known_annotated_metadata.py`. When a function validator wraps a type (`function-before`, `function-wrap`, `function-after`), string constraints like `pattern` were appended as an extra step in a `chain_schema` rather than being pushed onto the inner schema. The JSON Schema generator's `chain_schema` handler only reads one step in validation mode, so the constraint step was never emitted.

The fix extends the existing `strict` special-case (which already recurses into the inner schema instead of chaining) to also apply for all constraints in `chain_schema_constraints` — `pattern`, `strip_whitespace`, `to_lower`, `to_upper`, `coerce_numbers_to_str`, and `ascii_only`:

```python
# before
if schema_type in {'function-before', 'function-wrap', 'function-after'} \
        and constraint == 'strict':

# after
if schema_type in {'function-before', 'function-wrap', 'function-after'} \
        and (constraint in chain_schema_constraints or constraint == 'strict'):
```

No changes to `pydantic/json_schema.py` are required.

## Related issue number

fix #12417

Please Review: @Viicos 

Selected Reviewer: @Viicos