### PR TITLE
Fix `__pydantic_extra__` ignored if `extra = 'forbid'` at model level, overridden at runtime

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -818,7 +818,7 @@ class GenerateSchema:
 
                 extras_schema = None
                 extras_keys_schema = None
-                if core_config.get('extra_fields_behavior') == 'allow' and extra_info is not None:
+                if extra_info is not None:
                     tp = get_origin(extra_info.annotation)
                     if tp not in DICT_TYPES:
                         raise PydanticSchemaGenerationError(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2862,6 +2862,26 @@ def test_extra_equality_runtime_override() -> None:
     assert MyModel.model_validate({'a': 1}) == MyModel.model_validate({'a': 1}, extra='forbid')
 
 
+def test_pydantic_extra_type_respected_with_runtime_extra_override() -> None:
+    """https://github.com/pydantic/pydantic/issues/13024"""
+
+    class A(BaseModel, extra='forbid'):
+        __pydantic_extra__: dict[str, int]
+        a: int
+
+    # When extra='allow' is passed at runtime, __pydantic_extra__ type hint should be respected
+    a = A.model_validate({'a': 1, 'b': 2}, extra='allow')
+    assert a.a == 1
+    assert a.model_extra == {'b': 2}
+
+    # 'test' is not an int, so this should fail validation
+    with pytest.raises(ValidationError) as exc_info:
+        A.model_validate({'a': 1, 'b': 'test'}, extra='allow')
+    assert exc_info.value.error_count() == 1
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'int_parsing'
+    assert exc_info.value.errors(include_url=False)[0]['loc'] == ('b',)
+
+
 def test_equality_delegation():
     from unittest.mock import ANY
 


### PR DESCRIPTION
## Summary

Fixes #13024

When a model has `extra='forbid'` but `__pydantic_extra__` is annotated with a type hint (e.g. `dict[str, int]`), and `extra='allow'` is passed at runtime via `model_validate()`, the type hint was being ignored.

## Root Cause

In `_generate_schema.py`, the `extras_schema` was only generated when `core_config.get('extra_fields_behavior') == 'allow'`. When the model's config had `extra='forbid'`, the extras schema was never built, so when `extra='allow'` was passed at runtime, extra fields were accepted without type validation.

## Changes

### pydantic (this PR)
- **`pydantic/_internal/_generate_schema.py`**: Generate `extras_schema` whenever `__pydantic_extra__` is annotated, regardless of config-level `extra` setting
- **`tests/test_main.py`**: Added test `test_pydantic_extra_type_respected_with_runtime_extra_override` verifying that `__pydantic_extra__` type hints are respected with runtime extra override

### pydantic-core (companion change needed)
This fix also requires a corresponding change in pydantic-core to accept `extras_schema` regardless of the `extra_fields_behavior` config setting. Currently pydantic-core rejects `extras_schema` unless `extra_behavior=allow`.