### PR TITLE
Fix incomplete generic models with recursive union bounds (#13085)

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -327,9 +327,11 @@ def replace_types(type_: Any, type_map: Mapping[TypeVar, Any] | None) -> Any:
         parametrized = type_[resolved_type_args]
         if isinstance(parametrized, PydanticRecursiveRef):
             target_ref = parametrized.type_ref
-            for candidate in reversed(_generic_model_build_stack.get()):
-                if get_type_ref(candidate) == target_ref:
-                    return candidate
+            build_stack = _generic_model_build_stack.get()
+            if build_stack:
+                for candidate in reversed(build_stack):
+                    if get_type_ref(candidate) == target_ref:
+                        return candidate
             cached = get_cached_generic_type_early(type_, resolved_type_args)
             if cached is not None:
                 return cached
@@ -407,13 +409,15 @@ def map_generic_model_arguments(cls: type[BaseModel], args: tuple[Any, ...]) -> 
 
 _generic_recursion_cache: ContextVar[set[str] | None] = ContextVar('_generic_recursion_cache', default=None)
 
-_generic_model_build_stack: ContextVar[tuple[type[BaseModel], ...]] = ContextVar(
-    '_generic_model_build_stack', default=()
+_generic_model_build_stack: ContextVar[list[type[BaseModel]] | None] = ContextVar(
+    '_generic_model_build_stack', default=None
 )
 """Stack of parametrized generic models currently being built (see `generic_model_under_construction`).
 
 Used so that `replace_types()` can resolve `PydanticRecursiveRef` placeholders emitted by nested
 `__class_getitem__` calls back to the real in-construction class (same `type_ref` as the placeholder).
+
+Implemented as a list with append/pop so nested construction stays O(1) per level (no tuple copying).
 """
 
 
@@ -427,12 +431,18 @@ def generic_model_under_construction(cls: type[BaseModel]) -> Iterator[None]:
     if not cls.__pydantic_generic_metadata__.get('origin'):
         yield
         return
-    prev = _generic_model_build_stack.get()
-    token = _generic_model_build_stack.set(prev + (cls,))
+    stack = _generic_model_build_stack.get()
+    token = None
+    if stack is None:
+        stack = []
+        token = _generic_model_build_stack.set(stack)
+    stack.append(cls)
     try:
         yield
     finally:
-        _generic_model_build_stack.reset(token)
+        stack.pop()
+        if token is not None:
+            _generic_model_build_stack.reset(token)
 
 
 @contextmanager

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -324,7 +324,20 @@ def replace_types(type_: Any, type_map: Mapping[TypeVar, Any] | None) -> Any:
         resolved_type_args = tuple(replace_types(t, type_map) for t in parameters)
         if all_identical(parameters, resolved_type_args):
             return type_
-        return type_[resolved_type_args]
+        parametrized = type_[resolved_type_args]
+        if isinstance(parametrized, PydanticRecursiveRef):
+            target_ref = parametrized.type_ref
+            for candidate in reversed(_generic_model_build_stack.get()):
+                if get_type_ref(candidate) == target_ref:
+                    return candidate
+            cached = get_cached_generic_type_early(type_, resolved_type_args)
+            if cached is not None:
+                return cached
+            if len(resolved_type_args) == 1:
+                cached = get_cached_generic_type_early(type_, resolved_type_args[0])
+                if cached is not None:
+                    return cached
+        return parametrized
 
     # Handle special case for typehints that can have lists as arguments.
     # `typing.Callable[[int, str], int]` is an example for this.
@@ -393,6 +406,33 @@ def map_generic_model_arguments(cls: type[BaseModel], args: tuple[Any, ...]) -> 
 
 
 _generic_recursion_cache: ContextVar[set[str] | None] = ContextVar('_generic_recursion_cache', default=None)
+
+_generic_model_build_stack: ContextVar[tuple[type[BaseModel], ...]] = ContextVar(
+    '_generic_model_build_stack', default=()
+)
+"""Stack of parametrized generic models currently being built (see `generic_model_under_construction`).
+
+Used so that `replace_types()` can resolve `PydanticRecursiveRef` placeholders emitted by nested
+`__class_getitem__` calls back to the real in-construction class (same `type_ref` as the placeholder).
+"""
+
+
+@contextmanager
+def generic_model_under_construction(cls: type[BaseModel]) -> Iterator[None]:
+    """Push `cls` onto a stack while its fields/schema are being finalized.
+
+    Only used for concrete parametrizations (generic origin set in metadata), so that recursive
+    `type_[args]` calls during field collection can be mapped back to the class object under construction.
+    """
+    if not cls.__pydantic_generic_metadata__.get('origin'):
+        yield
+        return
+    prev = _generic_model_build_stack.get()
+    token = _generic_model_build_stack.set(prev + (cls,))
+    try:
+        yield
+    finally:
+        _generic_model_build_stack.reset(token)
 
 
 @contextmanager

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -329,8 +329,9 @@ def replace_types(type_: Any, type_map: Mapping[TypeVar, Any] | None) -> Any:
             target_ref = parametrized.type_ref
             build_stack = _generic_model_build_stack.get()
             if build_stack:
-                for candidate in reversed(build_stack):
-                    if get_type_ref(candidate) == target_ref:
+                # Entries store precomputed refs to avoid repeated get_type_ref() in this hot path.
+                for candidate, cls_type_ref in reversed(build_stack):
+                    if cls_type_ref == target_ref:
                         return candidate
             cached = get_cached_generic_type_early(type_, resolved_type_args)
             if cached is not None:
@@ -409,7 +410,7 @@ def map_generic_model_arguments(cls: type[BaseModel], args: tuple[Any, ...]) -> 
 
 _generic_recursion_cache: ContextVar[set[str] | None] = ContextVar('_generic_recursion_cache', default=None)
 
-_generic_model_build_stack: ContextVar[list[type[BaseModel]] | None] = ContextVar(
+_generic_model_build_stack: ContextVar[list[tuple[type[BaseModel], str]] | None] = ContextVar(
     '_generic_model_build_stack', default=None
 )
 """Stack of parametrized generic models currently being built (see `generic_model_under_construction`).
@@ -417,6 +418,7 @@ _generic_model_build_stack: ContextVar[list[type[BaseModel]] | None] = ContextVa
 Used so that `replace_types()` can resolve `PydanticRecursiveRef` placeholders emitted by nested
 `__class_getitem__` calls back to the real in-construction class (same `type_ref` as the placeholder).
 
+Each entry is ``(cls, get_type_ref(cls))`` so ``replace_types`` matches refs by string equality only.
 Implemented as a list with append/pop so nested construction stays O(1) per level (no tuple copying).
 """
 
@@ -436,7 +438,7 @@ def generic_model_under_construction(cls: type[BaseModel]) -> Iterator[None]:
     if stack is None:
         stack = []
         token = _generic_model_build_stack.set(stack)
-    stack.append(cls)
+    stack.append((cls, get_type_ref(cls)))
     try:
         yield
     finally:

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -30,7 +30,7 @@ from ._config import ConfigWrapper
 from ._decorators import DecoratorInfos, PydanticDescriptorProxy, get_attribute_from_bases, unwrap_wrapped_function
 from ._fields import collect_model_fields, is_valid_field_name, is_valid_privateattr_name, rebuild_model_fields
 from ._generate_schema import GenerateSchema, InvalidSchemaError
-from ._generics import PydanticGenericMetadata, get_model_typevars_map
+from ._generics import PydanticGenericMetadata, generic_model_under_construction, get_model_typevars_map
 from ._import_utils import import_cached_base_model, import_cached_field_info
 from ._mock_val_ser import set_model_mocks
 from ._namespace_utils import NsResolver
@@ -246,26 +246,27 @@ class ModelMetaclass(ABCMeta):
 
             ns_resolver = NsResolver(parent_namespace=parent_namespace)
 
-            set_model_fields(cls, config_wrapper=config_wrapper, ns_resolver=ns_resolver)
+            with generic_model_under_construction(cls):
+                set_model_fields(cls, config_wrapper=config_wrapper, ns_resolver=ns_resolver)
 
-            # This is also set in `complete_model_class()`, after schema gen because they are recreated.
-            # We set them here as well for backwards compatibility:
-            cls.__pydantic_computed_fields__ = {
-                k: v.info for k, v in cls.__pydantic_decorators__.computed_fields.items()
-            }
+                # This is also set in `complete_model_class()`, after schema gen because they are recreated.
+                # We set them here as well for backwards compatibility:
+                cls.__pydantic_computed_fields__ = {
+                    k: v.info for k, v in cls.__pydantic_decorators__.computed_fields.items()
+                }
 
-            if config_wrapper.defer_build:
-                set_model_mocks(cls)
-            else:
-                # Any operation that requires accessing the field infos instances should be put inside
-                # `complete_model_class()`:
-                complete_model_class(
-                    cls,
-                    config_wrapper,
-                    ns_resolver,
-                    raise_errors=False,
-                    create_model_module=_create_model_module,
-                )
+                if config_wrapper.defer_build:
+                    set_model_mocks(cls)
+                else:
+                    # Any operation that requires accessing the field infos instances should be put inside
+                    # `complete_model_class()`:
+                    complete_model_class(
+                        cls,
+                        config_wrapper,
+                        ns_resolver,
+                        raise_errors=False,
+                        create_model_module=_create_model_module,
+                    )
 
             if config_wrapper.frozen and '__hash__' not in namespace:
                 set_default_hash_func(cls, bases)

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations as _annotations
 
+import contextlib
 import operator
 import sys
 import typing
@@ -246,7 +247,15 @@ class ModelMetaclass(ABCMeta):
 
             ns_resolver = NsResolver(parent_namespace=parent_namespace)
 
-            with generic_model_under_construction(cls):
+            # Only track generic parametrizations (`origin` set); the stack is used by `replace_types` when
+            # resolving `PydanticRecursiveRef` during recursive `__class_getitem__`. `nullcontext` avoids
+            # context-manager and ContextVar overhead on the common path (non-parametrized models).
+            _gen_build_ctx = (
+                generic_model_under_construction(cls)
+                if cls.__pydantic_generic_metadata__.get('origin')
+                else contextlib.nullcontext()
+            )
+            with _gen_build_ctx:
                 set_model_fields(cls, config_wrapper=config_wrapper, ns_resolver=ns_resolver)
 
                 # This is also set in `complete_model_class()`, after schema gen because they are recreated.

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1731,7 +1731,6 @@ def test_generic_recursive_models_parametrized_with_model_subclass() -> None:
     Base[Other].model_validate({'t': {'child': {'t': {'child': None}}}})
 
 
-@pytest.mark.xfail(reason='Core schema generation is missing the M1 definition')
 def test_generic_recursive_models_inheritance() -> None:
     """https://github.com/pydantic/pydantic/issues/9969"""
 
@@ -1746,6 +1745,32 @@ def test_generic_recursive_models_inheritance() -> None:
     M2.model_rebuild()
 
     assert M2.__pydantic_complete__
+
+
+def test_generic_recursive_union_bound_issue_13085() -> None:
+    """https://github.com/pydantic/pydantic/issues/13085"""
+
+    from typing import Generic, TypeVar, Union
+
+    from pydantic._internal._forward_ref import PydanticRecursiveRef
+
+    TBaseItem = Union['GroupSpec', 'ArraySpec']
+    TItem = TypeVar('TItem', bound=TBaseItem)
+
+    class ArraySpec(BaseModel):
+        pass
+
+    class GroupSpec(BaseModel, Generic[TItem]):
+        members: TItem
+
+    class BaseGroupv04(GroupSpec[TBaseItem]):
+        pass
+
+    assert BaseGroupv04.__pydantic_complete__
+
+    members_ann = BaseGroupv04.model_fields['members'].annotation
+    args = get_args(members_ann)
+    assert not any(isinstance(a, PydanticRecursiveRef) for a in args)
 
 
 def test_generic_recursive_models_separate_parameters(create_module):


### PR DESCRIPTION
## Change Summary

Track generic model construction to avoid leaking `PydanticRecursiveRef` into field metadata when resolving recursive `TypeVar` bounds (re-entrant `__class_getitem__` during `replace_types`). Wrap generic model field setup / completion in a construction context and resolve recursive refs from the build stack (with cache fallback). Add `test_generic_recursive_union_bound_issue_13085` and remove `xfail` from `test_generic_recursive_models_inheritance` now that it passes.

## Related issue number

Fixes #13085

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable (no user-facing API or docs changes; internal generics fix only)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Selected Reviewer: @Viicos