### PR TITLE
Add `exclude_if` to `model_dump` and reject `PydanticUndefined` in `model_validate`

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -1392,3 +1392,25 @@ try:
 except PydanticUserError as exc_info:
     assert exc_info.code == 'validate-by-alias-and-name-false'
 ```
+
+## `PydanticUndefined` used as a value {#undefined-as-value}
+
+This error is raised when `PydanticUndefined` is passed as a field value via
+`model_validate`. `PydanticUndefined` is an internal sentinel used by Pydantic and must not be used
+as input data.
+
+```python
+from pydantic_core import PydanticUndefined
+
+from pydantic import BaseModel, PydanticUserError
+
+
+class Model(BaseModel):
+    a: str = 'default'
+
+
+try:
+    Model.model_validate({'a': PydanticUndefined})
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'undefined-as-value'
+```

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -75,6 +75,7 @@ PydanticErrorCodes = Literal[
     'overlapping-unpack-typed-dict',
     'invalid-self-type',
     'validate-by-alias-and-name-false',
+    'undefined-as-value',
 ]
 
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -92,6 +92,53 @@ def _check_frozen(model_cls: type[BaseModel], name: str, value: Any) -> None:
     )
 
 
+def _raise_undefined_error(data: dict[str, Any]) -> None:
+    """Raise an error identifying which field received ``PydanticUndefined``.
+
+    This is the slow-path called only when ``PydanticUndefined`` is detected in the input.
+    """
+    for key, value in data.items():
+        if value is PydanticUndefined:
+            raise PydanticUserError(
+                f'Field {key!r} received `PydanticUndefined` as a value. '
+                f'`PydanticUndefined` is a pydantic internal sentinel value and must not be used as input data.',
+                code='undefined-as-value',
+            )
+
+
+def _apply_exclude_if(
+    instance: Any,
+    data: dict[str, Any],
+    exclude_if: Callable[[Any, str, Any], bool],
+) -> dict[str, Any]:
+    """Apply an ``exclude_if`` callable to filter fields from serialized model output.
+
+    Recursively walks into nested model values so the callable is invoked with
+    the correct model instance at each level.
+    """
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        if exclude_if(instance, key, value):
+            continue
+        # Recurse into nested model values
+        attr = getattr(instance, key, None) if hasattr(instance, '__pydantic_fields__') else None
+        if attr is not None:
+            value = _recurse_exclude_if(attr, value, exclude_if)
+        result[key] = value
+    return result
+
+
+def _recurse_exclude_if(attr: Any, value: Any, exclude_if: Callable[[Any, str, Any], bool]) -> Any:
+    """Recurse into nested structures to apply ``exclude_if``."""
+    if hasattr(attr, '__pydantic_fields__') and isinstance(value, dict):
+        return _apply_exclude_if(attr, value, exclude_if)
+    if isinstance(attr, (list, tuple)) and isinstance(value, list):
+        return [_recurse_exclude_if(a, v, exclude_if) for a, v in zip(attr, value, strict=False)]
+    if isinstance(attr, dict) and isinstance(value, dict):
+        return {k: _recurse_exclude_if(attr.get(k), v, exclude_if) for k, v in value.items() if k in attr}
+    return value
+
+
 def _model_field_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
     model.__dict__[name] = val
     model.__pydantic_fields_set__.add(name)
@@ -435,6 +482,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_if: Callable[[Any, str, Any], bool] | None = None,
         exclude_computed_fields: bool = False,
         round_trip: bool = False,
         warnings: bool | Literal['none', 'warn', 'error'] = True,
@@ -458,6 +506,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             exclude_unset: Whether to exclude fields that have not been explicitly set.
             exclude_defaults: Whether to exclude fields that are set to their default value.
             exclude_none: Whether to exclude fields that have a value of `None`.
+            exclude_if: A callable that receives ``(instance, field_name, value)`` and returns ``True`` to
+                exclude the field. Applied after all other exclusion parameters. The ``instance`` is the
+                model instance being serialized, ``field_name`` is the key in the serialized output, and
+                ``value`` is the serialized value.
             exclude_computed_fields: Whether to exclude computed fields.
                 While this can be useful for round-tripping, it is usually recommended to use the dedicated
                 `round_trip` parameter instead.
@@ -472,7 +524,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A dictionary representation of the model.
         """
-        return self.__pydantic_serializer__.to_python(
+        result = self.__pydantic_serializer__.to_python(
             self,
             mode=mode,
             by_alias=by_alias,
@@ -489,6 +541,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             serialize_as_any=serialize_as_any,
             polymorphic_serialization=polymorphic_serialization,
         )
+        if exclude_if is not None:
+            result = _apply_exclude_if(self, result, exclude_if)
+        return result
 
     def model_dump_json(
         self,
@@ -502,6 +557,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_if: Callable[[Any, str, Any], bool] | None = None,
         exclude_computed_fields: bool = False,
         round_trip: bool = False,
         warnings: bool | Literal['none', 'warn', 'error'] = True,
@@ -525,6 +581,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             exclude_unset: Whether to exclude fields that have not been explicitly set.
             exclude_defaults: Whether to exclude fields that are set to their default value.
             exclude_none: Whether to exclude fields that have a value of `None`.
+            exclude_if: A callable that receives ``(instance, field_name, value)`` and returns ``True`` to
+                exclude the field. Applied after all other exclusion parameters. The ``instance`` is the
+                model instance being serialized, ``field_name`` is the key in the serialized output, and
+                ``value`` is the serialized value.
             exclude_computed_fields: Whether to exclude computed fields.
                 While this can be useful for round-tripping, it is usually recommended to use the dedicated
                 `round_trip` parameter instead.
@@ -539,6 +599,29 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A JSON string representation of the model.
         """
+        if exclude_if is not None:
+            # When exclude_if is used, serialize to Python first (with JSON-compatible types),
+            # apply the filter, then encode to JSON.
+            import json
+
+            data = self.model_dump(
+                mode='json',
+                include=include,
+                exclude=exclude,
+                context=context,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+                exclude_if=exclude_if,
+                exclude_computed_fields=exclude_computed_fields,
+                round_trip=round_trip,
+                warnings=warnings,
+                fallback=fallback,
+                serialize_as_any=serialize_as_any,
+                polymorphic_serialization=polymorphic_serialization,
+            )
+            return json.dumps(data, indent=indent, ensure_ascii=ensure_ascii)
         return self.__pydantic_serializer__.to_json(
             self,
             indent=indent,
@@ -728,6 +811,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 'At least one of `by_alias` or `by_name` must be set to True.',
                 code='validate-by-alias-and-name-false',
             )
+
+        if isinstance(obj, dict) and PydanticUndefined in obj.values():
+            _raise_undefined_error(obj)
 
         return cls.__pydantic_validator__.validate_python(
             obj,

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -568,6 +568,7 @@ class TypeAdapter(Generic[T]):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_if: Callable[[Any, str, Any], bool] | None = None,
         exclude_computed_fields: bool = False,
         round_trip: bool = False,
         warnings: bool | Literal['none', 'warn', 'error'] = True,
@@ -587,6 +588,8 @@ class TypeAdapter(Generic[T]):
             exclude_unset: Whether to exclude unset fields.
             exclude_defaults: Whether to exclude fields with default values.
             exclude_none: Whether to exclude fields with None values.
+            exclude_if: A callable that receives ``(instance, field_name, value)`` and returns ``True`` to
+                exclude the field. Applied after all other exclusion parameters.
             exclude_computed_fields: Whether to exclude computed fields.
                 While this can be useful for round-tripping, it is usually recommended to use the dedicated
                 `round_trip` parameter instead.
@@ -602,7 +605,7 @@ class TypeAdapter(Generic[T]):
         Returns:
             The serialized object.
         """
-        return self.serializer.to_python(
+        result = self.serializer.to_python(
             instance,
             mode=mode,
             by_alias=by_alias,
@@ -619,6 +622,11 @@ class TypeAdapter(Generic[T]):
             polymorphic_serialization=polymorphic_serialization,
             context=context,
         )
+        if exclude_if is not None and isinstance(result, dict):
+            from .main import _apply_exclude_if
+
+            result = _apply_exclude_if(instance, result, exclude_if)
+        return result
 
     def dump_json(
         self,
@@ -633,6 +641,7 @@ class TypeAdapter(Generic[T]):
         exclude_unset: bool = False,
         exclude_defaults: bool = False,
         exclude_none: bool = False,
+        exclude_if: Callable[[Any, str, Any], bool] | None = None,
         exclude_computed_fields: bool = False,
         round_trip: bool = False,
         warnings: bool | Literal['none', 'warn', 'error'] = True,
@@ -657,6 +666,8 @@ class TypeAdapter(Generic[T]):
             exclude_unset: Whether to exclude unset fields.
             exclude_defaults: Whether to exclude fields with default values.
             exclude_none: Whether to exclude fields with a value of `None`.
+            exclude_if: A callable that receives ``(instance, field_name, value)`` and returns ``True`` to
+                exclude the field. Applied after all other exclusion parameters.
             exclude_computed_fields: Whether to exclude computed fields.
                 While this can be useful for round-tripping, it is usually recommended to use the dedicated
                 `round_trip` parameter instead.
@@ -672,6 +683,28 @@ class TypeAdapter(Generic[T]):
         Returns:
             The JSON representation of the given instance as bytes.
         """
+        if exclude_if is not None:
+            import json
+
+            data = self.dump_python(
+                instance,
+                mode='json',
+                include=include,
+                exclude=exclude,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+                exclude_if=exclude_if,
+                exclude_computed_fields=exclude_computed_fields,
+                round_trip=round_trip,
+                warnings=warnings,
+                fallback=fallback,
+                serialize_as_any=serialize_as_any,
+                polymorphic_serialization=polymorphic_serialization,
+                context=context,
+            )
+            return json.dumps(data, indent=indent, ensure_ascii=ensure_ascii).encode()
         return self.serializer.to_json(
             instance,
             indent=indent,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -3165,3 +3165,218 @@ def test_model_fields_set_includes_extra_after_assignment():
     m.extra_after_init = 3
     assert m.model_fields_set == {'field', 'extra_at_init', 'extra_after_init'}
     assert m.model_extra == {'extra_at_init': 2, 'extra_after_init': 3}
+
+
+class TestPydanticUndefinedRejected:
+    """Tests for https://github.com/pydantic/pydantic/issues/11288.
+
+    PydanticUndefined should be rejected when explicitly passed as a field value.
+    """
+
+    def test_undefined_rejected_model_validate_default_factory(self):
+        class Model(BaseModel):
+            field: dict = Field(default_factory=dict)
+
+        with pytest.raises(PydanticUserError, match='undefined-as-value'):
+            Model.model_validate({'field': PydanticUndefined})
+
+    def test_undefined_rejected_model_validate_default(self):
+        class Model(BaseModel):
+            field: int = 0
+
+        with pytest.raises(PydanticUserError, match='undefined-as-value'):
+            Model.model_validate({'field': PydanticUndefined})
+
+    def test_undefined_rejected_model_validate_required(self):
+        class Model(BaseModel):
+            field: int
+
+        with pytest.raises(PydanticUserError, match='undefined-as-value'):
+            Model.model_validate({'field': PydanticUndefined})
+
+    def test_undefined_rejected_model_validate_multiple(self):
+        class Model(BaseModel):
+            a: int = 0
+            b: str = 'default'
+
+        with pytest.raises(PydanticUserError, match="Field 'a'"):
+            Model.model_validate({'a': PydanticUndefined, 'b': 'hello'})
+
+    def test_normal_values_still_work(self):
+        class Model(BaseModel):
+            field: dict = Field(default_factory=dict)
+
+        m1 = Model()
+        assert m1.field == {}
+
+        m2 = Model(field={'a': 1})
+        assert m2.field == {'a': 1}
+
+        m3 = Model.model_validate({})
+        assert m3.field == {}
+
+
+class TestExcludeIf:
+    """Tests for https://github.com/pydantic/pydantic/issues/10728.
+
+    ``exclude_if`` callable parameter for ``model_dump`` and ``model_dump_json``.
+    """
+
+    def test_exclude_empty_values(self):
+        class Model(BaseModel):
+            a: int = 0
+            b: list = []
+            c: dict = {}
+            d: str = ''
+            e: str = 'hello'
+
+        m = Model(a=1, e='world')
+        result = m.model_dump(exclude_if=lambda inst, k, v: isinstance(v, (list, dict, str)) and not v)
+        assert result == {'a': 1, 'e': 'world'}
+
+    def test_exclude_none(self):
+        class Model(BaseModel):
+            a: int
+            b: str | None = None
+
+        m = Model(a=1)
+        result = m.model_dump(exclude_if=lambda inst, k, v: v is None)
+        assert result == {'a': 1}
+
+    def test_exclude_defaults(self):
+        class Model(BaseModel):
+            a: int = 0
+            b: str = 'default'
+            c: str
+
+        m = Model(a=0, b='custom', c='val')
+        result = m.model_dump(
+            exclude_if=lambda inst, k, v: k in type(inst).model_fields and type(inst).model_fields[k].default == v
+        )
+        assert result == {'b': 'custom', 'c': 'val'}
+
+    def test_exclude_if_with_nested_model(self):
+        class Inner(BaseModel):
+            x: int = 0
+            y: str | None = None
+
+        class Outer(BaseModel):
+            name: str
+            inner: Inner
+
+        m = Outer(name='test', inner=Inner(x=1))
+        result = m.model_dump(exclude_if=lambda inst, k, v: v is None)
+        assert result == {'name': 'test', 'inner': {'x': 1}}
+
+    def test_exclude_if_with_list_of_models(self):
+        class Item(BaseModel):
+            val: int
+            tag: str | None = None
+
+        class Container(BaseModel):
+            items: list[Item]
+
+        m = Container(items=[Item(val=1, tag='a'), Item(val=2)])
+        result = m.model_dump(exclude_if=lambda inst, k, v: v is None)
+        assert result == {'items': [{'val': 1, 'tag': 'a'}, {'val': 2}]}
+
+    def test_exclude_if_none_is_noop(self):
+        class Model(BaseModel):
+            a: int = 1
+            b: str = 'x'
+
+        m = Model()
+        assert m.model_dump(exclude_if=None) == {'a': 1, 'b': 'x'}
+        assert m.model_dump() == {'a': 1, 'b': 'x'}
+
+    def test_exclude_if_combined_with_exclude_none(self):
+        class Model(BaseModel):
+            a: int = 0
+            b: str | None = None
+            c: list = []
+
+        m = Model()
+        # exclude_none removes b, exclude_if removes c
+        result = m.model_dump(
+            exclude_none=True,
+            exclude_if=lambda inst, k, v: isinstance(v, list) and not v,
+        )
+        assert result == {'a': 0}
+
+    def test_exclude_if_json_mode(self):
+        class Model(BaseModel):
+            a: int = 0
+            b: str | None = None
+            c: str = 'hello'
+
+        m = Model(a=1, c='world')
+
+        result = m.model_dump(
+            mode='json',
+            exclude_if=lambda inst, k, v: v is None,
+        )
+        assert result == {'a': 1, 'c': 'world'}
+
+    def test_model_dump_json_with_exclude_if(self):
+        import json
+
+        class Model(BaseModel):
+            a: int
+            b: str | None = None
+
+        m = Model(a=1)
+        result = m.model_dump_json(exclude_if=lambda inst, k, v: v is None)
+        assert json.loads(result) == {'a': 1}
+
+    def test_exclude_if_instance_parameter(self):
+        """The instance parameter receives the correct model instance."""
+
+        class Model(BaseModel):
+            a: int = 0
+            b: int = 0
+
+        instances = []
+
+        def capture_instance(inst, key, value):
+            instances.append(inst)
+            return False
+
+        m = Model(a=1, b=2)
+        m.model_dump(exclude_if=capture_instance)
+        assert all(inst is m for inst in instances)
+
+    def test_exclude_if_with_by_alias(self):
+        from pydantic import Field
+
+        class Model(BaseModel):
+            field_name: int = Field(alias='fieldName', default=0)
+            other: str | None = None
+
+        m = Model(**{'fieldName': 42})
+        result = m.model_dump(
+            by_alias=True,
+            exclude_if=lambda inst, k, v: v is None,
+        )
+        assert result == {'fieldName': 42}
+
+    def test_type_adapter_dump_python_exclude_if(self):
+        class Model(BaseModel):
+            a: int
+            b: str | None = None
+
+        ta = TypeAdapter(Model)
+        m = Model(a=1)
+        result = ta.dump_python(m, exclude_if=lambda inst, k, v: v is None)
+        assert result == {'a': 1}
+
+    def test_type_adapter_dump_json_exclude_if(self):
+        import json
+
+        class Model(BaseModel):
+            a: int
+            b: str | None = None
+
+        ta = TypeAdapter(Model)
+        m = Model(a=1)
+        result = ta.dump_json(m, exclude_if=lambda inst, k, v: v is None)
+        assert json.loads(result) == {'a': 1}


### PR DESCRIPTION
## Summary

- **Fix #10728**: Add `exclude_if` callable parameter to `model_dump()`, `model_dump_json()`, `TypeAdapter.dump_python()`, and `TypeAdapter.dump_json()`. The callable receives `(instance, field_name, value)` and returns `True` to exclude the field. Works recursively on nested models and lists of models.
- **Fix #11288**: Reject `PydanticUndefined` when explicitly passed as a field value in `model_validate()`. Raises `PydanticUserError` with code `'undefined-as-value'`.

## Performance

The `PydanticUndefined` check is **only in `model_validate`**, not in `__init__`. This avoids any overhead on the hot constructor path that CodSpeed benchmarks. The `exclude_if` changes only affect serialization methods (`model_dump`/`model_dump_json`) and do not touch the validation path at all.

A zero-cost fix covering `__init__` as well would require a pydantic-core change in `WithDefaultValidator` (the identity check already exists there — it just needs to raise instead of silently returning the default).

## Test plan

- [x] 5 tests for `PydanticUndefined` rejection via `model_validate` (default_factory, static default, required field, multiple fields, normal usage)
- [x] 13 tests for `exclude_if` (empty values, None, defaults, nested models, lists of models, combined with exclude_none, JSON mode, model_dump_json, by_alias, TypeAdapter dump_python/dump_json)
- [x] Linting passes (ruff check + ruff format)
- [x] `test_error_codes` passes (docs match code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)