### PR TITLE
Fix `__pydantic_extra__` type hint ignored with runtime `extra='allow'` override

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -49,7 +49,7 @@ impl BuildSerializer for ModelFieldsBuilder {
 
         let extra_serializer = match (schema.get_item(intern!(py, "extras_schema"))?, &fields_mode) {
             (Some(v), FieldsMode::ModelExtra) => Some(CombinedSerializer::build(&v.extract()?, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
+            (Some(v), _) => Some(CombinedSerializer::build(&v.extract()?, config, definitions)?),
             (_, _) => None,
         };
 

--- a/pydantic-core/src/serializers/type_serializers/typed_dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/typed_dict.rs
@@ -51,7 +51,7 @@ impl BuildSerializer for TypedDictSerializer {
             (Some(v), FieldsMode::TypedDictAllow) => {
                 Some(CombinedSerializer::build(&v.extract()?, config, definitions)?)
             }
-            (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
+            (Some(v), _) => Some(CombinedSerializer::build(&v.extract()?, config, definitions)?),
             (_, _) => None,
         };
 

--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -61,10 +61,9 @@ impl BuildValidator for DataclassArgsValidator {
 
         let extra_behavior = ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Ignore)?;
 
-        let extras_validator = match (schema.get_item(intern!(py, "extras_schema"))?, &extra_behavior) {
-            (Some(v), ExtraBehavior::Allow) => Some(build_validator(&v, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
-            (_, _) => None,
+        let extras_validator = match schema.get_item(intern!(py, "extras_schema"))? {
+            Some(v) => Some(build_validator(&v, config, definitions)?),
+            None => None,
         };
 
         let fields_schema: Bound<'_, PyList> = schema.get_as_req(intern!(py, "fields"))?;

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -66,15 +66,13 @@ impl BuildValidator for ModelFieldsValidator {
 
         let extra_behavior = ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Ignore)?;
 
-        let extras_validator = match (schema.get_item(intern!(py, "extras_schema"))?, &extra_behavior) {
-            (Some(v), ExtraBehavior::Allow) => Some(build_validator(&v, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
-            (_, _) => None,
+        let extras_validator = match schema.get_item(intern!(py, "extras_schema"))? {
+            Some(v) => Some(build_validator(&v, config, definitions)?),
+            None => None,
         };
-        let extras_keys_validator = match (schema.get_item(intern!(py, "extras_keys_schema"))?, &extra_behavior) {
-            (Some(v), ExtraBehavior::Allow) => Some(build_validator(&v, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_keys_schema can only be used if extra_behavior=allow"),
-            (_, _) => None,
+        let extras_keys_validator = match schema.get_item(intern!(py, "extras_keys_schema"))? {
+            Some(v) => Some(build_validator(&v, config, definitions)?),
+            None => None,
         };
         let model_name: String = schema
             .get_as(intern!(py, "model_name"))?

--- a/pydantic-core/src/validators/typed_dict.rs
+++ b/pydantic-core/src/validators/typed_dict.rs
@@ -64,10 +64,9 @@ impl BuildValidator for TypedDictValidator {
 
         let extra_behavior = ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Ignore)?;
 
-        let extras_validator = match (schema.get_item(intern!(py, "extras_schema"))?, &extra_behavior) {
-            (Some(v), ExtraBehavior::Allow) => Some(build_validator(&v, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
-            (_, _) => None,
+        let extras_validator = match schema.get_item(intern!(py, "extras_schema"))? {
+            Some(v) => Some(build_validator(&v, config, definitions)?),
+            None => None,
         };
 
         let fields_dict: Bound<'_, PyDict> = schema.get_as_req(intern!(py, "fields"))?;

--- a/pydantic-core/tests/validators/test_model_fields.py
+++ b/pydantic-core/tests/validators/test_model_fields.py
@@ -211,20 +211,22 @@ def test_forbid_extra():
     ]
 
 
-def test_allow_extra_invalid():
-    with pytest.raises(SchemaError, match='extras_schema can only be used if extra_behavior=allow'):
-        SchemaValidator(
-            schema=core_schema.model_fields_schema(
-                fields={}, extras_schema=core_schema.int_schema(), extra_behavior='ignore'
-            )
+def test_extras_schema_with_non_allow_extra_behavior():
+    # extras_schema/extras_keys_schema are now allowed with any extra_behavior;
+    # they are only applied when extra_behavior resolves to 'allow' at runtime.
+    v = SchemaValidator(
+        schema=core_schema.model_fields_schema(
+            fields={}, extras_schema=core_schema.int_schema(), extra_behavior='ignore'
         )
+    )
+    assert v.validate_python({}) == ({}, None, set())
 
-    with pytest.raises(SchemaError, match='extras_keys_schema can only be used if extra_behavior=allow'):
-        SchemaValidator(
-            schema=core_schema.model_fields_schema(
-                fields={}, extras_keys_schema=core_schema.int_schema(), extra_behavior='ignore'
-            )
+    v = SchemaValidator(
+        schema=core_schema.model_fields_schema(
+            fields={}, extras_keys_schema=core_schema.int_schema(), extra_behavior='ignore'
         )
+    )
+    assert v.validate_python({}) == ({}, None, set())
 
 
 def test_allow_extra_wrong():

--- a/pydantic-core/tests/validators/test_typed_dict.py
+++ b/pydantic-core/tests/validators/test_typed_dict.py
@@ -194,13 +194,15 @@ def test_forbid_extra(schema_extra_behavior: dict[str, Any], validate_fn_extra_k
     ]
 
 
-def test_allow_extra_invalid():
-    with pytest.raises(SchemaError, match='extras_schema can only be used if extra_behavior=allow'):
-        SchemaValidator(
-            schema=core_schema.typed_dict_schema(
-                fields={}, extras_schema=core_schema.int_schema(), extra_behavior='ignore'
-            )
+def test_extras_schema_with_non_allow_extra_behavior():
+    # extras_schema is now allowed with any extra_behavior;
+    # it is only applied when extra_behavior resolves to 'allow' at runtime.
+    v = SchemaValidator(
+        schema=core_schema.typed_dict_schema(
+            fields={}, extras_schema=core_schema.int_schema(), extra_behavior='ignore'
         )
+    )
+    assert v.validate_python({}) == ({}, set())
 
 
 def test_str_config():

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -818,7 +818,7 @@ class GenerateSchema:
 
                 extras_schema = None
                 extras_keys_schema = None
-                if core_config.get('extra_fields_behavior') == 'allow' and extra_info is not None:
+                if extra_info is not None:
                     tp = get_origin(extra_info.annotation)
                     if tp not in DICT_TYPES:
                         raise PydanticSchemaGenerationError(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2732,6 +2732,43 @@ def test_model_validate_with_validate_fn_override() -> None:
     ]
 
 
+def test_model_validate_extra_allow_runtime_respects_pydantic_extra_annotation() -> None:
+    """Regression test for https://github.com/pydantic/pydantic/issues/13024.
+
+    When extra='allow' is passed at runtime, __pydantic_extra__ type annotation must be respected.
+    """
+
+    class A(BaseModel, extra='forbid'):
+        __pydantic_extra__: dict[str, int]
+        a: int
+
+    # Extra field with wrong type should fail even with runtime extra='allow'
+    with pytest.raises(ValidationError) as exc_info:
+        A.model_validate({'a': 1, 'b': 'test'}, extra='allow')
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_parsing',
+            'loc': ('b',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'test',
+        }
+    ]
+
+    # Extra field with correct type should pass
+    result = A.model_validate({'a': 1, 'b': 2}, extra='allow')
+    assert result.model_extra == {'b': 2}
+
+    # Subclass with extra='allow' statically should also respect the annotation
+    class B(A, extra='allow'):
+        pass
+
+    with pytest.raises(ValidationError):
+        B.model_validate({'a': 1, 'b': 'test'})
+
+    result_b = B.model_validate({'a': 1, 'b': 2})
+    assert result_b.model_extra == {'b': 2}
+
+
 def test_model_validate_json_with_validate_fn_override() -> None:
     class Model(BaseModel):
         a: float


### PR DESCRIPTION
## Summary

Fixes #13024.

When `extra='allow'` is passed at runtime via `model_validate()`, pydantic now correctly respects the `__pydantic_extra__: dict[str, T]` type annotation on the model for validating extra field values.

**Before:**
```python
class A(BaseModel, extra='forbid'):
    __pydantic_extra__: dict[str, int]
    a: int

# Silently accepted 'test' despite int annotation - BUG
a = A.model_validate({'a': 1, 'b': 'test'}, extra='allow')
```

**After:**
```python
# Correctly raises ValidationError
A.model_validate({'a': 1, 'b': 'test'}, extra='allow')
# ValidationError: b: Input should be a valid integer
```

## Root Cause

The fix has two parts:

1. **`pydantic-core`**: Removed the restriction that `extras_schema`/`extras_keys_schema` can only appear in a schema when `extra_behavior=allow`. The schemas are now built regardless and applied only when the effective extra behavior (static or runtime-overridden) resolves to `allow`.

2. **`pydantic/_internal/_generate_schema.py`**: Always generate `extras_schema` in the model core schema when `__pydantic_extra__` is annotated, regardless of the static `extra` config. Previously it was only generated when `extra_fields_behavior == 'allow'` in the static config, causing the type hint to be ignored for runtime overrides.

## Test plan

- [x] Added regression test `test_model_validate_extra_allow_runtime_respects_pydantic_extra_annotation` in `tests/test_main.py`
- [x] Updated pydantic-core tests to reflect the relaxed constraint on `extras_schema` usage

?? Generated with [Claude Code](https://claude.com/claude-code)