### PR TITLE
fix(v1): filter _build_values kwargs; utf-8 secret file reads

### DIFF
--- a/pydantic/v1/env_settings.py
+++ b/pydantic/v1/env_settings.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import warnings
 from pathlib import Path
@@ -37,15 +38,15 @@ class BaseSettings(BaseModel):
         **values: Any,
     ) -> None:
         # Uses something other than `self` the first arg to allow "self" as a settable attribute
-        super().__init__(
-            **__pydantic_self__._build_values(
-                values,
-                _env_file=_env_file,
-                _env_file_encoding=_env_file_encoding,
-                _env_nested_delimiter=_env_nested_delimiter,
-                _secrets_dir=_secrets_dir,
-            )
-        )
+        _build_kw = {
+            '_env_file': _env_file,
+            '_env_file_encoding': _env_file_encoding,
+            '_env_nested_delimiter': _env_nested_delimiter,
+            '_secrets_dir': _secrets_dir,
+        }
+        _sig = inspect.signature(__pydantic_self__._build_values)
+        _build_kw = {k: v for k, v in _build_kw.items() if k in _sig.parameters}
+        super().__init__(**__pydantic_self__._build_values(values, **_build_kw))
 
     def _build_values(
         self,
@@ -304,7 +305,7 @@ class SecretsSettingsSource:
                     continue
 
                 if path.is_file():
-                    secret_value = path.read_text().strip()
+                    secret_value = path.read_text(encoding='utf-8').strip()
                     if field.is_complex():
                         try:
                             secret_value = settings.__config__.parse_env_var(field.name, secret_value)

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -7,6 +7,7 @@ from pydantic import VERSION
 from pydantic import BaseModel as V2BaseModel
 from pydantic.v1 import VERSION as V1_VERSION
 from pydantic.v1 import BaseModel as V1BaseModel
+from pydantic.v1 import BaseSettings as V1BaseSettings
 from pydantic.v1 import root_validator as v1_root_validator
 
 
@@ -48,3 +49,30 @@ def test_isinstance_does_not_raise_deprecation_warnings():
         assert not isinstance(v1_obj, V2BaseModel)
         assert not isinstance(v2_obj, V1BaseModel)
         assert isinstance(v2_obj, V2BaseModel)
+
+
+def test_v1_base_settings_legacy_build_values_signature(tmp_path):
+    """Subclasses that override `_build_values` without newer kwargs must not break `__init__`."""
+
+    class Settings(V1BaseSettings):
+        foo: str = 'default'
+
+        class Config:
+            secrets_dir = tmp_path
+
+        def _build_values(self, init_kwargs, _env_file=None, _env_file_encoding=None):
+            return super()._build_values(init_kwargs, _env_file=_env_file, _env_file_encoding=_env_file_encoding)
+
+    (tmp_path / 'foo').write_text('from-secret', encoding='utf-8')
+    assert Settings().foo == 'from-secret'
+
+
+def test_v1_secrets_file_utf8(tmp_path):
+    class Settings(V1BaseSettings):
+        token: str
+
+        class Config:
+            secrets_dir = tmp_path
+
+    (tmp_path / 'token').write_text('\u03bb', encoding='utf-8')
+    assert Settings().token == '\u03bb'


### PR DESCRIPTION
## Summary

- `BaseSettings.__init__` passes only keyword arguments supported by the resolved `_build_values` implementation (via `inspect.signature`), so subclasses that override `_build_values` with older signatures (without `_env_nested_delimiter` / `_secrets_dir`) no longer hit `TypeError` from unexpected keywords.
- Secret files are read with explicit UTF-8 encoding for stable behavior across platforms.

## Context

Follow-up to compatibility and encoding notes from review of settings secret-file behavior (historical #1279 / #1820); same themes apply to the v1 compatibility layer in `pydantic.v1`.

## Verification

- `uv run pytest tests/test_deprecated.py -q` (48 passed)
- Manual `pydantic.v1.BaseSettings` subclass with legacy `_build_values(self, init_kwargs, _env_file=None, _env_file_encoding=None)` calling `super()._build_values(...)`
