### PR TITLE
 Add regression tests for non-dataclass subclass serialization bug

### DIFF
--- a/investigations/issue_11773_investigation.py
+++ b/investigations/issue_11773_investigation.py
@@ -63,3 +63,4 @@ print("pydantic-core detects __dataclass_fields__ via inheritance and overrides"
 print("the serialization schema regardless of what Python-side schema is provided.")
 print("Fix must be implemented in pydantic-core's Rust serializer.")
 print("Relevant file to fix: pydantic-core/src/serializers/")
+

--- a/investigations/issue_11773_investigation.py
+++ b/investigations/issue_11773_investigation.py
@@ -63,4 +63,3 @@ print("pydantic-core detects __dataclass_fields__ via inheritance and overrides"
 print("the serialization schema regardless of what Python-side schema is provided.")
 print("Fix must be implemented in pydantic-core's Rust serializer.")
 print("Relevant file to fix: pydantic-core/src/serializers/")
-

--- a/investigations/issue_11773_investigation.py
+++ b/investigations/issue_11773_investigation.py
@@ -1,0 +1,65 @@
+"""
+Investigation Report: Issue #11773
+Non-DC subclass serialized as dataclass despite custom __get_pydantic_core_schema__
+
+Authors: Jose Lima, Varidhi Jain
+Date: April 2026
+
+CONCLUSION: Root cause is in pydantic-core (Rust), not pydantic (Python).
+"""
+
+from dataclasses import dataclass
+from pydantic_core import core_schema, SchemaSerializer
+from pydantic import TypeAdapter
+from typing import Any
+
+
+@dataclass
+class BaseDC:
+    a: int = 1
+
+
+class SubNotDC(BaseDC):
+    def __init__(self):
+        self.x = 'test'
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source: Any, handler: Any) -> Any:
+        print("STEP 1: __get_pydantic_core_schema__ called — Python-side schema generation is CORRECT")
+        return core_schema.no_info_plain_validator_function(lambda v: cls())
+
+
+# PROOF 1: Python-side schema generation works correctly
+print("=== PROOF 1: Schema Generation ===")
+result = TypeAdapter(SubNotDC).dump_python(SubNotDC())
+print(f"Result: {result}")
+print(f"Bug confirmed: should not be a dict → isinstance(result, dict) = {isinstance(result, dict)}")
+print()
+
+# PROOF 2: The bug exists even when bypassing pydantic entirely
+# and using pydantic-core's SchemaSerializer directly
+print("=== PROOF 2: pydantic-core Serializer (bypassing pydantic) ===")
+schema = core_schema.no_info_plain_validator_function(lambda v: SubNotDC())
+serializer = SchemaSerializer(schema)
+result2 = serializer.to_python(SubNotDC())
+print(f"Result: {result2}")
+print(f"Bug persists with explicit schema: {isinstance(result2, dict)}")
+print()
+
+# PROOF 3: Even attaching an explicit serializer doesn't help
+print("=== PROOF 3: Explicit Serializer Attached ===")
+schema2 = core_schema.no_info_plain_validator_function(
+    lambda v: SubNotDC(),
+    serialization=core_schema.plain_serializer_function_ser_schema(lambda v: v)
+)
+serializer2 = SchemaSerializer(schema2)
+result3 = serializer2.to_python(SubNotDC())
+print(f"Result: {result3}")
+print(f"Bug persists even with explicit serializer: {isinstance(result3, dict)}")
+print()
+
+print("=== CONCLUSION ===")
+print("pydantic-core detects __dataclass_fields__ via inheritance and overrides")
+print("the serialization schema regardless of what Python-side schema is provided.")
+print("Fix must be implemented in pydantic-core's Rust serializer.")
+print("Relevant file to fix: pydantic-core/src/serializers/")

--- a/tests/test_dataclass_inheritance.py
+++ b/tests/test_dataclass_inheritance.py
@@ -1,0 +1,92 @@
+"""
+Regression tests for GitHub Issue #11773:
+Do not consider dataclass subclasses (that aren't themselves dataclasses) as dataclasses.
+
+Root cause: dataclasses.is_dataclass() returns True for any class that inherits
+__dataclass_fields__ via MRO, even if the subclass was never @dataclass-decorated.
+Fix (in _generate_schema.py): replace is_dataclass(cls) with
+'__dataclass_fields__' in cls.__dict__
+"""
+import dataclasses
+from typing import Any
+import pytest
+from pydantic import BaseModel, TypeAdapter, PydanticSchemaGenerationError
+from pydantic_core import core_schema
+
+# Shared Base Dataclass
+@dataclasses.dataclass
+class BaseDC:
+    a: int = 1
+
+def test_subclass_with_custom_schema_not_serialized_as_dataclass():
+    """1. Exact reproduction of #11773: Custom schema must override inherited DC traits."""
+    class SubNotDC(BaseDC):
+        def __init__(self):
+            self.x = "test"
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: Any) -> Any:
+            return core_schema.no_info_plain_validator_function(lambda v: cls())
+
+    # If the bug is present, dump_python wrongly returns the parent's dict: {'a': 1}
+    # If fixed, it returns the custom SubNotDC instance.
+    result = TypeAdapter(SubNotDC).dump_python(SubNotDC())
+    assert not isinstance(result, dict)
+    assert isinstance(result, SubNotDC)
+
+def test_non_dc_subclass_as_model_field():
+    """2. Real-world usage: Ensures the fix works inside a BaseModel."""
+    class SubNotDC(BaseDC):
+        def __init__(self):
+            self.x = "test"
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: Any) -> Any:
+            return core_schema.no_info_plain_validator_function(lambda v: cls())
+
+    class MyModel(BaseModel):
+        field: SubNotDC
+
+    dumped = MyModel(field="any").model_dump()
+    
+    # The field should retain its custom serialization, not revert to {'a': 1}
+    assert not isinstance(dumped["field"], dict)
+    assert isinstance(dumped["field"], SubNotDC)
+
+def test_deep_inheritance_chain():
+    """3. Edge case: Ensures the strict check holds up over multiple inheritance levels."""
+    class ChildNotDC(BaseDC):
+        pass
+
+    class GrandChildNotDC(ChildNotDC):
+        def __init__(self):
+            self.x = "test"
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: Any) -> Any:
+            return core_schema.no_info_plain_validator_function(lambda v: cls())
+
+    result = TypeAdapter(GrandChildNotDC).dump_python(GrandChildNotDC())
+    assert not isinstance(result, dict)
+    assert isinstance(result, GrandChildNotDC)
+
+def test_non_dc_subclass_json_serialization():
+    """4. JSON path must also respect the custom schema, not the inherited DC schema."""
+    class SubNotDC(BaseDC):
+        def __init__(self):
+            self.x = "test"
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: Any) -> Any:
+            return core_schema.no_info_plain_validator_function(
+                lambda v: cls(),
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda obj: "custom_marker"
+                ),
+            )
+
+    json_bytes = TypeAdapter(SubNotDC).dump_json(SubNotDC())
+    # Before fix: b'{"a":1}' — parent DC schema used
+    # After fix: b'"custom_marker"' — custom schema honoured
+    assert json_bytes != b'{"a":1}'
+    assert b"custom_marker" in json_bytes

--- a/tests/test_dataclass_inheritance.py
+++ b/tests/test_dataclass_inheritance.py
@@ -7,6 +7,8 @@ __dataclass_fields__ via MRO, even if the subclass was never @dataclass-decorate
 Fix (in _generate_schema.py): replace is_dataclass(cls) with
 '__dataclass_fields__' in cls.__dict__
 """
+from __future__ import annotations
+
 import dataclasses
 from typing import Any
 

--- a/tests/test_dataclass_inheritance.py
+++ b/tests/test_dataclass_inheritance.py
@@ -11,6 +11,7 @@ import dataclasses
 from typing import Any
 
 import pytest
+
 from pydantic import BaseModel, TypeAdapter
 from pydantic_core import core_schema
 

--- a/tests/test_dataclass_inheritance.py
+++ b/tests/test_dataclass_inheritance.py
@@ -18,6 +18,7 @@ from pydantic_core import core_schema
 class BaseDC:
     a: int = 1
 
+@pytest.mark.xfail(reason="Root cause in pydantic-core Rust serializer, see #11773", strict=True)
 def test_subclass_with_custom_schema_not_serialized_as_dataclass():
     """1. Exact reproduction of #11773: Custom schema must override inherited DC traits."""
     class SubNotDC(BaseDC):
@@ -34,6 +35,7 @@ def test_subclass_with_custom_schema_not_serialized_as_dataclass():
     assert not isinstance(result, dict)
     assert isinstance(result, SubNotDC)
 
+@pytest.mark.xfail(reason="Root cause in pydantic-core Rust serializer, see #11773", strict=True)
 def test_non_dc_subclass_as_model_field():
     """2. Real-world usage: Ensures the fix works inside a BaseModel."""
     class SubNotDC(BaseDC):
@@ -53,6 +55,7 @@ def test_non_dc_subclass_as_model_field():
     assert not isinstance(dumped["field"], dict)
     assert isinstance(dumped["field"], SubNotDC)
 
+@pytest.mark.xfail(reason="Root cause in pydantic-core Rust serializer, see #11773", strict=True)
 def test_deep_inheritance_chain():
     """3. Edge case: Ensures the strict check holds up over multiple inheritance levels."""
     class ChildNotDC(BaseDC):

--- a/tests/test_dataclass_inheritance.py
+++ b/tests/test_dataclass_inheritance.py
@@ -9,8 +9,9 @@ Fix (in _generate_schema.py): replace is_dataclass(cls) with
 """
 import dataclasses
 from typing import Any
+
 import pytest
-from pydantic import BaseModel, TypeAdapter, PydanticSchemaGenerationError
+from pydantic import BaseModel, TypeAdapter
 from pydantic_core import core_schema
 
 # Shared Base Dataclass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Adds regression tests and a root cause investigation for issue #11773.

When a plain class inherits from a `@dataclass` but is not itself decorated 
with `@dataclass`, Pydantic incorrectly serializes it as a dataclass, ignoring 
any custom `__get_pydantic_core_schema__` defined on the subclass.

Through investigation we confirmed that:
- `__get_pydantic_core_schema__` is called correctly on the Python side
- The bug persists when using `pydantic-core`'s `SchemaSerializer` directly
- Attaching an explicit serializer to the schema does not override the behavior

This points to the root cause being in **pydantic-core's Rust serializer**, 
which detects `__dataclass_fields__` via inheritance and overrides serialization 
regardless of the schema provided from the Python side.

## Related issue number
Related #11773

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**