### PR TITLE
Raise clear TypeError when AliasPath first arg is not a str

### DIFF
--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -25,6 +25,13 @@ class AliasPath:
     path: list[int | str]
 
     def __init__(self, first_arg: str, *args: str | int) -> None:
+        if not isinstance(first_arg, str):
+            raise TypeError(
+                f'The first argument to AliasPath must be a str (a dict key), '
+                f'got {type(first_arg).__name__}. '
+                f'Subsequent segments may be str (dict keys) or int (sequence indices), '
+                f"e.g. AliasPath('data', 0)."
+            )
         self.path = [first_arg] + list(args)
 
     def convert_to_aliases(self) -> list[str | int]:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -611,6 +611,18 @@ def test_search_dict_for_alias_path():
     assert ap.search_dict_for_path({'a': 'hello'}) is PydanticUndefined
 
 
+def test_alias_path_first_arg_must_be_str():
+    """The first segment of an AliasPath must be a string dict key.
+
+    Regression test for #13112: passing an int as the first arg used to
+    surface as an opaque pydantic-core SchemaError at model build time.
+    """
+    with pytest.raises(TypeError, match='first argument to AliasPath must be a str'):
+        AliasPath(0)
+    with pytest.raises(TypeError, match='first argument to AliasPath must be a str'):
+        AliasPath(0, 'a')
+
+
 def test_validation_alias_invalid_value_type():
     m = 'Invalid `validation_alias` type. it should be `str`, `AliasChoices`, or `AliasPath`'
     with pytest.raises(TypeError, match=m):


### PR DESCRIPTION
The first segment of an AliasPath is documented as a dict key, but passing a non-string would slide past Pythons unenforced type hint and surface later as an opaque pydantic-core SchemaError during model build:

    pydantic_core._pydantic_core.SchemaError: Error building model
    validator: ... TypeError: int object cannot be converted to
    PyList

Validate the first argument in AliasPath.__init__ and raise a TypeError that explains the constraint and shows a correct example.

Closes #13112

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
