### PR TITLE
docs(validators): document model_validator execution order with inheritance

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -551,6 +551,53 @@ decorator.
 
     Overriding a model validator in a subclass will override the base class' validator, and thus only the subclass' version of said validator will be called.
 
+    **Execution order with inheritance.** When the same mode is defined on both a base class and a subclass (under different names, so neither overrides the other), validators run in the following order:
+
+    * `mode='before'`: the **subclass** validator runs first, then the **base class** validator. The data flows from subclass to base before reaching pydantic-core.
+    * `mode='after'`: the **base class** validator runs first, then the **subclass** validator. The instance flows from base to subclass after pydantic-core has built it.
+    * `mode='wrap'`: the **subclass** wrapper is the outermost layer, and the **base class** wrapper sits inside it (so the subclass' wrapper begins first and ends last).
+
+    Note that subclass `mode='after'` validators run *outside* a base class `mode='wrap'` validator, not inside it. If you need an `after` validator to be wrapped by an inherited `wrap` validator, define the `wrap` validator on the subclass instead.
+
+    ```python {test="skip"}
+    from pydantic import BaseModel, model_validator
+
+
+    class Base(BaseModel):
+        @model_validator(mode='before')
+        @classmethod
+        def base_before(cls, data):
+            print('base before')
+            return data
+
+        @model_validator(mode='after')
+        def base_after(self):
+            print('base after')
+            return self
+
+
+    class Sub(Base):
+        @model_validator(mode='before')
+        @classmethod
+        def sub_before(cls, data):
+            print('sub before')
+            return data
+
+        @model_validator(mode='after')
+        def sub_after(self):
+            print('sub after')
+            return self
+
+
+    Sub()
+    """
+    sub before
+    base before
+    base after
+    sub after
+    """
+    ```
+
 ## Raising validation errors
 
 To raise a validation error, three types of exceptions can be used:


### PR DESCRIPTION
## Why

Issue #10790 (and the related thread in #8277) shows that the order in which `@model_validator` runs across an inheritance chain is non-obvious — especially that a subclass `mode='after'` validator runs *outside* a base class `mode='wrap'`, not inside it. The current "On inheritance" admonition only says inherited validators are called, not in what order.

## What

Extends the existing "On inheritance" admonition under `## Model validators` in `docs/concepts/validators.md` with:

- A short rule per mode (`before`, `after`, `wrap`) describing the parent/child execution order.
- An explicit note about the `wrap` + subclass `after` interaction (the surprising case in #10790).
- A minimal runnable example with a base class and a subclass each defining `before` and `after` validators, with the expected output as a docstring block.

The example is marked `{test="skip"}` to avoid coupling the doc test runner to print-ordering details, matching the pattern used by other examples in this file.

## Tested

Verified the documented order against the empirical output in #10790 (reproducer by the original reporter, confirmed independently by other commenters in the thread) and against the validator collection logic in `pydantic/_internal/_decorators.py` (`reversed(mro(typ)[1:-1])` plus the typ's own decorators last).

Closes #10790
