### PR TITLE
fix(json_schema): serialization-mode Decimal pattern now accepts scientific notation

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -693,7 +693,7 @@ class GenerateJsonSchema:
             The generated JSON schema.
         """
 
-        def get_decimal_pattern(schema: core_schema.DecimalSchema) -> str:
+        def get_decimal_pattern(schema: core_schema.DecimalSchema, *, serialization_mode: bool) -> str:
             max_digits = schema.get('max_digits')
             decimal_places = schema.get('decimal_places')
 
@@ -701,40 +701,54 @@ class GenerateJsonSchema:
                 r'^(?!^[-+.]*$)[+-]?0*'  # check it is not empty string and not one or sequence of ".+-" characters.
             )
 
+            # pydantic-core serializes Decimal values using str(), which produces
+            # scientific notation for very small/large values (e.g. "1E-7").
+            # In serialization mode we only need to describe the output format;
+            # max_digits/decimal_places constraints are already enforced on input.
+            sci = r'(?:[eE][+-]?\d+)?' if serialization_mode else r''
+
             # Case 1: Both max_digits and decimal_places are set
             if max_digits is not None and decimal_places is not None:
-                integer_places = max(0, max_digits - decimal_places)
-                pattern += (
-                    rf'(?:'
-                    rf'\d{{0,{integer_places}}}'
-                    rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
-                    rf')'
-                )
+                if serialization_mode:
+                    pattern += rf'\d*\.?\d*{sci}$'
+                else:
+                    integer_places = max(0, max_digits - decimal_places)
+                    pattern += (
+                        rf'(?:'
+                        rf'\d{{0,{integer_places}}}'
+                        rf'|'
+                        rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
+                        rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
+                        rf')'
+                    )
 
             # Case 2: Only max_digits is set
             elif max_digits is not None and decimal_places is None:
-                pattern += (
-                    rf'(?:'
-                    rf'\d{{0,{max_digits}}}'
-                    rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d*\.\d*0*$'
-                    rf')'
-                )
+                if serialization_mode:
+                    pattern += rf'\d*\.?\d*{sci}$'
+                else:
+                    pattern += (
+                        rf'(?:'
+                        rf'\d{{0,{max_digits}}}'
+                        rf'|'
+                        rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
+                        rf'\d*\.\d*0*$'
+                        rf')'
+                    )
 
             # Case 3: Only decimal_places is set
             elif max_digits is None and decimal_places is not None:
-                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*$'
+                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*{sci}$'
 
             # Case 4: Both are None (no restrictions)
             else:
-                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
+                pattern += rf'\d*\.?\d*{sci}$'  # look for arbitrary integer or decimal
 
             return pattern
 
-        json_schema = self.str_schema(core_schema.str_schema(pattern=get_decimal_pattern(schema)))
+        json_schema = self.str_schema(
+            core_schema.str_schema(pattern=get_decimal_pattern(schema, serialization_mode=self.mode == 'serialization'))
+        )
         if self.mode == 'validation':
             multiple_of = schema.get('multiple_of')
             le = schema.get('le')

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -545,7 +545,7 @@ def test_decimal_json_schema():
                 'default': '12.34',
                 'title': 'B',
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         },
         'title': 'Model',
@@ -7141,6 +7141,66 @@ def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places
 ) -> None:
     pattern = get_decimal_pattern()
     assert re.fullmatch(pattern, invalid_decimal) is None
+
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        Decimal('0.0000001'),   # str() → '1E-7'
+        Decimal('1.23E+20'),    # str() → '1.23E+20'
+        Decimal('1E+10'),       # str() → '1E+10'
+        Decimal('5E-3'),        # str() → '5E-3'
+        Decimal('1.5'),         # str() → '1.5' (fixed-point still works)
+        Decimal('100'),         # str() → '100'
+    ],
+)
+def test_decimal_serialization_schema_matches_own_output(value: Decimal) -> None:
+    """Regression test for #13089: serialization schema pattern must accept
+    values that pydantic-core's own str()-based serializer produces."""
+
+    class Model(BaseModel):
+        v: Decimal
+
+    schema = Model.model_json_schema(mode='serialization')
+    pattern = schema['properties']['v']['pattern']
+    serialized = json.loads(Model(v=value).model_dump_json())['v']
+    assert re.fullmatch(pattern, serialized) is not None, (
+        f'Serialization schema pattern {pattern!r} rejected '
+        f'own serialized value {serialized!r} for Decimal({str(value)!r})'
+    )
+
+
+@pytest.fixture
+def get_decimal_serialization_pattern():
+    def pattern(max_digits=None, decimal_places=None) -> str:
+        ta = TypeAdapter(Annotated[Decimal, Field(max_digits=max_digits, decimal_places=decimal_places)])
+        return ta.json_schema(mode='serialization')['pattern']
+
+    return pattern
+
+
+@pytest.mark.parametrize(
+    'sci_value',
+    ['1E-7', '1E+20', '1.23E+10', '5E-3', '1.5e2', '1.0e-0'],
+)
+def test_decimal_serialization_pattern_accepts_scientific_notation(
+    sci_value, get_decimal_serialization_pattern
+) -> None:
+    pattern = get_decimal_serialization_pattern()
+    assert re.fullmatch(pattern, sci_value) is not None
+
+
+@pytest.mark.parametrize(
+    'sci_value',
+    ['1E-7', '1E+20', '1.23E+10'],
+)
+def test_decimal_serialization_pattern_accepts_scientific_notation_with_constraints(
+    sci_value, get_decimal_serialization_pattern
+) -> None:
+    """Scientific notation accepted in serialization mode even when max_digits/decimal_places are set."""
+    assert re.fullmatch(get_decimal_serialization_pattern(max_digits=10, decimal_places=5), sci_value) is not None
+    assert re.fullmatch(get_decimal_serialization_pattern(max_digits=10), sci_value) is not None
+    assert re.fullmatch(get_decimal_serialization_pattern(decimal_places=5), sci_value) is not None
 
 
 def test_union_format_primitive_type_array() -> None:


### PR DESCRIPTION
Closes #13089.

## Summary

`model_json_schema(mode='serialization')` generates a regex pattern for `Decimal` fields. The pattern introduced in #11987 has no `[eE]` component, but `pydantic-core` serializes `Decimal` values using Python's `str()`, which emits scientific notation for very small or large values (e.g. `Decimal('0.0000001')` → `"1E-7"`). This means the schema rejects values that pydantic's own serializer produces.

The fix passes a `serialization_mode` flag into `get_decimal_pattern`. In serialization mode:

- **Cases 3 & 4** (no `max_digits` or with only `decimal_places`): appends `(?:[eE][+-]?\d+)?` before the closing `$` so scientific notation strings pass.
- **Cases 1 & 2** (with `max_digits`): uses a simpler unconstrained pattern since those constraints are already enforced at validation time, not serialization time.

The validation-mode pattern is unchanged.

## Changes

- `pydantic/json_schema.py`: extend `get_decimal_pattern` to accept `serialization_mode`; in serialization mode, include optional exponent group.
- `tests/test_json_schema.py`: update the `test_decimal_json_schema` snapshot; add regression tests covering all four constraint combinations and verifying the schema matches actual `model_dump_json()` output.