### PR TITLE
docs: clarify before model validator input

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -517,7 +517,9 @@ decorator.
        can be anything.
     2. Most of the time, the input data will be a dictionary (e.g. when calling `UserModel(username='...')`). However,
        this is not always the case. For instance, if the [`from_attributes`][pydantic.ConfigDict.from_attributes]
-       configuration value is set, you might receive an arbitrary class instance for the `data` argument.
+       configuration value is set, you might receive an arbitrary class instance for the `data` argument. Because
+       the raw input can be any object, avoid assuming that `data` is a dictionary and guard dictionary-specific
+       access with `isinstance()` checks before mutating or reading from it.
 
 * ***Wrap* validators**: are the most flexible of all. You can run code before or after Pydantic and
   other validators process the input data, or you can terminate validation immediately, either by returning


### PR DESCRIPTION
## Change Summary

Clarify that `mode='before'` model validators receive raw input, so the value passed to the validator is not always a dictionary. The docs now recommend guarding dictionary-specific access with `isinstance()` before reading or mutating the input.

## Related issue number

fix #12945

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## Local validation

* `uv sync --python 3.12 --frozen --all-packages --group docs --group testing-extra`
* `PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}" make docs`
* `git diff --check -- docs/concepts/validators.md`

Notes: this is a documentation-only change, so I did not add unit tests. I also ran `uv run pytest tests/test_docs.py::test_docs_examples -q -k validators --tb=short`; it fails with existing Ruff I001 import-order failures in docs examples, and the same failure reproduces after reverting `docs/concepts/validators.md` to `origin/main`.


Selected Reviewer: @Viicos