### PR TITLE
Preserve RootModel root field examples in JSON schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1665,6 +1665,11 @@ class GenerateJsonSchema:
         elif issubclass(cls, RootModel) and (root_description := cls.__pydantic_fields__['root'].description):
             json_schema.setdefault('description', root_description)
 
+        if issubclass(cls, RootModel):
+            root_examples = cls.__pydantic_fields__['root'].examples
+            if root_examples is not None:
+                json_schema['examples'] = to_jsonable_python(root_examples)
+
         extra = config.get('extra')
         if 'additionalProperties' not in json_schema:  # This check is particularly important for `typed_dict_schema()`
             if extra == 'allow':

--- a/tests/test_root_model.py
+++ b/tests/test_root_model.py
@@ -590,6 +590,30 @@ def test_json_schema_extra_on_field():
     }
 
 
+def test_json_schema_examples_on_parametrized_root_model():
+    root_type = Annotated[str, Field(examples=['hello', 'world'])]
+
+    class Model(RootModel[root_type]):
+        pass
+
+    assert Model.model_json_schema() == {
+        'examples': ['hello', 'world'],
+        'title': 'Model',
+        'type': 'string',
+    }
+
+
+def test_json_schema_examples_on_annotated_root_field():
+    class Model(RootModel):
+        root: Annotated[str, Field(examples=['hello', 'world'])]
+
+    assert Model.model_json_schema() == {
+        'examples': ['hello', 'world'],
+        'title': 'Model',
+        'type': 'string',
+    }
+
+
 def test_json_schema_extra_on_model_and_on_field():
     class Model(RootModel):
         model_config = ConfigDict(json_schema_extra={'schema key on model': 'schema value on model'})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Preserve `Field(examples=...)` declared on `RootModel.root` in the top-level JSON schema, including when the root type is provided via `RootModel[Annotated[..., Field(...)]].`

## Related issue number

Fix #13123

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
