### PR TITLE
fix(docs): preserve nested code block indentation

### DIFF
--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -158,6 +158,7 @@ def upgrade_python(markdown: str) -> str:
 
         py_code = match.group(2)
         numbers = match.group(3)
+        base_indent = re.match(r' *', prefix).group(0)
         # import devtools
         # devtools.debug(numbers)
         output = []
@@ -171,8 +172,8 @@ def upgrade_python(markdown: str) -> str:
                     continue
                 last_code = tab_code
 
-            content = indent(f'{prefix}\n{tab_code}```{numbers}', ' ' * 4)
-            output.append(f'=== "Python 3.{minor_version} and above"\n\n{content}')
+            content = indent(f'{prefix}\n{tab_code}```{numbers}', f'{base_indent}    ')
+            output.append(f'{base_indent}=== "Python 3.{minor_version} and above"\n\n{content}')
 
         if len(output) == 1:
             return match.group(0)


### PR DESCRIPTION
## Change Summary

Preserve the original indentation level when `upgrade_python()` rewrites nested documentation code blocks into version tabs, so `Run Code` examples in nested validator docs keep their class/method indentation intact.

## Related issue number

Fixes #7968

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos