### PR TITLE
Adapt `MISSING` sentinel test to work with unreleased `typing_extensions` version

### DIFF
--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -2,6 +2,7 @@ import pickle
 from typing import Annotated
 
 import pytest
+import typing_extensions
 from annotated_types import Ge
 from pydantic_core import MISSING, PydanticSerializationUnexpectedValue
 
@@ -53,7 +54,11 @@ class ModelPickle(BaseModel):
     f: int | MISSING = MISSING
 
 
-@pytest.mark.xfail(reason="PEP 661 sentinels aren't picklable yet in the experimental typing-extensions implementation")
+@pytest.mark.xfail(
+    # Unreleased typing-extensions has the final sentinel implementation with pickle support:
+    condition=not hasattr(typing_extensions, 'sentinel'),
+    reason="PEP 661 sentinels aren't picklable yet in the experimental typing-extensions implementation",
+)
 def test_missing_sentinel_pickle() -> None:
     m = ModelPickle()
     m_reconstructed = pickle.loads(pickle.dumps(m))


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

To unblock https://github.com/python/typing_extensions/issues/746#issuecomment-4357746912.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
