### PR TITLE
Fallback to `create_model()` overload definition when `__base__` is set to a type variable

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -105,7 +105,7 @@ MYPY_VERSION_TUPLE = parse_mypy_version(mypy_version)
 BUILTINS_NAME = 'builtins'
 
 # Increment version if plugin changes and mypy caches should be invalidated
-__version__ = 2
+__version__ = 3
 
 
 def plugin(version: str) -> type[Plugin]:
@@ -190,8 +190,18 @@ class PydanticPlugin(Plugin):
             if arg_name == '__base__' and isinstance(arg_expr, RefExpr) and arg_expr.node is not None:
                 if isinstance(arg_expr.node, TypeInfo):
                     base_fullname = arg_expr.node.fullname
-                elif isinstance(arg_expr.node, Var) and isinstance(arg_expr.node.type, Instance):
-                    base_fullname = arg_expr.node.type.type.fullname
+                elif isinstance(arg_expr.node, Var):
+                    arg_type = get_proper_type(arg_expr.node.type)
+                    if isinstance(arg_type, Instance):
+                        base_fullname = arg_type.type.fullname
+                    elif isinstance(arg_type, TypeType):
+                        item_type = get_proper_type(arg_type.item)
+                        if isinstance(item_type, TypeVarType):
+                            # Inside classmethods, ``cls`` is modeled as ``type[Self]``. Creating a concrete
+                            # synthetic type here loses that type variable, so let mypy use the overload return.
+                            return
+                        if isinstance(item_type, Instance):
+                            base_fullname = item_type.type.fullname
 
         base_sym = ctx.api.lookup_fully_qualified_or_none(base_fullname)
         if base_sym is None or not isinstance(base_sym.node, TypeInfo):

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -106,7 +106,7 @@ MYPY_VERSION_TUPLE = parse_mypy_version(mypy_version)
 BUILTINS_NAME = 'builtins'
 
 # Increment version if plugin changes and mypy caches should be invalidated
-__version__ = 3
+__version__ = 2
 
 
 def plugin(version: str) -> type[Plugin]:
@@ -198,8 +198,9 @@ class PydanticPlugin(Plugin):
                     elif isinstance(arg_type, TypeType):
                         item_type = get_proper_type(arg_type.item)
                         if isinstance(item_type, TypeVarType):
-                            # Inside classmethods, ``cls`` is modeled as ``type[Self]``. Creating a concrete
-                            # synthetic type here loses that type variable, so let mypy use the overload return.
+                            # Inside classmethods, `cls` is modeled as `type[Self]`. Creating a concrete
+                            # synthetic type here loses that type variable, so let mypy use infer the correct type
+                            # from the `create_model()` overload with the type var instead.
                             return
                         if isinstance(item_type, Instance):
                             base_fullname = item_type.type.fullname

--- a/tests/mypy/modules/create_model_var.py
+++ b/tests/mypy/modules/create_model_var.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+from typing_extensions import Self
+
 from pydantic import BaseModel, create_model
 
 
@@ -10,3 +14,11 @@ SubModel = create_model('SubModel', __base__=Model)
 
 class Main(BaseModel):
     sub: SubModel
+
+
+class ClassmethodModel(BaseModel):
+    @classmethod
+    def composite(cls) -> type[Self]:
+        fields: dict[str, Any] = {'plugin_id': (int, ...)}
+        model = create_model(cls.__name__, __base__=cls, **fields)
+        return model

--- a/tests/mypy/outputs/mypy-plugin_ini/create_model_var.py
+++ b/tests/mypy/outputs/mypy-plugin_ini/create_model_var.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+from typing_extensions import Self
+
 from pydantic import BaseModel, create_model
 
 
@@ -10,3 +14,11 @@ SubModel = create_model('SubModel', __base__=Model)
 
 class Main(BaseModel):
     sub: SubModel
+
+
+class ClassmethodModel(BaseModel):
+    @classmethod
+    def composite(cls) -> type[Self]:
+        fields: dict[str, Any] = {'plugin_id': (int, ...)}
+        model = create_model(cls.__name__, __base__=cls, **fields)
+        return model


### PR DESCRIPTION
## Change Summary

- Let mypy keep the normal `create_model()` overload return when `__base__` is a classmethod `cls` typed as `type[Self]`, instead of creating a concrete synthetic dynamic class that loses `Self`.
- Add a mypy regression for `create_model(..., __base__=cls)` inside a `@classmethod` returning `type[Self]`.

## Related issue number

Fix #13115

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos