### PR TITLE
Adapt `pydantic-core` linker flags on macOS

### DIFF
--- a/pydantic-core/build.rs
+++ b/pydantic-core/build.rs
@@ -13,4 +13,13 @@ fn main() {
     }
     println!("cargo:rustc-check-cfg=cfg(specified_profile_use)");
     println!("cargo:rustc-env=PROFILE={}", std::env::var("PROFILE").unwrap());
+
+    // The macOS `ld_prime` new Linker (used in macOS 15 GitHub CI runners),
+    // reserves significantly less Mach-O header padding than the old linker.
+    // Tools like Homebrew use install_name_tool to rewrite dylib paths post-install,
+    // and that requires spare space in the header. Without this flag the relink
+    // fails with "updated load commands do not fit in the header".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
+    }
 }


### PR DESCRIPTION
This allows downsteam tools to rewrite dylib after installation.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13136.

@washingtoneg, do you happen to have a link pointing to where this was initially found? Is there any Homebrew issue about it?

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
