### PR TITLE
Warn on unknown config keys in the Mypy plugin

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -264,11 +264,8 @@ class PydanticPluginConfig:
                     raise ValueError(f'Configuration value must be a boolean for key: {key}')
                 setattr(self, key, setting)
             unknown_keys = config.keys() - set(self.__slots__)
-            if unknown_keys:
-                warnings.warn(
-                    f'Unknown pydantic-mypy config keys: {", ".join(sorted(unknown_keys))}',
-                    stacklevel=2,
-                )
+            for key in sorted(unknown_keys):
+                print(f'[pydantic-mypy]: Unrecognized option: {key} = {config[key]}', file=sys.stderr)
         else:
             plugin_config = ConfigParser()
             plugin_config.read(options.config_file)
@@ -277,11 +274,8 @@ class PydanticPluginConfig:
                 setattr(self, key, setting)
             if plugin_config.has_section(CONFIGFILE_KEY):
                 unknown_keys = set(plugin_config.options(CONFIGFILE_KEY)) - set(self.__slots__)
-                if unknown_keys:
-                    warnings.warn(
-                        f'Unknown pydantic-mypy config keys: {", ".join(sorted(unknown_keys))}',
-                        stacklevel=2,
-                    )
+                for key in sorted(unknown_keys):
+                    print(f'[pydantic-mypy]: Unrecognized option: {key} = {plugin_config.get(CONFIGFILE_KEY, key)}', file=sys.stderr)
 
     def to_data(self) -> dict[str, Any]:
         """Returns a dict of config names to their values."""

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from collections.abc import Callable, Iterator
 from configparser import ConfigParser
 from typing import Any
@@ -262,12 +263,25 @@ class PydanticPluginConfig:
                 if not isinstance(setting, bool):
                     raise ValueError(f'Configuration value must be a boolean for key: {key}')
                 setattr(self, key, setting)
+            unknown_keys = config.keys() - set(self.__slots__)
+            if unknown_keys:
+                warnings.warn(
+                    f'Unknown pydantic-mypy config keys: {", ".join(sorted(unknown_keys))}',
+                    stacklevel=2,
+                )
         else:
             plugin_config = ConfigParser()
             plugin_config.read(options.config_file)
             for key in self.__slots__:
                 setting = plugin_config.getboolean(CONFIGFILE_KEY, key, fallback=False)
                 setattr(self, key, setting)
+            if plugin_config.has_section(CONFIGFILE_KEY):
+                unknown_keys = set(plugin_config.options(CONFIGFILE_KEY)) - set(self.__slots__)
+                if unknown_keys:
+                    warnings.warn(
+                        f'Unknown pydantic-mypy config keys: {", ".join(sorted(unknown_keys))}',
+                        stacklevel=2,
+                    )
 
     def to_data(self) -> dict[str, Any]:
         """Returns a dict of config names to their values."""

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import warnings
 from collections.abc import Callable, Iterator
 from configparser import ConfigParser
 from typing import Any
@@ -265,7 +264,7 @@ class PydanticPluginConfig:
                 setattr(self, key, setting)
             unknown_keys = config.keys() - set(self.__slots__)
             for key in sorted(unknown_keys):
-                print(f'[pydantic-mypy]: Unrecognized option: {key} = {config[key]}', file=sys.stderr)
+                print(f'[pydantic-mypy]: Unrecognized option: {key} = {config[key]}', file=sys.stderr)  # noqa: T201
         else:
             plugin_config = ConfigParser()
             plugin_config.read(options.config_file)
@@ -275,7 +274,7 @@ class PydanticPluginConfig:
             if plugin_config.has_section(CONFIGFILE_KEY):
                 unknown_keys = set(plugin_config.options(CONFIGFILE_KEY)) - set(self.__slots__)
                 for key in sorted(unknown_keys):
-                    print(f'[pydantic-mypy]: Unrecognized option: {key} = {plugin_config.get(CONFIGFILE_KEY, key)}', file=sys.stderr)
+                    print(f'[pydantic-mypy]: Unrecognized option: {key} = {plugin_config.get(CONFIGFILE_KEY, key)}', file=sys.stderr)  # noqa: T201
 
     def to_data(self) -> dict[str, Any]:
         """Returns a dict of config names to their values."""

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -274,7 +274,10 @@ class PydanticPluginConfig:
             if plugin_config.has_section(CONFIGFILE_KEY):
                 unknown_keys = set(plugin_config.options(CONFIGFILE_KEY)) - set(self.__slots__)
                 for key in sorted(unknown_keys):
-                    print(f'[pydantic-mypy]: Unrecognized option: {key} = {plugin_config.get(CONFIGFILE_KEY, key)}', file=sys.stderr)  # noqa: T201
+                    print(  # noqa: T201
+                        f'[pydantic-mypy]: Unrecognized option: {key} = {plugin_config.get(CONFIGFILE_KEY, key)}',
+                        file=sys.stderr,
+                    )
 
     def to_data(self) -> dict[str, Any]:
         """Returns a dict of config names to their values."""

--- a/tests/mypy/configs/mypy-plugin-unknown-param.ini
+++ b/tests/mypy/configs/mypy-plugin-unknown-param.ini
@@ -1,0 +1,20 @@
+[mypy]
+plugins = pydantic.mypy
+
+follow_imports = silent
+strict_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+disallow_any_generics = True
+check_untyped_defs = True
+no_implicit_reexport = True
+disallow_untyped_defs = True
+
+python_version = 3.10
+
+[pydantic-mypy]
+init_forbid_extra = True
+warn_untyped_fields = True
+
+[mypy-pydantic_core.*]
+follow_imports = skip

--- a/tests/mypy/configs/mypy-plugin-very-strict.ini
+++ b/tests/mypy/configs/mypy-plugin-very-strict.ini
@@ -9,4 +9,3 @@ python_version = 3.10
 init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True
-warn_untyped_fields = True

--- a/tests/mypy/configs/pyproject-plugin-unknown-param.toml
+++ b/tests/mypy/configs/pyproject-plugin-unknown-param.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["poetry>=0.12"]
+build_backend = "poetry.masonry.api"
+
+[tool.poetry]
+name = "test"
+version = "0.0.1"
+readme = "README.md"
+authors = [
+    "author@example.com"
+]
+
+[tool.poetry.dependencies]
+python = "*"
+
+[tool.pytest.ini_options]
+addopts = "-v -p no:warnings"
+
+[tool.mypy]
+plugins = [
+    "pydantic.mypy"
+]
+follow_imports = "silent"
+strict_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+disallow_untyped_defs = true
+
+python_version = '3.10'
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+warn_untyped_fields = true  # unknown key, should trigger a warning
+
+[[tool.mypy.overrides]]
+module = [
+    'pydantic_core.*',
+]
+follow_imports = "skip"

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -197,6 +197,16 @@ def test_bad_toml_config() -> None:
     assert str(e.value) == 'Configuration value must be a boolean for key: init_forbid_extra'
 
 
+def test_unknown_toml_config_key() -> None:
+    full_config_filename = 'tests/mypy/configs/pyproject-plugin-unknown-param.toml'
+    full_filename = 'tests/mypy/modules/generics.py'  # File doesn't matter
+
+    command = [full_filename, '--config-file', full_config_filename, '--show-error-codes']
+    print(f'\nExecuting: mypy {" ".join(command)}')  # makes it easier to debug as necessary
+    with pytest.warns(UserWarning, match='Unknown pydantic-mypy config keys: warn_untyped_fields'):
+        mypy_api.run(command)
+
+
 @pytest.mark.parametrize('module', ['dataclass_no_any', 'plugin_success', 'plugin_success_baseConfig'])
 def test_success_cases_run(module: str) -> None:
     """

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -202,7 +202,6 @@ def test_unknown_toml_config_key(capsys: pytest.CaptureFixture[str]) -> None:
     full_filename = 'tests/mypy/modules/generics.py'  # File doesn't matter
 
     command = [full_filename, '--config-file', full_config_filename, '--show-error-codes']
-    print(f'\nExecuting: mypy {" ".join(command)}')  # makes it easier to debug as necessary
     mypy_api.run(command)
     captured = capsys.readouterr()
     assert '[pydantic-mypy]: Unrecognized option: warn_untyped_fields = True' in captured.err
@@ -213,7 +212,6 @@ def test_unknown_ini_config_key(capsys: pytest.CaptureFixture[str]) -> None:
     full_filename = 'tests/mypy/modules/generics.py'  # File doesn't matter
 
     command = [full_filename, '--config-file', full_config_filename, '--show-error-codes']
-    print(f'\nExecuting: mypy {" ".join(command)}')  # makes it easier to debug as necessary
     mypy_api.run(command)
     captured = capsys.readouterr()
     assert '[pydantic-mypy]: Unrecognized option: warn_untyped_fields = True' in captured.err

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -197,14 +197,26 @@ def test_bad_toml_config() -> None:
     assert str(e.value) == 'Configuration value must be a boolean for key: init_forbid_extra'
 
 
-def test_unknown_toml_config_key() -> None:
+def test_unknown_toml_config_key(capsys: pytest.CaptureFixture[str]) -> None:
     full_config_filename = 'tests/mypy/configs/pyproject-plugin-unknown-param.toml'
     full_filename = 'tests/mypy/modules/generics.py'  # File doesn't matter
 
     command = [full_filename, '--config-file', full_config_filename, '--show-error-codes']
     print(f'\nExecuting: mypy {" ".join(command)}')  # makes it easier to debug as necessary
-    with pytest.warns(UserWarning, match='Unknown pydantic-mypy config keys: warn_untyped_fields'):
-        mypy_api.run(command)
+    mypy_api.run(command)
+    captured = capsys.readouterr()
+    assert '[pydantic-mypy]: Unrecognized option: warn_untyped_fields = True' in captured.err
+
+
+def test_unknown_ini_config_key(capsys: pytest.CaptureFixture[str]) -> None:
+    full_config_filename = 'tests/mypy/configs/mypy-plugin-unknown-param.ini'
+    full_filename = 'tests/mypy/modules/generics.py'  # File doesn't matter
+
+    command = [full_filename, '--config-file', full_config_filename, '--show-error-codes']
+    print(f'\nExecuting: mypy {" ".join(command)}')  # makes it easier to debug as necessary
+    mypy_api.run(command)
+    captured = capsys.readouterr()
+    assert '[pydantic-mypy]: Unrecognized option: warn_untyped_fields = True' in captured.err
 
 
 @pytest.mark.parametrize('module', ['dataclass_no_any', 'plugin_success', 'plugin_success_baseConfig'])


### PR DESCRIPTION
Closes #13148.

## What this does

Unknown keys in `[tool.pydantic-mypy]` / `[pydantic-mypy]` config sections were silently ignored. This makes it easy for users to have dead config (e.g. `warn_untyped_fields`, which was never ported from V1 to V2) with no feedback.

This PR prints to stderr for each unrecognised key, one line per key, for both the TOML and INI config paths.

**Example:**

```toml
[tool.pydantic-mypy]
init_forbid_extra = true
warn_untyped_fields = true  # V1 leftover — now warns instead of silently ignoring
```

```
[pydantic-mypy]: Unrecognized option: warn_untyped_fields = True
```

## Changes

- `pydantic/mypy.py`: added unknown key validation in `PydanticPluginConfig.__init__` for both TOML and INI paths
- `tests/mypy/configs/mypy-plugin-very-strict.ini`: removed `warn_untyped_fields = True` (V1 leftover with no effect in V2)
- `tests/mypy/configs/pyproject-plugin-unknown-param.toml`: new test config with an unknown key for TOML path
- `tests/mypy/configs/mypy-plugin-unknown-param.ini`: new test config with an unknown key for INI path
- `tests/mypy/test_mypy.py`: added `test_unknown_toml_config_key` and `test_unknown_ini_config_key`

Note: re-implementing `warn_untyped_fields` for V2 is out of scope for this PR.