### PR TITLE
Fix TzInfo shutdown SIGSEGV via Python-level inheritance (pydantic#12…

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,17 @@
 <!-- markdownlint-disable descriptive-link-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 
+## v2.13.4 (unreleased)
+
+### What's Changed
+
+#### Fixes
+
+* Fix SIGSEGV (exit 139) during CPython interpreter shutdown when a `pydantic_core.TzInfo` instance is alive at process exit (#12867).
+  Removes C-level `extends = PyTzInfo`; instead creates a Python-level `TzInfo` class that inherits from both the Rust-backed base and `datetime.tzinfo`.
+  `datetime.tzinfo` remains in the MRO (so `PyTZInfo_Check` still passes), but `tp_base` is the Rust class so `subtype_dealloc` never traverses `PyDateTimeAPI` pointers that may be dangling after `_datetime` cleanup.
+  A `PyOnceLock<Py<PyAny>>` static holds a permanent strong reference to the class, keeping it alive past `_PyImport_Cleanup` without a manual `Py_INCREF`.
+
 ## v2.13.3 (2026-04-20)
 
 [GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.3)

--- a/pydantic-core/src/input/datetime.rs
+++ b/pydantic-core/src/input/datetime.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::pyclass::CompareOp;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::PyDateAccess;
 use pyo3::types::PyTimeAccess;
 use pyo3::types::PyTuple;
@@ -402,8 +403,13 @@ impl EitherTime<'_> {
 fn time_as_tzinfo<'py>(py: Python<'py>, time: &Time) -> PyResult<Option<Bound<'py, PyTzInfo>>> {
     match time.tz_offset {
         Some(offset) => {
-            let tz_info: TzInfo = offset.try_into()?;
-            Ok(Some(Bound::new(py, tz_info)?.into_any().cast_into()?))
+            // Instantiate via the Python-level TzInfo class (set at module init).
+            // That class inherits from (RustTzInfo, datetime.tzinfo) so instances
+            // pass PyTZInfo_Check while tp_base does NOT point to datetime.tzinfo,
+            // eliminating the PyDateTimeAPI-pointer-chain traversal during shutdown.
+            let tz_class = TZINFO_PY_CLASS.get(py).expect("pydantic_core not fully initialized");
+            let tz_obj = tz_class.bind(py).call1((offset,))?;
+            Ok(Some(tz_obj.cast_into()?))
         }
         None => Ok(None),
     }
@@ -726,7 +732,17 @@ pub fn float_as_duration(input: impl ToErrorValue, total_seconds: f64) -> ValRes
         .map_err(|err| map_timedelta_err(input, err))
 }
 
-#[pyclass(module = "pydantic_core._pydantic_core", extends = PyTzInfo, frozen, skip_from_py_object)]
+// Holds the Python-level TzInfo class created at module init.
+// The PyOnceLock is never dropped (static lifetime), so this acts as a permanent
+// strong reference that keeps the class alive past _PyImport_Cleanup.
+static TZINFO_PY_CLASS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+/// Called from `module_init` with the Python-level `TzInfo` class object.
+pub fn set_tzinfo_py_class(py: Python<'_>, class: Py<PyAny>) {
+    let _ = TZINFO_PY_CLASS.get_or_init(py, || class);
+}
+
+#[pyclass(module = "pydantic_core._pydantic_core", frozen, subclass, skip_from_py_object)]
 #[derive(Clone)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct TzInfo {
@@ -806,13 +822,19 @@ impl TzInfo {
         }
     }
 
-    fn __deepcopy__(&self, py: Python, _memo: &Bound<'_, PyDict>) -> PyResult<Py<Self>> {
-        Py::new(py, self.clone())
+    fn __deepcopy__<'py>(&self, py: Python<'py>, _memo: &Bound<'_, PyDict>) -> PyResult<Bound<'py, PyAny>> {
+        // TzInfo is frozen (immutable), so deepcopy can create a new instance of the
+        // same Python-level class with the same offset rather than cloning the Rust struct.
+        let tz_class = TZINFO_PY_CLASS.get(py).expect("pydantic_core not fully initialized");
+        tz_class.bind(py).call1((self.seconds,))
     }
 
     pub fn __reduce__<'py>(slf: &Bound<'py, Self>) -> PyResult<Bound<'py, PyTuple>> {
-        let args = (slf.get().seconds,);
-        (slf.get_type(), args).into_pyobject(slf.py())
+        // Always pickle using the public Python-level TzInfo class so that unpickling
+        // produces a proper datetime.tzinfo subclass instance.
+        let py = slf.py();
+        let tz_class = TZINFO_PY_CLASS.get(py).expect("pydantic_core not fully initialized");
+        (tz_class.bind(py), (slf.get().seconds,)).into_pyobject(py)
     }
 }
 

--- a/pydantic-core/src/input/mod.rs
+++ b/pydantic-core/src/input/mod.rs
@@ -10,11 +10,11 @@ mod input_string;
 mod return_enums;
 mod shared;
 
-pub use datetime::TzInfo;
 pub(crate) use datetime::{
     EitherDate, EitherDateTime, EitherTimedelta, duration_as_pytimedelta, pydate_as_date, pydatetime_as_datetime,
     pytime_as_time,
 };
+pub use datetime::{TzInfo, set_tzinfo_py_class};
 pub(crate) use input_abstract::{
     Arguments, BorrowInput, ConsumeIterator, Input, InputType, KeywordArgs, PositionalArgs, ValidatedDict,
     ValidatedList, ValidatedSet, ValidatedTuple,

--- a/pydantic-core/src/lib.rs
+++ b/pydantic-core/src/lib.rs
@@ -126,6 +126,39 @@ pub mod _pydantic_core {
         m.add("build_info", build_info())?;
         m.add("_recursion_limit", recursion_guard::RECURSION_GUARD_LIMIT)?;
         m.add("PydanticUndefined", PydanticUndefinedType::get(m.py()))?;
+        // ---------------------------------------------------------------------------
+        // Fix for pydantic_core.TzInfo shutdown SIGSEGV (pydantic#12867)
+        //
+        // The Rust TzInfo struct has no C-level `extends = PyTzInfo` so its tp_base
+        // chain is simply `object`.  Here we create a Python-level class that inherits
+        // from *both* the Rust-backed TzInfo *and* `datetime.tzinfo`:
+        //
+        //   class TzInfo(RustTzInfo, datetime.tzinfo): pass
+        //
+        // This gives instances the correct MRO so that PyTZInfo_Check still passes
+        // (datetime.tzinfo is in the MRO), while tp_base stays as RustTzInfo (the
+        // "best base" — largest basicsize).  subtype_dealloc therefore traverses:
+        //   TzInfo → RustTzInfo → object
+        // ...and never touches PyDateTime_CAPI pointers that may be dangling after
+        // _datetime module cleanup.
+        //
+        // The PyOnceLock in `input::datetime` holds a strong Py<PyAny> reference to
+        // the new class.  PyOnceLock is intentionally never dropped (static lifetime),
+        // which keeps the class alive past _PyImport_Cleanup — fixing the class-freed-
+        // before-instances race (Bug 1) without a manual Py_INCREF.
+        // ---------------------------------------------------------------------------
+        let py = m.py();
+        let rust_tzinfo = py.get_type::<TzInfo>().into_any();
+        let datetime_mod = py.import("datetime")?;
+        let py_tzinfo_base = datetime_mod.getattr("tzinfo")?;
+        let bases = pyo3::types::PyTuple::new(py, [rust_tzinfo, py_tzinfo_base])?;
+        let class_dict = pyo3::types::PyDict::new(py);
+        class_dict.set_item("__module__", "pydantic_core._pydantic_core")?;
+        let new_tzinfo: Bound<'_, PyAny> = py
+            .get_type::<pyo3::types::PyType>()
+            .call1(("TzInfo", bases, class_dict))?;
+        m.setattr("TzInfo", &new_tzinfo)?;
+        crate::input::set_tzinfo_py_class(py, new_tzinfo.unbind());
         Ok(())
     }
 }


### PR DESCRIPTION
…867)

Alternative to the dealloc-guard approach: removes C-level `extends = PyTzInfo` from the TzInfo #[pyclass] and instead builds the inheritance relationship at module init time via Python's type machinery:

    class TzInfo(RustTzInfo, datetime.tzinfo): pass   # created in module_init

This gives instances the correct MRO so that PyTZInfo_Check still passes (datetime.tzinfo is in the MRO via Python-level multiple inheritance), while tp_base stays as RustTzInfo (the "best base" — largest tp_basicsize). subtype_dealloc therefore traverses RustTzInfo → object and never touches PyDateTime_CAPI type pointers that may be dangling after _datetime cleanup.

Bug 1 (class freed before instances) is fixed for free: the PyOnceLock static in input/datetime.rs holds a Py<PyAny> strong reference to the Python-level class and is never dropped (static lifetime), keeping the class alive past _PyImport_Cleanup without a manual Py_INCREF.

Additional changes:
- TzInfo gains the `subclass` pyclass flag (sets Py_TPFLAGS_BASETYPE) so Python's type() can use it as a base when building the wrapper class.
- time_as_tzinfo(), __deepcopy__(), and __reduce__() all instantiate/return the Python-level TzInfo class (via TZINFO_PY_CLASS PyOnceLock) so that all public-facing instances are proper datetime.tzinfo subtype instances.

No regression test: the bug cannot be reliably reproduced on CPython 3.12 in the current codebase (TzInfo accumulates ~22 internal references from method descriptors, keeping the class alive past _PyImport_Cleanup even without the fix). See pydantic#12867 for details.

Closes pydantic#12867.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
