### PR TITLE
support rfc2822 temporal_mode in pydantic_core.to_json

### DIFF
--- a/pydantic-core/python/pydantic_core/_pydantic_core.pyi
+++ b/pydantic-core/python/pydantic_core/_pydantic_core.pyi
@@ -425,7 +425,7 @@ def to_json(
     exclude_none: bool = False,
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',
-    temporal_mode: Literal['iso8601', 'seconds', 'milliseconds'] = 'iso8601',
+    temporal_mode: Literal['iso8601', 'seconds', 'milliseconds', 'rfc2822'] = 'iso8601',
     bytes_mode: Literal['utf8', 'base64', 'hex'] = 'utf8',
     inf_nan_mode: Literal['null', 'constants', 'strings'] = 'constants',
     serialize_unknown: bool = False,
@@ -450,8 +450,9 @@ def to_json(
         exclude_none: Whether to exclude fields that have a value of `None`.
         round_trip: Whether to enable serialization and validation round-trip support.
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
-        temporal_mode: How to serialize datetime-like objects (`datetime`, `date`, `time`), either `'iso8601'`, `'seconds'`, or `'milliseconds'`.
-            `iso8601` returns an ISO 8601 string; `seconds` returns the Unix timestamp in seconds as a float; `milliseconds` returns the Unix timestamp in milliseconds as a float.
+        temporal_mode: How to serialize datetime-like objects (`datetime`, `date`, `time`), either `'iso8601'`, `'seconds'`, `'milliseconds'`, or `'rfc2822'`.
+            `iso8601` returns an ISO 8601 string; `seconds` returns the Unix timestamp in seconds as a float; `milliseconds` returns the Unix timestamp in milliseconds as a float;
+            `rfc2822` returns an RFC 2822 (HTTP) date string (e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`), matching the output of `werkzeug.http.http_date`. `datetime` values are converted to UTC before formatting (naive datetimes are assumed UTC), and bare `date` values are treated as midnight UTC; `time` and `timedelta` fall back to ISO 8601.
 
         bytes_mode: How to serialize `bytes` objects, either `'utf8'`, `'base64'`, or `'hex'`.
         inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.
@@ -512,7 +513,7 @@ def to_jsonable_python(
     exclude_none: bool = False,
     round_trip: bool = False,
     timedelta_mode: Literal['iso8601', 'float'] = 'iso8601',
-    temporal_mode: Literal['iso8601', 'seconds', 'milliseconds'] = 'iso8601',
+    temporal_mode: Literal['iso8601', 'seconds', 'milliseconds', 'rfc2822'] = 'iso8601',
     bytes_mode: Literal['utf8', 'base64', 'hex'] = 'utf8',
     inf_nan_mode: Literal['null', 'constants', 'strings'] = 'constants',
     serialize_unknown: bool = False,
@@ -535,8 +536,9 @@ def to_jsonable_python(
         exclude_none: Whether to exclude fields that have a value of `None`.
         round_trip: Whether to enable serialization and validation round-trip support.
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
-        temporal_mode: How to serialize datetime-like objects (`datetime`, `date`, `time`), either `'iso8601'`, `'seconds'`, or `'milliseconds'`.
-            `iso8601` returns an ISO 8601 string; `seconds` returns the Unix timestamp in seconds as a float; `milliseconds` returns the Unix timestamp in milliseconds as a float.
+        temporal_mode: How to serialize datetime-like objects (`datetime`, `date`, `time`), either `'iso8601'`, `'seconds'`, `'milliseconds'`, or `'rfc2822'`.
+            `iso8601` returns an ISO 8601 string; `seconds` returns the Unix timestamp in seconds as a float; `milliseconds` returns the Unix timestamp in milliseconds as a float;
+            `rfc2822` returns an RFC 2822 (HTTP) date string (e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`), matching the output of `werkzeug.http.http_date`. `datetime` values are converted to UTC before formatting (naive datetimes are assumed UTC), and bare `date` values are treated as midnight UTC; `time` and `timedelta` fall back to ISO 8601.
 
         bytes_mode: How to serialize `bytes` objects, either `'utf8'`, `'base64'`, or `'hex'`.
         inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.

--- a/pydantic-core/python/pydantic_core/_pydantic_core.pyi
+++ b/pydantic-core/python/pydantic_core/_pydantic_core.pyi
@@ -452,7 +452,7 @@ def to_json(
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
         temporal_mode: How to serialize datetime-like objects (`datetime`, `date`, `time`), either `'iso8601'`, `'seconds'`, `'milliseconds'`, or `'rfc2822'`.
             `iso8601` returns an ISO 8601 string; `seconds` returns the Unix timestamp in seconds as a float; `milliseconds` returns the Unix timestamp in milliseconds as a float;
-            `rfc2822` returns an RFC 2822 (HTTP) date string (e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`), matching the output of `werkzeug.http.http_date`. `datetime` values are converted to UTC before formatting (naive datetimes are assumed UTC), and bare `date` values are treated as midnight UTC; `time` and `timedelta` fall back to ISO 8601.
+            `rfc2822` returns an RFC 2822 (HTTP) date string (e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`), produced by delegating to Python's `email.utils.format_datetime(dt, usegmt=True)`. `datetime` values are converted to UTC before formatting (naive datetimes are assumed UTC), and bare `date` values are treated as midnight UTC; `time` and `timedelta` fall back to ISO 8601.
 
         bytes_mode: How to serialize `bytes` objects, either `'utf8'`, `'base64'`, or `'hex'`.
         inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.
@@ -538,7 +538,7 @@ def to_jsonable_python(
         timedelta_mode: How to serialize `timedelta` objects, either `'iso8601'` or `'float'`.
         temporal_mode: How to serialize datetime-like objects (`datetime`, `date`, `time`), either `'iso8601'`, `'seconds'`, `'milliseconds'`, or `'rfc2822'`.
             `iso8601` returns an ISO 8601 string; `seconds` returns the Unix timestamp in seconds as a float; `milliseconds` returns the Unix timestamp in milliseconds as a float;
-            `rfc2822` returns an RFC 2822 (HTTP) date string (e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`), matching the output of `werkzeug.http.http_date`. `datetime` values are converted to UTC before formatting (naive datetimes are assumed UTC), and bare `date` values are treated as midnight UTC; `time` and `timedelta` fall back to ISO 8601.
+            `rfc2822` returns an RFC 2822 (HTTP) date string (e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`), produced by delegating to Python's `email.utils.format_datetime(dt, usegmt=True)`. `datetime` values are converted to UTC before formatting (naive datetimes are assumed UTC), and bare `date` values are treated as midnight UTC; `time` and `timedelta` fall back to ISO 8601.
 
         bytes_mode: How to serialize `bytes` objects, either `'utf8'`, `'base64'`, or `'hex'`.
         inf_nan_mode: How to serialize `Infinity`, `-Infinity` and `NaN` values, either `'null'`, `'constants'`, or `'strings'`.

--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -110,7 +110,7 @@ class CoreConfig(TypedDict, total=False):
     allow_inf_nan: bool  # default: True
     # the config options are used to customise serialization to JSON
     ser_json_timedelta: Literal['iso8601', 'float']  # default: 'iso8601'
-    ser_json_temporal: Literal['iso8601', 'seconds', 'milliseconds']  # default: 'iso8601'
+    ser_json_temporal: Literal['iso8601', 'seconds', 'milliseconds', 'rfc2822']  # default: 'iso8601'
     ser_json_bytes: Literal['utf8', 'base64', 'hex']  # default: 'utf8'
     ser_json_inf_nan: Literal['null', 'constants', 'strings']  # default: 'null'
     val_json_bytes: Literal['utf8', 'base64', 'hex']  # default: 'utf8'

--- a/pydantic-core/src/serializers/config.rs
+++ b/pydantic-core/src/serializers/config.rs
@@ -11,8 +11,8 @@ use serde::ser::Error;
 use crate::build_tools::py_schema_err;
 use crate::input::{EitherTimedelta, pydate_as_date, pydatetime_as_datetime, pytime_as_time};
 use crate::serializers::type_serializers::datetime_etc::{
-    date_to_milliseconds, date_to_seconds, datetime_to_milliseconds, datetime_to_seconds, time_to_milliseconds,
-    time_to_seconds,
+    date_to_milliseconds, date_to_rfc2822, date_to_seconds, datetime_to_milliseconds, datetime_to_rfc2822,
+    datetime_to_seconds, time_to_milliseconds, time_to_seconds,
 };
 use crate::tools::SchemaDict;
 
@@ -127,7 +127,8 @@ serialization_mode! {
     "ser_json_temporal",
     Iso8601 => "iso8601",
     Seconds => "seconds",
-    Milliseconds => "milliseconds"
+    Milliseconds => "milliseconds",
+    Rfc2822 => "rfc2822",
 }
 
 serialization_mode! {
@@ -164,6 +165,7 @@ impl TemporalMode {
             Self::Iso8601 => dt.to_string().into_py_any(py),
             Self::Seconds => datetime_to_seconds(dt).into_py_any(py),
             Self::Milliseconds => datetime_to_milliseconds(dt).into_py_any(py),
+            Self::Rfc2822 => datetime_to_rfc2822(dt).into_py_any(py),
         }
     }
 
@@ -173,13 +175,16 @@ impl TemporalMode {
             Self::Iso8601 => date.to_string().into_py_any(py),
             Self::Seconds => date_to_seconds(date).into_py_any(py),
             Self::Milliseconds => date_to_milliseconds(date).into_py_any(py),
+            // A bare `date` is treated as midnight UTC, matching `werkzeug.http.http_date`.
+            Self::Rfc2822 => date_to_rfc2822(date).into_py_any(py),
         }
     }
 
     pub fn time_to_json(self, py: Python, time: &Bound<'_, PyTime>) -> PyResult<Py<PyAny>> {
         let time = pytime_as_time(time)?;
         match self {
-            Self::Iso8601 => time.to_string().into_py_any(py),
+            // RFC 2822 has no standalone time format, so we fall back to ISO 8601.
+            Self::Iso8601 | Self::Rfc2822 => time.to_string().into_py_any(py),
             Self::Seconds => time_to_seconds(time).into_py_any(py),
             Self::Milliseconds => time_to_milliseconds(time).into_py_any(py),
         }
@@ -187,7 +192,8 @@ impl TemporalMode {
 
     pub fn timedelta_to_json(self, py: Python, either_delta: EitherTimedelta) -> PyResult<Py<PyAny>> {
         match self {
-            Self::Iso8601 => {
+            // RFC 2822 has no concept of duration, so we fall back to ISO 8601.
+            Self::Iso8601 | Self::Rfc2822 => {
                 let d = either_delta.to_duration()?;
                 d.to_string().into_py_any(py)
             }
@@ -208,6 +214,7 @@ impl TemporalMode {
             Self::Iso8601 => Ok(dt.to_string().into()),
             Self::Seconds => Ok(datetime_to_seconds(dt).to_string().into()),
             Self::Milliseconds => Ok(datetime_to_milliseconds(dt).to_string().into()),
+            Self::Rfc2822 => Ok(datetime_to_rfc2822(dt).into()),
         }
     }
 
@@ -217,13 +224,16 @@ impl TemporalMode {
             Self::Iso8601 => Ok(date.to_string().into()),
             Self::Seconds => Ok(date_to_seconds(date).to_string().into()),
             Self::Milliseconds => Ok(date_to_milliseconds(date).to_string().into()),
+            // A bare `date` is treated as midnight UTC, matching `werkzeug.http.http_date`.
+            Self::Rfc2822 => Ok(date_to_rfc2822(date).into()),
         }
     }
 
     pub fn time_json_key<'py>(self, time: &Bound<'_, PyTime>) -> PyResult<Cow<'py, str>> {
         let time = pytime_as_time(time)?;
         match self {
-            Self::Iso8601 => Ok(time.to_string().into()),
+            // RFC 2822 has no standalone time format, so we fall back to ISO 8601.
+            Self::Iso8601 | Self::Rfc2822 => Ok(time.to_string().into()),
             Self::Seconds => Ok(time_to_seconds(time).to_string().into()),
             Self::Milliseconds => Ok(time_to_milliseconds(time).to_string().into()),
         }
@@ -231,7 +241,8 @@ impl TemporalMode {
 
     pub fn timedelta_json_key<'py>(self, either_delta: &EitherTimedelta) -> PyResult<Cow<'py, str>> {
         match self {
-            Self::Iso8601 => {
+            // RFC 2822 has no concept of duration, so we fall back to ISO 8601.
+            Self::Iso8601 | Self::Rfc2822 => {
                 let d = either_delta.to_duration()?;
                 Ok(d.to_string().into())
             }
@@ -256,6 +267,7 @@ impl TemporalMode {
             Self::Iso8601 => serializer.collect_str(&dt),
             Self::Seconds => serializer.serialize_f64(datetime_to_seconds(dt)),
             Self::Milliseconds => serializer.serialize_f64(datetime_to_milliseconds(dt)),
+            Self::Rfc2822 => serializer.serialize_str(&datetime_to_rfc2822(dt)),
         }
     }
 
@@ -269,6 +281,8 @@ impl TemporalMode {
             Self::Iso8601 => serializer.collect_str(&date),
             Self::Seconds => serializer.serialize_f64(date_to_seconds(date)),
             Self::Milliseconds => serializer.serialize_f64(date_to_milliseconds(date)),
+            // A bare `date` is treated as midnight UTC, matching `werkzeug.http.http_date`.
+            Self::Rfc2822 => serializer.serialize_str(&date_to_rfc2822(date)),
         }
     }
 
@@ -279,7 +293,8 @@ impl TemporalMode {
     ) -> Result<S::Ok, S::Error> {
         let time = pytime_as_time(time).map_err(py_err_se_err)?;
         match self {
-            Self::Iso8601 => serializer.collect_str(&time),
+            // RFC 2822 has no standalone time format, so we fall back to ISO 8601.
+            Self::Iso8601 | Self::Rfc2822 => serializer.collect_str(&time),
             Self::Seconds => serializer.serialize_f64(time_to_seconds(time)),
             Self::Milliseconds => serializer.serialize_f64(time_to_milliseconds(time)),
         }
@@ -291,7 +306,8 @@ impl TemporalMode {
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         match self {
-            Self::Iso8601 => {
+            // RFC 2822 has no concept of duration, so we fall back to ISO 8601.
+            Self::Iso8601 | Self::Rfc2822 => {
                 let d = either_delta.to_duration().map_err(py_err_se_err)?;
                 serializer.collect_str(&d)
             }

--- a/pydantic-core/src/serializers/config.rs
+++ b/pydantic-core/src/serializers/config.rs
@@ -160,23 +160,32 @@ impl From<TimedeltaMode> for TemporalMode {
 
 impl TemporalMode {
     pub fn datetime_to_json(self, py: Python, datetime: &Bound<'_, PyDateTime>) -> PyResult<Py<PyAny>> {
+        // For `Rfc2822` we delegate to Python's `email.utils.format_datetime` without going
+        // through speedate, so handle it before parsing.
+        if let Self::Rfc2822 = self {
+            return datetime_to_rfc2822(py, datetime)?.into_py_any(py);
+        }
         let dt = pydatetime_as_datetime(datetime)?;
         match self {
             Self::Iso8601 => dt.to_string().into_py_any(py),
             Self::Seconds => datetime_to_seconds(dt).into_py_any(py),
             Self::Milliseconds => datetime_to_milliseconds(dt).into_py_any(py),
-            Self::Rfc2822 => datetime_to_rfc2822(dt).into_py_any(py),
+            Self::Rfc2822 => unreachable!("handled above"),
         }
     }
 
     pub fn date_to_json(self, py: Python, date: &Bound<'_, PyDate>) -> PyResult<Py<PyAny>> {
+        // For `Rfc2822` we delegate to Python's `email.utils.format_datetime` without going
+        // through speedate, so handle it before parsing.
+        if let Self::Rfc2822 = self {
+            return date_to_rfc2822(py, date)?.into_py_any(py);
+        }
         let date = pydate_as_date(date)?;
         match self {
             Self::Iso8601 => date.to_string().into_py_any(py),
             Self::Seconds => date_to_seconds(date).into_py_any(py),
             Self::Milliseconds => date_to_milliseconds(date).into_py_any(py),
-            // A bare `date` is treated as midnight UTC, matching `werkzeug.http.http_date`.
-            Self::Rfc2822 => date_to_rfc2822(date).into_py_any(py),
+            Self::Rfc2822 => unreachable!("handled above"),
         }
     }
 
@@ -209,23 +218,28 @@ impl TemporalMode {
     }
 
     pub fn datetime_json_key<'py>(self, datetime: &Bound<'_, PyDateTime>) -> PyResult<Cow<'py, str>> {
+        if let Self::Rfc2822 = self {
+            return Ok(datetime_to_rfc2822(datetime.py(), datetime)?.into());
+        }
         let dt = pydatetime_as_datetime(datetime)?;
         match self {
             Self::Iso8601 => Ok(dt.to_string().into()),
             Self::Seconds => Ok(datetime_to_seconds(dt).to_string().into()),
             Self::Milliseconds => Ok(datetime_to_milliseconds(dt).to_string().into()),
-            Self::Rfc2822 => Ok(datetime_to_rfc2822(dt).into()),
+            Self::Rfc2822 => unreachable!("handled above"),
         }
     }
 
     pub fn date_json_key<'py>(self, date: &Bound<'_, PyDate>) -> PyResult<Cow<'py, str>> {
-        let date = pydate_as_date(date)?;
+        if let Self::Rfc2822 = self {
+            return Ok(date_to_rfc2822(date.py(), date)?.into());
+        }
+        let parsed = pydate_as_date(date)?;
         match self {
-            Self::Iso8601 => Ok(date.to_string().into()),
-            Self::Seconds => Ok(date_to_seconds(date).to_string().into()),
-            Self::Milliseconds => Ok(date_to_milliseconds(date).to_string().into()),
-            // A bare `date` is treated as midnight UTC, matching `werkzeug.http.http_date`.
-            Self::Rfc2822 => Ok(date_to_rfc2822(date).into()),
+            Self::Iso8601 => Ok(parsed.to_string().into()),
+            Self::Seconds => Ok(date_to_seconds(parsed).to_string().into()),
+            Self::Milliseconds => Ok(date_to_milliseconds(parsed).to_string().into()),
+            Self::Rfc2822 => unreachable!("handled above"),
         }
     }
 
@@ -262,12 +276,16 @@ impl TemporalMode {
         datetime: &Bound<'_, PyDateTime>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
+        if let Self::Rfc2822 = self {
+            let formatted = datetime_to_rfc2822(datetime.py(), datetime).map_err(py_err_se_err)?;
+            return serializer.serialize_str(&formatted);
+        }
         let dt = pydatetime_as_datetime(datetime).map_err(py_err_se_err)?;
         match self {
             Self::Iso8601 => serializer.collect_str(&dt),
             Self::Seconds => serializer.serialize_f64(datetime_to_seconds(dt)),
             Self::Milliseconds => serializer.serialize_f64(datetime_to_milliseconds(dt)),
-            Self::Rfc2822 => serializer.serialize_str(&datetime_to_rfc2822(dt)),
+            Self::Rfc2822 => unreachable!("handled above"),
         }
     }
 
@@ -276,13 +294,16 @@ impl TemporalMode {
         date: &Bound<'_, PyDate>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        let date = pydate_as_date(date).map_err(py_err_se_err)?;
+        if let Self::Rfc2822 = self {
+            let formatted = date_to_rfc2822(date.py(), date).map_err(py_err_se_err)?;
+            return serializer.serialize_str(&formatted);
+        }
+        let parsed = pydate_as_date(date).map_err(py_err_se_err)?;
         match self {
-            Self::Iso8601 => serializer.collect_str(&date),
-            Self::Seconds => serializer.serialize_f64(date_to_seconds(date)),
-            Self::Milliseconds => serializer.serialize_f64(date_to_milliseconds(date)),
-            // A bare `date` is treated as midnight UTC, matching `werkzeug.http.http_date`.
-            Self::Rfc2822 => serializer.serialize_str(&date_to_rfc2822(date)),
+            Self::Iso8601 => serializer.collect_str(&parsed),
+            Self::Seconds => serializer.serialize_f64(date_to_seconds(parsed)),
+            Self::Milliseconds => serializer.serialize_f64(date_to_milliseconds(parsed)),
+            Self::Rfc2822 => unreachable!("handled above"),
         }
     }
 

--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -43,6 +43,71 @@ pub(crate) fn time_to_milliseconds(time: Time) -> f64 {
         + f64::from(time.microsecond) / 1_000.0
 }
 
+const RFC2822_DAY_NAMES: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const RFC2822_MONTH_NAMES: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/// Format a `Date` as an RFC 2822 (HTTP) date string at midnight UTC,
+/// e.g. "Mon, 01 Jan 2024 00:00:00 GMT".
+///
+/// This mirrors the behaviour of `werkzeug.http.http_date`, which combines a bare
+/// `date` with midnight in UTC before formatting.
+pub(crate) fn date_to_rfc2822(date: Date) -> String {
+    let midnight = Time {
+        hour: 0,
+        minute: 0,
+        second: 0,
+        microsecond: 0,
+        tz_offset: None,
+    };
+    datetime_to_rfc2822(DateTime { date, time: midnight })
+}
+
+/// Format a `DateTime` as an RFC 2822 date string with `GMT` as the zone label,
+/// e.g. "Mon, 01 Jan 2024 12:00:00 GMT".
+///
+/// This matches the output of Python's `email.utils.format_datetime(dt, usegmt=True)`,
+/// which is what `werkzeug.http.http_date` uses for the HTTP `Date` header (the format
+/// is RFC 2822 / RFC 5322 §3.3, which RFC 7231 §7.1.1.1 designates as the preferred HTTP
+/// date format).
+///
+/// The datetime is converted to UTC before formatting:
+/// - If `tz_offset` is `None` (naive), it is assumed to already be UTC.
+/// - If `tz_offset` is `Some`, the offset is subtracted from the timestamp to get UTC.
+pub(crate) fn datetime_to_rfc2822(dt: DateTime) -> String {
+    // Compute the UTC unix timestamp (seconds since 1970-01-01 UTC).
+    // `DateTime::timestamp()` ignores the timezone offset and returns the timestamp
+    // as if the date/time were UTC, so we need to subtract the offset to get the
+    // true UTC timestamp.
+    let local_ts = dt.date.timestamp()
+        + i64::from(dt.time.hour) * 3600
+        + i64::from(dt.time.minute) * 60
+        + i64::from(dt.time.second);
+    let tz_offset = i64::from(dt.time.tz_offset.unwrap_or(0));
+    let utc_ts = local_ts - tz_offset;
+
+    // Compute date parts from the UTC timestamp using `Date::from_timestamp`-style
+    // logic via `DateTime::from_timestamp`. We pass microseconds separately.
+    let utc = DateTime::from_timestamp(utc_ts, 0).expect("RFC 2822 timestamp must be in valid range");
+
+    // Day-of-week: 1970-01-01 (UTC, ts=0) was a Thursday (index 3 in our Mon-first array).
+    // Normalize the day count to be non-negative before taking modulo to handle pre-1970 dates.
+    let days_since_epoch = utc_ts.div_euclid(86_400);
+    let weekday_index = (days_since_epoch + 3).rem_euclid(7) as usize;
+
+    format!(
+        "{day_name}, {day:02} {month_name} {year:04} {hour:02}:{minute:02}:{second:02} GMT",
+        day_name = RFC2822_DAY_NAMES[weekday_index],
+        day = utc.date.day,
+        month_name = RFC2822_MONTH_NAMES[(utc.date.month as usize).saturating_sub(1)],
+        year = utc.date.year,
+        hour = utc.time.hour,
+        minute = utc.time.minute,
+        second = utc.time.second,
+    )
+}
+
 fn downcast_date_reject_datetime<'a, 'py>(py_date: &'a Bound<'py, PyAny>) -> PyResult<&'a Bound<'py, PyDate>> {
     if let Ok(py_date) = py_date.cast::<PyDate>() {
         // because `datetime` is a subclass of `date` we have to check that the value is not a

--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateTime, PyDict, PyTime};
 use speedate::{Date, DateTime, Time};
@@ -43,69 +44,58 @@ pub(crate) fn time_to_milliseconds(time: Time) -> f64 {
         + f64::from(time.microsecond) / 1_000.0
 }
 
-const RFC2822_DAY_NAMES: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const RFC2822_MONTH_NAMES: [&str; 12] = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
-
-/// Format a `Date` as an RFC 2822 (HTTP) date string at midnight UTC,
-/// e.g. "Mon, 01 Jan 2024 00:00:00 GMT".
+/// Format a Python `datetime` as an RFC 2822 date string with `GMT` as the zone label,
+/// e.g. `"Mon, 01 Jan 2024 12:00:00 GMT"`.
 ///
-/// This mirrors the behaviour of `werkzeug.http.http_date`, which combines a bare
-/// `date` with midnight in UTC before formatting.
-pub(crate) fn date_to_rfc2822(date: Date) -> String {
-    let midnight = Time {
-        hour: 0,
-        minute: 0,
-        second: 0,
-        microsecond: 0,
-        tz_offset: None,
+/// Delegates to Python's [`email.utils.format_datetime(dt, usegmt=True)`](https://docs.python.org/3/library/email.utils.html#email.utils.format_datetime).
+/// The datetime is normalised to UTC first:
+/// - naive datetimes are assumed to be UTC and have their `tzinfo` set to UTC,
+/// - aware datetimes are converted to UTC via `astimezone()`.
+pub(crate) fn datetime_to_rfc2822<'py>(py: Python<'py>, datetime: &Bound<'py, PyDateTime>) -> PyResult<String> {
+    let datetime_module = py.import(intern!(py, "datetime"))?;
+    let timezone_utc = datetime_module
+        .getattr(intern!(py, "timezone"))?
+        .getattr(intern!(py, "utc"))?;
+
+    let utc_datetime = if datetime.getattr(intern!(py, "tzinfo"))?.is_none() {
+        // Naive datetime: assume it represents UTC, attach `tzinfo=timezone.utc`.
+        let replace_kwargs = PyDict::new(py);
+        replace_kwargs.set_item(intern!(py, "tzinfo"), &timezone_utc)?;
+        datetime.call_method(intern!(py, "replace"), (), Some(&replace_kwargs))?
+    } else {
+        // Aware datetime: convert to UTC.
+        datetime.call_method1(intern!(py, "astimezone"), (&timezone_utc,))?
     };
-    datetime_to_rfc2822(DateTime { date, time: midnight })
+
+    let format_kwargs = PyDict::new(py);
+    format_kwargs.set_item(intern!(py, "usegmt"), true)?;
+    py.import(intern!(py, "email.utils"))?
+        .call_method(intern!(py, "format_datetime"), (utc_datetime,), Some(&format_kwargs))?
+        .extract()
 }
 
-/// Format a `DateTime` as an RFC 2822 date string with `GMT` as the zone label,
-/// e.g. "Mon, 01 Jan 2024 12:00:00 GMT".
+/// Format a Python `date` as an RFC 2822 date string at midnight UTC,
+/// e.g. `"Mon, 01 Jan 2024 00:00:00 GMT"`.
 ///
-/// This matches the output of Python's `email.utils.format_datetime(dt, usegmt=True)`,
-/// which is what `werkzeug.http.http_date` uses for the HTTP `Date` header (the format
-/// is RFC 2822 / RFC 5322 §3.3, which RFC 7231 §7.1.1.1 designates as the preferred HTTP
-/// date format).
-///
-/// The datetime is converted to UTC before formatting:
-/// - If `tz_offset` is `None` (naive), it is assumed to already be UTC.
-/// - If `tz_offset` is `Some`, the offset is subtracted from the timestamp to get UTC.
-pub(crate) fn datetime_to_rfc2822(dt: DateTime) -> String {
-    // Compute the UTC unix timestamp (seconds since 1970-01-01 UTC).
-    // `DateTime::timestamp()` ignores the timezone offset and returns the timestamp
-    // as if the date/time were UTC, so we need to subtract the offset to get the
-    // true UTC timestamp.
-    let local_ts = dt.date.timestamp()
-        + i64::from(dt.time.hour) * 3600
-        + i64::from(dt.time.minute) * 60
-        + i64::from(dt.time.second);
-    let tz_offset = i64::from(dt.time.tz_offset.unwrap_or(0));
-    let utc_ts = local_ts - tz_offset;
+/// Combines the bare `date` with midnight in UTC and then delegates to Python's
+/// [`email.utils.format_datetime(dt, usegmt=True)`](https://docs.python.org/3/library/email.utils.html#email.utils.format_datetime).
+pub(crate) fn date_to_rfc2822<'py>(py: Python<'py>, date: &Bound<'py, PyDate>) -> PyResult<String> {
+    let datetime_module = py.import(intern!(py, "datetime"))?;
+    let datetime_cls = datetime_module.getattr(intern!(py, "datetime"))?;
+    let midnight = datetime_module.getattr(intern!(py, "time"))?.call0()?;
+    let timezone_utc = datetime_module
+        .getattr(intern!(py, "timezone"))?
+        .getattr(intern!(py, "utc"))?;
 
-    // Compute date parts from the UTC timestamp using `Date::from_timestamp`-style
-    // logic via `DateTime::from_timestamp`. We pass microseconds separately.
-    let utc = DateTime::from_timestamp(utc_ts, 0).expect("RFC 2822 timestamp must be in valid range");
+    let combine_kwargs = PyDict::new(py);
+    combine_kwargs.set_item(intern!(py, "tzinfo"), &timezone_utc)?;
+    let utc_datetime = datetime_cls.call_method(intern!(py, "combine"), (date, midnight), Some(&combine_kwargs))?;
 
-    // Day-of-week: 1970-01-01 (UTC, ts=0) was a Thursday (index 3 in our Mon-first array).
-    // Normalize the day count to be non-negative before taking modulo to handle pre-1970 dates.
-    let days_since_epoch = utc_ts.div_euclid(86_400);
-    let weekday_index = (days_since_epoch + 3).rem_euclid(7) as usize;
-
-    format!(
-        "{day_name}, {day:02} {month_name} {year:04} {hour:02}:{minute:02}:{second:02} GMT",
-        day_name = RFC2822_DAY_NAMES[weekday_index],
-        day = utc.date.day,
-        month_name = RFC2822_MONTH_NAMES[(utc.date.month as usize).saturating_sub(1)],
-        year = utc.date.year,
-        hour = utc.time.hour,
-        minute = utc.time.minute,
-        second = utc.time.second,
-    )
+    let kwargs = PyDict::new(py);
+    kwargs.set_item(intern!(py, "usegmt"), true)?;
+    py.import(intern!(py, "email.utils"))?
+        .call_method(intern!(py, "format_datetime"), (utc_datetime,), Some(&kwargs))?
+        .extract()
 }
 
 fn downcast_date_reject_datetime<'a, 'py>(py_date: &'a Bound<'py, PyAny>) -> PyResult<&'a Bound<'py, PyDate>> {

--- a/pydantic-core/tests/serializers/test_any.py
+++ b/pydantic-core/tests/serializers/test_any.py
@@ -448,6 +448,17 @@ def test_base64():
         (lambda: MyEnum.b, {}, b'"b"'),
         (lambda: [MyDataclass(1, 'a', 2), MyModel(a=2, b='b')], {}, b'[{"a":1,"b":"a"},{"a":2,"b":"b"}]'),
         (lambda: re.compile('^regex$'), {}, b'"^regex$"'),
+        # rfc2822 temporal mode for datetime
+        (
+            lambda: datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            dict(temporal_mode='rfc2822'),
+            b'"Mon, 01 Jan 2024 12:00:00 GMT"',
+        ),
+        (
+            lambda: datetime(2024, 1, 1, 0, 0, 0),
+            dict(temporal_mode='rfc2822'),
+            b'"Mon, 01 Jan 2024 00:00:00 GMT"',
+        ),
     ],
 )
 def test_encoding(any_serializer, gen_input, kwargs, expected_json):

--- a/pydantic-core/tests/serializers/test_datetime.py
+++ b/pydantic-core/tests/serializers/test_datetime.py
@@ -158,6 +158,34 @@ def test_date_datetime_union():
             b'{"1704070861000.023":"foo"}',
             'milliseconds',
         ),
+        # rfc2822: naive datetime (treated as UTC)
+        (
+            datetime(2024, 1, 1, 0, 0, 0),
+            'Mon, 01 Jan 2024 00:00:00 GMT',
+            b'"Mon, 01 Jan 2024 00:00:00 GMT"',
+            {'Mon, 01 Jan 2024 00:00:00 GMT': 'foo'},
+            b'{"Mon, 01 Jan 2024 00:00:00 GMT":"foo"}',
+            'rfc2822',
+        ),
+        # rfc2822: UTC datetime
+        (
+            datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            'Mon, 01 Jan 2024 12:00:00 GMT',
+            b'"Mon, 01 Jan 2024 12:00:00 GMT"',
+            {'Mon, 01 Jan 2024 12:00:00 GMT': 'foo'},
+            b'{"Mon, 01 Jan 2024 12:00:00 GMT":"foo"}',
+            'rfc2822',
+        ),
+        # rfc2822: non-UTC datetime is converted to UTC before formatting
+        # +02:00 offset means local 14:00 -> UTC 12:00
+        (
+            datetime(2024, 1, 1, 14, 0, 0, tzinfo=tz(hours=2)),
+            'Mon, 01 Jan 2024 12:00:00 GMT',
+            b'"Mon, 01 Jan 2024 12:00:00 GMT"',
+            {'Mon, 01 Jan 2024 12:00:00 GMT': 'foo'},
+            b'{"Mon, 01 Jan 2024 12:00:00 GMT":"foo"}',
+            'rfc2822',
+        ),
     ],
 )
 def test_config_datetime(
@@ -172,7 +200,7 @@ def test_config_datetime(
         UserWarning,
         match=(
             r'Expected `datetime` - serialized value may not be as expected '
-            r"\[input_value=\{datetime\.datetime\([^)]*\): 'foo'\}, input_type=dict\]"
+            r"\[input_value=\{datetime\.datetime\(.*\): 'foo'\}, input_type=dict\]"
         ),
     ):
         assert s.to_python({dt: 'foo'}) == {dt: 'foo'}
@@ -180,7 +208,7 @@ def test_config_datetime(
         UserWarning,
         match=(
             r'Expected `datetime` - serialized value may not be as expected '
-            r"\[input_value=\{datetime\.datetime\([^)]*\): 'foo'\}, input_type=dict\]"
+            r"\[input_value=\{datetime\.datetime\(.*\): 'foo'\}, input_type=dict\]"
         ),
     ):
         assert s.to_python({dt: 'foo'}, mode='json') == expected_to_python_dict
@@ -188,7 +216,7 @@ def test_config_datetime(
         UserWarning,
         match=(
             r'Expected `datetime` - serialized value may not be as expected '
-            r"\[input_value=\{datetime\.datetime\([^)]*\): 'foo'\}, input_type=dict\]"
+            r"\[input_value=\{datetime\.datetime\(.*\): 'foo'\}, input_type=dict\]"
         ),
     ):
         assert s.to_json({dt: 'foo'}) == expected_to_json_dict
@@ -220,6 +248,15 @@ def test_config_datetime(
             {'1704067200000': 'foo'},
             b'{"1704067200000":"foo"}',
             'milliseconds',
+        ),
+        # rfc2822: bare `date` is treated as midnight UTC, matching werkzeug.http.http_date
+        (
+            date(2024, 1, 1),
+            'Mon, 01 Jan 2024 00:00:00 GMT',
+            b'"Mon, 01 Jan 2024 00:00:00 GMT"',
+            {'Mon, 01 Jan 2024 00:00:00 GMT': 'foo'},
+            b'{"Mon, 01 Jan 2024 00:00:00 GMT":"foo"}',
+            'rfc2822',
         ),
     ],
 )
@@ -283,6 +320,15 @@ def test_config_date(
             {'11641059.263': 'foo'},
             b'{"11641059.263":"foo"}',
             'milliseconds',
+        ),
+        # rfc2822 has no standalone time format, so we fall back to ISO 8601
+        (
+            time(3, 14, 1, 59263),
+            '03:14:01.059263',
+            b'"03:14:01.059263"',
+            {'03:14:01.059263': 'foo'},
+            b'{"03:14:01.059263":"foo"}',
+            'rfc2822',
         ),
     ],
 )

--- a/pydantic-core/tests/serializers/test_datetime.py
+++ b/pydantic-core/tests/serializers/test_datetime.py
@@ -176,16 +176,6 @@ def test_date_datetime_union():
             b'{"Mon, 01 Jan 2024 12:00:00 GMT":"foo"}',
             'rfc2822',
         ),
-        # rfc2822: non-UTC datetime is converted to UTC before formatting
-        # +02:00 offset means local 14:00 -> UTC 12:00
-        (
-            datetime(2024, 1, 1, 14, 0, 0, tzinfo=tz(hours=2)),
-            'Mon, 01 Jan 2024 12:00:00 GMT',
-            b'"Mon, 01 Jan 2024 12:00:00 GMT"',
-            {'Mon, 01 Jan 2024 12:00:00 GMT': 'foo'},
-            b'{"Mon, 01 Jan 2024 12:00:00 GMT":"foo"}',
-            'rfc2822',
-        ),
     ],
 )
 def test_config_datetime(
@@ -200,7 +190,7 @@ def test_config_datetime(
         UserWarning,
         match=(
             r'Expected `datetime` - serialized value may not be as expected '
-            r"\[input_value=\{datetime\.datetime\(.*\): 'foo'\}, input_type=dict\]"
+            r"\[input_value=\{datetime\.datetime\([^)]*\): 'foo'\}, input_type=dict\]"
         ),
     ):
         assert s.to_python({dt: 'foo'}) == {dt: 'foo'}
@@ -208,7 +198,7 @@ def test_config_datetime(
         UserWarning,
         match=(
             r'Expected `datetime` - serialized value may not be as expected '
-            r"\[input_value=\{datetime\.datetime\(.*\): 'foo'\}, input_type=dict\]"
+            r"\[input_value=\{datetime\.datetime\([^)]*\): 'foo'\}, input_type=dict\]"
         ),
     ):
         assert s.to_python({dt: 'foo'}, mode='json') == expected_to_python_dict
@@ -216,10 +206,26 @@ def test_config_datetime(
         UserWarning,
         match=(
             r'Expected `datetime` - serialized value may not be as expected '
-            r"\[input_value=\{datetime\.datetime\(.*\): 'foo'\}, input_type=dict\]"
+            r"\[input_value=\{datetime\.datetime\([^)]*\): 'foo'\}, input_type=dict\]"
         ),
     ):
         assert s.to_json({dt: 'foo'}) == expected_to_json_dict
+
+
+@pytest.mark.parametrize(
+    'dt,expected',
+    [
+        # +02:00 offset: local 14:00 -> UTC 12:00
+        (datetime(2024, 1, 1, 14, 0, 0, tzinfo=tz(hours=2)), 'Mon, 01 Jan 2024 12:00:00 GMT'),
+        # -05:00 offset: local 07:00 -> UTC 12:00
+        (datetime(2024, 1, 1, 7, 0, 0, tzinfo=tz(hours=-5)), 'Mon, 01 Jan 2024 12:00:00 GMT'),
+    ],
+)
+def test_config_datetime_rfc2822_non_utc(dt: datetime, expected: str):
+    """Non-UTC datetimes are converted to UTC before RFC 2822 formatting."""
+    s = SchemaSerializer(core_schema.datetime_schema(), config={'ser_json_temporal': 'rfc2822'})
+    assert s.to_python(dt, mode='json') == expected
+    assert s.to_json(dt) == f'"{expected}"'.encode()
 
 
 @pytest.mark.parametrize(
@@ -249,7 +255,7 @@ def test_config_datetime(
             b'{"1704067200000":"foo"}',
             'milliseconds',
         ),
-        # rfc2822: bare `date` is treated as midnight UTC, matching werkzeug.http.http_date
+        # rfc2822: bare `date` is treated as midnight UTC, matching email.utils.format_datetime
         (
             date(2024, 1, 1),
             'Mon, 01 Jan 2024 00:00:00 GMT',

--- a/pydantic-core/tests/serializers/test_timedelta.py
+++ b/pydantic-core/tests/serializers/test_timedelta.py
@@ -358,6 +358,20 @@ def test_config_timedelta_timedelta_ser_flag_prioritised(
         assert s.to_json({td: 'foo'}) == expected_to_json_dict
 
 
+def test_config_timedelta_rfc2822_falls_back_to_iso8601():
+    """RFC 2822 has no concept of duration, so `timedelta` falls back to ISO 8601."""
+    s = SchemaSerializer(core_schema.timedelta_schema(), config={'ser_json_temporal': 'rfc2822'})
+    td = timedelta(hours=2)
+    assert s.to_python(td) == td
+    assert s.to_python(td, mode='json') == 'PT2H'
+    assert s.to_json(td) == b'"PT2H"'
+    # As a dict key
+    with pytest.warns(UserWarning):
+        assert s.to_python({td: 'foo'}, mode='json') == {'PT2H': 'foo'}
+    with pytest.warns(UserWarning):
+        assert s.to_json({td: 'foo'}) == b'{"PT2H":"foo"}'
+
+
 def test_union_timedelta_respects_instanceof_check():
     serialization_schema = core_schema.plain_serializer_function_ser_schema(lambda v: None)
     json_validation_schema = core_schema.no_info_plain_validator_function(

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -64,7 +64,7 @@ class ConfigWrapper:
     # whether instances of models and dataclasses (including subclass instances) should re-validate, default 'never'
     revalidate_instances: Literal['always', 'never', 'subclass-instances']
     ser_json_timedelta: Literal['iso8601', 'float']
-    ser_json_temporal: Literal['iso8601', 'seconds', 'milliseconds']
+    ser_json_temporal: Literal['iso8601', 'seconds', 'milliseconds', 'rfc2822']
     val_temporal_unit: Literal['seconds', 'milliseconds', 'infer']
     ser_json_bytes: Literal['utf8', 'base64', 'hex']
     val_json_bytes: Literal['utf8', 'base64', 'hex']

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -575,7 +575,7 @@ class ConfigDict(TypedDict, total=False):
     ///
     """
 
-    ser_json_temporal: Literal['iso8601', 'seconds', 'milliseconds']
+    ser_json_temporal: Literal['iso8601', 'seconds', 'milliseconds', 'rfc2822']
     """
     The format of JSON serialized temporal types from the [`datetime`][] module. This includes:
 
@@ -589,12 +589,24 @@ class ConfigDict(TypedDict, total=False):
     - `'iso8601'` will serialize date-like types to [ISO 8601 text format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
     - `'milliseconds'` will serialize date-like types to a floating point number of milliseconds since the epoch.
     - `'seconds'` will serialize date-like types to a floating point number of seconds since the epoch.
+    - `'rfc2822'` will serialize date-like types to an [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822)
+      date string with a `GMT` zone label, e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`. This mirrors the behaviour of
+      [`werkzeug.http.http_date`](https://werkzeug.palletsprojects.com/en/stable/http/#werkzeug.http.http_date)
+      and is the preferred date format for the HTTP `Date` header per
+      [RFC 7231 §7.1.1.1](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).
+      [`datetime.datetime`][] values are converted to UTC before formatting (naive datetimes are assumed UTC),
+      and bare [`datetime.date`][] values are treated as midnight UTC. [`datetime.time`][] and
+      [`datetime.timedelta`][] have no RFC 2822 representation and fall back to ISO 8601.
 
     Defaults to `'iso8601'`.
 
     /// version-added | v2.12
     This setting replaces [`ser_json_timedelta`][pydantic.config.ConfigDict.ser_json_timedelta],
     which will be deprecated in v3. `ser_json_temporal` adds more configurability for the other temporal types.
+    ///
+
+    /// version-changed | v2.14
+    Added the `'rfc2822'` option.
     ///
     """
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -590,9 +590,9 @@ class ConfigDict(TypedDict, total=False):
     - `'milliseconds'` will serialize date-like types to a floating point number of milliseconds since the epoch.
     - `'seconds'` will serialize date-like types to a floating point number of seconds since the epoch.
     - `'rfc2822'` will serialize date-like types to an [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822)
-      date string with a `GMT` zone label, e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`. This mirrors the behaviour of
-      [`werkzeug.http.http_date`](https://werkzeug.palletsprojects.com/en/stable/http/#werkzeug.http.http_date)
-      and is the preferred date format for the HTTP `Date` header per
+      date string with a `GMT` zone label, e.g. `'Mon, 01 Jan 2024 12:00:00 GMT'`. Formatting is delegated to
+      [`email.utils.format_datetime(dt, usegmt=True)`](https://docs.python.org/3/library/email.utils.html#email.utils.format_datetime),
+      which is the preferred date format for the HTTP `Date` header per
       [RFC 7231 §7.1.1.1](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1).
       [`datetime.datetime`][] values are converted to UTC before formatting (naive datetimes are assumed UTC),
       and bare [`datetime.date`][] values are treated as midnight UTC. [`datetime.time`][] and

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -742,6 +742,18 @@ def test_datetime_from_date_str():
             b'1704070861000.023',
             'milliseconds',
         ),
+        # rfc2822: naive datetime (treated as UTC)
+        (
+            datetime(2024, 1, 1, 0, 0, 0),
+            b'"Mon, 01 Jan 2024 00:00:00 GMT"',
+            'rfc2822',
+        ),
+        # rfc2822: UTC datetime
+        (
+            datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            b'"Mon, 01 Jan 2024 12:00:00 GMT"',
+            'rfc2822',
+        ),
     ],
 )
 def test_config_datetime(dt: datetime, expected_to_json, mode):
@@ -770,6 +782,12 @@ def test_config_datetime(dt: datetime, expected_to_json, mode):
             date(2024, 1, 1),
             b'1704067200000.0',
             'milliseconds',
+        ),
+        # rfc2822: bare `date` is treated as midnight UTC, matching werkzeug.http.http_date
+        (
+            date(2024, 1, 1),
+            b'"Mon, 01 Jan 2024 00:00:00 GMT"',
+            'rfc2822',
         ),
     ],
 )
@@ -800,6 +818,12 @@ def test_config_date(dt: date, expected_to_json, mode):
             b'11641059.263',
             'milliseconds',
         ),
+        # rfc2822 has no standalone time format, so we fall back to ISO 8601
+        (
+            time(3, 14, 1, 59263),
+            b'"03:14:01.059263"',
+            'rfc2822',
+        ),
     ],
 )
 def test_config_time(t: date, expected_to_json, mode):
@@ -809,3 +833,9 @@ def test_config_time(t: date, expected_to_json, mode):
 
     assert instance == t
     assert ta.dump_json(instance) == expected_to_json
+
+
+def test_config_timedelta_rfc2822_falls_back_to_iso8601():
+    """RFC 2822 has no concept of duration, so `timedelta` falls back to ISO 8601."""
+    ta = TypeAdapter(timedelta, config={'ser_json_temporal': 'rfc2822'})
+    assert ta.dump_json(timedelta(hours=2)) == b'"PT2H"'

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -783,7 +783,7 @@ def test_config_datetime(dt: datetime, expected_to_json, mode):
             b'1704067200000.0',
             'milliseconds',
         ),
-        # rfc2822: bare `date` is treated as midnight UTC, matching werkzeug.http.http_date
+        # rfc2822: bare `date` is treated as midnight UTC, matching email.utils.format_datetime
         (
             date(2024, 1, 1),
             b'"Mon, 01 Jan 2024 00:00:00 GMT"',


### PR DESCRIPTION
## Change Summary

add rfc2822 date support to temporal_mode.  this is aimed at aiding clients who are transitioning from `flask.json.dumps`

## Related issue number

Fix https://github.com/pydantic/pydantic/issues/13169

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos