### PR TITLE
Avoid explicit `Any` on `**kwargs` synthesized for models with dynamic aliases

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -934,7 +934,9 @@ class PydanticModelTransformer:
 
         if not self.should_init_forbid_extra(fields, config):
             var = Var('kwargs')
-            args.append(Argument(var, AnyType(TypeOfAny.explicit), None, ARG_STAR2))
+            # Use `from_omitted_generics` rather than `explicit` so that this `Any` does not trip
+            # `--disallow-any-explicit` when `**kwargs` is added because of a dynamic alias.
+            args.append(Argument(var, AnyType(TypeOfAny.from_omitted_generics), None, ARG_STAR2))
 
         add_method(self._api, self._cls, '__init__', args=args, return_type=NoneType())
 
@@ -965,7 +967,7 @@ class PydanticModelTransformer:
             )
         if not self.should_init_forbid_extra(fields, config):
             var = Var('kwargs')
-            args.append(Argument(var, AnyType(TypeOfAny.explicit), None, ARG_STAR2))
+            args.append(Argument(var, AnyType(TypeOfAny.from_omitted_generics), None, ARG_STAR2))
 
         args = args + [fields_set_argument] if is_root_model else [fields_set_argument] + args
 

--- a/tests/mypy/modules/plugin_no_any.py
+++ b/tests/mypy/modules/plugin_no_any.py
@@ -1,0 +1,23 @@
+"""Regression test for https://github.com/pydantic/pydantic/issues/13161.
+
+Even when ``init_forbid_extra`` is enabled, a dynamic validation alias forces the
+plugin to add ``**kwargs`` to ``__init__`` because the static signature can't be
+fully determined. The synthesized ``Any`` for ``**kwargs`` should not trip
+``--disallow-any-explicit``.
+"""
+
+from pydantic import AliasChoices, AliasPath, BaseModel, Field
+
+
+class ModelWithAliasChoices(BaseModel):
+    test_field: str = Field(default='', validation_alias=AliasChoices('choice', 'other_choice'))
+
+
+class ModelWithAliasPath(BaseModel):
+    test_field: str = Field(default='', validation_alias=AliasPath('outer', 'inner'))
+
+
+class ModelWithAliasGenerator(BaseModel):
+    model_config = {'alias_generator': str.upper}
+
+    test_field: str = ''

--- a/tests/mypy/outputs/mypy-plugin-strict-no-any_ini/plugin_no_any.py
+++ b/tests/mypy/outputs/mypy-plugin-strict-no-any_ini/plugin_no_any.py
@@ -1,0 +1,26 @@
+"""Regression test for https://github.com/pydantic/pydantic/issues/13161.
+
+Even when ``init_forbid_extra`` is enabled, a dynamic validation alias forces the
+plugin to add ``**kwargs`` to ``__init__`` because the static signature can't be
+fully determined. The synthesized ``Any`` for ``**kwargs`` should not trip
+``--disallow-any-explicit``.
+"""
+
+from pydantic import AliasChoices, AliasPath, BaseModel, Field
+
+
+class ModelWithAliasChoices(BaseModel):
+    test_field: str = Field(default='', validation_alias=AliasChoices('choice', 'other_choice'))
+# MYPY: error: Required dynamic aliases disallowed  [pydantic-alias]
+
+
+class ModelWithAliasPath(BaseModel):
+    test_field: str = Field(default='', validation_alias=AliasPath('outer', 'inner'))
+# MYPY: error: Required dynamic aliases disallowed  [pydantic-alias]
+
+
+class ModelWithAliasGenerator(BaseModel):
+    model_config = {'alias_generator': str.upper}
+
+    test_field: str = ''
+# MYPY: error: Required dynamic aliases disallowed  [pydantic-alias]

--- a/tests/mypy/test_mypy.py
+++ b/tests/mypy/test_mypy.py
@@ -111,6 +111,7 @@ cases: list[ParameterSet | tuple[str, str]] = [
         ('mypy-plugin.ini', 'final_with_default.py'),
         ('mypy-plugin.ini', 'create_model_var.py'),
         ('mypy-plugin-strict-no-any.ini', 'dataclass_no_any.py'),
+        ('mypy-plugin-strict-no-any.ini', 'plugin_no_any.py'),
         ('mypy-plugin-very-strict.ini', 'metaclass_args.py'),
         ('pyproject-plugin-no-strict-optional.toml', 'no_strict_optional.py'),
         ('pyproject-plugin-strict-equality.toml', 'strict_equality.py'),


### PR DESCRIPTION
## Change Summary

When a model has a dynamic validation alias (`AliasChoices`, `AliasPath`, or an `alias_generator`), the plugin cannot fully determine the keyword-argument signature at static-analysis time, so `should_init_forbid_extra` returns `False` and `**kwargs: Any` gets appended to the synthesized `__init__` (and `model_construct`). Since 2.11.0a1, that `Any` was annotated `TypeOfAny.explicit`, so any project running with `--disallow-any-explicit` saw a spurious

```
error: Explicit "Any" is not allowed  [explicit-any]
```

on the model class itself.

Reproducer (matches the report exactly):

```python
from pydantic import AliasChoices, BaseModel, Field

validation_alias_choices = AliasChoices("choice", "other_choice")

class ModelWithMypyError(BaseModel):
    test_field: str = Field(validation_alias=validation_alias_choices)
```

with `disallow_any_explicit = true` plus the pydantic plugin produces the explicit-any error on the class definition; replacing the `AliasChoices` with a plain string alias makes it disappear.

Switch the synthesized `**kwargs` `Any` to `TypeOfAny.from_omitted_generics`, mirroring the existing workaround used for `_cli_settings_source` / `_build_sources` a few lines above (`pydantic/mypy.py:929-931`). The synthesized `**kwargs` is closer in spirit to an unparameterized generic than an explicit user-written `Any`, and `--disallow-any-explicit` only flags the latter.

A new module `tests/mypy/modules/plugin_no_any.py` covers all three dynamic-alias triggers (`AliasChoices`, `AliasPath`, `alias_generator`) under `mypy-plugin-strict-no-any.ini`.

## Related issue number

Closes #13161

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Selected Reviewer: @Viicos