### PR TITLE
Fix custom JSON schema refs to local defs

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2435,6 +2435,10 @@ class GenerateJsonSchema:
                             raise self._core_defs_invalid_for_json_schema[defs_ref]
                         _add_json_refs(self.definitions[defs_ref])
                     except KeyError:
+                        local_schema = _get_local_json_schema_definition(json_schema, json_ref)
+                        if local_schema is not None:
+                            _add_json_refs(local_schema)
+                            return
                         if not json_ref.startswith(('http://', 'https://')):
                             raise
 
@@ -2504,6 +2508,10 @@ class GenerateJsonSchema:
                 visited_defs_refs.add(next_defs_ref)
                 unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
             except KeyError:
+                local_schema = _get_local_json_schema_definition(schema, next_json_ref)
+                if local_schema is not None:
+                    unvisited_json_refs.update(_get_all_json_refs(local_schema))
+                    continue
                 if not next_json_ref.startswith(('http://', 'https://')):
                     raise
 
@@ -2816,6 +2824,18 @@ def _get_all_json_refs(item: Any) -> set[JsonRef]:
             stack.extend(current)
 
     return refs
+
+
+def _get_local_json_schema_definition(schema: Any, json_ref: JsonRef) -> Any | None:
+    if not isinstance(schema, dict) or not json_ref.startswith('#/$defs/'):
+        return None
+
+    definitions = schema.get('$defs')
+    if not isinstance(definitions, dict):
+        return None
+
+    key = json_ref.removeprefix('#/$defs/').replace('~1', '/').replace('~0', '~')
+    return definitions.get(key)
 
 
 AnyType = TypeVar('AnyType')

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7265,3 +7265,24 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_type_adapter_custom_json_schema_with_local_defs_ref() -> None:
+    schema = {
+        '$defs': {'Tire': {'type': 'object'}},
+        'properties': {'tires': {'items': {'$ref': '#/$defs/Tire'}, 'type': 'array'}},
+        'type': 'object',
+    }
+
+    class CarDict(dict[str, Any]):
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+            return core_schema.dict_schema()
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return schema
+
+    assert TypeAdapter(CarDict).json_schema() == schema


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Handle `$ref` values that point to local `$defs` included by a custom `__get_pydantic_json_schema__`, so `TypeAdapter(...).json_schema()` no longer raises `KeyError` for those schemas.

## Related issue number

Fix #12145

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos