### PR TITLE
Mypy plugin workaround for dynamic models defined in functions

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -15,6 +15,7 @@ from mypy.nodes import (
     ARG_OPT,
     ARG_POS,
     ARG_STAR2,
+    GDEF,
     INVARIANT,
     MDEF,
     Argument,
@@ -208,6 +209,12 @@ class PydanticPlugin(Plugin):
         info.metaclass_type = base_info.metaclass_type
 
         ctx.api.add_symbol_table_node(ctx.name, SymbolTableNode(MDEF, info))
+
+        # Mypy has a quirk for serialization of classes nested in functions. This is
+        # a workaround that should work in most cases, until mypy has a better plugin API.
+        if "@" in info.fullname:
+            _, name = info.fullname.rsplit(".", maxsplit=1)
+            ctx.api.modules[ctx.api.cur_mod_id].names[name] = SymbolTableNode(GDEF, info)
 
 
 class PydanticPluginConfig:

--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -212,8 +212,8 @@ class PydanticPlugin(Plugin):
 
         # Mypy has a quirk for serialization of classes nested in functions. This is
         # a workaround that should work in most cases, until mypy has a better plugin API.
-        if "@" in info.fullname:
-            _, name = info.fullname.rsplit(".", maxsplit=1)
+        if '@' in info.fullname:
+            _, name = info.fullname.rsplit('.', maxsplit=1)
             ctx.api.modules[ctx.api.cur_mod_id].names[name] = SymbolTableNode(GDEF, info)
 
 

--- a/tests/mypy/modules/create_model_var.py
+++ b/tests/mypy/modules/create_model_var.py
@@ -10,3 +10,12 @@ SubModel = create_model('SubModel', __base__=Model)
 
 class Main(BaseModel):
     sub: SubModel
+
+
+def dyn_model() -> type[BaseModel]:
+    Inner = create_model("Inner", __base__=BaseModel, value=(int, ...))
+
+    class Outer(Inner):
+        pass
+
+    return Outer

--- a/tests/mypy/modules/create_model_var.py
+++ b/tests/mypy/modules/create_model_var.py
@@ -12,6 +12,7 @@ class Main(BaseModel):
     sub: SubModel
 
 
+# This only crashes in parallel mode (see https://github.com/python/mypy/issues/21472):
 def dyn_model() -> type[BaseModel]:
     Inner = create_model("Inner", __base__=BaseModel, value=(int, ...))
 

--- a/tests/mypy/outputs/mypy-plugin_ini/create_model_var.py
+++ b/tests/mypy/outputs/mypy-plugin_ini/create_model_var.py
@@ -10,3 +10,12 @@ SubModel = create_model('SubModel', __base__=Model)
 
 class Main(BaseModel):
     sub: SubModel
+
+
+def dyn_model() -> type[BaseModel]:
+    Inner = create_model("Inner", __base__=BaseModel, value=(int, ...))
+
+    class Outer(Inner):
+        pass
+
+    return Outer

--- a/tests/mypy/outputs/mypy-plugin_ini/create_model_var.py
+++ b/tests/mypy/outputs/mypy-plugin_ini/create_model_var.py
@@ -12,6 +12,7 @@ class Main(BaseModel):
     sub: SubModel
 
 
+# This only crashes in parallel mode (see https://github.com/python/mypy/issues/21472):
 def dyn_model() -> type[BaseModel]:
     Inner = create_model("Inner", __base__=BaseModel, value=(int, ...))
 


### PR DESCRIPTION
## Change Summary

Add a workaround to mypy plugin that fixes incremental and parallel modes for models that are created using `create_model()` inside a function. See https://github.com/python/mypy/issues/21472 for an example of code that is currently crashing mypy.

Note: this will not fix dynamic models created in _methods_. However, this workaround will become much more robust once https://github.com/python/mypy/pull/21478 is merged. If no issues will appear within one-two mypy releases, we will turn this into a public mypy plugin API.

## Related issue number

Ref https://github.com/python/mypy/issues/21472

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos