### PR TITLE
Fix duplicated word in wasm preview README

### DIFF
--- a/pydantic-core/wasm-preview/README.md
+++ b/pydantic-core/wasm-preview/README.md
@@ -8,4 +8,4 @@ This doesn't work for version of pydantic-core before v0.23.0 as before that we 
 
 If the output appears to stop prematurely, try looking in the developer console for more details.
 
-For pydantic-core versions prior to `2.2.0`, tests will freeze at  at 10-15% of the way through on Chrome due to a suspected V8 bug, see [pyodide/pyodide#3792](https://github.com/pyodide/pyodide/issues/3792) for more information.
+For pydantic-core versions prior to `2.2.0`, tests will freeze at 10-15% of the way through on Chrome due to a suspected V8 bug, see [pyodide/pyodide#3792](https://github.com/pyodide/pyodide/issues/3792) for more information.


### PR DESCRIPTION
## Change Summary

Fix a duplicated `at` in `pydantic-core/wasm-preview/README.md`:

> tests will freeze at  at 10-15%

becomes:

> tests will freeze at 10-15%

## Related issue number

N/A — trivial docs typo fix.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist (not applicable: docs-only typo fix)
* [x] Tests pass on CI (not run locally: docs-only typo fix)
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
