### PR TITLE
Reapply URL constraints to existing URL instances

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import dataclasses as _dataclasses
 import re
+from collections.abc import Mapping
 from dataclasses import fields
 from functools import lru_cache
 from importlib.metadata import version
@@ -121,6 +122,13 @@ class UrlConstraints:
         for constraint_key, constraint_value in self.defined_constraints.items():
             schema_to_mutate[constraint_key] = constraint_value
         return schema
+
+
+_URL_CONSTRAINT_FIELDS = tuple(field.name for field in fields(UrlConstraints))
+
+
+def _url_schema_has_constraints(schema: Mapping[str, Any]) -> bool:
+    return any(schema.get(field_name) is not None for field_name in _URL_CONSTRAINT_FIELDS)
 
 
 class _BaseUrl:
@@ -313,11 +321,15 @@ class _BaseUrl:
     def __get_pydantic_core_schema__(
         cls, source: type[_BaseUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
+        url_schema = core_schema.url_schema(**cls._constraints.defined_constraints)
+
         def wrap_val(v, h):
             if isinstance(v, source):
-                return v
-            if isinstance(v, _BaseUrl):
-                v = str(v)
+                if not _url_schema_has_constraints(url_schema):
+                    return v
+                v = v._url
+            elif isinstance(v, _BaseUrl):
+                v = v._url
             core_url = h(v)
             instance = source.__new__(source)
             instance._url = core_url
@@ -325,7 +337,7 @@ class _BaseUrl:
 
         return core_schema.no_info_wrap_validator_function(
             wrap_val,
-            schema=core_schema.url_schema(**cls._constraints.defined_constraints),
+            schema=url_schema,
             serialization=core_schema.plain_serializer_function_ser_schema(
                 cls.serialize_url, info_arg=True, when_used='always'
             ),
@@ -529,11 +541,15 @@ class _BaseMultiHostUrl:
     def __get_pydantic_core_schema__(
         cls, source: type[_BaseMultiHostUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
+        url_schema = core_schema.multi_host_url_schema(**cls._constraints.defined_constraints)
+
         def wrap_val(v, h):
             if isinstance(v, source):
-                return v
-            if isinstance(v, _BaseMultiHostUrl):
-                v = str(v)
+                if not _url_schema_has_constraints(url_schema):
+                    return v
+                v = v._url
+            elif isinstance(v, _BaseMultiHostUrl):
+                v = v._url
             core_url = h(v)
             instance = source.__new__(source)
             instance._url = core_url
@@ -541,7 +557,7 @@ class _BaseMultiHostUrl:
 
         return core_schema.no_info_wrap_validator_function(
             wrap_val,
-            schema=core_schema.multi_host_url_schema(**cls._constraints.defined_constraints),
+            schema=url_schema,
             serialization=core_schema.plain_serializer_function_ser_schema(
                 cls.serialize_url, info_arg=True, when_used='always'
             ),

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -127,8 +127,8 @@ class UrlConstraints:
 _URL_CONSTRAINT_FIELDS = tuple(field.name for field in fields(UrlConstraints))
 
 
-def _url_schema_has_constraints(schema: Mapping[str, Any]) -> bool:
-    return any(schema.get(field_name) is not None for field_name in _URL_CONSTRAINT_FIELDS)
+def _url_schema_constraints_match(schema: Mapping[str, Any], constraints: Mapping[str, Any]) -> bool:
+    return all(schema.get(field_name) == constraints.get(field_name) for field_name in _URL_CONSTRAINT_FIELDS)
 
 
 class _BaseUrl:
@@ -321,15 +321,16 @@ class _BaseUrl:
     def __get_pydantic_core_schema__(
         cls, source: type[_BaseUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        url_schema = core_schema.url_schema(**cls._constraints.defined_constraints)
-        schema_has_constraints: bool | None = None
+        defined_constraints = cls._constraints.defined_constraints
+        url_schema = core_schema.url_schema(**defined_constraints)
+        schema_matches_class_constraints: bool | None = None
 
         def wrap_val(v, h):
-            nonlocal schema_has_constraints
+            nonlocal schema_matches_class_constraints
             if isinstance(v, source):
-                if schema_has_constraints is None:
-                    schema_has_constraints = _url_schema_has_constraints(url_schema)
-                if not schema_has_constraints:
+                if schema_matches_class_constraints is None:
+                    schema_matches_class_constraints = _url_schema_constraints_match(url_schema, defined_constraints)
+                if schema_matches_class_constraints:
                     return v
                 v = v._url
             elif isinstance(v, _BaseUrl):
@@ -545,15 +546,16 @@ class _BaseMultiHostUrl:
     def __get_pydantic_core_schema__(
         cls, source: type[_BaseMultiHostUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        url_schema = core_schema.multi_host_url_schema(**cls._constraints.defined_constraints)
-        schema_has_constraints: bool | None = None
+        defined_constraints = cls._constraints.defined_constraints
+        url_schema = core_schema.multi_host_url_schema(**defined_constraints)
+        schema_matches_class_constraints: bool | None = None
 
         def wrap_val(v, h):
-            nonlocal schema_has_constraints
+            nonlocal schema_matches_class_constraints
             if isinstance(v, source):
-                if schema_has_constraints is None:
-                    schema_has_constraints = _url_schema_has_constraints(url_schema)
-                if not schema_has_constraints:
+                if schema_matches_class_constraints is None:
+                    schema_matches_class_constraints = _url_schema_constraints_match(url_schema, defined_constraints)
+                if schema_matches_class_constraints:
                     return v
                 v = v._url
             elif isinstance(v, _BaseMultiHostUrl):

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -322,10 +322,14 @@ class _BaseUrl:
         cls, source: type[_BaseUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         url_schema = core_schema.url_schema(**cls._constraints.defined_constraints)
+        schema_has_constraints: bool | None = None
 
         def wrap_val(v, h):
+            nonlocal schema_has_constraints
             if isinstance(v, source):
-                if not _url_schema_has_constraints(url_schema):
+                if schema_has_constraints is None:
+                    schema_has_constraints = _url_schema_has_constraints(url_schema)
+                if not schema_has_constraints:
                     return v
                 v = v._url
             elif isinstance(v, _BaseUrl):
@@ -542,10 +546,14 @@ class _BaseMultiHostUrl:
         cls, source: type[_BaseMultiHostUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         url_schema = core_schema.multi_host_url_schema(**cls._constraints.defined_constraints)
+        schema_has_constraints: bool | None = None
 
         def wrap_val(v, h):
+            nonlocal schema_has_constraints
             if isinstance(v, source):
-                if not _url_schema_has_constraints(url_schema):
+                if schema_has_constraints is None:
+                    schema_has_constraints = _url_schema_has_constraints(url_schema)
+                if not schema_has_constraints:
                     return v
                 v = v._url
             elif isinstance(v, _BaseMultiHostUrl):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1106,6 +1106,16 @@ def test_custom_constraints() -> None:
     with pytest.raises(ValidationError):
         ta.validate_python('ftp://example.com')
 
+    existing_file_url = AnyUrl('file:///etc/passwd')
+    with pytest.raises(ValidationError, match="URL scheme should be 'http' or 'https'"):
+        ta.validate_python(existing_file_url)
+
+    class Model(BaseModel):
+        v: HttpUrl
+
+    with pytest.raises(ValidationError, match="URL scheme should be 'http' or 'https'"):
+        Model.model_validate({'v': existing_file_url})
+
 
 def test_url_constraints_invalid_annotated_type() -> None:
     with pytest.raises(PydanticUserError):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1117,6 +1117,22 @@ def test_custom_constraints() -> None:
         Model.model_validate({'v': existing_file_url})
 
 
+def test_custom_constraints_revalidate_existing_url_instances() -> None:
+    http_url = AnyHttpUrl('https://example.com')
+    assert TypeAdapter(AnyHttpUrl).validate_python(http_url) is http_url
+
+    ShortHttpUrl = Annotated[AnyHttpUrl, UrlConstraints(max_length=10)]
+    with pytest.raises(ValidationError, match='URL should have at most 10 characters'):
+        TypeAdapter(ShortHttpUrl).validate_python(http_url)
+
+    postgres_dsn = PostgresDsn('postgres://user:pass@localhost:5432/app')
+    assert TypeAdapter(PostgresDsn).validate_python(postgres_dsn) is postgres_dsn
+
+    ShortPostgresDsn = Annotated[PostgresDsn, UrlConstraints(max_length=20)]
+    with pytest.raises(ValidationError, match='URL should have at most 20 characters'):
+        TypeAdapter(ShortPostgresDsn).validate_python(postgres_dsn)
+
+
 def test_url_constraints_invalid_annotated_type() -> None:
     with pytest.raises(PydanticUserError):
         TypeAdapter(Annotated[str, UrlConstraints(max_length=1)])


### PR DESCRIPTION
## Change Summary

Re-apply URL schema constraints when an existing `_BaseUrl` or `_BaseMultiHostUrl` instance is validated by a constrained URL schema.

The wrapper still preserves the existing fast path for unconstrained schemas, so `TypeAdapter(AnyUrl).validate_python(existing_url)` keeps returning the existing object. When constraints such as `allowed_schemes` are present, the wrapper now passes the underlying core URL back through the inner validator before constructing the result.

## Related issue number

fix #13170

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
  * Local targeted tests pass; CI has not run yet.
* [x] Documentation reflects the changes where applicable
  * Not applicable; this is a validation behavior fix with no docs change.
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

Local validation:

* `uv run pytest tests/test_networks.py -q` -> 302 passed, 1 skipped, 1 xfailed
* `uv run ruff check pydantic/networks.py tests/test_networks.py` -> passed
* `uv run ruff format --check pydantic/networks.py tests/test_networks.py` -> passed

Selected Reviewer: @Viicos