### PR TITLE
Build PEP 783 pyemscripten_2026_0_wasm32 pydantic-core wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
     name: core / Build WASM Emscripten
     runs-on: ubuntu-latest
     env:
-      PYODIDE_VERSION: '314.0.0a1'
+      PYODIDE_VERSION: '314.0.0a2'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,39 +240,32 @@ jobs:
   core-build-wasm-emscripten:
     name: core / Build WASM Emscripten
     runs-on: ubuntu-latest
+    env:
+      PYODIDE_VERSION: '314.0.0a1'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Install rust nightly
+      - name: Install rust stable
         # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
-          components: rust-src
           targets: wasm32-unknown-emscripten
-          toolchain: nightly
+          toolchain: stable
 
       - name: Cache rust
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
 
-      - uses: mymindstorm/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
-        with:
-          # NOTE!: as per https://github.com/pydantic/pydantic-core/pull/149 this version needs to match the version
-          # in pydantic-core/node_modules/pyodide/pyodide-lock.json, to get the version, run:
-          # `cat pydantic-core/node_modules/pyodide/pyodide-lock.json | jq .info.platform`
-          version: '4.0.9'
-          actions-cache-folder: emsdk-cache
-
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           enable-cache: false
 
-      - name: Install dependencies
-        run: uv sync --all-packages --group testing-extra --group wasm --all-extras
+      - name: Install Pyodide xbuildenv
+        run: uvx --from pyodide-cli --with pyodide-build pyodide xbuildenv install "$PYODIDE_VERSION"
 
       - name: Build wheels
         run: make -C pydantic-core build-wasm
@@ -294,7 +287,7 @@ jobs:
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: pydantic_core_wasm_wheels
+          name: pydantic_core_pypi_files_wasm_emscripten
           path: pydantic-core/dist
 
   core-bench:

--- a/pydantic-core/Makefile
+++ b/pydantic-core/Makefile
@@ -68,8 +68,8 @@ build-pgo:
 
 .PHONY: build-wasm  ## Build the WebAssembly version of the package
 build-wasm:
-	@echo 'This requires python 3.13, maturin and emsdk to be installed'
-	uvx maturin build --release --target wasm32-unknown-emscripten --out dist -i 3.13
+	@echo 'This requires Python 3.14 and a Pyodide xbuildenv to be installed'
+	uvx --from pyodide-cli --with pyodide-build pyodide build --outdir dist
 	ls -lh dist
 
 .PHONY: format  ## Auto-format rust and python source files

--- a/pydantic-core/package.json
+++ b/pydantic-core/package.json
@@ -8,7 +8,7 @@
   "main": "tests/emscripten_runner.js",
   "dependencies": {
     "prettier": "^2.7.1",
-    "pyodide": "^0.28.3"
+    "pyodide": "314.0.0-alpha.1"
   },
   "scripts": {
     "test": "node tests/emscripten_runner.js",

--- a/pydantic-core/package.json
+++ b/pydantic-core/package.json
@@ -8,7 +8,7 @@
   "main": "tests/emscripten_runner.js",
   "dependencies": {
     "prettier": "^2.7.1",
-    "pyodide": "314.0.0-alpha.1"
+    "pyodide": "314.0.0-alpha.2"
   },
   "scripts": {
     "test": "node tests/emscripten_runner.js",

--- a/pydantic-core/pyproject.toml
+++ b/pydantic-core/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['maturin>=1.10,<2']
+requires = ['maturin>=1.13.2,<2']
 build-backend = 'maturin'
 
 [project]


### PR DESCRIPTION
We love Pydantic. [RenderCV](https://github.com/rendercv/rendercv) is built on top of Pydantic, and [rendercv.com](https://rendercv.com) runs Python in the browser with WASM. Publishing a Pyodide-compatible pydantic-core wheel to PyPI would let browser environments install pydantic-core normally.

Closes #13156.

There is already #13157. This PR is intentionally narrower: it updates the existing pydantic-core WASM build/test/release path instead of adding a separate build path.

`.github/workflows/ci.yml`:
- Build the existing WASM job against Pyodide `314.0.0a1` / Python 3.14, which targets the `pyemscripten_2026_0` platform.
- Use stable Rust and drop `rust-src`, because Pyodide documents that `pyemscripten_2026_0` only needs Rust 1.93+ rather than the previous nightly/custom-sysroot path: https://pyodide.org/en/stable/development/abi/314.html#rust-toolchain-simplified
- Drop the manual `setup-emsdk` step; `pyodide build`/xbuildenv provides the matching Emscripten cross-build environment.
- Upload the WASM wheel as `pydantic_core_pypi_files_wasm_emscripten`, so the existing release artifact glob can publish it.

`pydantic-core/Makefile`:
- Change `build-wasm` from direct `maturin build --target wasm32-unknown-emscripten` to `pyodide build --outdir dist`.
- This produces a PEP 783 wheel such as `cp314-cp314-pyemscripten_2026_0_wasm32`: https://peps.python.org/pep-0783/

`pydantic-core/package.json`:
- Run the existing Node/Pyodide test runner with `pyodide@314.0.0-alpha.1`, so it can install and test the generated `pyemscripten_2026_0` wheel.

`pydantic-core/pyproject.toml`:
- Require `maturin>=1.13.2`, the first maturin release with PEP 783 `pyemscripten_*_wasm32` platform tag support: https://github.com/PyO3/maturin/releases/tag/v1.13.2

Not changed:

`pydantic-core/wasm-preview`:
- Left unchanged for this PR. It is still tied to the old GitHub-release `emscripten_*_wasm32` wheel URL and older Pyodide runtime, and can move to Pyodide 314 / PyPI installation separately.
