### PR TITLE
Use `email_error` type for `EmailStr` validation failures

### DIFF
--- a/docs/examples/files.md
+++ b/docs/examples/files.md
@@ -84,7 +84,7 @@ except ValidationError as err:
     Input should be greater than 0 [type=greater_than, input_value=-30, input_type=int]
         For further information visit https://errors.pydantic.dev/2.10/v/greater_than
     email
-    value is not a valid email address: An email address must have an @-sign. [type=value_error, input_value='not-an-email-address', input_type=str]
+    value is not a valid email address: An email address must have an @-sign. [type=email_error, input_value='not-an-email-address', input_type=str]
     """
 ```
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1333,9 +1333,9 @@ def validate_email(value: str) -> tuple[str, str]:
 
     if len(value) > MAX_EMAIL_LENGTH:
         raise PydanticCustomError(
-            'value_error',
-            'value is not a valid email address: {reason}',
-            {'reason': f'Length must not exceed {MAX_EMAIL_LENGTH} characters'},
+            'email_error',
+            'value is not a valid email address: {error}',
+            {'error': f'Length must not exceed {MAX_EMAIL_LENGTH} characters'},
         )
 
     m = pretty_email_regex.fullmatch(value)
@@ -1350,7 +1350,7 @@ def validate_email(value: str) -> tuple[str, str]:
         parts = email_validator.validate_email(email, check_deliverability=False)
     except email_validator.EmailNotValidError as e:
         raise PydanticCustomError(
-            'value_error', 'value is not a valid email address: {reason}', {'reason': str(e.args[0])}
+            'email_error', 'value is not a valid email address: {error}', {'error': str(e.args[0])}
         ) from e
 
     email = parts.normalized

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -978,6 +978,23 @@ def test_address_invalid(value: str, reason: str | None):
         validate_email(value)
 
 
+@pytest.mark.skipif(not email_validator, reason='email_validator not installed')
+@pytest.mark.parametrize(
+    'value',
+    [
+        'foobar',
+        'a' * (2048 + 1),
+    ],
+    ids=['parse_failure', 'too_long'],
+)
+def test_email_error_type_and_ctx(value: str):
+    with pytest.raises(PydanticCustomError) as exc_info:
+        validate_email(value)
+    assert exc_info.value.type == 'email_error'
+    assert 'error' in exc_info.value.context
+    assert 'reason' not in exc_info.value.context
+
+
 def test_email_validator_not_installed(mocker):
     mocker.patch('pydantic.networks.email_validator', None)
     m = mocker.patch('pydantic.networks.import_email_validator', side_effect=ImportError)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1957,20 +1957,20 @@ def test_string_fails():
             'ctx': {'min_length': 5},
         },
         {
-            'type': 'value_error',
+            'type': 'email_error',
             'loc': ('str_email',),
             'msg': 'value is not a valid email address: An open angle bracket at the start of the email address has to be followed by a close angle bracket at the end.',
             'input': 'foobar<@example.com',
             'ctx': {
-                'reason': 'An open angle bracket at the start of the email address has to be followed by a close angle bracket at the end.'
+                'error': 'An open angle bracket at the start of the email address has to be followed by a close angle bracket at the end.'
             },
         },
         {
-            'type': 'value_error',
+            'type': 'email_error',
             'loc': ('name_email',),
             'msg': 'value is not a valid email address: The email address contains invalid characters before the @-sign: SPACE.',
             'input': 'foobar @example.com',
-            'ctx': {'reason': 'The email address contains invalid characters before the @-sign: SPACE.'},
+            'ctx': {'error': 'The email address contains invalid characters before the @-sign: SPACE.'},
         },
     ]
 


### PR DESCRIPTION
## Change Summary

Replaces the generic value_error type and non-standard ctx.reason key in validate_email with a dedicated email_error type and ctx.error key, aligning with color_error, ip_v4_address, and base64_decode patterns elsewhere in the codebase. This makes email validation errors distinguishable by type alone and lets i18n consumers (e.g. i18next ICU) resolve the failure reason via the standard ctx.error key.

## Related issue number

Closes #12807


## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [ ] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**


Selected Reviewer: @Viicos