### PR TITLE
Fix Decimal serialization schema to accept scientific notation

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -730,7 +730,7 @@ class GenerateJsonSchema:
 
             # Case 4: Both are None (no restrictions)
             else:
-                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
+                pattern += r'\d*\.?\d*(?:[eE][+-]?\d+)?$'  # look for arbitrary integer, decimal, or scientific notation
 
             return pattern
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7133,6 +7133,17 @@ def test_decimal_pattern_reject_invalid_with_decimal_places_max_digits_unset(
 
 
 @pytest.mark.parametrize(
+    'scientific_decimal',
+    ['1E-7', '1E+7', '1.5E-3', '2.5e10', '+1E-7', '-1E-7', '1e0', '1.23E+45'],
+)
+def test_decimal_pattern_accepts_scientific_notation_with_no_constraints(scientific_decimal, get_decimal_pattern) -> None:
+    """Serialization mode pattern must accept scientific notation (e.g. 1E-7) since pydantic-core can produce it."""
+    pattern = get_decimal_pattern()
+
+    assert re.fullmatch(pattern, scientific_decimal) is not None
+
+
+@pytest.mark.parametrize(
     'valid_decimal', ['10.01', '11.11', '010.010', '011.110', '11', '0011', '001.100', '.1', '.11000', '00011.']
 )
 def test_decimal_pattern_with_decimal_places_max_digits_set(valid_decimal, get_decimal_pattern) -> None:
@@ -7175,6 +7186,32 @@ def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places
 ) -> None:
     pattern = get_decimal_pattern()
     assert re.fullmatch(pattern, invalid_decimal) is None
+
+
+def test_decimal_serialization_schema_matches_scientific_notation_output() -> None:
+    """Serialization schema pattern must accept values that pydantic-core itself produces.
+
+    pydantic-core calls str() on Decimal, which can produce scientific notation
+    (e.g. Decimal('0.0000001') -> '1E-7'). The generated pattern must match.
+    """
+    import json
+    import re
+    from decimal import Decimal
+
+    class MyModel(BaseModel):
+        value: Decimal
+
+    schema = MyModel.model_json_schema(mode='serialization')
+    pattern = schema['properties']['value']['pattern']
+    regex = re.compile(pattern)
+
+    for raw in ['0.0000001', '1E-7', '1.5E-10', '0.001']:
+        m = MyModel(value=Decimal(raw))
+        serialized_value = json.loads(m.model_dump_json())['value']
+        assert regex.match(serialized_value), (
+            f'Serialization schema pattern {pattern!r} rejected serialized value {serialized_value!r} '
+            f'(from Decimal({raw!r}))'
+        )
 
 
 def test_union_format_primitive_type_array() -> None:


### PR DESCRIPTION
## Summary

Fixes #13089

`pydantic-core` serializes `Decimal` values using `str()`, which produces scientific notation for small/large values (e.g. `Decimal('0.0000001')` → `'1E-7'`). The unconstrained `Decimal` pattern in `json_schema.py` (Case 4, no `max_digits`/`decimal_places` constraints) was missing an exponent group, so the generated schema rejected values that pydantic itself serializes.

**Root cause** — the pattern added in #11987:

```
^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
```

has no `[eE]` component, so `'1E-7'` never matches.

**Fix** — append `(?:[eE][+-]?\d+)?` before `$` in the unconstrained case:

```
^(?!^[-+.]*$)[+-]?0*\d*\.?\d*(?:[eE][+-]?\d+)?$
```

This makes the serialization schema accurately describe all values that `model_dump_json()` can produce for `Decimal` fields.

## Changes

- `pydantic/json_schema.py`: add optional exponent group to the Case 4 (unconstrained) decimal pattern
- `tests/test_json_schema.py`: add parametrized test for scientific notation matches, and an end-to-end round-trip test that validates serialized values against their own schema

## Test plan

- [ ] New `test_decimal_pattern_accepts_scientific_notation_with_no_constraints` — directly tests that `'1E-7'`, `'1E+7'`, `'1.5E-3'`, `'2.5e10'`, etc. match the pattern
- [ ] New `test_decimal_serialization_schema_matches_scientific_notation_output` — end-to-end round-trip: constructs a model, calls `model_dump_json()`, extracts the serialized string, and asserts it matches `model_json_schema(mode='serialization')`
- [ ] Existing decimal pattern tests still pass (the added group is optional, so no regressions)