### PR TITLE
Add support for string.templatelib.Template

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -38,6 +38,11 @@ from typing import (
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
+try:
+    from string.templatelib import Template
+except ImportError:
+    Template = None
+
 import typing_extensions
 from pydantic_core import (
     MISSING,
@@ -1134,6 +1139,25 @@ class GenerateSchema:
             return self.generate_schema(obj.__supertype__)
         elif obj in PATTERN_TYPES:
             return self._pattern_schema(obj)
+        elif Template is not None and obj is Template:
+            return core_schema.is_instance_schema(
+                Template,
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda t: {
+                        'strings': list(t.strings),
+                        'interpolations': [
+                            {
+                                'value': i.value,
+                                'expression': i.expression,
+                                'conversion': i.conversion,
+                                'format_spec': i.format_spec,
+                            }
+                            for i in t.interpolations
+                        ],
+                    },
+                    when_used='json',
+                ),
+            )
         elif _typing_extra.is_hashable(obj):
             return self._hashable_schema()
         elif isinstance(obj, typing.TypeVar):

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -39,7 +39,9 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 try:
-    from string.templatelib import Template
+    import importlib
+
+    Template = importlib.import_module('string.templatelib').Template
 except ImportError:
     Template = None
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4384,6 +4384,86 @@ def test_pattern_error(pattern_type, pattern_value, error_type, error_msg):
     ]
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='templatelib added in Python 3.14',
+)
+def test_template_type_accepts_template():
+    from string.templatelib import Template
+
+    class Model(BaseModel):
+        field: Template
+
+    value = eval("t'hello'")
+
+    m = Model(field=value)
+
+    assert m.field is value
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='templatelib added in Python 3.14',
+)
+def test_template_type_rejects_str():
+    from string.templatelib import Template
+
+    class Model(BaseModel):
+        field: Template
+
+    with pytest.raises(ValidationError):
+        Model(field='hello')
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='templatelib added in Python 3.14',
+)
+def test_template_json_serialization():
+    from string.templatelib import Template
+
+    class Model(BaseModel):
+        field: Template
+
+    m = Model(field=eval("t'hello'"))
+
+    assert m.model_dump(mode='json') == {
+        'field': {
+            'strings': ['hello'],
+            'interpolations': [],
+        }
+    }
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason='templatelib added in Python 3.14',
+)
+def test_template_json_serialization_interpolation():
+    from string.templatelib import Template
+
+    class Model(BaseModel):
+        field: Template
+
+    value = 'world'
+
+    m = Model(field=eval("""t'hello {value}'""", {}, {'value': value}))
+
+    assert m.model_dump(mode='json') == {
+        'field': {
+            'strings': ['hello ', ''],
+            'interpolations': [
+                {
+                    'value': 'world',
+                    'expression': 'value',
+                    'conversion': None,
+                    'format_spec': '',
+                }
+            ],
+        }
+    }
+
+
 @pytest.mark.parametrize('validate_json', [True, False])
 def test_secretstr(validate_json):
     class Foobar(BaseModel):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4389,7 +4389,7 @@ def test_pattern_error(pattern_type, pattern_value, error_type, error_msg):
     reason='templatelib added in Python 3.14',
 )
 def test_template_type_accepts_template():
-    from string.templatelib import Template
+    Template = __import__('string.templatelib', fromlist=['Template']).Template
 
     class Model(BaseModel):
         field: Template
@@ -4406,7 +4406,7 @@ def test_template_type_accepts_template():
     reason='templatelib added in Python 3.14',
 )
 def test_template_type_rejects_str():
-    from string.templatelib import Template
+    Template = __import__('string.templatelib', fromlist=['Template']).Template
 
     class Model(BaseModel):
         field: Template
@@ -4420,7 +4420,7 @@ def test_template_type_rejects_str():
     reason='templatelib added in Python 3.14',
 )
 def test_template_json_serialization():
-    from string.templatelib import Template
+    Template = __import__('string.templatelib', fromlist=['Template']).Template
 
     class Model(BaseModel):
         field: Template
@@ -4440,7 +4440,7 @@ def test_template_json_serialization():
     reason='templatelib added in Python 3.14',
 )
 def test_template_json_serialization_interpolation():
-    from string.templatelib import Template
+    Template = __import__('string.templatelib', fromlist=['Template']).Template
 
     class Model(BaseModel):
         field: Template


### PR DESCRIPTION
Fixes #13160 

This allows Template objects to be used directly in Pydantic models and adds JSON serialization support for templates and interpolations.

Also added tests for validation and serialization.