### PR TITLE
fix: enforce URL constraints on existing URL instances

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -315,6 +315,7 @@ class _BaseUrl:
     ) -> core_schema.CoreSchema:
         def wrap_val(v, h):
             if isinstance(v, source):
+                h(v._url)
                 return v
             if isinstance(v, _BaseUrl):
                 v = str(v)
@@ -531,6 +532,7 @@ class _BaseMultiHostUrl:
     ) -> core_schema.CoreSchema:
         def wrap_val(v, h):
             if isinstance(v, source):
+                h(v._url)
                 return v
             if isinstance(v, _BaseMultiHostUrl):
                 v = str(v)

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1107,6 +1107,24 @@ def test_custom_constraints() -> None:
         ta.validate_python('ftp://example.com')
 
 
+def test_custom_constraints_reject_existing_url_instance() -> None:
+    HttpUrl = Annotated[AnyUrl, UrlConstraints(allowed_schemes=['http', 'https'])]
+    ta = TypeAdapter(HttpUrl)
+
+    with pytest.raises(ValidationError):
+        ta.validate_python(AnyUrl('file:///etc/passwd'))
+
+
+def test_model_validate_reapplies_url_constraints_to_existing_instance() -> None:
+    HttpUrl = Annotated[AnyUrl, UrlConstraints(allowed_schemes=['http', 'https'])]
+
+    class Model(BaseModel):
+        v: HttpUrl
+
+    with pytest.raises(ValidationError):
+        Model.model_validate({'v': AnyUrl('file:///etc/passwd')})
+
+
 def test_url_constraints_invalid_annotated_type() -> None:
     with pytest.raises(PydanticUserError):
         TypeAdapter(Annotated[str, UrlConstraints(max_length=1)])


### PR DESCRIPTION
## Change Summary

Fixes #13170

`UrlConstraints` applied through `Annotated[AnyUrl, ...]` could be bypassed when validation received an already-constructed `AnyUrl` instance instead of a raw string. In that case, `_BaseUrl` would take a fast path and return the existing instance without re-checking the constrained URL schema.

### Root Cause

The URL wrapper in `pydantic/networks.py` short-circuited for `isinstance(v, source)` before the inner constrained schema had a chance to run. That meant constraints such as `allowed_schemes` were enforced for string inputs, but skipped for existing URL objects.

### Fix

Re-validate the underlying core URL value on the fast path before returning an existing URL instance. This preserves the existing optimization for already-built URL objects while ensuring the inner `UrlConstraints` are still applied. The same logic is applied consistently to multi-host URL wrappers as well.

### Changes

- Updated the URL wrapper validation path in `pydantic/networks.py` to validate `v._url` before returning an existing instance.
- Added regression tests in `tests/test_networks.py` covering `TypeAdapter` validation and `BaseModel.model_validate()` with existing `AnyUrl` instances.

## Testing

Focused regression tests:
- `path -m pytest -q tests/test_networks.py -k "custom_constraints_reject_existing_url_instance or model_validate_reapplies_url_constraints_to_existing_instance"`


## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**