### PR TITLE
Fix JSON schema pattern for Decimals to allow scientific notation

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -708,8 +708,8 @@ class GenerateJsonSchema:
                     rf'(?:'
                     rf'\d{{0,{integer_places}}}'
                     rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
+                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*(?:[eE][+-]?\d+)?$)'
+                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*(?:[eE][+-]?\d+)?$'
                     rf')'
                 )
 
@@ -719,18 +719,18 @@ class GenerateJsonSchema:
                     rf'(?:'
                     rf'\d{{0,{max_digits}}}'
                     rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d*\.\d*0*$'
+                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*(?:[eE][+-]?\d+)?$)'
+                    rf'\d*\.\d*0*(?:[eE][+-]?\d+)?$'
                     rf')'
                 )
 
             # Case 3: Only decimal_places is set
             elif max_digits is None and decimal_places is not None:
-                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*$'
+                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*(?:[eE][+-]?\d+)?$'
 
             # Case 4: Both are None (no restrictions)
             else:
-                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
+                pattern += r'\d*\.?\d*(?:[eE][+-]?\d+)?$'  # look for arbitrary integer or decimal
 
             return pattern
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7265,3 +7265,15 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+d e f   t e s t _ d e c i m a l _ s c h e m a _ s c i e n t i f i c _ n o t a t i o n ( ) :  
+         f r o m   d e c i m a l   i m p o r t   D e c i m a l  
+         f r o m   p y d a n t i c   i m p o r t   B a s e M o d e l  
+         i m p o r t   r e  
+         c l a s s   M y M o d e l ( B a s e M o d e l ) :  
+                 v a l u e :   D e c i m a l  
+         s c h e m a   =   M y M o d e l . m o d e l _ j s o n _ s c h e m a ( )  
+         p a t t e r n   =   n e x t ( v   f o r   v   i n   s c h e m a [ ' p r o p e r t i e s ' ] [ ' v a l u e ' ] [ ' a n y O f ' ]   i f   v . g e t ( ' t y p e ' )   = =   ' s t r i n g ' ) [ ' p a t t e r n ' ]  
+         r e g e x   =   r e . c o m p i l e ( p a t t e r n )  
+         a s s e r t   b o o l ( r e g e x . m a t c h ( ' 1 e - 7 ' ) )   i s   T r u e  
+         a s s e r t   b o o l ( r e g e x . m a t c h ( ' 1 E - 7 ' ) )   i s   T r u e  
+ 


### PR DESCRIPTION
## Change Summary

This PR updates `get_decimal_pattern` in `pydantic/json_schema.py` to allow optional scientific notation `(?:[eE][+-]?\d+)?` at the end of the regex strings. Pydantic's core validation successfully parses scientific notation (e.g., `1E-7`), and `model_dump_json()` inherently produces scientific notation for extreme Decimals, but the regex explicitly rejected it, breaking downstream OpenAPI clients. This PR rectifies the generated JSON schema to accurately reflect Pydantic's underlying compatibility with scientific notation formats.

## Related issue number

Fixes #13089 
## Checklist

- The pull request title is a good summary of the changes.
- - Unit tests for the changes exist.
- - Tests pass on CI.
- - Documentation reflects the changes.
- - My PR is ready to review.