### PR TITLE
fix: route private attributes to __pydantic_private__ and respect extra settings in model_copy

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -441,12 +441,22 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 for k, v in update.items():
                     if k in self.__pydantic_fields__:
                         copied.__dict__[k] = v
+                    elif self.__private_attributes__ and k in self.__private_attributes__:
+                        if copied.__pydantic_private__ is None:
+                            copied.__pydantic_private__ = {}
+                        copied.__pydantic_private__[k] = v
                     else:
                         if copied.__pydantic_extra__ is None:
                             copied.__pydantic_extra__ = {}
                         copied.__pydantic_extra__[k] = v
             else:
-                copied.__dict__.update(update)
+                for k, v in update.items():
+                    if k in self.__pydantic_fields__:
+                        copied.__dict__[k] = v
+                    elif self.__private_attributes__ and k in self.__private_attributes__:
+                        if copied.__pydantic_private__ is None:
+                            copied.__pydantic_private__ = {}
+                        copied.__pydantic_private__[k] = v
 
             copied.__pydantic_fields_set__.update(update.keys())
 

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -391,6 +391,53 @@ def test_model_copy_deep_update_with_private_attributes() -> None:
     assert m2._private is not m._private
 
 
+def test_model_copy_update_private_attribute() -> None:
+    """Private attributes in model_copy(update=...) should route to __pydantic_private__, not __dict__."""
+
+    class M(BaseModel):
+        a: int
+        _private: str = PrivateAttr(default='old')
+
+    m = M(a=1)
+    m2 = m.model_copy(update={'_private': 'new'})
+
+    # Private attribute should be accessible via property
+    assert m2._private == 'new'
+    # Private attribute should NOT be in __dict__
+    assert '_private' not in m2.__dict__
+    # Private attribute should be in __pydantic_private__
+    assert m2.__pydantic_private__ is not None
+    assert m2.__pydantic_private__['_private'] == 'new'
+
+
+def test_model_copy_update_respects_extra_forbid() -> None:
+    """model_copy(update=...) should respect extra='forbid' and not set unknown keys."""
+
+    class M(BaseModel, extra='forbid'):
+        a: int
+
+    m = M(a=1)
+    m2 = m.model_copy(update={'nonexistent': 'value'})
+
+    assert m2.a == 1
+    assert 'nonexistent' not in m2.__dict__
+    assert m2.__pydantic_extra__ is None or 'nonexistent' not in (m2.__pydantic_extra__ or {})
+
+
+def test_model_copy_update_respects_extra_ignore() -> None:
+    """model_copy(update=...) should respect extra='ignore' and not set unknown keys."""
+
+    class M(BaseModel, extra='ignore'):
+        a: int
+
+    m = M(a=1)
+    m2 = m.model_copy(update={'nonexistent': 'value'})
+
+    assert m2.a == 1
+    assert 'nonexistent' not in m2.__dict__
+    assert m2.__pydantic_extra__ is None or 'nonexistent' not in (m2.__pydantic_extra__ or {})
+
+
 def test_copy_set_fields(ModelTwo, copy_method):
     m = ModelTwo(a=24, d=Model(a='12'))
     m2 = copy_method(m)


### PR DESCRIPTION
## What
Fixes two bugs in `model_copy(update=...)`:

1. **Private attributes routed to `__dict__` instead of `__pydantic_private__`** — when `model_copy(update={"_private": "new"})` is called, the value was stored in `__dict__` instead of `__pydantic_private__`, making it inaccessible via the private attribute property.
2. **`extra='forbid'` / `extra='ignore'` not respected** — unknown keys passed in `update` were silently added to `__dict__` even when extra forbids or ignores extras.

## Why
When a model uses `PrivateAttr`, calling `model_copy(update={"_private": val})` stores the value in `__dict__` instead of `__pydantic_private__`. This means subsequent access via `self._private` returns the original value, not the updated one.

Additionally, `model_copy` docs state "Only the known fields are updated" but the implementation allowed unknown keys to be injected into `__dict__` even when extras are forbidden or ignored.

## How
The `update` block in `model_copy` now:
- Checks if a key is a private attribute (via `self.__private_attributes__`) and routes to `copied.__pydantic_private__` instead of `copied.__dict__` or `__pydantic_extra__`.
- For non-allow extra modes, iterates through update keys and only sets known fields and private attributes, silently ignoring unknown keys (consistent with `model_construct` semantics).

## Testing
- `test_model_copy_update_private_attribute` — verifies private attrs route to `__pydantic_private__`
- `test_model_copy_update_respects_extra_forbid` — verifies unknown keys are blocked when `extra='forbid'`
- `test_model_copy_update_respects_extra_ignore` — verifies unknown keys are blocked when `extra='ignore'`

Fixes #13208