### PR TITLE
fix: allow periods in unquoted NameEmail display names

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1296,7 +1296,7 @@ else:
 
 
 def _build_pretty_email_regex() -> re.Pattern[str]:
-    name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'
+    name_chars = r'[\w!#$%&\'*+\-./=?^_`{|}~]'
     unquoted_name_group = rf'((?:{name_chars}+\s+)*{name_chars}+)'
     quoted_name_group = r'"((?:[^"]|\")+)"'
     email_group = r'<(.+)>'

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1009,6 +1009,8 @@ def test_name_email():
     assert str(Model(v=NameEmail('foo bar', 'foobaR@example.com')).v) == 'foo bar <foobaR@example.com>'
     assert str(Model(v='foo bar  <foobaR@example.com>').v) == 'foo bar <foobaR@example.com>'
     assert str(Model(v='foobaR@example.com').v) == 'foobaR <foobaR@example.com>'
+    # periods are allowed in unquoted display names per RFC 5322 (fixes #13206)
+    assert str(Model(v='Homer J. Simpson <homer@example.com>').v) == 'Homer J. Simpson <homer@example.com>'
     assert NameEmail('foo bar', 'foobaR@example.com') == NameEmail('foo bar', 'foobaR@example.com')
     assert NameEmail('foo bar', 'foobaR@example.com') != NameEmail('foo bar', 'different@example.com')
 


### PR DESCRIPTION
The \`NameEmail\` validator currently rejects display names containing periods in unquoted form, such as:

\`\`\`
Homer J. Simpson <homer@example.com>
\`\`\`

This is valid per RFC 5322 — periods are allowed in unquoted display names (in the \`display-name\` production via \`phrase\` / \`word\` / \`atom\` / \`atext\`, which includes \`.`).

## Root cause

In \`_build_pretty_email_regex()\` within \`pydantic/networks.py\`, the \`name_chars\` character class did not include \`.\`:

\`\`\`python
# Before
name_chars = r'[\w!#$%&\'*+\-/=?^_`{|}~]'

# After
name_chars = r'[\w!#$%&\'*+\-./=?^_`{|}~]'
\`\`\`

## Changes

- \`pydantic/networks.py\`: added \`.\` to the \`name_chars\` character class in \`_build_pretty_email_regex()\`
- \`tests/test_networks.py\`: added a test case for period-containing unquoted display names

Fixes #13206