### PR TITLE
Add `use_enum_names` config to validate/serialize enums by name

### DIFF
--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -1318,6 +1318,7 @@ class EnumSchema(TypedDict, total=False):
     members: Required[list[Any]]
     sub_type: Literal['str', 'int', 'float']
     missing: Callable[[Any], Any]
+    use_enum_name: bool
     strict: bool
     ref: str
     metadata: dict[str, Any]
@@ -1330,6 +1331,7 @@ def enum_schema(
     *,
     sub_type: Literal['str', 'int', 'float'] | None = None,
     missing: Callable[[Any], Any] | None = None,
+    use_enum_name: bool | None = None,
     strict: bool | None = None,
     ref: str | None = None,
     metadata: dict[str, Any] | None = None,
@@ -1357,6 +1359,7 @@ def enum_schema(
         members: The members of the enum, generally `list(MyEnum.__members__.values())`
         sub_type: The type of the enum, either 'str' or 'int' or None for plain enums
         missing: A function to use when the value is not found in the enum, from `_missing_`
+        use_enum_name: Whether to validate/serialize using the enum member's name instead of value
         strict: Whether to use strict mode, defaults to False
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
@@ -1368,6 +1371,7 @@ def enum_schema(
         members=members,
         sub_type=sub_type,
         missing=missing,
+        use_enum_name=use_enum_name,
         strict=strict,
         ref=ref,
         metadata=metadata,

--- a/pydantic-core/src/serializers/type_serializers/enum_.rs
+++ b/pydantic-core/src/serializers/type_serializers/enum_.rs
@@ -21,6 +21,7 @@ use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
 pub struct EnumSerializer {
     class: Py<PyType>,
     serializer: Option<Arc<CombinedSerializer>>,
+    use_enum_name: bool,
 }
 
 impl BuildSerializer for EnumSerializer {
@@ -31,18 +32,21 @@ impl BuildSerializer for EnumSerializer {
         config: Option<&Bound<'_, PyDict>>,
         _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
     ) -> PyResult<Arc<CombinedSerializer>> {
-        let sub_type: Option<String> = schema.get_as(intern!(schema.py(), "sub_type"))?;
+        let py = schema.py();
+        let use_enum_name: bool = schema.get_as(intern!(py, "use_enum_name"))?.unwrap_or(false);
+        let sub_type: Option<String> = schema.get_as(intern!(py, "sub_type"))?;
 
         let serializer = match sub_type.as_deref() {
             Some("int") => Some(IntSerializer::get().clone()),
             Some("str") => Some(StrSerializer::get().clone()),
-            Some("float") => Some(FloatSerializer::get(schema.py(), config)?.clone()),
+            Some("float") => Some(FloatSerializer::get(py, config)?.clone()),
             Some(_) => return py_schema_err!("`sub_type` must be one of: 'int', 'str', 'float' or None"),
             None => None,
         };
         Ok(CombinedSerializer::Enum(Self {
-            class: schema.get_as_req(intern!(schema.py(), "cls"))?,
+            class: schema.get_as_req(intern!(py, "cls"))?,
             serializer,
+            use_enum_name,
         })
         .into())
     }
@@ -54,15 +58,21 @@ impl TypeSerializer for EnumSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let py = value.py();
         if value.is_exact_instance(self.class.bind(py)) {
-            // if we're in JSON mode, we need to get the value attribute and serialize that
-            if state.extra.mode.is_json() {
-                let dot_value = value.getattr(intern!(py, "value"))?;
-                match self.serializer {
-                    Some(ref s) => s.to_python(&dot_value, state),
-                    None => infer_to_python(&dot_value, state),
-                }
+            let attr = if self.use_enum_name {
+                intern!(py, "name")
             } else {
-                // if we're not in JSON mode, we assume the value is safe to return directly
+                intern!(py, "value")
+            };
+            if state.extra.mode.is_json() {
+                let dot_attr = value.getattr(attr)?;
+                match self.serializer {
+                    Some(ref s) => s.to_python(&dot_attr, state),
+                    None => infer_to_python(&dot_attr, state),
+                }
+            } else if self.use_enum_name {
+                let dot_attr = value.getattr(attr)?;
+                Ok(dot_attr.unbind())
+            } else {
                 Ok(value.clone().unbind())
             }
         } else {
@@ -78,13 +88,16 @@ impl TypeSerializer for EnumSerializer {
     ) -> PyResult<Cow<'a, str>> {
         let py = key.py();
         if key.is_exact_instance(self.class.bind(py)) {
-            let dot_value = key.getattr(intern!(py, "value"))?;
+            let attr = if self.use_enum_name {
+                intern!(py, "name")
+            } else {
+                intern!(py, "value")
+            };
+            let dot_attr = key.getattr(attr)?;
             let k = match self.serializer {
-                Some(ref s) => s.json_key(&dot_value, state),
-                None => infer_json_key(&dot_value, state),
+                Some(ref s) => s.json_key(&dot_attr, state),
+                None => infer_json_key(&dot_attr, state),
             }?;
-            // since dot_value is a local reference, we need to allocate it and returned an
-            // owned variant of cow.
             Ok(Cow::Owned(k.into_owned()))
         } else {
             state.warn_fallback_py(self.get_name(), key)?;
@@ -98,11 +111,17 @@ impl TypeSerializer for EnumSerializer {
         serializer: S,
         state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
-        if value.is_exact_instance(self.class.bind(value.py())) {
-            let dot_value = value.getattr(intern!(value.py(), "value")).map_err(py_err_se_err)?;
+        let py = value.py();
+        if value.is_exact_instance(self.class.bind(py)) {
+            let attr = if self.use_enum_name {
+                intern!(py, "name")
+            } else {
+                intern!(py, "value")
+            };
+            let dot_attr = value.getattr(attr).map_err(py_err_se_err)?;
             match self.serializer {
-                Some(ref s) => s.serde_serialize(&dot_value, serializer, state),
-                None => infer_serialize(&dot_value, serializer, state),
+                Some(ref s) => s.serde_serialize(&dot_attr, serializer, state),
+                None => infer_serialize(&dot_attr, serializer, state),
             }
         } else {
             state.warn_fallback_ser::<S>(self.get_name(), value)?;

--- a/pydantic-core/src/validators/enum_.rs
+++ b/pydantic-core/src/validators/enum_.rs
@@ -34,10 +34,15 @@ impl BuildValidator for BuildEnumValidator {
         }
 
         let py = schema.py();
-        let value_str = intern!(py, "value");
+        let use_enum_name: bool = schema.get_as(intern!(py, "use_enum_name"))?.unwrap_or(false);
+        let attr_str = if use_enum_name {
+            intern!(py, "name")
+        } else {
+            intern!(py, "value")
+        };
         let expected: Vec<(Bound<'_, PyAny>, Py<PyAny>)> = members
             .iter()
-            .map(|v| Ok((v.getattr(value_str)?, v.into())))
+            .map(|v| Ok((v.getattr(attr_str)?, v.into())))
             .collect::<PyResult<_>>()?;
 
         let repr_args: Vec<_> = expected.iter().map(|(k, _)| k.repr()).collect::<PyResult<_>>()?;
@@ -58,6 +63,7 @@ impl BuildValidator for BuildEnumValidator {
                     expected_repr,
                     strict: is_strict(schema, config)?,
                     class_repr: class_repr.clone(),
+                    use_enum_name,
                     name: format!("{}[{class_repr}]", $name_prefix),
                 }
             };
@@ -92,6 +98,7 @@ pub struct EnumValidator<T: EnumValidateValue> {
     expected_repr: String,
     strict: bool,
     class_repr: String,
+    use_enum_name: bool,
     name: String,
 }
 
@@ -122,9 +129,12 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
 
         if let Some(v) = T::validate_value(py, input, &self.lookup, strict)? {
             return Ok(v);
-        } else if let Ok(res) = class.as_unbound().call1(py, (input.as_python(),)) {
-            return Ok(res);
-        } else if let Some(ref missing) = self.missing {
+        } else if !self.use_enum_name {
+            if let Ok(res) = class.as_unbound().call1(py, (input.as_python(),)) {
+                return Ok(res);
+            }
+        }
+        if let Some(ref missing) = self.missing {
             let enum_value = missing.bind(py).call1((input.to_object(py)?,)).map_err(|_| {
                 ValError::new(
                     ErrorType::Enum {

--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -45,6 +45,7 @@ class ConfigWrapper:
     frozen: bool
     populate_by_name: bool
     use_enum_values: bool
+    use_enum_names: bool
     validate_assignment: bool
     arbitrary_types_allowed: bool
     from_attributes: bool
@@ -279,6 +280,7 @@ config_defaults = ConfigDict(
     frozen=False,
     populate_by_name=False,
     use_enum_values=False,
+    use_enum_names=False,
     validate_assignment=False,
     arbitrary_types_allowed=False,
     from_attributes=False,

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -432,6 +432,10 @@ class GenerateSchema:
             # TODO this is an ugly hack, how do we trigger an Any schema for serialization?
             value_ser_type = core_schema.plain_serializer_function_ser_schema(lambda x: x)
 
+        use_enum_names = self._config_wrapper.use_enum_names
+        if use_enum_names:
+            sub_type = 'str'
+
         if cases:
 
             def get_json_schema(schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
@@ -447,6 +451,7 @@ class GenerateSchema:
                 cases,
                 sub_type=sub_type,
                 missing=None if default_missing else enum_type._missing_,
+                use_enum_name=use_enum_names or None,
                 ref=enum_ref,
                 metadata={'pydantic_js_functions': [get_json_schema]},
             )

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -261,6 +261,45 @@ class ConfigDict(TypedDict, total=False):
     ```
     """
 
+    use_enum_names: bool
+    """
+    Whether to validate and serialize enums using the member
+    [`name`][enum.Enum.name] instead of the [`value`][enum.Enum.value].
+    Defaults to `False`.
+
+    When enabled, input data should use the enum member's name (e.g. `'NY'`)
+    rather than its value (e.g. `'New York'`), and serialization will output
+    the member name. JSON schemas will also list member names.
+
+    This is useful when enum names serve as short codes and values are
+    human-readable descriptions, or when interoperating with systems
+    like SQLAlchemy that store enum names.
+
+    ```python
+    from enum import Enum
+
+    from pydantic import BaseModel, ConfigDict
+
+    class StateAbbrev(Enum):
+        NY = 'New York'
+        MA = 'Massachusetts'
+
+    class Address(BaseModel):
+        model_config = ConfigDict(use_enum_names=True)
+
+        state: StateAbbrev
+
+    addr = Address(state='NY')
+    print(addr.state)
+    #> StateAbbrev.NY
+    print(addr.model_dump())
+    #> {'state': 'NY'}
+    ```
+
+    /// version-added | v2.14
+    ///
+    """
+
     validate_assignment: bool
     """
     Whether to validate the data when the model is changed. Defaults to `False`.

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -894,7 +894,11 @@ class GenerateJsonSchema:
         result: dict[str, Any] = {'title': enum_type.__name__, 'description': description}
         result = {k: v for k, v in result.items() if v is not None}
 
-        expected = [to_jsonable_python(v.value) for v in schema['members']]
+        use_enum_name = schema.get('use_enum_name', False)
+        if use_enum_name:
+            expected = [v.name for v in schema['members']]
+        else:
+            expected = [to_jsonable_python(v.value) for v in schema['members']]
 
         result['enum'] = expected
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7314,3 +7314,154 @@ def test_string_constraints_ascii_only() -> None:
         'msg': 'String should contain only ASCII characters',
         'input': 'caf\xe9',
     }
+
+
+class TestUseEnumNames:
+    """Tests for the use_enum_names config option."""
+
+    def test_basic_validation_by_name(self) -> None:
+        class StateAbbrev(Enum):
+            NY = 'New York'
+            MA = 'Massachusetts'
+            CA = 'California'
+
+        class Address(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            state: StateAbbrev
+
+        addr = Address(state='NY')
+        assert addr.state is StateAbbrev.NY
+
+    def test_validation_rejects_value_when_use_enum_names(self) -> None:
+        class StateAbbrev(Enum):
+            NY = 'New York'
+            MA = 'Massachusetts'
+
+        class Address(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            state: StateAbbrev
+
+        with pytest.raises(ValidationError):
+            Address(state='New York')
+
+    def test_serialization_by_name(self) -> None:
+        class StateAbbrev(Enum):
+            NY = 'New York'
+            MA = 'Massachusetts'
+
+        class Address(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            state: StateAbbrev
+
+        addr = Address(state='NY')
+        assert addr.model_dump() == {'state': 'NY'}
+        assert addr.model_dump_json() == '{"state":"NY"}'
+
+    def test_json_schema_lists_names(self) -> None:
+        class StateAbbrev(Enum):
+            NY = 'New York'
+            MA = 'Massachusetts'
+
+        class Address(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            state: StateAbbrev
+
+        schema = Address.model_json_schema()
+        state_schema = schema['$defs']['StateAbbrev']
+        assert state_schema['enum'] == ['NY', 'MA']
+        assert state_schema['type'] == 'string'
+
+    def test_int_enum_with_use_enum_names(self) -> None:
+        class Priority(IntEnum):
+            LOW = 1
+            MEDIUM = 2
+            HIGH = 3
+
+        class Task(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            priority: Priority
+
+        task = Task(priority='HIGH')
+        assert task.priority is Priority.HIGH
+        assert task.model_dump() == {'priority': 'HIGH'}
+        assert task.model_dump_json() == '{"priority":"HIGH"}'
+
+        with pytest.raises(ValidationError):
+            Task(priority=3)
+
+    def test_str_enum_with_use_enum_names(self) -> None:
+        class Color(str, Enum):
+            RED = 'red_value'
+            GREEN = 'green_value'
+
+        class Model(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            color: Color
+
+        m = Model(color='RED')
+        assert m.color is Color.RED
+        assert m.model_dump() == {'color': 'RED'}
+
+        with pytest.raises(ValidationError):
+            Model(color='red_value')
+
+    def test_default_behavior_unchanged(self) -> None:
+        class StateAbbrev(Enum):
+            NY = 'New York'
+            MA = 'Massachusetts'
+
+        class Address(BaseModel):
+            state: StateAbbrev
+
+        addr = Address(state='New York')
+        assert addr.state is StateAbbrev.NY
+        assert addr.model_dump() == {'state': StateAbbrev.NY}
+        assert addr.model_dump_json() == '{"state":"New York"}'
+
+    def test_enum_member_passthrough(self) -> None:
+        class StateAbbrev(Enum):
+            NY = 'New York'
+            MA = 'Massachusetts'
+
+        class Address(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            state: StateAbbrev
+
+        addr = Address(state=StateAbbrev.NY)
+        assert addr.state is StateAbbrev.NY
+
+    def test_use_enum_names_with_use_enum_values(self) -> None:
+        class StateAbbrev(Enum):
+            NY = 'New York'
+            MA = 'Massachusetts'
+
+        class Address(BaseModel):
+            model_config = ConfigDict(use_enum_names=True, use_enum_values=True)
+
+            state: StateAbbrev
+
+        addr = Address(state='NY')
+        assert addr.state == 'New York'
+
+    def test_json_schema_names_for_int_enum(self) -> None:
+        class Priority(IntEnum):
+            LOW = 1
+            MEDIUM = 2
+            HIGH = 3
+
+        class Task(BaseModel):
+            model_config = ConfigDict(use_enum_names=True)
+
+            priority: Priority
+
+        schema = Task.model_json_schema()
+        priority_schema = schema['$defs']['Priority']
+        assert priority_schema['enum'] == ['LOW', 'MEDIUM', 'HIGH']
+        assert priority_schema['type'] == 'string'


### PR DESCRIPTION
## Change Summary

Add a new `use_enum_names` configuration option that validates and serializes
enums using member names instead of values. This addresses a long-standing
disconnect between pydantic (validates by value) and systems like SQLAlchemy
(stores by name), allowing enums to serve as CODE→HUMAN_READABLE mappings.

Changes span pydantic-core (Rust validator/serializer + Python schema) and
pydantic (config, schema generation, JSON schema, tests).

## Related issue number

fix #13195

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

