### PR TITLE
Preserve slots on generic models

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -121,6 +121,8 @@ def create_generic_submodel(
         The created submodel.
     """
     namespace: dict[str, Any] = {'__module__': origin.__module__}
+    if '__slots__' in origin.__dict__:
+        namespace['__slots__'] = origin.__dict__['__slots__']
     bases = (origin,)
     meta, ns, kwds = prepare_class(model_name, bases)
     namespace.update(ns)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -4,6 +4,7 @@ import json
 import platform
 import re
 import sys
+import weakref
 from collections import Counter, OrderedDict, defaultdict, deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import Enum, IntEnum
@@ -380,6 +381,30 @@ def test_cache_keys_are_hashable(mocker: MockerFixture):
     models.append(Model)
     assert len(cache) == cache_size + 15
     del models
+
+
+def test_generic_submodel_preserves_slots() -> None:
+    T = TypeVar('T')
+
+    class Model(BaseModel, Generic[T]):
+        __slots__ = ()
+
+        value: T | None = None
+
+    with pytest.raises(TypeError):
+        weakref.ref(Model())
+
+    ModelInt = Model[int]
+    assert ModelInt.__slots__ == ()
+
+    with pytest.raises(TypeError):
+        weakref.ref(ModelInt())
+
+    class SubModel(ModelInt):
+        __slots__ = ()
+
+    with pytest.raises(TypeError):
+        weakref.ref(SubModel())
 
 
 @pytest.mark.thread_unsafe(reason='GC is flaky')


### PR DESCRIPTION
## Change Summary

Preserve an explicit `__slots__` declaration when generating parameterized generic model subclasses. This keeps `Model[int]` from adding a weakref slot when `Model` opted out with `__slots__ = ()`.

Added regression coverage for the parameterized model and a subclass of it.

## Related issue number

fix #13215

## Tests

- `uv run --frozen pytest tests\test_generics.py -k "generic_submodel_preserves_slots" -q`
- `uv run --frozen pytest tests\test_generics.py -q`
- `uv run --frozen ruff check pydantic\_internal\_generics.py tests\test_generics.py`
- `uv run --frozen ruff format --check pydantic\_internal\_generics.py tests\test_generics.py`
- `uv run --frozen --extra timezone pytest -q`

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**