### PR TITLE
Pass through external JSON schema `$ref` values verbatim

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2317,15 +2317,14 @@ class GenerateJsonSchema:
         return json_schema
 
     def get_schema_from_definitions(self, json_ref: JsonRef) -> JsonSchemaValue | None:
-        try:
-            def_ref = self.json_to_defs_refs[json_ref]
-            if def_ref in self._core_defs_invalid_for_json_schema:
-                raise self._core_defs_invalid_for_json_schema[def_ref]
-            return self.definitions.get(def_ref, None)
-        except KeyError:
-            if json_ref.startswith(('http://', 'https://')):
-                return None
-            raise
+        if json_ref not in self.json_to_defs_refs:
+            # An external reference (e.g. set via `json_schema_extra`) that doesn't point to one
+            # of our own definitions. It is passed through verbatim and has no local definition.
+            return None
+        def_ref = self.json_to_defs_refs[json_ref]
+        if def_ref in self._core_defs_invalid_for_json_schema:
+            raise self._core_defs_invalid_for_json_schema[def_ref]
+        return self.definitions.get(def_ref, None)
 
     def encode_default(self, dft: Any) -> Any:
         """Encode a default value to a JSON-serializable value.
@@ -2429,14 +2428,13 @@ class GenerateJsonSchema:
                     json_refs[json_ref] += 1
                     if already_visited:
                         return  # prevent recursion on a definition that was already visited
-                    try:
+                    if json_ref in self.json_to_defs_refs:
+                        # Only recurse into references that point to one of our own definitions.
+                        # External references (e.g. set via `json_schema_extra`) are passed through verbatim.
                         defs_ref = self.json_to_defs_refs[json_ref]
                         if defs_ref in self._core_defs_invalid_for_json_schema:
                             raise self._core_defs_invalid_for_json_schema[defs_ref]
                         _add_json_refs(self.definitions[defs_ref])
-                    except KeyError:
-                        if not json_ref.startswith(('http://', 'https://')):
-                            raise
 
                 for k, v in schema.items():
                     if k == 'examples' and isinstance(v, list):
@@ -2497,15 +2495,14 @@ class GenerateJsonSchema:
         unvisited_json_refs = _get_all_json_refs(schema)
         while unvisited_json_refs:
             next_json_ref = unvisited_json_refs.pop()
-            try:
-                next_defs_ref = self.json_to_defs_refs[next_json_ref]
-                if next_defs_ref in visited_defs_refs:
-                    continue
-                visited_defs_refs.add(next_defs_ref)
-                unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
-            except KeyError:
-                if not next_json_ref.startswith(('http://', 'https://')):
-                    raise
+            if next_json_ref not in self.json_to_defs_refs:
+                # An external reference that doesn't point to one of our own definitions.
+                continue
+            next_defs_ref = self.json_to_defs_refs[next_json_ref]
+            if next_defs_ref in visited_defs_refs:
+                continue
+            visited_defs_refs.add(next_defs_ref)
+            unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
 
         self.definitions = {k: v for k, v in self.definitions.items() if k in visited_defs_refs}
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1713,6 +1713,27 @@ def test_external_ref():
     }
 
 
+@pytest.mark.parametrize(
+    'ref',
+    [
+        'https://example.com/schema.json#/$defs/Model',
+        'schema.json#/$defs/Model',
+        '#/$defs/External',
+        'urn:example:schema',
+    ],
+)
+def test_external_ref_not_a_local_definition(ref):
+    """External `$ref` values are passed through verbatim, regardless of the URI scheme.
+
+    https://github.com/pydantic/pydantic/issues/12093
+    """
+
+    class Model(BaseModel):
+        model_config = ConfigDict(json_schema_extra={'$ref': ref})
+
+    assert Model.model_json_schema() == {'$ref': ref, 'properties': {}, 'title': 'Model', 'type': 'object'}
+
+
 def test_schema_no_definitions():
     keys_map, model_schema = models_json_schema([], title='Schema without definitions')
     assert keys_map == {}


### PR DESCRIPTION
## Change Summary

External `$ref` values that don't point to one of pydantic's own definitions are now passed through verbatim regardless of the URI scheme.

Previously such refs were only tolerated when they started with `http://` or `https://`. Any other form — a relative reference like `schema.json#/$defs/Model`, a bare fragment, or another URI scheme such as a `urn:` — raised a `KeyError` during schema generation, even though these are all valid JSON Schema references.

### Root cause

`GenerateJsonSchema` looks every `$ref` up in `self.json_to_defs_refs` to resolve it to a local definition. Three sites (`get_schema_from_definitions`, `get_json_ref_counts`, `_garbage_collect_definitions`) wrapped that lookup in `try/except KeyError` and re-raised unless the ref happened to start with `http://`/`https://`. That URI-scheme check is too narrow: it only accounts for absolute HTTP(S) URIs, so any other external ref fell through to the re-raise.

```python
from pydantic import BaseModel, ConfigDict

class ModelRef(BaseModel):
    model_config = ConfigDict(json_schema_extra={"$ref": "schema.json#/$defs/Model"})

ModelRef.model_json_schema()  # KeyError: 'schema.json#/$defs/Model'
```

### Fix

`json_to_defs_refs` already holds exactly the references pydantic generates internally, so membership in it is the authoritative test for "is this one of ours". The three sites now check that explicitly: a ref that isn't registered there is external and is left untouched, while a registered ref whose definition is genuinely missing (or is flagged invalid for JSON schema) still raises as before. This also removes the special-casing of HTTP(S) URIs, since they're now handled by the same general path.

### Testing

- Added a parametrized regression test (`test_external_ref_not_a_local_definition`) covering an absolute HTTP ref, a relative path ref, a bare fragment, and a `urn:` ref. It fails on `main` for the three non-HTTP cases and passes with this change.
- The existing `test_external_ref` (the HTTP case from #9783) still passes, confirming behavior is preserved.
- `tests/test_json_schema.py` is green (plus `test_main`, `test_type_adapter`, `test_edge_cases`), and `ruff check` / `ruff format` pass.

## Related issue number

fix #12093

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**