### PR TITLE
Fix V1.10 Documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We've launched Pydantic Logfire to help you monitor your applications.
 Pydantic V2 is a ground-up rewrite that offers many new features, performance improvements, and some breaking changes compared to Pydantic V1.
 
 If you're using Pydantic V1 you may want to look at the
-[pydantic V1.10 Documentation](https://docs.pydantic.dev/) or,
+[pydantic V1.10 Documentation](https://docs.pydantic.dev/1.10/) or,
 [`1.10.X-fixes` git branch](https://github.com/pydantic/pydantic/tree/1.10.X-fixes). Pydantic V2 also ships with the latest version of Pydantic V1 built in so that you can incrementally upgrade your code base and projects: `from pydantic import v1 as pydantic_v1`.
 
 ## Help


### PR DESCRIPTION
## Change Summary

The "Pydantic V1.10 Documentation" link in the V1 vs. V2 section of `README.md` currently points to `https://docs.pydantic.dev/`, which serves the V2 docs root. Readers clicking "V1.10 Documentation" land on V2 docs instead.

The repo's own migration guide already documents the correct V1 URL: `docs/migration.md` states that "Pydantic V1 documentation is available at https://docs.pydantic.dev/1.10/."

This PR updates the link target in `README.md` to match — `https://docs.pydantic.dev/1.10/`.

## Related issue number

N/A — trivial docs fix per `CONTRIBUTING.md`'s "trivial typo/docs tweak" exception.

## Checklist

* [x] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist — N/A, docs-only
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review