### PR TITLE
Fix Coverage badge link target on docs landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Pydantic Validation
 
 [![CI](https://img.shields.io/github/actions/workflow/status/pydantic/pydantic/ci.yml?branch=main&logo=github&label=CI)](https://github.com/pydantic/pydantic/actions?query=event%3Apush+branch%3Amain+workflow%3ACI)
-[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic.svg)](https://github.com/pydantic/pydantic/actions?query=event%3Apush+branch%3Amain+workflow%3ACI)<br>
+[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/pydantic/pydantic.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic)<br>
 [![pypi](https://img.shields.io/pypi/v/pydantic.svg)](https://pypi.python.org/pypi/pydantic)
 [![CondaForge](https://img.shields.io/conda/v/conda-forge/pydantic.svg)](https://anaconda.org/conda-forge/pydantic)
 [![downloads](https://static.pepy.tech/badge/pydantic/month)](https://pepy.tech/project/pydantic)<br>


### PR DESCRIPTION
## Change Summary

The Coverage badge on the docs landing page (`docs/index.md`) currently links to the CI workflow URL — the same target as the CI badge directly above it. This looks like a copy-paste from the CI badge where the link URL wasn't swapped.

The identical Coverage badge in `README.md` uses the correct target: `https://coverage-badge.samuelcolvin.workers.dev/redirect/pydantic/pydantic`.

This PR updates `docs/index.md` to use the same target as `README.md`, so both pages point at the coverage report rather than at CI.

## Related issue number

N/A — trivial docs fix per `CONTRIBUTING.md`'s "trivial typo/docs tweak" exception.

## Checklist

* [x] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist — N/A, docs-only
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review