### PR TITLE
Support AliasPath root list indices

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -872,6 +872,11 @@ class GenerateSchema:
                         extras_keys_schema=extras_keys_schema,
                         model_name=cls.__name__,
                     )
+                    if any(_alias_has_int_first_segment(field.validation_alias) for field in fields.values()):
+                        fields_schema = core_schema.no_info_before_validator_function(
+                            _sequence_root_to_index_mapping,
+                            fields_schema,
+                        )
                     inner_schema = apply_validators(fields_schema, decorators.root_validators.values())
                     inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
 
@@ -2601,10 +2606,37 @@ def _validators_require_validate_default(validators: Iterable[Decorator[Validato
 def _convert_to_aliases(
     alias: str | AliasChoices | AliasPath | None,
 ) -> str | list[str | int] | list[list[str | int]] | None:
-    if isinstance(alias, (AliasChoices, AliasPath)):
-        return alias.convert_to_aliases()
-    else:
-        return alias
+    if isinstance(alias, AliasPath):
+        return _stringify_int_first_segment(alias.convert_to_aliases())
+    if isinstance(alias, AliasChoices):
+        return [_stringify_int_first_segment(path) for path in alias.convert_to_aliases()]
+    return alias
+
+
+def _stringify_int_first_segment(path: list[str | int]) -> list[str | int]:
+    if path and isinstance(path[0], int):
+        return [str(path[0]), *path[1:]]
+    return path
+
+
+def _alias_has_int_first_segment(alias: str | AliasChoices | AliasPath | None) -> bool:
+    if isinstance(alias, AliasPath):
+        return bool(alias.path) and isinstance(alias.path[0], int)
+    if isinstance(alias, AliasChoices):
+        return any(
+            isinstance(choice, AliasPath) and bool(choice.path) and isinstance(choice.path[0], int)
+            for choice in alias.choices
+        )
+    return False
+
+
+def _sequence_root_to_index_mapping(value: Any) -> Any:
+    if not isinstance(value, (list, tuple)):
+        return value
+
+    result = {str(index): item for index, item in enumerate(value)}
+    result.update({str(index - len(value)): item for index, item in enumerate(value)})
+    return result
 
 
 def apply_model_validators(

--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -24,7 +24,7 @@ class AliasPath:
 
     path: list[int | str]
 
-    def __init__(self, first_arg: str, *args: str | int) -> None:
+    def __init__(self, first_arg: str | int, *args: str | int) -> None:
         self.path = [first_arg] + list(args)
 
     def convert_to_aliases(self) -> list[str | int]:
@@ -35,8 +35,8 @@ class AliasPath:
         """
         return self.path
 
-    def search_dict_for_path(self, d: dict) -> Any:
-        """Searches a dictionary for the path specified by the alias.
+    def search_dict_for_path(self, d: Any) -> Any:
+        """Searches a dictionary, list, or tuple for the path specified by the alias.
 
         Returns:
             The value at the specified path, or `PydanticUndefined` if the path is not found.

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -611,6 +611,21 @@ def test_search_dict_for_alias_path():
     assert ap.search_dict_for_path({'a': 'hello'}) is PydanticUndefined
 
 
+def test_validation_alias_path_with_root_list_index():
+    class Model(BaseModel):
+        id: int = Field(validation_alias=AliasPath(0))
+        name: str = Field(validation_alias=AliasChoices('name', AliasPath(1)))
+        status: str = Field(validation_alias=AliasPath(7))
+        last: str = Field(validation_alias=AliasPath(-1))
+
+    data = [42, 'alice', None, None, None, None, None, 'active']
+    expected = {'id': 42, 'name': 'alice', 'status': 'active', 'last': 'active'}
+
+    assert Model.model_validate(data).model_dump() == expected
+    assert Model.model_validate(tuple(data)).model_dump() == expected
+    assert Model.model_validate_json(b'[42, "alice", null, null, null, null, null, "active"]').model_dump() == expected
+
+
 def test_validation_alias_invalid_value_type():
     m = 'Invalid `validation_alias` type. it should be `str`, `AliasChoices`, or `AliasPath`'
     with pytest.raises(TypeError, match=m):


### PR DESCRIPTION
Fixes #13112.\n\n## Summary\n- allow AliasPath to be constructed with an integer first segment\n- normalize top-level list and tuple inputs for models that use integer-first AliasPath validation aliases\n- cover direct AliasPath, AliasChoices fallback, tuple input, negative indexing, and JSON validation\n\n## Compatibility\nThis is guarded to models that declare an integer-first validation alias. Existing string-first AliasPath behavior is unchanged. The normalization only applies to root list/tuple inputs before model field validation, so ordinary mapping inputs continue through the existing pydantic-core path.