### PR TITLE
fix: sort union members so subclasses are tried first during serialization

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -282,6 +282,39 @@ def apply_each_item_validators(
     return schema
 
 
+def _sort_union_args_subclasses_first(args: list[Any]) -> list[Any]:
+    """Sort union args so subclasses come before their parent classes.
+
+    This ensures correct serialization when a subclass instance is serialized
+    against a union that includes both the subclass and one of its parent classes.
+    pydantic-core's union serializer uses the first matching schema, so without
+    this sorting a ``Parent | Child`` union would incorrectly serialize ``Child``
+    instances as ``Parent`` (since ``isinstance(child, Parent)`` is ``True``).
+
+    The sort is stable: unrelated types preserve their original relative order.
+    Only types that are strict subclasses of other union members are moved earlier.
+
+    Args:
+        args: The union member types to sort.
+
+    Returns:
+        A new list with subclasses ordered before their parent classes.
+    """
+
+    def _is_strict_subclass(a: Any, b: Any) -> bool:
+        try:
+            return isinstance(a, type) and isinstance(b, type) and issubclass(a, b) and a is not b
+        except TypeError:
+            return False
+
+    n = len(args)
+    # Specificity of arg[i] = count of other union members that arg[i] is a strict subclass of.
+    # A higher specificity means the type is more derived and should come first.
+    specificity = [sum(1 for j in range(n) if i != j and _is_strict_subclass(args[i], args[j])) for i in range(n)]
+    # Stable descending sort: higher specificity (more derived) types come first.
+    return [arg for arg, _ in sorted(zip(args, specificity), key=lambda x: -x[1])]
+
+
 def _extract_json_schema_info_from_field_info(
     info: FieldInfo | ComputedFieldInfo,
 ) -> tuple[JsonDict | None, JsonDict | JsonSchemaExtraCallable | None]:
@@ -1333,6 +1366,12 @@ class GenerateSchema:
     def _union_schema(self, union_type: Any) -> core_schema.CoreSchema:
         """Generate schema for a Union."""
         args = self._get_args_resolving_forward_refs(union_type, required=True)
+        # Sort args so subclasses come before their parent classes. This ensures
+        # that pydantic-core's union serializer (which uses the first matching
+        # schema) selects the correct, most specific schema when serializing a
+        # subclass instance against a union containing both the subclass and a
+        # parent class. See https://github.com/pydantic/pydantic/issues/12099.
+        args = _sort_union_args_subclasses_first(list(args))
         choices: list[CoreSchema] = []
         nullable = False
         for arg in args:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1224,6 +1224,43 @@ def test_subclass_support_unions_with_forward_ref() -> None:
     assert foo_recursive.model_dump() == {'items': [{'items': [{'bar_id': 42}]}]}
 
 
+def test_union_subclass_serialization_with_unvalidated_default() -> None:
+    """Regression test for https://github.com/pydantic/pydantic/issues/12099.
+
+    When a union contains both a parent class and a subclass (e.g. ``Parent | Child``),
+    pydantic-core's union serializer uses the first matching schema.  Because
+    ``isinstance(child_instance, Parent)`` is ``True``, the Parent schema was
+    incorrectly selected first, causing the child's extra fields to be dropped.
+
+    Sorting union args so subclasses come before their parent classes ensures
+    the most specific type is tried first during serialization.
+    """
+
+    class Parent(BaseModel):
+        a: float = 0  # default is int 0, not float — triggers the wrong schema path
+
+    class Child(Parent):
+        b: int
+
+    class Container(BaseModel):
+        union: Parent | Child
+
+    # Subclass instance must serialise with *all* its fields, not just Parent's
+    container = Container(union=Child(b=3))
+    assert container.model_dump() == {'union': {'a': 0, 'b': 3}}
+
+    # Parent instance must still serialise correctly
+    container2 = Container(union=Parent())
+    assert container2.model_dump() == {'union': {'a': 0}}
+
+    # Reversed annotation order should also work
+    class ContainerReversed(BaseModel):
+        union: Child | Parent
+
+    container3 = ContainerReversed(union=Child(b=3))
+    assert container3.model_dump() == {'union': {'a': 0, 'b': 3}}
+
+
 def test_serialize_python_context() -> None:
     contexts: list[Any] = [None, None, {'foo': 'bar'}]
 


### PR DESCRIPTION
## Fix

Closes #12099

### Root cause

When a union contains both a parent class and its subclass (e.g. ), pydantic-core's union serializer picks the **first** matching schema. Because  is , the  schema was selected before , causing the child's extra fields to be silently dropped.

The issue was most reliably triggered when the parent had a field whose default value's type was not an exact match for the field annotation (e.g.  where the default `0` is an `int`). In that case pydantic-core's type-narrowing logic fell back to structural matching and landed on the `Parent` schema.

### Fix

In  (inside ), sort the union args **before** generating the pydantic-core choice list, using a new stable-sort helper `_sort_union_args_subclasses_first`:

- For each type, compute its *specificity* = the number of other union members it is a strict subclass of.
- Sort descending by specificity (stable, so unrelated types keep their original relative order).
- Result: `Parent | Child` is generated as `union_schema(choices=[Child, Parent])`, so the most-derived type is tried first.

This matches the suggestion in the issue:
> we can probably make a better experience in general by rearranging the order of the union members to try subclasses first

### Tests

Added  to  which directly reproduces the reported scenario. All existing serialize, edge-case, generics, and main tests continue to pass.