### PR TITLE
fix: propagate __slots__ to generic parameterizations (#13215)

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -121,6 +121,8 @@ def create_generic_submodel(
         The created submodel.
     """
     namespace: dict[str, Any] = {'__module__': origin.__module__}
+    if '__slots__' in origin.__dict__:
+        namespace['__slots__'] = origin.__slots__
     bases = (origin,)
     meta, ns, kwds = prepare_class(model_name, bases)
     namespace.update(ns)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -3178,3 +3178,31 @@ def test_revalidation_with_basic_inference() -> None:
     holder2 = Holder(inner=Inner(inner=1))
     # implies that validation succeeds for both
     assert holder1 == holder2
+
+
+def test_generic_model_slots_propagation() -> None:
+    import weakref
+
+    T = TypeVar('T')
+
+    class Envelope(BaseModel, Generic[T]):
+        __slots__ = ()
+        content: None | T = None
+
+    base = Envelope()
+    assert '__weakref__' not in type(base).__dict__
+    with pytest.raises(TypeError):
+        weakref.ref(base)
+
+    param = Envelope[int]()
+    assert '__weakref__' not in type(param).__dict__
+    with pytest.raises(TypeError):
+        weakref.ref(param)
+
+    class Sub(Envelope[int]):
+        __slots__ = ()
+
+    sub = Sub()
+    assert '__weakref__' not in type(sub).__dict__
+    with pytest.raises(TypeError):
+        weakref.ref(sub)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fix __slots__ propagation in generic parameterizations (#13215)
- Update `create_generic_submodel` to copy `__slots__` from the origin model's namespace to the synthesized submodel.
- Add regression test in `test_generics.py` to ensure `__weakref__` is not silently re-added to parameterized models.
- Run `make format` to apply standard code formatting (ruff) to `_internal/_generics.py`.

## Related issue number

fix #13215 

## Checklist

* [X] The pull request title is a good summary of the changes - it will be used in the changelog
* [X] Unit tests for the changes exist
* [X] Tests pass on CI
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
