### PR TITLE
fix: propagate `__slots__` from origin to generic parameterizations

### DIFF
--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -121,6 +121,8 @@ def create_generic_submodel(
         The created submodel.
     """
     namespace: dict[str, Any] = {'__module__': origin.__module__}
+    if '__slots__' in origin.__dict__:
+        namespace['__slots__'] = origin.__slots__
     bases = (origin,)
     meta, ns, kwds = prepare_class(model_name, bases)
     namespace.update(ns)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -3178,3 +3178,41 @@ def test_revalidation_with_basic_inference() -> None:
     holder2 = Holder(inner=Inner(inner=1))
     # implies that validation succeeds for both
     assert holder1 == holder2
+
+
+def test_slots_propagated_to_generic_parameterizations() -> None:
+    """Regression test for https://github.com/pydantic/pydantic/issues/13215.
+
+    __slots__ declared on a generic BaseModel origin should be forwarded to every
+    synthesized parameterization so that weakref suppression (and any other
+    slot-level invariant) is preserved.
+    """
+    import weakref
+
+    T = TypeVar('T')
+
+    class Envelope(BaseModel, Generic[T]):
+        __slots__ = ()
+        content: Optional[T] = None
+
+    # Un-parameterized: __slots__ = () suppresses __weakref__
+    base = Envelope()
+    assert '__weakref__' not in type(base).__dict__
+    with pytest.raises(TypeError):
+        weakref.ref(base)
+
+    # Parameterized: __slots__ must still be forwarded
+    param = Envelope[int]()
+    assert '__weakref__' not in type(param).__dict__, (
+        'create_generic_submodel must propagate __slots__ from origin so that '
+        '__weakref__ is not silently re-added on parameterized subclasses'
+    )
+    with pytest.raises(TypeError):
+        weakref.ref(param)
+
+    # Explicit subclass of a parameterized model should also stay slot-clean
+    class Sub(Envelope[int]):
+        __slots__ = ()
+
+    with pytest.raises(TypeError):
+        weakref.ref(Sub())


### PR DESCRIPTION
## Summary

Fixes #13215.

`create_generic_submodel()` in `pydantic/_internal/_generics.py` builds the synthesized-class namespace with only `__module__` and never copies `__slots__` from the origin. Python's class machinery then silently re-adds `__dict__` and `__weakref__` descriptors to every parameterization, breaking any `__slots__ = ()` invariant declared on the origin.

## Root cause

```python
# before
namespace: dict[str, Any] = {'__module__': origin.__module__}
bases = (origin,)
meta, ns, kwds = prepare_class(model_name, bases)
```

Because `__slots__` is absent from the namespace, `type.__new__` adds the default storage descriptors, ignoring the parent's declaration.

## Fix

```python
namespace: dict[str, Any] = {'__module__': origin.__module__}
if '__slots__' in origin.__dict__:
    namespace['__slots__'] = origin.__slots__
bases = (origin,)
meta, ns, kwds = prepare_class(model_name, bases)
```

Copying the origin's slot tuple into the namespace before `prepare_class()` is called ensures every synthesized `Model[X]` honours the same slot declaration as its origin.

## Changes

- **`pydantic/_internal/_generics.py`** — propagate `__slots__` from origin into the namespace in `create_generic_submodel()`
- **`tests/test_generics.py`** — `test_slots_propagated_to_generic_parameterizations`: verifies that `__weakref__` is suppressed on parameterized subclasses and on explicit subclasses of parameterized models, mirroring the un-parameterized behaviour

## Behaviour change

Models that do **not** declare `__slots__` are entirely unaffected (the `if '__slots__' in origin.__dict__:` guard is false). Only models that explicitly declare `__slots__` benefit — their parameterizations now get the same descriptor layout.