### PR TITLE
Fix Enum._missing_ receiving None for JSON inputs

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -447,9 +447,17 @@ class GenerateSchema:
                 cases,
                 sub_type=sub_type,
                 missing=None if default_missing else enum_type._missing_,
-                ref=enum_ref,
+                ref=None if not default_missing else enum_ref,
                 metadata={'pydantic_js_functions': [get_json_schema]},
             )
+
+            if not default_missing:
+                # Wrap so that JSON inputs are converted to Python objects before reaching
+                # `_missing_`, which otherwise receives `None` from `input.as_python()`.
+                # See https://github.com/pydantic/pydantic/issues/12960
+                enum_schema = core_schema.no_info_wrap_validator_function(
+                    lambda value, handler: handler(value), enum_schema, ref=enum_ref
+                )
 
             if self._config_wrapper.use_enum_values:
                 enum_schema = core_schema.no_info_after_validator_function(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1754,6 +1754,33 @@ def test_enum_missing_custom():
     assert ta.validate_python(2) is MyEnum.a
 
 
+def test_enum_missing_called_with_correct_value_in_json():
+    """
+    Test that _missing_ receives the real value in JSON mode, not None.
+
+    See https://github.com/pydantic/pydantic/issues/12960
+    """
+    class MyEnum(Enum):
+        a = 'a'
+        b = 'b'
+
+        @classmethod
+        def _missing_(cls, value: Any) -> Any:
+            if isinstance(value, str):
+                return cls.__members__.get(value.lower())
+            return None
+
+    ta = TypeAdapter(MyEnum)
+
+    assert ta.validate_python('A') is MyEnum.a
+    assert ta.validate_json('"A"') is MyEnum.a
+
+    with pytest.raises(ValidationError):
+        ta.validate_python(0)
+    with pytest.raises(ValidationError):
+        ta.validate_json('0')
+
+
 def test_int_enum_type():
     class Model(BaseModel):
         my_enum: IntEnum


### PR DESCRIPTION
## Change Summary

When an enum defines a custom `_missing_` method, `model_validate_json` passes `None` to it instead of the actual value. This happens because pydantic-core calls `_missing_` with `input.as_python()`, which is `None` for JSON inputs.

This wraps the enum schema in a no-op wrap validator when `_missing_` is custom, so JSON values are converted to Python objects before reaching `_missing_`.

## Related issue number

fix #12960

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
