### PR TITLE
Validate falsy `AliasGenerator` outputs

### DIFF
--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -113,9 +113,11 @@ class AliasGenerator:
             TypeError: If the alias generator produces an invalid type.
         """
         alias = None
-        if alias_generator := getattr(self, alias_kind):
+        alias_generator = getattr(self, alias_kind)
+
+        if alias_generator is not None:
             alias = alias_generator(field_name)
-            if alias and not isinstance(alias, allowed_types):
+            if alias is not None and not isinstance(alias, allowed_types):
                 raise TypeError(
                     f'Invalid `{alias_kind}` type. `{alias_kind}` generator must produce one of `{allowed_types}`'
                 )

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -730,7 +730,8 @@ def test_alias_generator_with_computed_field(alias_generator) -> None:
     assert r.model_dump(by_alias=True) == {'WIDTH': 10, 'HEIGHT': 20, 'AREA': 200}
 
 
-def test_alias_generator_with_invalid_callables() -> None:
+@pytest.mark.parametrize('return_value', [1, 0, False, []])
+def test_alias_generator_with_invalid_callables(return_value) -> None:
     for alias_kind in ('validation_alias', 'serialization_alias', 'alias'):
         with pytest.raises(
             TypeError, match=f'Invalid `{alias_kind}` type. `{alias_kind}` generator must produce one of'
@@ -739,7 +740,7 @@ def test_alias_generator_with_invalid_callables() -> None:
             class Foo(BaseModel):
                 a: str
 
-                model_config = ConfigDict(alias_generator=AliasGenerator(**{alias_kind: lambda x: 1}))
+                model_config = ConfigDict(alias_generator=AliasGenerator(**{alias_kind: lambda x: return_value}))
 
 
 def test_all_alias_kinds_specified() -> None:


### PR DESCRIPTION
## Summary

Validate falsy invalid values returned by `AliasGenerator` callables before they reach pydantic-core.

The existing check only rejected truthy invalid values, so `0`, `False`, and `[]` could bypass the Python-level `TypeError` and fail later with a lower-level `SchemaError`. Empty strings remain valid aliases, and a returned `None` keeps the existing behavior of leaving the alias unset.

## Checks

- `uv run pytest tests/test_aliases.py::test_alias_generator_with_invalid_callables tests/test_aliases.py::test_alias_gen_with_empty_string tests/test_aliases.py::test_alias_gen_with_empty_string_and_computed_field -q`
- `uv run pytest tests/test_aliases.py -q`
- `uv run ruff check pydantic/aliases.py tests/test_aliases.py`