### PR TITLE
Support deferred annotations in `@validate_call`

### DIFF
--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -84,10 +84,20 @@ class ValidateCallWrapper:
             namespaces_tuple=ns_for_function(self.schema_type, parent_namespace=parent_namespace)
         )
         self.config_wrapper = ConfigWrapper(config)
-        if not self.config_wrapper.defer_build:
-            self._create_validators()
-        else:
+        if self.config_wrapper.defer_build:
             self.__pydantic_complete__ = False
+        else:
+            try:
+                self._create_validators()
+            except NameError:
+                # Some annotations cannot be resolved yet (e.g. forward references to names
+                # that are introduced later in the enclosing module/namespace, which is also
+                # the case for every annotation when `from __future__ import annotations` is
+                # used). Instead of failing eagerly at decoration time, defer building the
+                # validators until the wrapper is first called, mirroring the behavior of
+                # models (`PydanticUndefinedAnnotation` is itself a `NameError` subclass).
+                # See https://github.com/pydantic/pydantic/issues/12620.
+                self.__pydantic_complete__ = False
 
     def _create_validators(self) -> None:
         gen_schema = GenerateSchema(self.config_wrapper, self.ns_resolver)

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -1222,8 +1222,10 @@ class A[T]:
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason='requires Python 3.12+ for PEP 695 syntax with generics')
 def test_pep695_with_nested_scopes(create_module):
-    """Nested scopes generally cannot be caught by `parent_frame_namespace`,
-    so currently this test is expected to fail.
+    """Nested scopes (PEP 695 class-scoped TypeVars) cannot be captured by
+    `parent_frame_namespace`. Decoration is now deferred (no error at decoration time),
+    but calling the decorated function still raises `NameError` because the TypeVar
+    is not in the module namespace and can never be resolved.
     """
 
     module = create_module(
@@ -1235,36 +1237,43 @@ class A[T]:
     def g(self):
         @validate_call(validate_return=True)
         def inner(a: T) -> T: ...
+        return inner
 
     def h[S](self):
         @validate_call(validate_return=True)
         def inner(a: T) -> S: ...
+        return inner
         """
     )
 
     A = module.A
     a = A[int]()
+    # Decoration is deferred; NameError surfaces on first call to the wrapped function
     with pytest.raises(NameError):
-        a.g()
+        a.g()(1)
     with pytest.raises(NameError):
-        a.h()
+        a.h()(1)
 
-    with pytest.raises(NameError):
-        create_module(
-            """
+    # Module import succeeds (decoration deferred), but calling the method still fails
+    module2 = create_module(
+        """
 from __future__ import annotations
 from pydantic import validate_call
 
 class A[T]:
     class B:
         @validate_call(validate_return=True)
-        def f(a: T) -> T: ...
+        def f(self, a: T) -> T: ...
 
     class C[S]:
         @validate_call(validate_return=True)
-        def f(a: T) -> S: ...
+        def f(self, a: T) -> S: ...
             """
-        )
+    )
+    with pytest.raises(NameError):
+        module2.A[int]().B().f(1)
+    with pytest.raises(NameError):
+        module2.A[int]().C[str]().f(1)
 
 
 class M0(BaseModel):
@@ -1329,3 +1338,48 @@ def test_pickle_validate_call_with_basemodel() -> None:
 
     assert unpickled == {1: _PickleTestModel(number=1.0)}
     assert unpickled[1].number == 1.0
+
+
+# https://github.com/pydantic/pydantic/issues/12620
+# `@validate_call` should support deferred annotations: when an annotation references a name
+# not yet defined at decoration time, schema building is deferred until first call, mirroring
+# models. The symbols below are intentionally defined *after* the decorated callables.
+
+
+@validate_call(validate_return=True)
+def _vc_deferred_func(x: '_VCDeferredAlias') -> '_VCDeferredAlias':
+    return x
+
+
+@validate_call
+def _vc_deferred_undefined(x: '_VCNeverDefined') -> int:  # noqa: F821
+    return x
+
+
+class _VCDeferredMethodHost:
+    @validate_call(validate_return=True)
+    def method(self, x: '_VCDeferredAlias') -> '_VCDeferredAlias':
+        return x
+
+
+_VCDeferredAlias = int
+
+
+def test_validate_call_deferred_annotation() -> None:
+    """Forward reference resolved at call time, not decoration time."""
+    assert _vc_deferred_func('5') == 5
+
+
+def test_validate_call_deferred_annotation_validation_enforced() -> None:
+    with pytest.raises(ValidationError):
+        _vc_deferred_func('not an int')
+
+
+def test_validate_call_deferred_annotation_on_method() -> None:
+    assert _VCDeferredMethodHost().method('2') == 2
+
+
+def test_validate_call_deferred_undefined_annotation_raises_on_call() -> None:
+    """A truly-undefined name should not raise at decoration time, but on first call."""
+    with pytest.raises(NameError, match='_VCNeverDefined'):
+        _vc_deferred_undefined(1)


### PR DESCRIPTION
## Change Summary

`@validate_call` built the core schema **eagerly** at decoration time, so decorating a function whose annotations reference a name not yet defined raised `NameError`/`PydanticUndefinedAnnotation` immediately. This happens with plain forward references and — most commonly — with every annotation when `from __future__ import annotations` is in effect:

```python
from __future__ import annotations
from pydantic import validate_call

@validate_call
def foo(arg: int) -> Response:  # `Response` defined later in the file
    return Response()

class Response: ...

foo(1)  # previously raised NameError at decoration time; now works
```

This mirrors the behavior of models, which already support deferred schema building:

- When `_create_validators()` raises a `NameError` at decoration time, the build is deferred (`__pydantic_complete__ = False`) instead of propagating. (`PydanticUndefinedAnnotation` is itself a `NameError` subclass; the arguments-schema path via `get_function_type_hints()` may also surface a plain `NameError`.)
- On the first call, validators are built. Because `ns_for_function` holds a live reference to the module's `__dict__`, module-level names defined after the decorator is applied are now present.
- If the annotation is still unresolvable at call time (e.g. PEP 695 class-scoped TypeVars), the `NameError` is raised then, as before.

The existing `defer_build` config path is unchanged. `test_pep695_with_nested_scopes` is updated to match the improved behavior: those TypeVars still fail, but now at first call rather than decoration.

## Related issue number

fix #12620

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
