### PR TITLE
fix(json_schema): support scientific notation in Decimal serialization pattern

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -732,6 +732,11 @@ class GenerateJsonSchema:
             else:
                 pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
 
+            # Serialization mode: also accept scientific notation (e.g. '1E-7')
+            # since pydantic's serializer calls str() on Decimal objects.
+            if self.mode == 'serialization':
+                pattern = pattern.replace('$', r'(?:[eE][+-]?\d+)?$')
+
             return pattern
 
         json_schema = self.str_schema(core_schema.str_schema(pattern=get_decimal_pattern(schema)))

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -547,7 +547,7 @@ def test_decimal_json_schema():
                 'default': '12.34',
                 'title': 'B',
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*(?:[eE][+-]?\\d+)?$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         },
         'title': 'Model',
@@ -2139,7 +2139,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*(?:[eE][+-]?\\d+)?$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2147,7 +2147,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*(?:[eE][+-]?\\d+)?$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2155,7 +2155,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*(?:[eE][+-]?\\d+)?$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2163,7 +2163,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*(?:[eE][+-]?\\d+)?$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
         (
@@ -2171,7 +2171,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^(?!^[-+.]*(?:[eE][+-]?\\d+)?$)[+-]?0*\\d*\\.?\\d*(?:[eE][+-]?\\d+)?$',
             },
         ),
     ],


### PR DESCRIPTION
### Problem

  When Decimal values are serialized, `str()` can produce scientific notation
  (e.g. `Decimal('0.0000001')` → `'1E-7'`). But the JSON schema pattern
  added in #11987 did not accept `[eE]` notation, causing
  `model_json_schema(mode='serialization')` to generate a pattern that
  rejects pydantic's own serialization output. This is a regression in v2.12.

  For example, `Decimal('0.0000001')` serializes to `"1E-7"`, but the pattern
  `^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$` doesn't match scientific notation.

  ### Solution

  Appended `(?:[eE][+-]?\d+)?` (optional scientific notation suffix) before
  each `$` anchor, but only in serialization mode. Validation mode is unchanged.

  ### Testing

  - All 121 existing Decimal-related JSON schema tests pass
  - `test_decimal_json_schema` updated to expect new pattern in serialization mode
  - `test_constraints_schema_serialization` Decimal cases updated

  Closes #13089