### PR TITLE
fix: catch ZeroDivisionError in fraction_validator for zero-denominator input

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 


### PR DESCRIPTION
Fixes #13257

## Problem
The `fraction_validator` in `pydantic/_internal/_validators.py` only catches `ValueError` when constructing a `fractions.Fraction` from user input. However, Python's `fractions.Fraction` raises `ZeroDivisionError` when the denominator is zero (e.g., the string `"6/0"`). This raw exception bubbles up instead of being converted into a `ValidationError`.

## Fix
Added `ZeroDivisionError` to the `except` clause in `fraction_validator` so that zero-denominator inputs are properly reported as validation errors.

**Before:**
```python
except ValueError:
    raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
```

**After:**
```python
except (ValueError, ZeroDivisionError):
    raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
```

## Testing
```python
from pydantic import TypeAdapter
from fractions import Fraction

ta = TypeAdapter(Fraction)
# This should raise ValidationError, not ZeroDivisionError
try:
    ta.validate_python("6/0")
except ZeroDivisionError:
    print("BUG: ZeroDivisionError leaked through")
except Exception as e:
    print(f"FIXED: Got {type(e).__name__}: {e}")
```