### PR TITLE
fix: catch ZeroDivisionError in fraction_validator for zero-denominator input

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1894,6 +1894,19 @@ def test_fraction_validation():
     ]
 
 
+def test_fraction_validation_zero_denominator():
+    """ZeroDivisionError from Fraction('6/0') should be caught and re-raised as ValidationError."""
+
+    class Model(BaseModel):
+        a: Fraction
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='6/0')
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'fraction_parsing', 'loc': ('a',), 'msg': 'Input is not a valid fraction', 'input': '6/0'}
+    ]
+
+
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 def test_string_success():
     class MoreStringsModel(BaseModel):


### PR DESCRIPTION
## Problem

`fraction_validator` in `pydantic/_internal/_validators.py` only catches `ValueError` when constructing a `Fraction` from user input. However, `fractions.Fraction("6/0")` raises `ZeroDivisionError` because the denominator is zero. This exception escapes as a raw Python exception instead of being converted into a `ValidationError`, violating Pydantic's contract that all invalid user input should produce a `ValidationError`.

Discovered via fuzzing with Atheris on `TypeAdapter.validate_strings()`.

Fixes #13257

## Solution

Added `ZeroDivisionError` to the `except` clause in `fraction_validator` alongside `ValueError`:

```python
# Before
except ValueError:
# After
except (ValueError, ZeroDivisionError):
```

This is consistent with how other validators in the same file handle exceptions from standard library constructors.

## Verification

```python
from fractions import Fraction
from pydantic import TypeAdapter, ValidationError

ta = TypeAdapter(Fraction)

# Before fix: raises ZeroDivisionError
# After fix: raises ValidationError with type 'fraction_parsing'
ta.validate_strings("6/0")  # ValidationError ✓

# Valid fractions still work
ta.validate_python("1/3")  # Fraction(1, 3) ✓

# Invalid format still raises ValidationError
ta.validate_python("wrong_format")  # ValidationError ✓
```

Added regression test `test_fraction_validation_zero_denominator` in `tests/test_types.py`.

## Uncertainty

- This is a one-line fix to exception handling. Low risk.
- The Pyright diagnostic on the test (`Literal['6/0']` not assignable to `Fraction`) is expected — the test intentionally passes invalid input to verify rejection.