### PR TITLE
Fix fraction_validator not catching ZeroDivisionError

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 


### PR DESCRIPTION
## Problem

The `fraction_validator` only catches `ValueError` when constructing a `fractions.Fraction`. Passing a string like `"6/0"` raises `ZeroDivisionError` instead, which bypasses validation and bubbles up as an unhandled exception.

## Fix

Add `ZeroDivisionError` to the caught exception types so invalid fractions always produce a proper `ValidationError`.

Closes #13257