### PR TITLE
Allow None as type argument in __class_getitem__

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -930,7 +930,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
 
     def __class_getitem__(
-        cls, typevar_values: type[Any] | tuple[type[Any], ...]
+        cls, typevar_values: type[Any] | tuple[type[Any], ...] | None
     ) -> type[BaseModel] | _forward_ref.PydanticRecursiveRef:
         cached = _generics.get_cached_generic_type_early(cls, typevar_values)
         if cached is not None:


### PR DESCRIPTION
Accept None as a valid type argument in BaseModel.__class_getitem__ to avoid type checker errors when using None in type annotations.

Closes #13207