### PR TITLE
Resolve inherited field forward refs using the base class namespace

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations as _annotations
 
+import contextlib
 import dataclasses
 import warnings
 from collections.abc import Callable, Mapping
@@ -460,9 +461,20 @@ def rebuild_model_fields(
             if field_info._complete:
                 rebuilt_fields[f_name] = field_info
             else:
-                new_field = _recreate_field_info(
-                    field_info, ns_resolver=ns_resolver, typevars_map=typevars_map, lenient=False
+                # The field might have been inherited from a base class defined in a different module.
+                # In that case, the forward references in its annotation must be resolved using the
+                # namespace of the base class that defined the field, not the one of `cls` (see
+                # https://github.com/pydantic/pydantic/issues/12000).
+                defining_base = _defining_base_of_field(cls, f_name)
+                base_ns_ctx = (
+                    ns_resolver.push(defining_base)
+                    if defining_base is not None and defining_base is not cls
+                    else contextlib.nullcontext()
                 )
+                with base_ns_ctx:
+                    new_field = _recreate_field_info(
+                        field_info, ns_resolver=ns_resolver, typevars_map=typevars_map, lenient=False
+                    )
                 update_field_from_config(config_wrapper, f_name, new_field)
                 rebuilt_fields[f_name] = new_field
 
@@ -477,6 +489,23 @@ def rebuild_model_fields(
             rebuilt_extra_info = cls.__pydantic_extra_info__
 
     return rebuilt_fields, rebuilt_extra_info
+
+
+def _defining_base_of_field(cls: type[BaseModel], field_name: str) -> type[BaseModel] | None:
+    """Find the base class in the MRO of `cls` that defines `field_name` in its own annotations.
+
+    Fields can be inherited from a base class defined in a separate module. When rebuilding such a
+    field, the forward references in its annotation must be evaluated using the namespace of the
+    class that actually defined it. This walks the MRO from the most derived class and returns the
+    first one whose own annotations contain `field_name`, or `None` if no such class is found.
+    """
+    BaseModel_ = import_cached_base_model()
+    for base in cls.__mro__:
+        if base is BaseModel_ or not issubclass(base, BaseModel_):
+            continue
+        if field_name in _typing_extra.safe_get_annotations(base):
+            return base
+    return None
 
 
 def _recreate_field_info(

--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -1115,12 +1115,6 @@ def test_pydantic_extra_forward_ref_evaluated_pep585() -> None:
     assert 'extras_keys_schema' not in Bar.__pydantic_core_schema__['schema']
 
 
-@pytest.mark.xfail(
-    reason='While `get_cls_type_hints` uses the correct module ns for each base, `collect_model_fields` '
-    'will still use the `FieldInfo` instances from each base (see the `parent_fields_lookup` logic). '
-    'This means that `f` is still a forward ref in `Foo.model_fields`, and it gets evaluated in '
-    '`GenerateSchema._model_schema`, where only the module of `Foo` is considered.'
-)
 def test_uses_the_correct_globals_to_resolve_model_forward_refs(create_module):
     @create_module
     def module_1():
@@ -1143,6 +1137,40 @@ class Foo(Bar):
     )
 
     assert module_2.Foo.model_fields['f'].annotation is int
+
+
+def test_inherited_field_uses_base_class_globals_when_subclassed_in_other_module(create_module):
+    """A field inherited from a base class defined in another module should have its forward
+    references resolved using the base class' module namespace, not the subclass' one.
+
+    See https://github.com/pydantic/pydantic/issues/12000.
+    """
+
+    @create_module
+    def module_1():
+        from pydantic import BaseModel
+
+        class Outer1(BaseModel):
+            class Inner1(BaseModel):
+                outer: 'Outer1'
+
+    # Note: `Outer1` is intentionally *not* imported at the top level of `module_2`, so the
+    # `'Outer1'` forward reference can only be resolved using `module_1`'s namespace.
+    module_2 = create_module(
+        f"""
+import {module_1.__name__} as module_1
+
+from pydantic import BaseModel
+
+
+class Outer2(BaseModel):
+    class Inner2(module_1.Outer1.Inner1):
+        pass
+        """
+    )
+
+    instance = module_2.Outer2.Inner2(outer=module_1.Outer1())
+    assert isinstance(instance.outer, module_1.Outer1)
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Fixes #12000.

When a model field is inherited from a base class that lives in a different module, rebuilding the field used the wrong namespace to resolve its forward references. The annotation was evaluated against the namespace of the most derived class rather than the class that actually defined the field, so a name that was only importable from the base class' module could not be found.

Here is a minimal reproduction. With `Outer1` defined in one module and a subclass of its nested `Inner1` defined in another module that does not import `Outer1` into its own globals, instantiating the subclass raised `PydanticUserError: Inner2 is not fully defined`. The forward reference `'Outer1'` was being looked up in the subclass' module, where it does not exist, even though `Inner1` resolves it fine in its own module.

The cause is in `rebuild_model_fields` in `pydantic/_internal/_fields.py`. It pushed only the final class onto the namespace resolver and evaluated every field, including inherited ones, against that single namespace. The global namespace used during evaluation comes from the module of the class on top of the resolver stack, so inherited fields were resolved in the wrong module.

The fix locates, for each incomplete field, the class in the MRO that defines the field in its own annotations and pushes that class onto the resolver before re-evaluating the annotation. This matches the per-base handling that `collect_dataclass_fields` already does for stdlib dataclasses, where each base is pushed so its own module namespace is used.

This also turns the existing `test_uses_the_correct_globals_to_resolve_model_forward_refs` xfail into a passing test, since that test documents the same class of bug, so I removed its xfail marker. A new regression test covering the nested class scenario from the issue is added as well.

The full `tests/test_forward_ref.py` suite passes, along with `test_main`, `test_edge_cases`, `test_generics`, `test_dataclasses`, `test_config`, `test_create_model`, `test_fields`, and `test_validators`.
