### PR TITLE
Fix missing `max_length` check on lazy iteration validation

### DIFF
--- a/pydantic-core/src/validators/generator.rs
+++ b/pydantic-core/src/validators/generator.rs
@@ -126,36 +126,36 @@ impl ValidatorIterator {
         macro_rules! next {
             ($iter:ident) => {
                 match $iter.next(py)? {
-                    Some((next, index)) => match validator {
-                        Some(validator) => {
-                            if let Some(max_length) = max_length
-                                && index >= max_length
-                            {
-                                let val_error = ValError::new_custom_input(
-                                    ErrorType::TooLong {
-                                        field_type: "Generator".to_string(),
-                                        max_length,
-                                        actual_length: None,
-                                        context: None,
-                                    },
-                                    $iter.input_as_error_value(py),
-                                );
-                                return Err(ValidationError::from_val_error(
-                                    py,
-                                    "ValidatorIterator".into_pyobject(py)?.into(),
-                                    InputType::Python,
-                                    val_error,
-                                    None,
-                                    hide_input_in_errors,
-                                    validation_error_cause,
-                                ));
-                            }
-                            validator
-                                .validate(py, next.borrow_input(), Some(index.into()))
-                                .map(Some)
+                    Some((next, index)) => {
+                        if let Some(max_length) = max_length
+                            && index >= max_length
+                        {
+                            let val_error = ValError::new_custom_input(
+                                ErrorType::TooLong {
+                                    field_type: "Generator".to_string(),
+                                    max_length,
+                                    actual_length: None,
+                                    context: None,
+                                },
+                                $iter.input_as_error_value(py),
+                            );
+                            return Err(ValidationError::from_val_error(
+                                py,
+                                "ValidatorIterator".into_pyobject(py)?.into(),
+                                InputType::Python,
+                                val_error,
+                                None,
+                                hide_input_in_errors,
+                                validation_error_cause,
+                            ));
                         }
-                        None => Ok(Some(next.into_pyobject(py)?.unbind())),
-                    },
+                        match validator {
+                            Some(validator) => validator
+                                .validate(py, next.borrow_input(), Some(index.into()))
+                                .map(Some),
+                            None => Ok(Some(next.into_py_any(py)?)),
+                        }
+                    }
                     None => {
                         if let Some(min_length) = min_length
                             && $iter.index() < min_length

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2299,6 +2299,22 @@ def test_iterable_any(type_annotation):
         {'type': 'iterable_type', 'loc': ('it',), 'msg': 'Input should be iterable', 'input': 3}
     ]
 
+    class MaxLenModel(BaseModel):
+        it: type_annotation = Field(max_length=2)
+
+    m = MaxLenModel(it=[1, 2, 3])
+    with pytest.raises(ValidationError) as exc_info:
+        list(m.it)
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'too_long',
+            'loc': (),
+            'msg': 'Generator should have at most 2 items after validation, not more',
+            'input': [1, 2, 3],
+            'ctx': {'field_type': 'Generator', 'max_length': 2, 'actual_length': None},
+        }
+    ]
+
 
 def test_invalid_iterable():
     class Model(BaseModel):


### PR DESCRIPTION
## Change Summary

Fixes a bug where the `max_length` check on lazy iterator validation only applied if there was a type hint for the iterator (i.e. not `Any` items yielded from the iterator).

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
