### PR TITLE
Update `uuid` to 1.23.2

### DIFF
--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -603,12 +603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,9 +771,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -808,7 +802,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 

--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -44,7 +44,7 @@ idna = "1.1.0"
 base64 = "0.22.1"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-uuid = "1.23.0"
+uuid = "1.23.2"
 jiter = { version = "0.14.0", features = ["python"] }
 hex = "0.4.3"
 percent-encoding = "2.3.2"

--- a/pydantic-core/tests/validators/test_uuid.py
+++ b/pydantic-core/tests/validators/test_uuid.py
@@ -38,7 +38,7 @@ class MyStr(str): ...
         (UUID('12345678-1234-5678-1234-567812345678'), UUID('12345678-1234-5678-1234-567812345678')),
         (UUID('550e8400-e29b-41d4-a716-446655440000'), UUID('550e8400-e29b-41d4-a716-446655440000')),
         # Invalid UUIDs
-        ('not-a-valid-uuid', Err('Input should be a valid UUID, invalid character: found `n` at 1')),
+        ('not-a-valid-uuid', Err('Input should be a valid UUID, invalid character: found `n` at 0')),
         (
             '12345678-1234-5678-1234-5678123456789',
             Err('Input should be a valid UUID, invalid group length in group 4: expected 12, found 13'),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Release 1.23.2 of `uuid` contains https://github.com/uuid-rs/uuid/pull/882, which improved error messes. The change included a switch from one-based to zero-based indices, which affects one of the expected messages in `test_uuid`.

This PR updates `uuid` in `Cargo.lock` and adjusts one test to avoid a test regression. The minimum version of `uuid` is also updated to 1.23.2 in `Cargo.toml` since the tests will no longer pass with previous versions. Overall, this PR is similar to https://github.com/pydantic/pydantic/pull/12992 for 1.23.0.
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
