### PR TITLE
Fix missing period after 'e.g' in docstrings and grammar in docs

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -1028,7 +1028,7 @@ Any [`collections.abc.Sequence`][] instance (expect strings and bytes) is accept
 constructor, and then converted back to the original input type.
 
 !!! warning "Strings aren't treated as sequences"
-    While strings are technically valid sequence instances, this is frequently not intended as is a common source of bugs.
+    While strings are technically valid sequence instances, this is frequently not intended, and is a common source of bugs.
 
     As a result, Pydantic will *not* accept strings and bytes for the [`Sequence`][collections.abc.Sequence] type (see example below).
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -158,7 +158,7 @@ class _BaseUrl:
     def host(self) -> str | None:
         """The host part of the URL, or `None`.
 
-        If the URL must be punycode encoded, this is the encoded host, e.g if the input URL is `https://£££.com`,
+        If the URL must be punycode encoded, this is the encoded host, e.g. if the input URL is `https://£££.com`,
         `host` will be `xn--9aaa.com`
         """
         return self._url.host
@@ -168,7 +168,7 @@ class _BaseUrl:
 
         e.g. `host` in `https://user:pass@host:port/path?query#fragment`
 
-        If the URL must be punycode encoded, this is the decoded host, e.g if the input URL is `https://£££.com`,
+        If the URL must be punycode encoded, this is the decoded host, e.g. if the input URL is `https://£££.com`,
         `unicode_host()` will be `£££.com`
         """
         return self._url.unicode_host()
@@ -215,7 +215,7 @@ class _BaseUrl:
     def unicode_string(self) -> str:
         """The URL as a unicode string, unlike `__str__()` this will not punycode encode the host.
 
-        If the URL must be punycode encoded, this is the decoded string, e.g if the input URL is `https://£££.com`,
+        If the URL must be punycode encoded, this is the decoded string, e.g. if the input URL is `https://£££.com`,
         `unicode_string()` will be `https://£££.com`
         """
         return self._url.unicode_string()


### PR DESCRIPTION
## Changes

- **pydantic/networks.py**: Add missing period after abbreviation `e.g` in docstrings for `host`, `unicode_host()`, and `unicode_string()` properties/methods (3 occurrences)
- **docs/api/standard_library_types.md**: Fix grammar — `not intended as is a common` → `not intended, and is a common` in the Sequence type documentation

These are minor documentation/docstring improvements for consistency and correctness.