### PR TITLE
fix: catch ZeroDivisionError in fraction_validator for zero-denominator input

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -72,7 +72,7 @@ def test_fraction_validate_json(json_str, expected):
     'json_str,error',
     [
         ('"not a number"', ValidationError),
-        ('"1/0"', ZeroDivisionError),
+        ('"1/0"', ValidationError),
         (float('inf'), ValidationError),
         (float('nan'), ValidationError),
     ],
@@ -127,7 +127,7 @@ def test_fraction_strict_accepts_fraction(input_value):
     'input_value,error',
     [
         ('not a number', ValidationError),
-        ('1/0', ZeroDivisionError),
+        ('1/0', ValidationError),
         (float('inf'), OverflowError),
         (float('nan'), ValidationError),
         ([1, 2], TypeError),


### PR DESCRIPTION
## Change Summary

Fixes #13257

When a string like `"6/0"` is passed as input for a `Fraction` field, Python's `fractions.Fraction` raises `ZeroDivisionError`. Previously, only `ValueError` was caught in `fraction_validator`, allowing the raw exception to bubble up instead of being converted to a `ValidationError`.

This change adds `ZeroDivisionError` to the caught exceptions, ensuring all invalid fraction inputs produce a proper `PydanticCustomError` with the `'fraction_parsing'` error code.

## Related issue number

Fixes #13257

## Checklist

- [x] The pull request title is a good summary of the changes
- [x] Tests pass for this change
- [x] The changes are related to the issue

## Details

**Root cause:** In `pydantic/_internal/_validators.py`, the `fraction_validator` function catches only `ValueError`, but `Fraction("6/0")` raises `ZeroDivisionError`.

**Fix:** Change `except ValueError:` to `except (ValueError, ZeroDivisionError):`.

**Test updates:** Updated two existing test cases that previously expected `ZeroDivisionError` for `"1/0"` inputs to now correctly expect `ValidationError`, aligning with pydantic's contract that all invalid user input should produce a `ValidationError`.