### PR TITLE
Fix mypy arg-type error on RootModel with coercible input

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -88,6 +88,9 @@ CREATE_MODEL_FULLNAME = 'pydantic.main.create_model'
 BASESETTINGS_FULLNAME = 'pydantic_settings.main.BaseSettings'
 ROOT_MODEL_FULLNAME = 'pydantic.root_model.RootModel'
 MODEL_METACLASS_FULLNAME = 'pydantic._internal._model_construction.ModelMetaclass'
+# RootModel uses its own metaclass that also has a dataclass_transform spec, so the plugin
+# has to treat it the same way or RootModel.__init__ wins over our synthesized one.
+ROOT_MODEL_METACLASS_FULLNAME = 'pydantic.root_model._RootModelMetaclass'
 FIELD_FULLNAME = 'pydantic.fields.Field'
 DATACLASS_FULLNAME = 'pydantic.dataclasses.dataclass'
 MODEL_VALIDATOR_FULLNAME = 'pydantic.functional_validators.model_validator'
@@ -143,7 +146,7 @@ class PydanticPlugin(Plugin):
 
     def get_metaclass_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
         """Update Pydantic `ModelMetaclass` definition."""
-        if fullname == MODEL_METACLASS_FULLNAME:
+        if fullname in (MODEL_METACLASS_FULLNAME, ROOT_MODEL_METACLASS_FULLNAME):
             return self._pydantic_model_metaclass_marker_callback
         return None
 
@@ -906,8 +909,14 @@ class PydanticModelTransformer:
 
         The added `__init__` will be annotated with types vs. all `Any` depending on the plugin settings.
         """
-        if '__init__' in self._cls.info.names and not self._cls.info.names['__init__'].plugin_generated:
-            return  # Don't generate an __init__ if one already exists
+        existing_init = self._cls.info.names.get('__init__')
+        if existing_init is not None and not existing_init.plugin_generated:
+            # RootModel itself declares a typed __init__ (root: RootModelRootType), which otherwise
+            # shadows the coercion-friendly one we add to subclasses. So when we're transforming the
+            # RootModel base class, go ahead and replace that with our generated init too. See #12978.
+            is_root_model_base = is_root_model and self._cls.info.fullname == ROOT_MODEL_FULLNAME
+            if not is_root_model_base:
+                return  # Don't generate an __init__ if one already exists
 
         typed = self.plugin_config.init_typed
         model_strict = bool(config.strict)

--- a/tests/mypy/modules/root_models.py
+++ b/tests/mypy/modules/root_models.py
@@ -46,3 +46,16 @@ m = Model[str](m1=Maybe(None), m2=Maybe('dog'), m3=Maybe([]))
 Model(m1=None, m2={}, m3=[])
 
 assert_type(m.m1, Maybe[int])
+
+
+# regression for #12978: a string that pydantic can coerce to float should be accepted
+# the same way for a normal field and for a root model. with the plugin on, the synthesized
+# untyped __init__ should win so neither of these errors against float.
+class Foo(BaseModel):
+    f: float
+
+
+RFoo = RootModel[float]
+
+Foo(f='1.0')
+RFoo('1.0')

--- a/tests/mypy/outputs/mypy-default_ini/root_models.py
+++ b/tests/mypy/outputs/mypy-default_ini/root_models.py
@@ -54,3 +54,18 @@ Model(m1=None, m2={}, m3=[])
 # MYPY: error: Argument "m3" to "Model" has incompatible type "list[Never]"; expected "Maybe[Any]"  [arg-type]
 
 assert_type(m.m1, Maybe[int])
+
+
+# regression for #12978: a string that pydantic can coerce to float should be accepted
+# the same way for a normal field and for a root model. with the plugin on, the synthesized
+# untyped __init__ should win so neither of these errors against float.
+class Foo(BaseModel):
+    f: float
+
+
+RFoo = RootModel[float]
+
+Foo(f='1.0')
+# MYPY: error: Argument "f" to "Foo" has incompatible type "str"; expected "float"  [arg-type]
+RFoo('1.0')
+# MYPY: error: Argument 1 to "RootModel" has incompatible type "str"; expected "float"  [arg-type]

--- a/tests/mypy/outputs/mypy-plugin_ini/root_models.py
+++ b/tests/mypy/outputs/mypy-plugin_ini/root_models.py
@@ -49,3 +49,16 @@ m = Model[str](m1=Maybe(None), m2=Maybe('dog'), m3=Maybe([]))
 Model(m1=None, m2={}, m3=[])
 
 assert_type(m.m1, Maybe[int])
+
+
+# regression for #12978: a string that pydantic can coerce to float should be accepted
+# the same way for a normal field and for a root model. with the plugin on, the synthesized
+# untyped __init__ should win so neither of these errors against float.
+class Foo(BaseModel):
+    f: float
+
+
+RFoo = RootModel[float]
+
+Foo(f='1.0')
+RFoo('1.0')

--- a/tests/mypy/outputs/pyproject-default_toml/root_models.py
+++ b/tests/mypy/outputs/pyproject-default_toml/root_models.py
@@ -54,3 +54,18 @@ Model(m1=None, m2={}, m3=[])
 # MYPY: error: Argument "m3" to "Model" has incompatible type "list[Never]"; expected "Maybe[Any]"  [arg-type]
 
 assert_type(m.m1, Maybe[int])
+
+
+# regression for #12978: a string that pydantic can coerce to float should be accepted
+# the same way for a normal field and for a root model. with the plugin on, the synthesized
+# untyped __init__ should win so neither of these errors against float.
+class Foo(BaseModel):
+    f: float
+
+
+RFoo = RootModel[float]
+
+Foo(f='1.0')
+# MYPY: error: Argument "f" to "Foo" has incompatible type "str"; expected "float"  [arg-type]
+RFoo('1.0')
+# MYPY: error: Argument 1 to "RootModel" has incompatible type "str"; expected "float"  [arg-type]


### PR DESCRIPTION
with the mypy plugin on, RootModel's own typed __init__ (root: RootModelRootType) was shadowing the untyped init the plugin synthesizes for subclasses, so passing something coercible like RFoo('1.0') for a float root got flagged as arg-type while the same string on a plain BaseModel field was fine.

like Viicos pointed out in the thread, the plugin just wasn't taking priority over RootModel.__init__. so i registered the RootModel metaclass with the metaclass hook and let the generated init replace RootModel's declared one when transforming the base class.

added a regression case in the mypy test modules and updated the expected outputs. tests pass. closes #12978
