### PR TITLE
fix: avoid calling default_factory after missing field error

### DIFF
--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -264,6 +264,7 @@ impl Validator for DataclassArgsValidator {
                             set_item!(field, value);
                         }
                         Ok(None) => {
+                            state.has_field_error = true;
                             let error_type = ErrorTypeDefaults::Missing;
                             let error_loc = field.lookup_path_collection.error_loc(lookup_type, self.loc_by_alias);
                             // This means there was no default value

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -387,6 +387,7 @@ impl ModelFieldsValidator {
                     }
                     Ok(None) => {
                         // There was no default value
+                        state.has_field_error = true;
                         let error_type = ErrorTypeDefaults::Missing;
                         let error_loc = field.lookup_path_collection.error_loc(lookup_type, self.loc_by_alias);
                         errors.push(ValLineError::new_with_full_loc(error_type, input, error_loc));
@@ -664,6 +665,7 @@ impl ModelFieldsValidator {
                     Ok(Some(default_value)) => default_value,
                     Ok(None) => {
                         // There was no default value
+                        state.has_field_error = true;
                         let error_type = ErrorTypeDefaults::Missing;
                         let error_loc = field.lookup_path_collection.error_loc(lookup_type, self.loc_by_alias);
                         errors.push(ValLineError::new_with_full_loc(error_type, json_input, error_loc));

--- a/pydantic-core/src/validators/typed_dict.rs
+++ b/pydantic-core/src/validators/typed_dict.rs
@@ -254,6 +254,7 @@ impl Validator for TypedDictValidator {
                     }
                     Ok(None) => {
                         // This means there was no default value
+                        state.has_field_error = true;
                         if field.required {
                             let error_type = ErrorTypeDefaults::Missing;
                             let error_loc = field.lookup_path_collection.error_loc(lookup_type, self.loc_by_alias);

--- a/pydantic-core/tests/validators/test_with_default.py
+++ b/pydantic-core/tests/validators/test_with_default.py
@@ -936,6 +936,36 @@ b
     assert str(e.value) == expected
 
 
+def test_default_factory_not_called_if_field_missing(container_schema_builder, pydantic_version) -> None:
+    """When a required field is entirely missing from the input, default_factory_takes_data should not be called."""
+    schema = container_schema_builder(
+        {
+            'a': core_schema.int_schema(),
+            'b': core_schema.with_default_schema(
+                schema=core_schema.int_schema(), default_factory=lambda data: data['a'], default_factory_takes_data=True
+            ),
+        }
+    )
+    v = SchemaValidator(schema)
+    with pytest.raises(ValidationError) as e:
+        v.validate_python({})
+
+    assert e.value.errors(include_url=False) == [
+        {
+            'type': 'missing',
+            'loc': ('a',),
+            'msg': 'Field required',
+            'input': {},
+        },
+        {
+            'input': PydanticUndefined,
+            'loc': ('b',),
+            'msg': 'The default factory uses validated data, but at least one validation error occurred',
+            'type': 'default_factory_not_called',
+        },
+    ]
+
+
 def test_default_factory_not_called_union_ok(container_schema_builder) -> None:
     schema_fail = container_schema_builder(
         {


### PR DESCRIPTION
## Change Summary

Set `state.has_field_error = true` in the `Ok(None)` branch of `model_fields.rs` (two locations), `typed_dict.rs`, and `dataclass.rs` when a required field is missing from the input. This prevents `default_factory` functions that take validated data from being called, which would otherwise raise a `KeyError` on the missing field.

## Related issue number

Fixes #13266

This is a follow-up gap in the fix for #11358 (pydantic-core#1623). That PR added the `has_field_error` flag and set it when a field is present but fails validation. However, when a required field is entirely missing from the input, the flag was not set, allowing the `default_factory` to run and crash with a `KeyError`.

Note: The pydantic-core code now lives in the monorepo under `pydantic-core/`. The standalone pydantic-core repo is archived.

## Testing

- Added `test_default_factory_not_called_if_field_missing` covering model, typed_dict, and dataclass containers (parametrized via `container_schema_builder`)
- Verified the fix prevents the `KeyError` and produces `missing` + `default_factory_not_called` errors instead
- All existing tests in `test_with_default.py` pass (133 passed, 3 xfailed)
- All existing tests in `test_model_fields.py` pass (308 passed, 1 skipped)
- All existing tests in `test_dataclasses.py` pass (238 passed, 11 skipped)

## Checklist

* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable (N/A - bug fix only)
* [x] Pydantic tests pass with this pydantic-core (except for expected changes)
* [x] My PR is ready to review, please add a comment including the phrase "please review" to assign reviewers