### PR TITLE
Fix AttributeError on nested pipeline `|` and `&` composition

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -424,10 +424,23 @@ def _apply_step(step: _Step, s: cs.CoreSchema | None, handler: GetCoreSchemaHand
     elif isinstance(step, _Constraint):
         s = _apply_constraint(s, step.constraint)
     elif isinstance(step, _PipelineOr):
-        s = cs.union_schema([handler(step.left), handler(step.right)])
+        # Build operand schemas via the pipeline's own schema method, not handler():
+        # _Pipeline is a slotted dataclass, so handler() routes it to the dataclass
+        # schema path, which reads __dict__ and raises AttributeError once nested.
+        s = cs.union_schema(
+            [
+                step.left.__get_pydantic_core_schema__(source_type, handler),
+                step.right.__get_pydantic_core_schema__(source_type, handler),
+            ]
+        )
     else:
         assert isinstance(step, _PipelineAnd)
-        s = cs.chain_schema([handler(step.left), handler(step.right)])
+        s = cs.chain_schema(
+            [
+                step.left.__get_pydantic_core_schema__(source_type, handler),
+                step.right.__get_pydantic_core_schema__(source_type, handler),
+            ]
+        )
     return s
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -469,6 +469,45 @@ def test_composition() -> None:
     calls.clear()
 
 
+def test_nested_composition() -> None:
+    """Nested ``|``/``&`` compositions build and validate.
+
+    https://github.com/pydantic/pydantic/issues/13287 — a nested operand is itself a
+    ``_Pipeline``; resolving it used to crash schema generation with
+    ``AttributeError: '_Pipeline' object has no attribute '__dict__'``.
+    """
+    # the exact composition from the issue
+    ta = TypeAdapter[int](Annotated[int, (validate_as(int) | validate_as(int)) & validate_as(int)])
+    assert ta.validate_python(5) == 5
+
+    # nested OR: outer OR whose left operand is itself an OR
+    ta = TypeAdapter[int](Annotated[int, (validate_as(int).gt(10) | validate_as(int).lt(5)) | validate_as(int).eq(7)])
+    for ok in (1, 7, 20):
+        assert ta.validate_python(ok) == ok
+    with pytest.raises(ValidationError):
+        ta.validate_python(8)
+
+    # nested AND: outer AND whose left operand is itself an AND
+    ta = TypeAdapter[int](
+        Annotated[int, (validate_as(int).gt(0) & validate_as(int).lt(100)) & validate_as(int).multiple_of(5)]
+    )
+    assert ta.validate_python(15) == 15
+    for bad in (-5, 7, 105):
+        with pytest.raises(ValidationError):
+            ta.validate_python(bad)
+
+    # mixed: a nested OR on one side of an AND
+    ta = TypeAdapter[int](
+        Annotated[int, (validate_as(int).lt(0) | validate_as(int).gt(100)) & validate_as(int).multiple_of(10)]
+    )
+    assert ta.validate_python(110) == 110
+    assert ta.validate_python(-10) == -10
+    with pytest.raises(ValidationError):
+        ta.validate_python(50)  # fails the OR (0..100)
+    with pytest.raises(ValidationError):
+        ta.validate_python(105)  # passes the OR but not multiple_of(10)
+
+
 def test_validate_as_ellipsis_preserves_other_steps() -> None:
     """https://github.com/pydantic/pydantic/issues/11624"""
 


### PR DESCRIPTION
Closes #13287.

## The bug

Composing `pydantic.experimental.pipeline` validators with **nested** `|` / `&` crashes during schema generation:

```python
from typing import Annotated
from pydantic import BaseModel
from pydantic.experimental.pipeline import validate_as

class M(BaseModel):
    x: Annotated[int, (validate_as(int) | validate_as(int)) & validate_as(int)]
# AttributeError: '_Pipeline' object has no attribute '__dict__'
```

A single, non-nested `|`/`&` works fine — only nesting one operand inside another pipeline triggers it.

## Cause

In `_apply_step`, the `_PipelineOr` / `_PipelineAnd` branches resolve their operands with `handler(step.left)` / `handler(step.right)`. Each operand is itself a `_Pipeline`, which is a slotted dataclass (`@dataclass(**_slots_true)`).

At the top level this happens to work, because the handler pydantic uses for an annotation checks `__get_pydantic_core_schema__` first. But the handler that gets passed *into* a pipeline's own `__get_pydantic_core_schema__` goes straight to `GenerateSchema._generate_schema_inner` → `match_type`. There `dataclasses.is_dataclass(obj)` is true for the `_Pipeline` instance, so it dispatches to `_dataclass_schema`, which does `dataclass.__dict__.get('__pydantic_core_schema__')` — and a slotted instance has no `__dict__`, hence the `AttributeError`. So as soon as an operand is reached one level down (i.e. any nesting), it blows up.

## Fix

Resolve nested pipeline operands through their own `__get_pydantic_core_schema__` instead of routing them back through `handler()`. That's exactly what the pipeline already does for its top-level steps, and it doesn't depend on which handler variant pydantic happens to supply. The change is behaviour-preserving for the cases that already worked (verified the simple `|`/`&` schemas and validation outputs are unchanged) and fixes the nested ones.

## Tests

Added `test_nested_composition`, covering the exact composition from the issue plus nested-OR, nested-AND, and a mixed OR-inside-AND case (checking both that the schema builds and that validation accepts/rejects the right values). It fails on `main` with the reported `AttributeError` and passes with the fix; the full `tests/test_pipeline.py` suite stays green.

Thanks @Ethan0456 for the clear report and diagnosis.
