### PR TITLE
docs: add serialization context example for model_serializer

### DIFF
--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -521,6 +521,32 @@ print(model.model_dump())  # no context
 print(model.model_dump(context={'stopwords': ['this', 'is', 'an']}))
 #> {'text': 'example document'}
 ```
+The same context can also be used with `model_serializer`:
+
+```python
+from typing import Any
+
+from pydantic import BaseModel, SerializationInfo, model_serializer
+
+
+class Model(BaseModel):
+    text: str
+    value: int
+
+    @model_serializer(mode='wrap')
+    def serialize_model(self, handler: Any, info: SerializationInfo) -> dict[str, Any]:
+        data = handler(self)
+        if info.context and info.context.get('uppercase_text'):
+            data['text'] = data['text'].upper()
+        return data
+
+
+model = Model(text='hello world', value=10)
+print(model.model_dump())
+#> {'text': 'hello world', 'value': 10}
+print(model.model_dump(context={'uppercase_text': True}))
+#> {'text': 'HELLO WORLD', 'value': 10}
+```
 
 Similarly, you can [use a context for validation](../concepts/validators.md#validation-context).
 


### PR DESCRIPTION
## Description
The serialization context section in the docs only showed an example 
for `field_serializer`. This PR adds an example showing how to use 
serialization context with `model_serializer` as well.

## Related issue
Closes #9628

## Changes
- Added a `model_serializer` + context example in 
  `docs/concepts/serialization.md`