### PR TITLE
docs: add serialization context example for model_serializer 

### DIFF
--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -522,6 +522,35 @@ print(model.model_dump(context={'stopwords': ['this', 'is', 'an']}))
 #> {'text': 'example document'}
 ```
 
+Similarly, you can access the serialization context within a `@model_serializer`:
+
+```python
+from typing import Any
+
+from pydantic import BaseModel, SerializationInfo, model_serializer
+
+
+class Model(BaseModel):
+    text: str
+    value: int
+
+    @model_serializer(mode="wrap")
+    def serialize_model(
+        self, handler: Any, info: SerializationInfo
+    ) -> dict[str, Any]:
+        data = handler(self)
+        if info.context and info.context.get("uppercase_text"):
+            data["text"] = data["text"].upper()
+        return data
+
+
+model = Model(text="hello world", value=10)
+print(model.model_dump())
+#> {'text': 'hello world', 'value': 10}
+print(model.model_dump(context={"uppercase_text": True}))
+#> {'text': 'HELLO WORLD', 'value': 10}
+```
+
 Similarly, you can [use a context for validation](../concepts/validators.md#validation-context).
 
 ## Serializing subclasses


### PR DESCRIPTION
Closes #13290

## Change Summary

Adds an example showing how to use serialization context with `@model_serializer`, complementing the existing `@field_serializer` context example.

## Related Issue

#13290 - User requested better documentation for using serialization context with model serializers, noting it works but docs only show field serializer example.

## Checklist

- [x] Documentation change only (no code changes)
- [x] Example is Black-formatted and compliant