### PR TITLE
fix: catch ZeroDivisionError in fraction_validator

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -72,7 +72,7 @@ def test_fraction_validate_json(json_str, expected):
     'json_str,error',
     [
         ('"not a number"', ValidationError),
-        ('"1/0"', ZeroDivisionError),
+        ('"1/0"', ValidationError),
         (float('inf'), ValidationError),
         (float('nan'), ValidationError),
     ],
@@ -127,7 +127,7 @@ def test_fraction_strict_accepts_fraction(input_value):
     'input_value,error',
     [
         ('not a number', ValidationError),
-        ('1/0', ZeroDivisionError),
+        ('1/0', ValidationError),
         (float('inf'), OverflowError),
         (float('nan'), ValidationError),
         ([1, 2], TypeError),


### PR DESCRIPTION
## Summary

Fixes #13257

The  in  only catches  when constructing  from user input. However, Python's  raises  for zero-denominator strings like . This violates Pydantic's contract that all invalid user input should result in a .

## Changes

- ****: Add  to the except clause in 
- ****: Update 2 tests to expect  instead of  for zero-denominator fraction inputs ( and  non-strict paths)

## Testing

Verified that:
- Normal fractions still work:  → 
- Zero-denominator strings now raise :  → 
- Invalid strings still raise :  → 