### PR TITLE
Fix PydanticOmit handling for duplicated definition references

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -305,6 +305,7 @@ class GenerateJsonSchema:
         #  the reference) so instead of failing altogether if we can't build a definition we
         # store the error raised and re-throw it if we end up needing that def
         self._core_defs_invalid_for_json_schema: dict[DefsRef, PydanticInvalidForJsonSchema] = {}
+        self._core_defs_omitted_for_json_schema: set[DefsRef] = set()
 
         # This changes to True after generating a schema, to prevent issues caused by accidental reuse
         # of a single instance of a schema generator
@@ -2098,6 +2099,10 @@ class GenerateJsonSchema:
                 core_ref: CoreRef = CoreRef(definition['ref'])  # type: ignore
                 self._core_defs_invalid_for_json_schema[self.get_defs_ref((core_ref, self.mode))] = e
                 continue
+            except PydanticOmit:
+                core_ref: CoreRef = CoreRef(definition['ref'])  # type: ignore
+                self._core_defs_omitted_for_json_schema.add(self.get_defs_ref((core_ref, self.mode)))
+                continue
         return self.generate_inner(schema['schema'])
 
     def definition_ref_schema(self, schema: core_schema.DefinitionReferenceSchema) -> JsonSchemaValue:
@@ -2274,10 +2279,14 @@ class GenerateJsonSchema:
         core_mode_ref = (core_ref, self.mode)
         maybe_defs_ref = self.core_to_defs_refs.get(core_mode_ref)
         if maybe_defs_ref is not None:
+            if maybe_defs_ref in self._core_defs_omitted_for_json_schema:
+                raise PydanticOmit
             json_ref = self.core_to_json_refs[core_mode_ref]
             return maybe_defs_ref, {'$ref': json_ref}
 
         defs_ref = self.get_defs_ref(core_mode_ref)
+        if defs_ref in self._core_defs_omitted_for_json_schema:
+            raise PydanticOmit
 
         # populate the ref translation mappings
         self.core_to_defs_refs[core_mode_ref] = defs_ref

--- a/tests/test_issue_11553_regression.py
+++ b/tests/test_issue_11553_regression.py
@@ -81,3 +81,69 @@ def test_duplicated_field_omitted_type_regression() -> None:
     }
     # No stale $defs entry for the omitted type:
     assert '$defs' not in schema
+
+
+def test_recursive_with_omitted_type() -> None:
+    """Verifies that recursive definition refs resolve normally when an omitted type is in the recursion path."""
+
+    class RecursiveModel(BaseModel):
+        child: 'RecursiveModel | OmittedType | None' = None
+
+    schema = RecursiveModel.model_json_schema()
+
+    # The self-reference to RecursiveModel should resolve to a valid $ref schema.
+    # OmittedType should be completely omitted from the anyOf choices.
+    assert schema == {
+        '$defs': {
+            'RecursiveModel': {
+                'properties': {
+                    'child': {
+                        'anyOf': [
+                            {'$ref': '#/$defs/RecursiveModel'},
+                            {'type': 'null'},
+                        ],
+                        'default': None,
+                        'title': 'Child',
+                    }
+                },
+                'title': 'RecursiveModel',
+                'type': 'object',
+            }
+        },
+        '$ref': '#/$defs/RecursiveModel',
+    }
+
+
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+
+def test_generic_model_with_omitted_type() -> None:
+    """Verifies that generic models referencing the omitted type function correctly."""
+
+    class GenericModel(BaseModel, Generic[T]):
+        value: T
+        other: list[T | OmittedType]
+
+    schema = GenericModel[float].model_json_schema()
+
+    # GenericModel[float] should resolve T to float (number), and other should have OmittedType removed,
+    # leaving list[float] (items: {type: number}).
+    assert schema == {
+        'properties': {
+            'value': {
+                'title': 'Value',
+                'type': 'number',
+            },
+            'other': {
+                'items': {'type': 'number'},
+                'title': 'Other',
+                'type': 'array',
+            },
+        },
+        'required': ['value', 'other'],
+        'title': 'GenericModel[float]',
+        'type': 'object',
+    }
+

--- a/tests/test_issue_11553_regression.py
+++ b/tests/test_issue_11553_regression.py
@@ -1,0 +1,83 @@
+"""
+Regression test for https://github.com/pydantic/pydantic/issues/11553
+
+Title: PydanticOmit failing with duplicated union field
+
+When a custom type raises PydanticOmit in __get_pydantic_json_schema__,
+schema generation must succeed even when that type appears in multiple
+fields, causing pydantic-core to create a 'definitions' wrapper with
+'definition-ref' nodes.
+"""
+
+import pytest
+from pydantic_core import PydanticOmit
+from pydantic import BaseModel
+
+
+class OmittedType(BaseModel):
+    """A BaseModel subclass that raises PydanticOmit from its JSON schema hook."""
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema, handler):
+        raise PydanticOmit
+
+
+def test_single_field_omitted_type_works() -> None:
+    """Single field: already worked before, must keep working (non-regression)."""
+
+    class SingleField(BaseModel):
+        first_field: list[float | OmittedType]
+
+    schema = SingleField.model_json_schema()
+    assert schema == {
+        'properties': {
+            'first_field': {
+                'items': {'type': 'number'},
+                'title': 'First Field',
+                'type': 'array',
+            },
+        },
+        'required': ['first_field'],
+        'title': 'SingleField',
+        'type': 'object',
+    }
+
+
+def test_duplicated_field_omitted_type_regression() -> None:
+    """
+    Regression: two fields share the same omitted type.
+
+    pydantic-core generates a 'definitions' wrapper for DuplicatedField because
+    OmittedType is referenced from two fields. Each field's schema contains a
+    'definition-ref' node pointing at the OmittedType definition.
+
+    Expected: OmittedType is silently omitted from both union branches.
+    Actual (bug): PydanticOmit propagates uncaught and crashes schema generation.
+    """
+
+    class DuplicatedField(BaseModel):
+        first_field: list[float | OmittedType]
+        second_field: list[float | OmittedType]
+
+    # This must NOT raise PydanticOmit (or any other exception):
+    schema = DuplicatedField.model_json_schema()
+
+    assert schema == {
+        'properties': {
+            'first_field': {
+                'items': {'type': 'number'},
+                'title': 'First Field',
+                'type': 'array',
+            },
+            'second_field': {
+                'items': {'type': 'number'},
+                'title': 'Second Field',
+                'type': 'array',
+            },
+        },
+        'required': ['first_field', 'second_field'],
+        'title': 'DuplicatedField',
+        'type': 'object',
+    }
+    # No stale $defs entry for the omitted type:
+    assert '$defs' not in schema


### PR DESCRIPTION
Fixes #11553.

When a type raises `PydanticOmit` from `__get_pydantic_json_schema__`, omission works correctly when the type is used once, but fails when the same type is referenced from multiple fields and pydantic-core emits a shared definition.

The root cause is that omitted definitions are not tracked. Subsequent definition-reference lookups still resolve to a `$ref`, preventing omission semantics from propagating through the definition-reference path.

This change:
* Tracks definitions omitted via `PydanticOmit`
* Re-raises `PydanticOmit` when those definitions are later resolved through definition references
* Preserves existing omission behavior used elsewhere in JSON schema generation

Added regression tests covering:
* Single-field usage (existing working behavior)
* Duplicated-field usage (issue #11553)
* Shared omitted definitions referenced from multiple fields
* Recursive models with omitted types
* Generic models referencing omitted types
