### PR TITLE
docs: mention pickling parametrized generics

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -807,6 +807,19 @@ you would expect if you were to declare a distinct type for each parametrization
     Internally, Pydantic creates subclasses of the generic model at runtime when the generic model class is parametrized.
     These classes are cached, so there should be minimal overhead introduced by the use of generics models.
 
+!!! note "Pickling parametrized generic models"
+    Python's [`pickle`](https://docs.python.org/3/library/pickle.html) module restores classes by importing
+    them from their module and looking up their qualified name. When a generic model is parametrized inside a
+    function or another local scope, the runtime-created parametrized class may not be available from the module
+    namespace under that name, so pickle may fail to serialize or deserialize instances of that model.
+
+    If you need to pickle instances of a parametrized generic model, define a named subclass at module scope:
+
+    ```python {test="skip"}
+    class IntResponse(Response[int]):
+        pass
+    ```
+
 To inherit from a generic model and preserve the fact that it is generic, the subclass must also inherit from
 [`Generic`][typing.Generic]:
 


### PR DESCRIPTION
## Change Summary

Document the pickling limitation for parametrized generic models and show the stable module-level subclass pattern.

## Related issue number

Refs #9390

## Summary

This adds a short note to the generic models documentation explaining that parametrized generic model classes are created at runtime, and that Python's `pickle` resolves classes by module and qualified name.

## Reproduction

The issue report shows that pickling an instance of a generic model parametrized inside a function can fail because the runtime-created class is not available from the module namespace under the generated qualified name.

## Root cause

`pickle` restores classes by importing the defining module and looking up the class qualified name. A parametrized generic model created in a local scope may not be registered in that module namespace, so the class lookup can fail during serialization or deserialization.

## Changes

- Add a note under `Generic models` describing the pickle limitation.
- Recommend defining a named concrete subclass at module scope when pickling instances of parametrized generic models.

## Tests

- `git diff --check`
- Verified the documented subclass pattern in a temporary venv with `pydantic>=2` and a pickle round trip.

Not run locally:

- `make docs` because this environment does not have `uv` installed.

## Screenshots/Logs

Not applicable; documentation-only change.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist (not applicable: documentation-only change)
* [ ] Tests pass on CI (local checks listed above; full CI will run on the PR)
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
