### PR TITLE
Add MongoObjectId API docs page

### DIFF
--- a/docs/api/pydantic_extra_types_mongo_object_id.md
+++ b/docs/api/pydantic_extra_types_mongo_object_id.md
@@ -1,0 +1,1 @@
+::: pydantic_extra_types.mongo_object_id

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
           - Routing Numbers: api/pydantic_extra_types_routing_numbers.md
           - Coordinate: api/pydantic_extra_types_coordinate.md
           - Mac Address: api/pydantic_extra_types_mac_address.md
+          - Mongo ObjectId: api/pydantic_extra_types_mongo_object_id.md
           - ISBN: api/pydantic_extra_types_isbn.md
           - Pendulum: api/pydantic_extra_types_pendulum_dt.md
           - Currency: api/pydantic_extra_types_currency_code.md


### PR DESCRIPTION
Summary
- Add a Pydantic Extra Types API docs page for `pydantic_extra_types.mongo_object_id`.
- Add `Mongo ObjectId` to the Pydantic Extra Types API navigation.

Reproduction
- `https://docs.pydantic.dev/latest/api/pydantic-extra-types/pydantic_extra_types_mongo_object_id/` currently returns the Pydantic docs 404 page.
- `MongoObjectId` is available in the locked `pydantic-extra-types==2.10.6` package used by the docs.

Root cause
- The Pydantic docs nav and API source files include pages for several `pydantic-extra-types` modules, but there is no page for `mongo_object_id`.

Changes
- Added `docs/api/pydantic_extra_types_mongo_object_id.md` with a mkdocstrings directive for `pydantic_extra_types.mongo_object_id`.
- Added the page to the `Pydantic Extra Types` section in `mkdocs.yml`.

Tests
- `python3` smoke check that the nav entry exists and the new page contains `::: pydantic_extra_types.mongo_object_id`
- `git diff --check upstream/main..HEAD`
- Verified the new commit author and committer are `popsiclelmlm <7487674+popsiclelmlm@users.noreply.github.com>`
- Not run: `make docs` / `uv run mkdocs build --strict` because `uv` is not installed in this local environment.

Screenshots/Logs
- Not applicable; docs source-only change.

Related to pydantic/pydantic-extra-types#299.
