### PR TITLE
Support non-init dataclass fields with validate_assignment=True

### DIFF
--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use pyo3::exceptions::PyKeyError;
+use pyo3::exceptions::{PyAttributeError, PyKeyError};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
@@ -92,7 +92,10 @@ impl BuildValidator for DataclassArgsValidator {
             }
 
             let kw_only = field.get_as(intern!(py, "kw_only"))?.unwrap_or(true);
-            if !kw_only {
+            let init = field.get_as(intern!(py, "init"))?.unwrap_or(true);
+            // `init=False` fields are not part of the generated `__init__()` signature, so they
+            // never consume a positional argument slot.
+            if !kw_only && init {
                 positional_count += 1;
             }
 
@@ -104,7 +107,7 @@ impl BuildValidator for DataclassArgsValidator {
                 name,
                 lookup_path_collection,
                 validator,
-                init: field.get_as(intern!(py, "init"))?.unwrap_or(true),
+                init,
                 init_only: field.get_as(intern!(py, "init_only"))?.unwrap_or(false),
                 frozen: field.get_as::<bool>(intern!(py, "frozen"))?.unwrap_or(false),
             });
@@ -167,6 +170,10 @@ impl Validator for DataclassArgsValidator {
 
         let mut fields_set_count: usize = 0;
 
+        // Tracks the positional index of init fields. `init=False` fields do not appear in the
+        // generated `__init__()` signature, so they must not consume positional argument slots.
+        let mut positional_index: usize = 0;
+
         macro_rules! set_item {
             ($field:ident, $value:expr) => {{
                 if $field.init_only {
@@ -180,7 +187,7 @@ impl Validator for DataclassArgsValidator {
         }
 
         // go through fields getting the value from args or kwargs and validating it
-        for (index, field) in self.fields.iter().enumerate() {
+        for field in &self.fields {
             if !field.init {
                 match field.validator.default_value(py, Some(field.name.clone()), state) {
                     Ok(Some(value)) => {
@@ -198,6 +205,9 @@ impl Validator for DataclassArgsValidator {
                 }
                 continue;
             }
+
+            let index = positional_index;
+            positional_index += 1;
 
             let mut pos_value = None;
             if let Some(args) = args.args()
@@ -642,8 +652,19 @@ impl DataclassValidator {
         let py = dc.py();
         let dict = PyDict::new(py);
 
+        // A field may legitimately not be set on a genuine instance yet. This notably happens for
+        // `init=False` fields that are assigned for the first time inside `__post_init__()` while
+        // `validate_assignment` is enabled. For such instances we mirror the model validator
+        // behaviour (which reads `__dict__` directly) by simply skipping fields that aren't present.
+        // For anything that isn't an instance of the dataclass, the `AttributeError` is propagated.
+        let is_instance = dc.is_instance(self.class.bind(py))?;
+
         for field_name in &self.fields {
-            dict.set_item(field_name, dc.getattr(field_name)?)?;
+            match dc.getattr(field_name) {
+                Ok(value) => dict.set_item(field_name, value)?,
+                Err(e) if is_instance && e.is_instance_of::<PyAttributeError>(py) => continue,
+                Err(e) => return Err(e),
+            }
         }
         Ok(dict)
     }

--- a/pydantic-core/tests/validators/test_dataclasses.py
+++ b/pydantic-core/tests/validators/test_dataclasses.py
@@ -1713,6 +1713,68 @@ def test_dataclass_args_init_with_default(input_value, extra_behavior, expected)
         assert dataclasses.asdict(v.validate_python(input_value)) == expected
 
 
+def test_dataclass_init_false_positional_index():
+    """An `init=False` field declared before an `init=True` field must not consume a positional slot.
+
+    https://github.com/pydantic/pydantic/issues/5470
+    """
+
+    schema = core_schema.dataclass_args_schema(
+        'Foo',
+        [
+            core_schema.dataclass_field(name='b', schema=core_schema.int_schema(), init=False, kw_only=False),
+            core_schema.dataclass_field(name='a', schema=core_schema.int_schema(), kw_only=False),
+        ],
+    )
+    v = SchemaValidator(schema)
+
+    # The single positional argument maps to `a` (the only init field), not to `b`
+    # (which, being `init=False`, doesn't occupy a positional slot):
+    assert v.validate_python(ArgsKwargs((5,))) == ({'a': 5}, None)
+
+    # And one positional argument is still one too many (only `a` is positional):
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python(ArgsKwargs((5, 6)))
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'unexpected_positional_argument'
+
+
+def test_dataclass_validate_assignment_init_false_unset():
+    """Assigning a not-yet-set `init=False` field must validate rather than raise an ``AttributeError``."""
+
+    @dataclasses.dataclass
+    class Foo:
+        a: int
+        b: int = dataclasses.field(init=False)
+
+    schema = core_schema.dataclass_schema(
+        Foo,
+        core_schema.dataclass_args_schema(
+            'Foo',
+            [
+                core_schema.dataclass_field(name='a', schema=core_schema.int_schema()),
+                core_schema.dataclass_field(name='b', schema=core_schema.int_schema(), init=False),
+            ],
+        ),
+        ['a', 'b'],
+    )
+    v = SchemaValidator(schema)
+
+    foo = v.validate_python({'a': 1})
+    assert not hasattr(foo, 'b')
+
+    # `b` isn't set yet, but assignment still validates and succeeds:
+    v.validate_assignment(foo, 'b', '2')
+    assert foo.b == 2
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_assignment(foo, 'b', 'not an int')
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'int_parsing'
+
+    # A non-instance still raises a plain ``AttributeError``:
+    with pytest.raises(AttributeError):
+        v.validate_assignment('not a Foo', 'b', 1)
+
+
 @dataclasses.dataclass
 class BasicDataclass:
     a: str

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -570,15 +570,6 @@ def collect_dataclass_fields(
                 if _typing_extra.is_classvar_annotation(ann_type):
                     continue
 
-                if (
-                    not dataclass_field.init
-                    and dataclass_field.default is dataclasses.MISSING
-                    and dataclass_field.default_factory is dataclasses.MISSING
-                ):
-                    # TODO: We should probably do something with this so that validate_assignment behaves properly
-                    #   Issue: https://github.com/pydantic/pydantic/issues/5470
-                    continue
-
                 if isinstance(dataclass_field.default, FieldInfo_):
                     if dataclass_field.default.init_var:
                         if dataclass_field.default.init is False:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -399,6 +399,45 @@ def test_post_init_assignment():
     assert c.c == 0.30000000000000004
 
 
+def test_validate_assignment_with_init_false_field():
+    """https://github.com/pydantic/pydantic/issues/5470"""
+    from dataclasses import field
+
+    @pydantic.dataclasses.dataclass(config=ConfigDict(validate_assignment=True))
+    class C:
+        a: int
+        b: int = field(init=False)
+
+        def __post_init__(self):
+            self.b = self.a + 1
+
+    c = C(1)
+    assert c.a == 1
+    # The `init=False` field is collected, so it ends up in the fields:
+    assert set(c.__pydantic_fields__) == {'a', 'b'}
+    assert c.b == 2
+
+    # Assignment of the `init=False` field is still validated:
+    with pytest.raises(ValidationError) as exc_info:
+        c.b = 'not an int'
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'int_parsing'
+
+    c.b = '3'
+    assert c.b == 3
+
+    # Validation also applies when the field is first set inside `__post_init__()`:
+    @pydantic.dataclasses.dataclass(config=ConfigDict(validate_assignment=True))
+    class D:
+        b: int = field(init=False)
+
+        def __post_init__(self):
+            self.b = 'not an int'
+
+    with pytest.raises(ValidationError) as exc_info:
+        D()
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'int_parsing'
+
+
 def test_inheritance():
     @pydantic.dataclasses.dataclass
     class A:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Pydantic V2 dataclasses silently dropped `init=False` fields without a default
from `__pydantic_fields__`, so assigning such a field (e.g. in `__post_init__`)
under `validate_assignment=True` raised `AttributeError` instead of validating
it. These fields are now collected and validated like any other field, with
supporting changes in pydantic-core so `init=False` fields don't consume a
positional argument slot and `validate_assignment` tolerates a field not yet
set on the instance.

## Related issue number

fix #5470

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**