### PR TITLE
Add test coverage for LazyLocalNamespace length

### DIFF
--- a/tests/test_forward_ref.py
+++ b/tests/test_forward_ref.py
@@ -11,6 +11,7 @@ from typing_extensions import get_args, get_origin  # noqa: UP035
 from typing_inspection import typing_objects
 
 from pydantic import BaseModel, Field, PydanticUserError, TypeAdapter, ValidationError
+from pydantic._internal._namespace_utils import LazyLocalNamespace
 
 
 def test_postponed_annotations(create_module):
@@ -1113,6 +1114,12 @@ def test_pydantic_extra_forward_ref_evaluated_pep585() -> None:
     # `GenerateSchema._get_args_resolving_forward_refs()`) and as such `extra_keys_schema` isn't
     # set because `str` is the default.
     assert 'extras_keys_schema' not in Bar.__pydantic_core_schema__['schema']
+
+
+def test_lazy_local_namespace_len() -> None:
+    namespace = LazyLocalNamespace({'a': int}, {'b': str, 'a': str})
+
+    assert len(namespace) == 2
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## Change Summary

Adds test coverage for `LazyLocalNamespace.__len__`.

The new test verifies that `len()` returns the number of merged namespace keys when multiple local namespaces are provided, including when a later namespace overrides an earlier key.

## Related issue number

Refs #7656

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
