### PR TITLE
Allow `__pydantic_init_subclass__` to receive custom class keyword arguments

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -159,7 +159,13 @@ class ModelMetaclass(ABCMeta):
             namespace['__class_vars__'] = class_vars
             namespace['__private_attributes__'] = {**base_private_attributes, **private_attributes}
 
-            cls = cast('type[BaseModel]', super().__new__(mcs, cls_name, bases, namespace, **kwargs))
+            # `kwargs` now only contains the custom class keyword arguments (config keys were popped by
+            # `ConfigWrapper.for_model` above). `type.__new__` forwards these to `__init_subclass__`, so if a
+            # user defined one it can consume them. When none of the bases define `__init_subclass__`, the kwargs
+            # would otherwise reach `object.__init_subclass__` and raise a `TypeError`. In that case we withhold
+            # them from `type.__new__` and let `__pydantic_init_subclass__` receive them below instead (see #13300).
+            new_kwargs = kwargs if _bases_define_init_subclass(bases) else {}
+            cls = cast('type[BaseModel]', super().__new__(mcs, cls_name, bases, namespace, **new_kwargs))
             BaseModel_ = import_cached_base_model()
 
             mro = cls.__mro__
@@ -401,6 +407,28 @@ def get_model_post_init(namespace: dict[str, Any], bases: tuple[type[Any], ...])
     model_post_init = get_attribute_from_bases(bases, 'model_post_init')
     if model_post_init is not BaseModel.model_post_init:
         return model_post_init
+
+
+def _bases_define_init_subclass(bases: tuple[type[Any], ...]) -> bool:
+    """Return whether any class in the MRO of the given bases defines a custom `__init_subclass__`.
+
+    This mirrors the lookup `type.__new__` performs when forwarding class keyword arguments to
+    `__init_subclass__`: the first `__init_subclass__` found in the bases' MRO is the one that would be
+    invoked. When that resolves to `object.__init_subclass__`, no user code is able to consume custom
+    keyword arguments, so they should instead be routed to `__pydantic_init_subclass__` (see #13300).
+
+    Args:
+        bases: The base classes of the model being created.
+
+    Returns:
+        `True` if a base in the MRO defines `__init_subclass__`, `False` if it only resolves to
+        `object.__init_subclass__`.
+    """
+    for base in bases:
+        for klass in base.__mro__:
+            if '__init_subclass__' in klass.__dict__:
+                return klass is not object
+    return False
 
 
 def inspect_namespace(  # noqa C901

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2110,10 +2110,20 @@ def test_class_kwargs_config_and_attr_conflict():
 
 
 def test_class_kwargs_custom_config():
-    with pytest.raises(TypeError, match=r'__init_subclass__\(\) takes no keyword arguments'):
+    # A custom (non-config) class keyword argument is no longer rejected when no `__init_subclass__`
+    # is defined; it is delivered to `__pydantic_init_subclass__` instead (see #13300).
+    received = []
 
-        class Model(BaseModel, some_config='new_value'):
-            a: int
+    class Base(BaseModel):
+        @classmethod
+        def __pydantic_init_subclass__(cls, some_config: str | None = None, **kwargs: Any) -> None:
+            super().__pydantic_init_subclass__(**kwargs)
+            received.append(some_config)
+
+    class Model(Base, some_config='new_value'):
+        a: int
+
+    assert received == ['new_value']
 
 
 @pytest.mark.parametrize(
@@ -2925,6 +2935,25 @@ def test_pydantic_hooks() -> None:
 
     MyModel.model_rebuild(force=True)
     assert calls == []
+
+
+def test_pydantic_init_subclass_custom_kwargs_without_init_subclass() -> None:
+    """Custom class keyword arguments should reach `__pydantic_init_subclass__` even when no
+    `__init_subclass__` is defined to absorb them (see issue #13300).
+    """
+    registered = []
+
+    class Event(BaseModel):
+        e_type: str
+
+        @classmethod
+        def __pydantic_init_subclass__(cls, event_type: str | None = None, **kwargs: Any) -> None:
+            super().__pydantic_init_subclass__(**kwargs)
+            registered.append((cls.__name__, event_type))
+
+    class CreatedEvent(Event, event_type='created'): ...
+
+    assert registered == [('CreatedEvent', 'created')]
 
 
 def test_model_validate_with_context():


### PR DESCRIPTION
## Change Summary

`__pydantic_init_subclass__` is documented to "receive the same `kwargs` that would be passed to the standard `__init_subclass__`, namely, any kwargs passed to the class definition that aren't used internally by Pydantic." In practice, passing a custom class keyword argument (e.g. `class CreatedEvent(Event, event_type='created')`) raised `TypeError: ...__init_subclass__() takes no keyword arguments` unless the user *also* defined an `__init_subclass__` to swallow the kwarg — defeating the purpose of the hook.

### Root cause

In `ModelMetaclass.__new__`, after `ConfigWrapper.for_model` pops the recognized config keys out of `kwargs`, the remaining custom kwargs were forwarded to `super().__new__(mcs, ..., **kwargs)` (i.e. `type.__new__`). Python's class-creation machinery then routes those kwargs to `__init_subclass__` along the MRO; when no class consumes them, they reach `object.__init_subclass__`, which rejects extra keyword arguments and raises — before Pydantic ever calls `__pydantic_init_subclass__`.

### Fix

Added a small helper, `_bases_define_init_subclass(bases)`, that mirrors the lookup `type.__new__` performs: it walks the bases' MRO and reports whether a user-defined `__init_subclass__` exists. When one does, the custom kwargs are forwarded as before (so issue #867's behavior and existing user `__init_subclass__` hooks keep working). When none exists — the case in this issue — the leftover custom kwargs are withheld from `type.__new__` and instead delivered to `__pydantic_init_subclass__` (which already receives `**kwargs` further down), fulfilling the documented contract.

This keeps standard Python semantics intact: a user-defined `__init_subclass__` that does not accept a passed kwarg still raises `TypeError`, exactly as it would for any non-Pydantic class.

### Tests

- Added `test_pydantic_init_subclass_custom_kwargs_without_init_subclass` reproducing the issue (custom kwarg with only `__pydantic_init_subclass__` defined).
- Updated `test_class_kwargs_custom_config`, which previously asserted the buggy `TypeError`, to assert the corrected behavior (the custom kwarg now reaches `__pydantic_init_subclass__`).
- Existing `test_pydantic_hooks` and `test_custom_init_subclass_params` (issue #867) continue to pass unchanged.

Fixes #13300
