### PR TITLE
Fix tuple order in `AliasGenerator.generate_aliases()` docstring

### DIFF
--- a/pydantic/aliases.py
+++ b/pydantic/aliases.py
@@ -127,7 +127,7 @@ class AliasGenerator:
         """Generate `alias`, `validation_alias`, and `serialization_alias` for a field.
 
         Returns:
-            A tuple of three aliases - validation, alias, and serialization.
+            A tuple of three aliases - alias, validation, and serialization.
         """
         alias = self._generate_alias('alias', (str,), field_name)
         validation_alias = self._generate_alias('validation_alias', (str, AliasChoices, AliasPath), field_name)


### PR DESCRIPTION
The `AliasGenerator.generate_aliases` docstring describes the return value as "A tuple of three aliases - validation, alias, and serialization", but the method actually returns them in the order `(alias, validation_alias, serialization_alias)` (see the return statement and the type signature `tuple[str | None, str | AliasPath | AliasChoices | None, str | None]`). This swaps the first two entries and is misleading for anyone relying on the documented order. This updates the docstring to read "alias, validation, and serialization" so it matches the real return order. Docstring-only change, no behavior change.