### PR TITLE
Fix `ZeroDivisionError` leaking from fraction validator for zero denominator

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -72,7 +72,7 @@ def test_fraction_validate_json(json_str, expected):
     'json_str,error',
     [
         ('"not a number"', ValidationError),
-        ('"1/0"', ZeroDivisionError),
+        ('"1/0"', ValidationError),
         (float('inf'), ValidationError),
         (float('nan'), ValidationError),
     ],
@@ -127,7 +127,7 @@ def test_fraction_strict_accepts_fraction(input_value):
     'input_value,error',
     [
         ('not a number', ValidationError),
-        ('1/0', ZeroDivisionError),
+        ('1/0', ValidationError),
         (float('inf'), OverflowError),
         (float('nan'), ValidationError),
         ([1, 2], TypeError),
@@ -139,6 +139,20 @@ def test_fraction_validation_error_non_strict(input_value, error):
     with pytest.raises(error):
         ta = TypeAdapter(Fraction)
         ta.validate_python(input_value, strict=False)
+
+
+@pytest.mark.parametrize('input_value', ['1/0', '6/0', '-3/0'])
+def test_fraction_zero_denominator(input_value):
+    # https://github.com/pydantic/pydantic/issues/13257
+    # A zero denominator must raise a ValidationError, not a raw ZeroDivisionError.
+    ta = TypeAdapter(Fraction)
+
+    with pytest.raises(ValidationError) as exc_info:
+        ta.validate_strings(input_value)
+    assert exc_info.value.errors()[0]['type'] == 'fraction_parsing'
+
+    with pytest.raises(ValidationError):
+        ta.validate_python(input_value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

`fraction_validator` in `pydantic/_internal/_validators.py` only caught `ValueError` when constructing a `fractions.Fraction` from user input. Python's `Fraction` raises `ZeroDivisionError` for a zero denominator (e.g. `"6/0"`), so that exception leaked out as a raw Python error instead of being converted into a `ValidationError`, breaking Pydantic's contract that invalid input should always produce a `ValidationError`.

This fix catches `ZeroDivisionError` alongside `ValueError`, consistent with how other validators in the same file wrap stdlib constructor errors. Invalid zero-denominator input now produces a `fraction_parsing` `ValidationError`.

```python
from pydantic import TypeAdapter
import fractions

TypeAdapter(fractions.Fraction).validate_strings("6/0")
# before: ZeroDivisionError: Fraction(6, 0)
# after:  pydantic.ValidationError: ... Input is not a valid fraction
```

## Related issues

Fixes #13257

## Checklist

- [x] The pull request title is a good summary of the changes.
- [x] Unit tests for the changes exist.
- [x] Tests pass on CI (`tests/types/test_fraction.py` — 80 passed locally).
- [x] No documentation changes required.

Existing tests that asserted the previous (buggy) `ZeroDivisionError` behavior were updated to expect `ValidationError`, and a dedicated regression test `test_fraction_zero_denominator` was added.

---

Note to maintainers: happy to be assigned to #13257 per the contributing guide — opening this PR to make the small fix easy to review. Please let me know if you'd prefer any changes.
