### PR TITLE
Add Gitleaks pre-commit hook; annotate ephemeral CI test credentials

### DIFF
--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -339,7 +339,7 @@ jobs:
         image: postgres:15.1-bullseye
         env:
           POSTGRES_USER: polar
-          POSTGRES_PASSWORD: polar
+          POSTGRES_PASSWORD: polar # gitleaks:allow -- ephemeral CI test service, mirrors polarsource/polar test config
           POSTGRES_DB: polar_test
           POSTGRES_PORT: 5432
         options: >-
@@ -357,7 +357,7 @@ jobs:
           - 9001:9001
         env:
           MINIO_ROOT_USER: polar
-          MINIO_ROOT_PASSWORD: polarpolar
+          MINIO_ROOT_PASSWORD: polarpolar # gitleaks:allow -- ephemeral CI test service, mirrors polarsource/polar test config
         options: >-
           --health-cmd "curl -I http://127.0.0.1:9000/minio/health/live"
           --health-interval 10s
@@ -376,9 +376,9 @@ jobs:
         env:
           MINIO_HOST: 127.0.0.1
           MINIO_ROOT_USER: polar
-          MINIO_ROOT_PASSWORD: polarpolar
+          MINIO_ROOT_PASSWORD: polarpolar # gitleaks:allow -- ephemeral CI test service, mirrors polarsource/polar test config
           ACCESS_KEY: polar-development
-          SECRET_ACCESS_KEY: polar123456789
+          SECRET_ACCESS_KEY: polar123456789 # gitleaks:allow -- ephemeral CI test service, mirrors polarsource/polar test config
           BUCKET_NAME: polar-s3
           BUCKET_TESTING_NAME: testing-polar-s3
           POLICY_FILE: policy.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
     hooks:
       - id: zizmor
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks
+
   - repo: local
     hooks:
       - id: lint


### PR DESCRIPTION
## Summary

- Adds [Gitleaks](https://github.com/gitleaks/gitleaks) (v8.27.2) to `.pre-commit-config.yaml` so credential-like strings are caught at commit time before they reach the repo
- Annotates the three hardcoded test-service passwords in the `test-polar` CI job with `# gitleaks:allow` so Gitleaks doesn't flag them as false positives

## Background

The `test-polar` job in `.github/workflows/third-party.yml` contains three hardcoded service credentials (`POSTGRES_PASSWORD: polar`, `MINIO_ROOT_PASSWORD: polarpolar`, `SECRET_ACCESS_KEY: polar123456789`). These are ephemeral docker service passwords that intentionally mirror [polarsource/polar's own public test configuration](https://github.com/polarsource/polar) and carry no production risk. Nonetheless, credential-scanning bots routinely index public repos for such patterns, and the absence of any secret scanning tooling means future accidental credential commits would go undetected.

The `# gitleaks:allow` inline annotation is the standard Gitleaks mechanism for marking known-safe values without suppressing scanning on the rest of the file.

## Changes

| File | Change |
|------|--------|
| `.pre-commit-config.yaml` | Add `gitleaks/gitleaks` hook at v8.27.2 |
| `.github/workflows/third-party.yml` | Add `# gitleaks:allow` to 3 ephemeral test credential lines |

## Test plan

- [ ] `pre-commit run gitleaks --all-files` passes on the current codebase after the allowlist annotations are in place
- [ ] Confirm Gitleaks blocks a test commit containing a real-looking credential string (e.g., `AWS_SECRET_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE`)

Closes: n/a (related to internal security hygiene, not a user-facing bug)