### PR TITLE
fix: catch ZeroDivisionError in fraction_validator

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 


### PR DESCRIPTION
## Summary

Fixes #13257.

The `fraction_validator` in `pydantic/_internal/_validators.py` only caught `ValueError` when constructing a `fractions.Fraction` from user input. However, `Fraction('6/0')` raises `ZeroDivisionError`, which bubbled up as a raw Python exception instead of a `ValidationError`.

## Changes

- Added `ZeroDivisionError` to the exception tuple in `fraction_validator` (line 255)

This is consistent with how other validators in the same file handle exceptions from standard library constructors (e.g., `decimal_validator`, `uuid_validator`).

## Testing

- All 8 existing fraction-related tests pass (`tests/test_types.py -k fraction`)
- Manually verified that `TypeAdapter(Fraction).validate_strings('6/0')` now raises `ValidationError` instead of `ZeroDivisionError`
