### PR TITLE
Fix docstring errors in PrivateAttr, Field, and core validators

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -78,7 +78,7 @@ def import_string(value: Any) -> Any:
 
 def _import_string_logic(dotted_path: str) -> Any:
     """Inspired by uvicorn — dotted paths should include a colon before the final item if that item is not a module.
-    (This is necessary to distinguish between a submodule and an attribute when there is a conflict.).
+    (This is necessary to distinguish between a submodule and an attribute when there is a conflict.)
 
     If the dotted path does not include a colon and the final item is not a valid module, importing as an attribute
     rather than a submodule will be attempted automatically.
@@ -341,10 +341,10 @@ def max_length_validator(x: Any, max_length: Any) -> Any:
 
 
 def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
-    """Compute the total number of digits and decimal places for a given [`Decimal`][decimal.Decimal] instance.
+    """Compute the number of decimal places and total digits for a given [`Decimal`][decimal.Decimal] instance.
 
     This function handles both normalized and non-normalized Decimal instances.
-    Example: Decimal('1.230') -> 4 digits, 3 decimal places
+    Example: `Decimal('1.230')` returns `(3, 4)` — 3 decimal places, 4 total digits.
 
     Args:
         decimal (Decimal): The decimal number to analyze.

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1259,7 +1259,7 @@ def Field(  # noqa: C901
         max_length: Maximum length for iterables.
         pattern: Pattern for strings (a regular expression).
         allow_inf_nan: Allow `inf`, `-inf`, `nan`. Only applicable to float and [`Decimal`][decimal.Decimal] numbers.
-        max_digits: Maximum number of allow digits for strings.
+        max_digits: Maximum number of allowed digits for [`Decimal`][decimal.Decimal] numbers.
         decimal_places: Maximum number of decimal places allowed for numbers.
         union_mode: The strategy to apply when validating a union. Can be `smart` (the default), or `left_to_right`.
             See [Union Mode](../concepts/unions.md#union-modes) for details.
@@ -1539,7 +1539,7 @@ def PrivateAttr(
         An instance of [`ModelPrivateAttr`][pydantic.fields.ModelPrivateAttr] class.
 
     Raises:
-        ValueError: If both `default` and `default_factory` are set.
+        TypeError: If both `default` and `default_factory` are set.
     """
     if default is not PydanticUndefined and default_factory is not None:
         raise TypeError('cannot specify both default and default_factory')


### PR DESCRIPTION
## Summary

Fixes four documentation errors in pydantic core that were either factually incorrect or unclear to users reading the source.

## Changes

**`pydantic/fields.py`**
- `PrivateAttr`: the `Raises` section documented `ValueError`, but the implementation actually raises `TypeError` when both `default` and `default_factory` are set. Corrected to `TypeError`.
- `Field.max_digits`: the field description said the constraint applied "to strings". It actually constrains `Decimal` numbers. Reworded to reflect what the validator does.

**`pydantic/_internal/_validators.py`**
- `_extract_decimal_digits_info`: the summary line listed the return values in the wrong order relative to the function signature. Reordered the wording to match `(decimal_places, total_digits)`. The example value was also wrong — corrected to reflect the actual return value for `Decimal('1.230')`, which is `(3, 4)` (3 decimal places, 4 total digits including the trailing zero).
- `_import_string_logic`: removed a duplicated trailing period in the summary line.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
