### PR TITLE
Add support for `typing.Never`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1087,6 +1087,8 @@ class GenerateSchema:
             return core_schema.multi_host_url_schema()
         elif obj is None or obj is NoneType:
             return core_schema.none_schema()
+        elif typing_objects.is_never(obj) or typing_objects.is_noreturn(obj):
+            return self._never_schema()
         if obj is MISSING:
             return core_schema.missing_sentinel_schema()
         elif obj in IP_TYPES:
@@ -1338,10 +1340,16 @@ class GenerateSchema:
         for arg in args:
             if arg is None or arg is NoneType:
                 nullable = True
+            elif typing_objects.is_never(arg) or typing_objects.is_noreturn(arg):
+                continue
             else:
                 choices.append(self.generate_schema(arg))
 
-        if len(choices) == 1:
+        if len(choices) == 0:
+            if nullable:
+                return core_schema.none_schema()
+            return self._never_schema()
+        elif len(choices) == 1:
             s = choices[0]
         else:
             choices_with_tags: list[CoreSchema | tuple[CoreSchema, str]] = []
@@ -1714,6 +1722,16 @@ class GenerateSchema:
         return core_schema.no_info_plain_validator_function(
             validate_str_is_valid_iana_tz,
             serialization=core_schema.to_string_ser_schema(),
+            metadata=metadata,
+        )
+
+    def _never_schema(self) -> core_schema.CoreSchema:
+        """Generate schema for typing.Never / typing.NoReturn — always fails validation."""
+        from ._validators import never_validator
+
+        metadata = {'pydantic_js_functions': [lambda _1, _2: {'not': {}}]}
+        return core_schema.no_info_plain_validator_function(
+            never_validator,
             metadata=metadata,
         )
 

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -485,6 +485,10 @@ def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable
     return default_default_factory
 
 
+def never_validator(value: Any, /) -> Any:
+    raise PydanticCustomError('never_type', 'Value cannot be validated against type Never')
+
+
 def validate_str_is_valid_iana_tz(value: Any, /) -> ZoneInfo:
     if isinstance(value, ZoneInfo):
         return value

--- a/tests/test_types_never.py
+++ b/tests/test_types_never.py
@@ -1,0 +1,74 @@
+"""Tests for typing.Never / typing.NoReturn support.
+
+Never is the bottom type — no value satisfies it. Pydantic should:
+- Always fail validation for a Never-typed field
+- Eliminate Never from unions (Never | T → T)
+- Produce JSON Schema {"not": {}} (rejects everything)
+"""
+
+from typing import Generic, NoReturn, TypeVar
+
+import pytest
+from typing_extensions import Never
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+T = TypeVar('T')
+
+
+class ReadWriteResponse(BaseModel, Generic[T]):
+    data: dict
+    write_token: T | None = None
+
+
+def test_generic_knockout_disables_field():
+    WriteResponse = ReadWriteResponse[str]
+    ReadResponse = ReadWriteResponse[Never]
+
+    assert WriteResponse(data={'id': 1}, write_token='abc').write_token == 'abc'
+    assert ReadResponse(data={'id': 1}).write_token is None
+
+    with pytest.raises(ValidationError):
+        ReadResponse(data={'id': 1}, write_token='sneaky')
+
+
+def test_never_field_rejects_all_values():
+    class Unconstructable(BaseModel):
+        x: Never
+
+    with pytest.raises(ValidationError) as exc_info:
+        Unconstructable(x='anything')
+
+    error = exc_info.value.errors()[0]
+    assert error['type'] == 'never_type'
+    assert error['loc'] == ('x',)
+
+
+def test_noreturn_is_equivalent_to_never():
+    class Model(BaseModel):
+        x: NoReturn
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(x='anything')
+
+    assert exc_info.value.errors()[0]['type'] == 'never_type'
+
+
+def test_never_eliminated_from_union():
+    ta = TypeAdapter(Never | int)
+    assert ta.validate_python(42) == 42
+
+
+def test_optional_never_collapses_to_none():
+    ta = TypeAdapter(Never | None)
+    assert ta.validate_python(None) is None
+
+
+def test_never_json_schema_rejects_everything():
+    ta = TypeAdapter(Never)
+    assert ta.json_schema() == {'not': {}}
+
+
+def test_never_in_union_json_schema():
+    ta = TypeAdapter(Never | int)
+    assert ta.json_schema() == {'type': 'integer'}


### PR DESCRIPTION
## Change Summary
Add support for `typing.Never` as a field type.
  - `Never` field always fails validation with a `never_type` error
  - `Never` is eliminated from unions (`Never | int` → `int`)
  - JSON Schema produces `{"not": {}}` (rejects everything)
  - `typing.NoReturn` is handled identically (same semantics, pre python 3.11)

The primary use case is generic type parameter knockout: specialising a generic model with `T=Never` to disable a field (e.g. `MyModel[Never]` where `field: T | None` collapses to `None`)

## Related issue number
fix #9731 

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
