### PR TITLE
fix: add pathlib.WindowsPath to PATH_TYPES so schema generation works on Windows

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -153,6 +153,7 @@ PATH_TYPES: list[type] = [
     pathlib.PosixPath,
     pathlib.PurePosixPath,
     pathlib.PureWindowsPath,
+    pathlib.WindowsPath,
 ]
 MAPPING_TYPES = [
     typing.Mapping,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import math
 import os
+import pathlib
 import platform
 import re
 import sys
@@ -3849,6 +3850,24 @@ def test_path_union_ser() -> None:
     model = Model(a=[Path('potato')], b=[Path('potato')])
     assert model.model_dump() == {'a': [Path('potato')], 'b': [Path('potato')]}
     assert model.model_dump_json() == '{"a":["potato"],"b":["potato"]}'
+
+
+def test_windows_path_schema_generation() -> None:
+    """WindowsPath must be recognised by PATH_TYPES so schema/default generation works (GH #13318)."""
+    ta = TypeAdapter(pathlib.WindowsPath)
+    schema = ta.json_schema()
+    assert schema == {'type': 'string', 'format': 'path'}
+
+
+@pytest.mark.skipif(sys.platform != 'win32', reason='WindowsPath can only be instantiated on Windows')
+def test_windows_path_default_in_json_schema() -> None:
+    """Path() on Windows returns WindowsPath; model_json_schema() must include the default (GH #13318)."""
+
+    class Config(BaseModel):
+        path: pathlib.Path = pathlib.Path('config.toml')
+
+    schema = Config.model_json_schema()
+    assert schema['properties']['path'].get('default') == 'config.toml'
 
 
 def test_ser_path_incorrect() -> None:


### PR DESCRIPTION
## Change Summary

`pathlib.WindowsPath` was missing from `PATH_TYPES` in `pydantic/_internal/_generate_schema.py`, while `PosixPath`, `PurePosixPath`, and `PureWindowsPath` were all present.

on Windows, `Path()` returns a `WindowsPath` instance, so a model field with a `Path` default — e.g. `path: Path = Path('config.toml')` — caused two failures at schema generation time:

- `PydanticJsonSchemaWarning: Default value config.toml is not JSON serializable; excluding default from JSON schema`
- `PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'pathlib.WindowsPath'>`

the root cause: `encode_default` calls `TypeAdapter(type(dft))` which hits `match_type`. `WindowsPath` not being in `PATH_TYPES` meant `match_type` couldn't dispatch it to `_path_schema`, so it fell through to the unknown-type error path.

the fix is one line: add `pathlib.WindowsPath` to `PATH_TYPES`.

## Related issue number

fix #13318

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, please add a comment including the phrase "please review" to assign reviewers