### PR TITLE
Raise ValidationError for zero-denominator fractions

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,9 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
+        # Fraction raises ZeroDivisionError for a zero denominator (e.g. '6/0'),
+        # which must surface as a ValidationError like any other invalid input.
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -72,7 +72,7 @@ def test_fraction_validate_json(json_str, expected):
     'json_str,error',
     [
         ('"not a number"', ValidationError),
-        ('"1/0"', ZeroDivisionError),
+        ('"1/0"', ValidationError),
         (float('inf'), ValidationError),
         (float('nan'), ValidationError),
     ],
@@ -127,7 +127,7 @@ def test_fraction_strict_accepts_fraction(input_value):
     'input_value,error',
     [
         ('not a number', ValidationError),
-        ('1/0', ZeroDivisionError),
+        ('1/0', ValidationError),
         (float('inf'), OverflowError),
         (float('nan'), ValidationError),
         ([1, 2], TypeError),


### PR DESCRIPTION
Closes #13257

## Change Summary

`fraction_validator` in `pydantic/_internal/_validators.py` only caught `ValueError` when constructing a `fractions.Fraction` from user input. But `Fraction` raises `ZeroDivisionError` for a zero denominator (e.g. the string `"6/0"`), so that exception bubbled up as a raw `ZeroDivisionError` instead of a `pydantic.ValidationError` — violating the contract that invalid input produces a `ValidationError`. (Originally surfaced via Atheris fuzzing of `validate_strings()`.)

This catches `ZeroDivisionError` alongside `ValueError` so the input surfaces as the existing `fraction_parsing` error:

```python
from fractions import Fraction
from pydantic import TypeAdapter, ValidationError

ta = TypeAdapter(Fraction)
ta.validate_python("6/0")   # before: ZeroDivisionError — after: ValidationError (fraction_parsing)
ta.validate_strings("6/0")  # before: ZeroDivisionError — after: ValidationError (fraction_parsing)
```

The two existing `tests/types/test_fraction.py` cases that asserted the buggy `ZeroDivisionError` behavior (`'1/0'` in `test_fraction_validate_json_error` and `test_fraction_validation_error_non_strict`) are updated to expect `ValidationError`.

## Related issues
Closes #13257

## Checklist
- [x] Tests pass locally (`tests/types/test_fraction.py`, 77 passed)
- [x] `ruff` clean on the changed files
- [x] No behavior change beyond converting the uncaught `ZeroDivisionError` into the existing `fraction_parsing` `ValidationError`