### PR TITLE
Clarify to_json function reference in test_bytes.py comment

### DIFF
--- a/pydantic-core/tests/serializers/test_bytes.py
+++ b/pydantic-core/tests/serializers/test_bytes.py
@@ -169,7 +169,7 @@ def test_bytes_mode_set_via_model_config_not_serializer_config():
     assert s.to_python(bm, mode='json') == {'foo': 'Zm9vYmFy'}
 
     # assert doesn't override serializer config
-    # in V3, we can change the serialization settings provided to to_json to override model config settings,
+    # in V3, we can change the serialization settings provided to the to_json function to override model config settings,
     # but that'd be a breaking change
     BasicModel.__pydantic_serializer__ = s
     assert to_json(bm, bytes_mode='utf8') == b'{"foo":"Zm9vYmFy"}'


### PR DESCRIPTION
## Change Summary

This PR updates a comment in `tests/serializers/test_bytes.py` to clarify that `to_json` is a function reference. The previous phrasing ("provided to to_json") read like a double-word typo and was slightly confusing to understand at a glance. Added "the to_json function" for better readability/grammar without altering any logic.

## Related issue number

N/A - Trivial comment clarification.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**