### PR TITLE
Fix TypeAdapter union serialization for duck-typed objects (#13327)

### DIFF
--- a/pydantic-core/src/serializers/extra.rs
+++ b/pydantic-core/src/serializers/extra.rs
@@ -238,11 +238,13 @@ pub(crate) enum SerCheck {
     Strict,
     // check but allow subclasses
     Lax,
+    // allow duck-typed serialization when the input has at least one matching field
+    DuckTyped,
 }
 
 impl SerCheck {
     pub fn enabled(self) -> bool {
-        self != SerCheck::None
+        !matches!(self, SerCheck::None)
     }
 }
 

--- a/pydantic-core/src/serializers/fields.rs
+++ b/pydantic-core/src/serializers/fields.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::string::ToString;
 use std::sync::Arc;
 
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyDict;
@@ -143,6 +144,21 @@ impl GeneralFieldsSerializer {
                 }
             }
         }
+    }
+
+    pub(super) fn has_any_field_in_value(&self, value: &Bound<'_, PyAny>) -> PyResult<bool> {
+        let py = value.py();
+        if !value.hasattr(intern!(py, "__dict__"))? {
+            return Ok(false);
+        }
+        let dict = value.getattr(intern!(py, "__dict__"))?;
+        let attrs = dict.cast::<PyDict>()?;
+        for key in self.fields.keys() {
+            if attrs.contains(key.as_str())? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     fn serialize<'py, S: DoSerialize>(

--- a/pydantic-core/src/serializers/polymorphism_trampoline.rs
+++ b/pydantic-core/src/serializers/polymorphism_trampoline.rs
@@ -91,4 +91,8 @@ impl TypeSerializer for PolymorphismTrampoline {
     fn retry_with_lax_check(&self) -> bool {
         self.serializer.retry_with_lax_check()
     }
+
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.serializer.retry_with_duck_typed_check()
+    }
 }

--- a/pydantic-core/src/serializers/prebuilt.rs
+++ b/pydantic-core/src/serializers/prebuilt.rs
@@ -75,4 +75,8 @@ impl TypeSerializer for PrebuiltSerializer {
     fn retry_with_lax_check(&self) -> bool {
         self.schema_serializer.get().serializer.retry_with_lax_check()
     }
+
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.schema_serializer.get().serializer.retry_with_duck_typed_check()
+    }
 }

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -434,6 +434,11 @@ pub(crate) trait TypeSerializer: Send + Sync + Debug {
         false
     }
 
+    /// Used by union serializers to decide if it's worth trying duck-typed model/dataclass serialization
+    fn retry_with_duck_typed_check(&self) -> bool {
+        false
+    }
+
     fn get_default(&self, _py: Python) -> PyResult<Option<Py<PyAny>>> {
         Ok(None)
     }

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -128,6 +128,7 @@ impl DataclassSerializer {
             SerCheck::Strict => Ok(value.get_type().is(self.class.bind(value.py()))),
             SerCheck::Lax => value.is_instance(self.class.bind(value.py())),
             SerCheck::None => value.hasattr(intern!(value.py(), "__dataclass_fields__")),
+            SerCheck::DuckTyped => Ok(false),
         }
     }
 

--- a/pydantic-core/src/serializers/type_serializers/definitions.rs
+++ b/pydantic-core/src/serializers/type_serializers/definitions.rs
@@ -116,4 +116,9 @@ impl TypeSerializer for DefinitionRefSerializer {
             .retry_with_lax_check
             .get_or_init(|| self.definition.read(|s| s.unwrap().retry_with_lax_check()), &false)
     }
+
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.definition
+            .read(|s| s.is_some_and(|s| s.retry_with_duck_typed_check()))
+    }
 }

--- a/pydantic-core/src/serializers/type_serializers/float.rs
+++ b/pydantic-core/src/serializers/type_serializers/float.rs
@@ -95,7 +95,7 @@ impl TypeSerializer for FloatSerializer {
             IsType::Exact => Ok(value.clone().unbind()),
             IsType::Subclass => match state.check {
                 SerCheck::Strict => Err(PydanticSerializationUnexpectedValue::new_from_msg(None).to_py_err()),
-                SerCheck::Lax | SerCheck::None => match state.extra.mode {
+                SerCheck::Lax | SerCheck::None | SerCheck::DuckTyped => match state.extra.mode {
                     SerMode::Json => value.extract::<f64>()?.into_py_any(py),
                     _ => infer_to_python(value, state),
                 },

--- a/pydantic-core/src/serializers/type_serializers/list.rs
+++ b/pydantic-core/src/serializers/type_serializers/list.rs
@@ -122,4 +122,8 @@ impl TypeSerializer for ListSerializer {
     fn retry_with_lax_check(&self) -> bool {
         self.item_serializer.retry_with_lax_check()
     }
+
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.item_serializer.retry_with_duck_typed_check()
+    }
 }

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -145,13 +145,17 @@ impl ModelSerializer {
             SerCheck::Strict => Ok(value.get_type().is(&self.class)),
             SerCheck::Lax => value.is_instance(self.class.bind(value.py())),
             SerCheck::None => value.hasattr(intern!(value.py(), "__dict__")),
+            SerCheck::DuckTyped => match self.serializer.as_ref() {
+                CombinedSerializer::Fields(fields) => fields.has_any_field_in_value(value),
+                _ => Ok(false),
+            },
         }
     }
 
     fn allow_value_root_model(&self, value: &Bound<'_, PyAny>, check: SerCheck) -> PyResult<bool> {
         match check {
             SerCheck::Strict => Ok(value.get_type().is(&self.class)),
-            SerCheck::Lax | SerCheck::None => value.is_instance(self.class.bind(value.py())),
+            SerCheck::Lax | SerCheck::None | SerCheck::DuckTyped => value.is_instance(self.class.bind(value.py())),
         }
     }
 
@@ -291,5 +295,9 @@ impl TypeSerializer for ModelSerializer {
 
     fn retry_with_lax_check(&self) -> bool {
         true
+    }
+
+    fn retry_with_duck_typed_check(&self) -> bool {
+        matches!(self.serializer.as_ref(), CombinedSerializer::Fields(_))
     }
 }

--- a/pydantic-core/src/serializers/type_serializers/nullable.rs
+++ b/pydantic-core/src/serializers/type_serializers/nullable.rs
@@ -74,4 +74,8 @@ impl TypeSerializer for NullableSerializer {
     fn retry_with_lax_check(&self) -> bool {
         self.serializer.retry_with_lax_check()
     }
+
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.serializer.retry_with_duck_typed_check()
+    }
 }

--- a/pydantic-core/src/serializers/type_serializers/simple.rs
+++ b/pydantic-core/src/serializers/type_serializers/simple.rs
@@ -125,7 +125,7 @@ macro_rules! build_simple_serializer {
                     IsType::Exact => Ok(value.clone().unbind()),
                     IsType::Subclass => match state.check {
                         SerCheck::Strict => Err(PydanticSerializationUnexpectedValue::new_from_msg(None).to_py_err()),
-                        SerCheck::Lax | SerCheck::None => match state.extra.mode {
+                        SerCheck::Lax | SerCheck::None | SerCheck::DuckTyped => match state.extra.mode {
                             SerMode::Json => value.extract::<$rust_type>()?.into_py_any(py),
                             _ => infer_to_python(value, state),
                         },

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -111,6 +111,10 @@ impl TypeSerializer for UnionSerializer {
     fn retry_with_lax_check(&self) -> bool {
         self.choices.retry_with_lax_check()
     }
+
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.choices.retry_with_duck_typed_check()
+    }
 }
 
 #[derive(Debug)]
@@ -354,6 +358,10 @@ impl UnionChoices {
         self.choices.iter().any(|c| c.retry_with_lax_check())
     }
 
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.choices.iter().any(|c| c.retry_with_duck_typed_check())
+    }
+
     /// Try to serialize using the union choices from left to right
     fn serialize<'py, S>(
         &self,
@@ -385,6 +393,16 @@ impl UnionChoices {
         // otherwise, in a top level union, we retry with lax checking if any choice supports it
         if self.retry_with_lax_check() {
             let state = &mut scoped_check_level(state, SerCheck::Lax);
+            for comb_serializer in &self.choices {
+                if let Ok(v) = selector(comb_serializer, state) {
+                    return Ok(Some(v));
+                }
+            }
+        }
+
+        // retry with duck-typed checking, to allow serializing objects through model schemas
+        if self.retry_with_duck_typed_check() {
+            let state = &mut scoped_check_level(state, SerCheck::DuckTyped);
             for comb_serializer in &self.choices {
                 if let Ok(v) = selector(comb_serializer, state) {
                     return Ok(Some(v));

--- a/pydantic-core/src/serializers/type_serializers/with_default.rs
+++ b/pydantic-core/src/serializers/type_serializers/with_default.rs
@@ -68,6 +68,10 @@ impl TypeSerializer for WithDefaultSerializer {
         self.serializer.retry_with_lax_check()
     }
 
+    fn retry_with_duck_typed_check(&self) -> bool {
+        self.serializer.retry_with_duck_typed_check()
+    }
+
     fn get_default(&self, py: Python) -> PyResult<Option<Py<PyAny>>> {
         if let DefaultType::DefaultFactory(_, _takes_data @ true) = self.default {
             // We currently don't compute the default if the default factory takes

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -674,3 +674,37 @@ def test_validate_strings_with_incorrect_configuration():
 
     with pytest.raises(PydanticUserError, check=lambda e: e.code == 'validate-by-alias-and-name-false'):
         ta.validate_strings(1, by_alias=False, by_name=False)
+
+
+def test_type_adapter_union_serializes_duck_typed_models() -> None:
+    """Regression test for https://github.com/pydantic/pydantic/issues/13327"""
+
+    @dataclass
+    class TestModel:
+        id: int
+        name: str
+        description: str | None = None
+        derived_from_id: int | None = None
+
+    class TestSchema(BaseModel):
+        derived_from_id: int | None = None
+
+    class DifferentTestSchema(BaseModel):
+        unique_field: str
+
+    objs = [
+        TestModel(id=1, name='Obj 1', description='First object'),
+        TestModel(id=2, name='Obj 2', description='Second object', derived_from_id=1),
+    ]
+    expected = b'[{"derived_from_id":null},{"derived_from_id":1}]'
+
+    assert TypeAdapter(list[TestSchema]).dump_json(objs) == expected  # pyright: ignore[reportArgumentType]
+
+    union_types = [
+        list[TestSchema] | DifferentTestSchema,
+        Union[list[TestSchema], DifferentTestSchema],  # noqa: UP007
+        list[TestSchema] | list[DifferentTestSchema],
+        list[TestSchema | DifferentTestSchema],
+    ]
+    for union_type in union_types:
+        assert TypeAdapter(union_type).dump_json(objs, warnings='none') == expected  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Change Summary

Union serialization in `pydantic-core` did not duck-type objects the way non-union types do. For example, `TypeAdapter(list[TestSchema]).dump_json(orm_objects)` worked, but `TypeAdapter(list[TestSchema] | OtherSchema).dump_json(orm_objects)` fell back to raw inference and serialized every field on the dataclass/ORM object instead of projecting through `TestSchema`.

This adds a **`SerCheck::DuckTyped`** pass to union serialization. After strict and lax matching fail, union serializers retry choices using duck-typed rules: model serializers accept objects whose `__dict__` shares at least one schema field name, then serialize through that schema. That matches existing non-union behavior for ORM/dataclass → model projection.

Changes are in `pydantic-core` only (no Python `TypeAdapter` API changes). A regression test covers the issue’s union variants.

## Related issue number

fix #13327

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## Test plan

- [x] `pytest tests/test_type_adapter.py::test_type_adapter_union_serializes_duck_typed_models`
- [x] `pytest pydantic-core/tests/serializers/test_union.py`
- [x] Verified all union variants from #13327 serialize to schema-projected JSON