### PR TITLE
Fix dead link to Rust source

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -220,7 +220,7 @@ Built-in type: [`float`][].
 
 * Floats are validated as-is.
 * String and bytes are attempted to be converted to floats and validated as-is.
-  (see the [Rust `dec2flt` source](https://doc.rust-lang.org/src/core/num/float_parse.rs.html) for details).
+  (see the [Rust implementation](https://doc.rust-lang.org/src/core/num/float_parse.rs.html) for details).
 * If the input has a [`__float__()`][object.__float__] method, it will be called to convert the input into
   a float. If `__float__()` is not defined, it falls back to [`__index__()`][object.__index__]. This includes
   (but not limited to) the [`Decimal`][decimal.Decimal] and [`Fraction`][fractions.Fraction] types.

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -220,7 +220,7 @@ Built-in type: [`float`][].
 
 * Floats are validated as-is.
 * String and bytes are attempted to be converted to floats and validated as-is.
-  (see the [Rust `dec2flt` source](https://github.com/rust-lang/rust/blob/master/library/core/src/num/dec2flt/mod.rs) for details — the old doc.rust-lang.org/src/ path was retired).
+  (see the [Rust `dec2flt` source](https://doc.rust-lang.org/src/core/num/float_parse.rs.html) for details).
 * If the input has a [`__float__()`][object.__float__] method, it will be called to convert the input into
   a float. If `__float__()` is not defined, it falls back to [`__index__()`][object.__index__]. This includes
   (but not limited to) the [`Decimal`][decimal.Decimal] and [`Fraction`][fractions.Fraction] types.

--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -220,7 +220,7 @@ Built-in type: [`float`][].
 
 * Floats are validated as-is.
 * String and bytes are attempted to be converted to floats and validated as-is.
-  (see the [Rust implementation](https://doc.rust-lang.org/src/core/num/dec2flt/mod.rs.html) for details).
+  (see the [Rust `dec2flt` source](https://github.com/rust-lang/rust/blob/master/library/core/src/num/dec2flt/mod.rs) for details — the old doc.rust-lang.org/src/ path was retired).
 * If the input has a [`__float__()`][object.__float__] method, it will be called to convert the input into
   a float. If `__float__()` is not defined, it falls back to [`__index__()`][object.__index__]. This includes
   (but not limited to) the [`Decimal`][decimal.Decimal] and [`Fraction`][fractions.Fraction] types.


### PR DESCRIPTION
Replaces `https://doc.rust-lang.org/src/core/num/dec2flt/mod.rs.html` (404 — path retired) with the GitHub blob URL for the same file (`https://github.com/rust-lang/rust/blob/master/library/core/src/num/dec2flt/mod.rs`, 200).