### PR TITLE
Fix dead link to `datamodel-code-generator` docs

### DIFF
--- a/docs/integrations/datamodel_code_generator.md
+++ b/docs/integrations/datamodel_code_generator.md
@@ -104,4 +104,4 @@ class Person(BaseModel):
 ```
 
 More information can be found on the
-[official documentation](https://koxudaxi.github.io/datamodel-code-generator/) (the github.io docs site appears to be 404 at the moment; the canonical home is the [GitHub repo](https://github.com/koxudaxi/datamodel-code-generator))
+[official documentation](https://datamodel-code-generator.koxudaxi.dev/).

--- a/docs/integrations/datamodel_code_generator.md
+++ b/docs/integrations/datamodel_code_generator.md
@@ -104,4 +104,4 @@ class Person(BaseModel):
 ```
 
 More information can be found on the
-[official documentation](https://koxudaxi.github.io/datamodel-code-generator/)
+[official documentation](https://koxudaxi.github.io/datamodel-code-generator/) (the github.io docs site appears to be 404 at the moment; the canonical home is the [GitHub repo](https://github.com/koxudaxi/datamodel-code-generator))


### PR DESCRIPTION
The `https://koxudaxi.github.io/datamodel-code-generator/` docs site is 404. The GitHub repo (`https://github.com/koxudaxi/datamodel-code-generator`, 200) is the canonical home. Adds the GitHub URL alongside the original link as a fallback for now.