### PR TITLE
Use generic `/2/` path for docs links in code examples

### DIFF
--- a/docs/examples/custom_validators.md
+++ b/docs/examples/custom_validators.md
@@ -90,7 +90,7 @@ except ValidationError as ve:
     'loc': (),
     'msg': 'Assertion failed, Invalid tzinfo: Europe/London, expected: America/Los_Angeles',
     'type': 'assertion_error',
-    'url': 'https://errors.pydantic.dev/2.8/v/assertion_error'}]
+    'url': 'https://errors.pydantic.dev/2/v/assertion_error'}]
     """
 ```
 
@@ -170,7 +170,7 @@ except ValidationError as e:
     'loc': (),
     'msg': 'Assertion failed, Value out of bounds',
     'type': 'assertion_error',
-    'url': 'https://errors.pydantic.dev/2.8/v/assertion_error'}]
+    'url': 'https://errors.pydantic.dev/2/v/assertion_error'}]
     """
 ```
 

--- a/docs/examples/files.md
+++ b/docs/examples/files.md
@@ -79,10 +79,10 @@ except ValidationError as err:
     3 validation errors for Person
     name
     Field required [type=missing, input_value={'age': -30, 'email': 'not-an-email-address'}, input_type=dict]
-        For further information visit https://errors.pydantic.dev/2.10/v/missing
+        For further information visit https://errors.pydantic.dev/2/v/missing
     age
     Input should be greater than 0 [type=greater_than, input_value=-30, input_type=int]
-        For further information visit https://errors.pydantic.dev/2.10/v/greater_than
+        For further information visit https://errors.pydantic.dev/2/v/greater_than
     email
     value is not a valid email address: An email address must have an @-sign. [type=value_error, input_value='not-an-email-address', input_type=str]
     """


### PR DESCRIPTION
Updates version-specific error doc links (2.8 → 2, 2.10 → 2) to use the generic `/2/` prefix, consistent with the convention used throughout the rest of the documentation.

Files changed:
- `docs/examples/custom_validators.md`: `/2.8/v/assertion_error` → `/2/v/assertion_error` (2 occurrences)
- `docs/examples/files.md`: `/2.10/v/missing` and `/2.10/v/greater_than` → `/2/v/...`