### PR TITLE
fix: handle ZeroDivisionError in fraction_validator for zero denominators

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,7 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -72,7 +72,7 @@ def test_fraction_validate_json(json_str, expected):
     'json_str,error',
     [
         ('"not a number"', ValidationError),
-        ('"1/0"', ZeroDivisionError),
+        ('"1/0"', ValidationError),
         (float('inf'), ValidationError),
         (float('nan'), ValidationError),
     ],
@@ -127,7 +127,7 @@ def test_fraction_strict_accepts_fraction(input_value):
     'input_value,error',
     [
         ('not a number', ValidationError),
-        ('1/0', ZeroDivisionError),
+        ('1/0', ValidationError),
         (float('inf'), OverflowError),
         (float('nan'), ValidationError),
         ([1, 2], TypeError),
@@ -213,3 +213,35 @@ def test_fraction_constraints_error(constraint, input_value):
 def test_fraction_json_schema():
     ta = TypeAdapter(Fraction)
     assert ta.json_schema() == {'type': 'string', 'format': 'fraction'}
+
+
+def test_fraction_zero_denominator_raises_validation_error():
+    """Regression test for https://github.com/pydantic/pydantic/issues/13257.
+
+    A zero-denominator string like '6/0' should raise a ValidationError,
+    not an unhandled ZeroDivisionError.
+    """
+    ta = TypeAdapter(Fraction)
+
+    # validate_strings path
+    with pytest.raises(ValidationError) as exc_info:
+        ta.validate_strings('6/0')
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'fraction_parsing'
+
+    # validate_python path (non-strict)
+    with pytest.raises(ValidationError) as exc_info:
+        ta.validate_python('6/0', strict=False)
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'fraction_parsing'
+
+    # validate_json path
+    with pytest.raises(ValidationError) as exc_info:
+        ta.validate_json('"6/0"')
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'fraction_parsing'
+
+    # BaseModel path
+    class Model(BaseModel):
+        v: Fraction
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(v='6/0')
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'fraction_parsing'


### PR DESCRIPTION
## Fix

 in  only catches , but  raises , which bubbles up as an unhandled exception instead of a proper .

Closes #13257.

## Change

One-line fix:  → 

This ensures inputs like  produce a  with error type  — consistent with how other invalid fraction inputs are handled.

## Tests

- Updated two existing parametrized test cases that expected  for  inputs — now expect 
- Added regression test  covering all four validation paths: , , , and  construction

All 78 tests in  pass.

## Checklist

- [x] I have run ============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.1.1, pluggy-1.6.0
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=True warmup_iterations=100000)
rootdir: /tmp/pydantic-fix
configfile: pyproject.toml
plugins: benchmark-5.2.3
collected 78 items

tests/types/test_fraction.py ........................................... [ 55%]
...................................                                      [100%]

============================== 78 passed in 0.14s ============================== and all tests pass
- [x] The fix is minimal and targeted
- [x] Regression tests cover the new behavior