### PR TITLE
fix(validators): catch ZeroDivisionError in fraction_validator (#13257)

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -252,7 +252,11 @@ def fraction_validator(input_value: Any, /) -> Fraction:
 
     try:
         return Fraction(input_value)
-    except ValueError:
+    except (ValueError, ZeroDivisionError):
+        # `fractions.Fraction('6/0')` raises `ZeroDivisionError`, not `ValueError`,
+        # because the underlying denominator is 0. Without this catch, a
+        # `"6/0"` string input would surface as a raw `ZeroDivisionError`
+        # instead of a `ValidationError`. See https://github.com/pydantic/pydantic/issues/13257.
         raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1894,6 +1894,24 @@ def test_fraction_validation():
     ]
 
 
+def test_fraction_validation_zero_denominator():
+    """Regression test for https://github.com/pydantic/pydantic/issues/13257.
+
+    `fractions.Fraction('6/0')` raises `ZeroDivisionError` (not `ValueError`)
+    because the underlying denominator is zero. The validator must catch both
+    so the user sees a clean `ValidationError` instead of a raw Python
+    exception.
+    """
+    class Model(BaseModel):
+        a: Fraction
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(a='6/0')
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'fraction_parsing', 'loc': ('a',), 'msg': 'Input is not a valid fraction', 'input': '6/0'}
+    ]
+
+
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 def test_string_success():
     class MoreStringsModel(BaseModel):


### PR DESCRIPTION
## Summary

`fractions.Fraction('6/0')` raises `ZeroDivisionError`, not `ValueError`, because the underlying denominator is zero. The existing `fraction_validator` only catches `ValueError`, so a user-supplied string like `'6/0'` surfaces as a raw `ZeroDivisionError` instead of a `Pydantic ValidationError`.

This is a real input shape: fraction strings are parsed in pydantic-core's `Fraction` validator and then handed back to the Python validator, so any source that constructs `Fraction` from user-controlled strings (config files, env vars, request bodies) hits this.

## Fix

Widen the `except` clause to `(ValueError, ZeroDivisionError)` and reuse the same `fraction_parsing` `PydanticCustomError`. Comment explains the case for future readers.

## Regression test

`test_fraction_validation_zero_denominator` covers the `'6/0'` case. Existing `'wrong_format'` test continues to pass.

## Verification

```
$ python3 -c "from pydantic import BaseModel; from fractions import Fraction
class M(BaseModel): a: Fraction
try: M(a='6/0')
except Exception as e: print(type(e).__name__, e.errors(include_url=False)[0]['type'])"

ValidationError fraction_parsing
```

`pytest tests/test_types.py -k fraction` → 9 passed, 945 deselected.

Fixes #13257

## Diff

`pydantic/_internal/_validators.py` — 6 lines changed (1-line fix + comment)
`tests/test_types.py` — 18 lines added (new regression test)
Total: 2 files, +23 / -1