### PR TITLE
Support mariadbconnector_async dialect in MariaDBDsn

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -944,7 +944,13 @@ class MariaDBDsn(AnyUrl):
     """
 
     _constraints = UrlConstraints(
-        allowed_schemes=['mariadb', 'mariadb+mariadbconnector', 'mariadb+pymysql'],
+        allowed_schemes=[
+            'mariadb',
+            'mariadb+mariadbconnector',
+            'mariadb+pymysql',
+            'mariadb+mariadbconnector_async',
+            'mariadb+asyncmy',
+        ],
         default_port=3306,
     )
 

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -517,6 +517,8 @@ def test_mysql_dsns(dsn):
         'mariadb://user:pass@localhost:3306/app',
         'mariadb+mariadbconnector://user:pass@localhost:3306/app',
         'mariadb+pymysql://user:pass@localhost:3306/app',
+        'mariadb+mariadbconnector_async://user:pass@localhost:3306/app',
+        'mariadb+asyncmy://user:pass@localhost:3306/app',
     ],
 )
 def test_mariadb_dsns(dsn):


### PR DESCRIPTION
### Summary
This PR adds support for `mariadbconnector_async` (and `asyncmy`) to `MariaDBDsn` in `pydantic.networks`. This resolves an issue where attempting to use the asynchronous MariaDB connector for SQLAlchemy failed validation.

### Changes
- Extended the `allowed_schemes` array for `MariaDBDsn` inside `networks.py` to include `mariadb+mariadbconnector_async` and `mariadb+asyncmy`.
- Added test cases covering both new DSN schemes in `test_networks.py`.

### Related Issues
Fixes #13336