### PR TITLE
Support `Fraction` type in `pydantic-core`

### DIFF
--- a/docs/errors/validation_errors.md
+++ b/docs/errors/validation_errors.md
@@ -826,6 +826,48 @@ except ValidationError as exc:
     #> 'float_type'
 ```
 
+## `fraction_parsing`
+
+This error is raised when the value provided for an input that could not be parsed as a fraction:
+
+```python
+from fractions import Fraction
+
+from pydantic import BaseModel, ValidationError
+
+
+class Model(BaseModel):
+    x: Fraction
+
+
+try:
+    Model(x='invalid')
+except ValidationError as exc:
+    print(repr(exc.errors()[0]['type']))
+    #> 'fraction_parsing'
+```
+
+## `fraction_type`
+
+This error is raised when the value provided for a [`Fraction`][fractions.Fraction] is of the wrong type:
+
+```python
+from fractions import Fraction
+
+from pydantic import BaseModel, ValidationError
+
+
+class Model(BaseModel):
+    x: Fraction
+
+
+try:
+    Model.model_validate_json('{"x": [1, 2]}')
+except ValidationError as exc:
+    print(repr(exc.errors()[0]['type']))
+    #> 'fraction_type'
+```
+
 ## `frozen_field`
 
 This error is raised when you attempt to assign a value to a field with `frozen=True`, or to delete such a field:

--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -10,6 +10,7 @@ import warnings
 from collections.abc import Callable, Generator, Hashable, Mapping
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from fractions import Fraction
 from re import Pattern
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -827,6 +828,64 @@ def decimal_schema(
         decimal_places=decimal_places,
         multiple_of=multiple_of,
         allow_inf_nan=allow_inf_nan,
+        strict=strict,
+        ref=ref,
+        metadata=metadata,
+        serialization=serialization,
+    )
+
+
+class FractionSchema(TypedDict, total=False):
+    type: Required[Literal['fraction']]
+    le: Fraction
+    ge: Fraction
+    lt: Fraction
+    gt: Fraction
+    strict: bool
+    ref: str
+    metadata: dict[str, Any]
+    serialization: SerSchema
+
+
+def fraction_schema(
+    *,
+    le: Fraction | None = None,
+    ge: Fraction | None = None,
+    lt: Fraction | None = None,
+    gt: Fraction | None = None,
+    strict: bool | None = None,
+    ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> FractionSchema:
+    """
+    Returns a schema that matches a fraction value, e.g.:
+
+    ```py
+    from fractions import Fraction
+    from pydantic_core import SchemaValidator, core_schema
+
+    schema = core_schema.fraction_schema(le=Fraction(3, 4), ge=Fraction(1, 4))
+    v = SchemaValidator(schema)
+    assert v.validate_python('1/2') == Fraction(1, 2)
+    ```
+
+    Args:
+        le: The value must be less than or equal to this number
+        ge: The value must be greater than or equal to this number
+        lt: The value must be strictly less than this number
+        gt: The value must be strictly greater than this number
+        strict: Whether the value should be a Fraction or a value that can be converted to a Fraction
+        ref: optional unique identifier of the schema, used to reference the schema in other places
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
+        serialization: Custom serialization schema
+    """
+    return _dict_not_none(
+        type='fraction',
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
         strict=strict,
         ref=ref,
         metadata=metadata,
@@ -4133,6 +4192,7 @@ if not MYPY:
         | IntSchema
         | FloatSchema
         | DecimalSchema
+        | FractionSchema
         | StringSchema
         | BytesSchema
         | DateSchema
@@ -4192,6 +4252,7 @@ CoreSchemaType: TypeAlias = Literal[
     'int',
     'float',
     'decimal',
+    'fraction',
     'str',
     'bytes',
     'date',
@@ -4347,6 +4408,8 @@ ErrorType: TypeAlias = Literal[
     'decimal_max_digits',
     'decimal_max_places',
     'decimal_whole_digits',
+    'fraction_type',
+    'fraction_parsing',
     'complex_type',
     'complex_str_parsing',
 ]

--- a/pydantic-core/src/errors/types.rs
+++ b/pydantic-core/src/errors/types.rs
@@ -436,6 +436,9 @@ error_types! {
     DecimalWholeDigits {
         whole_digits: {ctx_type: u64, ctx_fn: field_from_context},
     },
+    // Fraction errors
+    FractionType {},
+    FractionParsing {},
     // Complex errors
     ComplexType {},
     ComplexStrParsing {},
@@ -604,6 +607,8 @@ impl ErrorType {
             Self::DecimalWholeDigits { .. } => {
                 "Decimal input should have no more than {whole_digits} digit{expected_plural} before the decimal point"
             }
+            Self::FractionParsing { .. } => "Input is not a valid fraction",
+            Self::FractionType { .. } => "Fraction input should be an integer, float, string or Fraction object",
             Self::ComplexType { .. } => {
                 "Input should be a valid python complex object, a number, or a valid complex string following the rules at https://docs.python.org/3/library/functions.html#complex"
             }

--- a/pydantic-core/src/input/input_abstract.rs
+++ b/pydantic-core/src/input/input_abstract.rs
@@ -120,6 +120,8 @@ pub(crate) trait Input<'py>: fmt::Debug {
 
     fn validate_decimal(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>>;
 
+    fn validate_fraction(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>>;
+
     type Dict<'a>: ValidatedDict<'py>
     where
         Self: 'a;

--- a/pydantic-core/src/input/input_python.rs
+++ b/pydantic-core/src/input/input_python.rs
@@ -3,7 +3,6 @@ use std::str::from_utf8;
 use pyo3::intern;
 use pyo3::prelude::*;
 
-use pyo3::sync::PyOnceLock;
 use pyo3::types::PyType;
 use pyo3::types::{
     PyBool, PyByteArray, PyBytes, PyComplex, PyDate, PyDateTime, PyDict, PyFloat, PyFrozenSet, PyInt, PyIterator,
@@ -23,6 +22,7 @@ use crate::validators::TemporalUnitMode;
 use crate::validators::ValBytesMode;
 use crate::validators::complex::{get_complex_type, string_to_complex};
 use crate::validators::decimal::{create_decimal, get_decimal_type};
+use crate::validators::fraction::{create_fraction, get_fraction_type};
 
 use super::Arguments;
 use super::ConsumeIterator;
@@ -48,20 +48,6 @@ use super::{
     BorrowInput, EitherBytes, EitherFloat, EitherInt, EitherString, EitherTimedelta, GenericIterator, Input,
     py_string_str,
 };
-
-static FRACTION_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
-
-pub fn get_fraction_type(py: Python<'_>) -> &Bound<'_, PyType> {
-    FRACTION_TYPE
-        .get_or_init(py, || {
-            py.import("fractions")
-                .and_then(|fractions_module| fractions_module.getattr("Fraction"))
-                .unwrap()
-                .extract()
-                .unwrap()
-        })
-        .bind(py)
-}
 
 pub(crate) fn downcast_python_input<'py, T: PyTypeCheck>(input: &(impl Input<'py> + ?Sized)) -> Option<&Bound<'py, T>> {
     input.as_python().and_then(|any| any.cast::<T>().ok())
@@ -285,8 +271,8 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
                     float_as_int(self, self.extract::<f64>()?)
                 } else if let Ok(decimal) = self.validate_decimal(true, self.py()) {
                     decimal_as_int(self, &decimal.into_inner())
-                } else if self.is_instance(get_fraction_type(self.py()))? {
-                    fraction_as_int(self)
+                } else if let Ok(fraction) = self.validate_fraction(true, self.py()) {
+                    fraction_as_int(self, &fraction.into_inner())
                 } else if let Ok(float) = self.extract::<f64>() {
                     float_as_int(self, float)
                 } else if let Some(enum_val) = maybe_as_enum(self) {
@@ -340,6 +326,35 @@ impl<'py> Input<'py> for Bound<'py, PyAny> {
         }
 
         Err(ValError::new(ErrorTypeDefaults::FloatType, self))
+    }
+
+    fn validate_fraction(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
+        let fraction_type = get_fraction_type(py);
+
+        // Fast path for existing fraction objects
+        if self.is_exact_instance(fraction_type) {
+            return Ok(ValidationMatch::exact(self.to_owned().clone()));
+        }
+
+        // Check for fraction subclasses
+        if self.is_instance(fraction_type)? {
+            return Ok(ValidationMatch::lax(self.to_owned().clone()));
+        }
+
+        if !strict {
+            return create_fraction(self, self).map(ValidationMatch::lax);
+        }
+
+        Err(ValError::new(
+            ErrorType::IsInstanceOf {
+                class: fraction_type
+                    .qualname()
+                    .and_then(|name| name.extract())
+                    .unwrap_or_else(|_| "Fraction".to_owned()),
+                context: None,
+            },
+            self,
+        ))
     }
 
     fn validate_decimal(&self, strict: bool, py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {

--- a/pydantic-core/src/input/input_string.rs
+++ b/pydantic-core/src/input/input_string.rs
@@ -9,6 +9,7 @@ use crate::lookup_key::LookupPath;
 use crate::tools::safe_repr;
 use crate::validators::complex::string_to_complex;
 use crate::validators::decimal::create_decimal;
+use crate::validators::fraction::create_fraction;
 use crate::validators::{TemporalUnitMode, ValBytesMode};
 
 use super::datetime::{
@@ -153,6 +154,13 @@ impl<'py> Input<'py> for StringMapping<'py> {
     fn validate_decimal(&self, _strict: bool, _py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         match self {
             Self::String(s) => create_decimal(s, self).map(ValidationMatch::strict),
+            Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::DecimalType, self)),
+        }
+    }
+
+    fn validate_fraction(&self, _strict: bool, _py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
+        match self {
+            Self::String(s) => create_fraction(s, self).map(ValidationMatch::strict),
             Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::DecimalType, self)),
         }
     }

--- a/pydantic-core/src/input/input_string.rs
+++ b/pydantic-core/src/input/input_string.rs
@@ -161,7 +161,7 @@ impl<'py> Input<'py> for StringMapping<'py> {
     fn validate_fraction(&self, _strict: bool, _py: Python<'py>) -> ValMatch<Bound<'py, PyAny>> {
         match self {
             Self::String(s) => create_fraction(s, self).map(ValidationMatch::strict),
-            Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::DecimalType, self)),
+            Self::Mapping(_) => Err(ValError::new(ErrorTypeDefaults::FractionType, self)),
         }
     }
 

--- a/pydantic-core/src/serializers/infer.rs
+++ b/pydantic-core/src/serializers/infer.rs
@@ -112,7 +112,7 @@ pub(crate) fn infer_to_python_known<'py>(
                 }
                 v.into_py_any(py)?
             }
-            ObType::Decimal => value.to_string().into_py_any(py)?,
+            ObType::Decimal | ObType::Fraction => value.to_string().into_py_any(py)?,
             ObType::StrSubclass => PyString::new(py, value.cast::<PyString>()?.to_str()?).into(),
             ObType::Bytes => state
                 .config
@@ -251,6 +251,7 @@ pub(crate) fn infer_to_python_known<'py>(
                 let v = value.cast::<PyComplex>()?;
                 v.into_py_any(py)?
             }
+            ObType::Fraction => value.to_string().into_py_any(py)?,
             ObType::Unknown => {
                 if let Some(fallback) = &state.extra.fallback {
                     let next_value = fallback.call1((value,))?;
@@ -367,7 +368,7 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
             let v = value.extract::<f64>().map_err(py_err_se_err)?;
             type_serializers::float::serialize_f64(v, serializer, state.config.inf_nan_mode)
         }
-        ObType::Decimal => value.to_string().serialize(serializer),
+        ObType::Decimal | ObType::Fraction => value.to_string().serialize(serializer),
         ObType::Str | ObType::StrSubclass => {
             let py_str = value.cast::<PyString>().map_err(py_err_se_err)?;
             serialize_to_json(serializer)
@@ -509,7 +510,7 @@ pub(crate) fn infer_json_key_known<'a, 'py>(
                 super::type_serializers::simple::to_str_json_key(key)
             }
         }
-        ObType::Decimal => Ok(Cow::Owned(key.to_string())),
+        ObType::Decimal | ObType::Fraction => Ok(Cow::Owned(key.to_string())),
         ObType::Bool => super::type_serializers::simple::bool_json_key(key),
         ObType::Str | ObType::StrSubclass => key.cast::<PyString>()?.to_cow(),
         ObType::Bytes => state

--- a/pydantic-core/src/serializers/ob_type.rs
+++ b/pydantic-core/src/serializers/ob_type.rs
@@ -23,6 +23,7 @@ pub struct ObTypeLookup {
     dict: usize,
     // other numeric types
     decimal_object: Py<PyAny>,
+    fraction_object: Py<PyAny>,
     // other string types
     bytes: usize,
     bytearray: usize,
@@ -76,6 +77,7 @@ impl ObTypeLookup {
             list: PyList::type_object_raw(py) as usize,
             dict: PyDict::type_object_raw(py) as usize,
             decimal_object: py.import("decimal").unwrap().getattr("Decimal").unwrap().unbind(),
+            fraction_object: py.import("fractions").unwrap().getattr("Fraction").unwrap().unbind(),
             string: PyString::type_object_raw(py) as usize,
             bytes: PyBytes::type_object_raw(py) as usize,
             bytearray: PyByteArray::type_object_raw(py) as usize,
@@ -148,6 +150,7 @@ impl ObTypeLookup {
             ObType::List => self.list == ob_type,
             ObType::Dict => self.dict == ob_type,
             ObType::Decimal => self.decimal_object.as_ptr() as usize == ob_type,
+            ObType::Fraction => self.fraction_object.as_ptr() as usize == ob_type,
             ObType::StrSubclass => self.string == ob_type && op_value.is_none(),
             ObType::Tuple => self.tuple == ob_type,
             ObType::Set => self.set == ob_type,
@@ -229,6 +232,8 @@ impl ObTypeLookup {
             ObType::Dict
         } else if ob_type == self.decimal_object.as_ptr() as usize {
             ObType::Decimal
+        } else if ob_type == self.fraction_object.as_ptr() as usize {
+            ObType::Fraction
         } else if ob_type == self.bytes {
             ObType::Bytes
         } else if ob_type == self.tuple {
@@ -341,6 +346,8 @@ impl ObTypeLookup {
             ObType::MultiHostUrl
         } else if value.is_instance(self.decimal_object.bind(py)).unwrap_or(false) {
             ObType::Decimal
+        } else if value.is_instance(self.fraction_object.bind(py)).unwrap_or(false) {
+            ObType::Fraction
         } else if value.is_instance(self.uuid_object.bind(py)).unwrap_or(false) {
             ObType::Uuid
         } else if value.is_instance(self.enum_object.bind(py)).unwrap_or(false) {
@@ -408,6 +415,7 @@ pub enum ObType {
     Float,
     FloatSubclass,
     Decimal,
+    Fraction,
     // string types
     Str,
     StrSubclass,

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -126,6 +126,7 @@ combined_serializer! {
         Bool: super::type_serializers::simple::BoolSerializer;
         Float: super::type_serializers::float::FloatSerializer;
         Decimal: super::type_serializers::decimal::DecimalSerializer;
+        Fraction: super::type_serializers::fraction::FractionSerializer;
         Str: super::type_serializers::string::StrSerializer;
         Bytes: super::type_serializers::bytes::BytesSerializer;
         Datetime: super::type_serializers::datetime_etc::DatetimeSerializer;
@@ -359,6 +360,7 @@ impl PyGcTraverse for CombinedSerializer {
             CombinedSerializer::Bool(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Float(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Decimal(inner) => inner.py_gc_traverse(visit),
+            CombinedSerializer::Fraction(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Str(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Bytes(inner) => inner.py_gc_traverse(visit),
             CombinedSerializer::Datetime(inner) => inner.py_gc_traverse(visit),

--- a/pydantic-core/src/serializers/type_serializers/fraction.rs
+++ b/pydantic-core/src/serializers/type_serializers/fraction.rs
@@ -1,0 +1,78 @@
+use std::borrow::Cow;
+use std::sync::{Arc, LazyLock};
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use crate::definitions::DefinitionsBuilder;
+use crate::serializers::infer::{infer_json_key_known, infer_serialize_known, infer_to_python_known};
+use crate::serializers::ob_type::{IsType, ObType};
+
+use crate::serializers::SerializationState;
+
+use super::{BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, infer_serialize, infer_to_python};
+
+#[derive(Debug)]
+pub struct FractionSerializer {}
+
+static FRACTION_SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
+    LazyLock::new(|| Arc::new(FractionSerializer {}.into()));
+
+impl BuildSerializer for FractionSerializer {
+    const EXPECTED_TYPE: &'static str = "fraction";
+
+    fn build(
+        _schema: &Bound<'_, PyDict>,
+        _config: Option<&Bound<'_, PyDict>>,
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+    ) -> PyResult<Arc<CombinedSerializer>> {
+        Ok(FRACTION_SERIALIZER.clone())
+    }
+}
+
+impl_py_gc_traverse!(FractionSerializer {});
+
+impl TypeSerializer for FractionSerializer {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
+        match state.extra.ob_type_lookup.is_type(value, ObType::Fraction) {
+            IsType::Exact | IsType::Subclass => infer_to_python_known(ObType::Fraction, value, state),
+            IsType::False => {
+                state.warn_fallback_py(self.get_name(), value)?;
+                infer_to_python(value, state)
+            }
+        }
+    }
+
+    fn json_key<'a, 'py>(
+        &self,
+        key: &'a Bound<'py, PyAny>,
+        state: &mut SerializationState<'py>,
+    ) -> PyResult<Cow<'a, str>> {
+        match state.extra.ob_type_lookup.is_type(key, ObType::Fraction) {
+            IsType::Exact | IsType::Subclass => infer_json_key_known(ObType::Fraction, key, state),
+            IsType::False => {
+                state.warn_fallback_py(self.get_name(), key)?;
+                infer_json_key(key, state)
+            }
+        }
+    }
+
+    fn serde_serialize<'py, S: serde::ser::Serializer>(
+        &self,
+        value: &Bound<'py, PyAny>,
+        serializer: S,
+        state: &mut SerializationState<'py>,
+    ) -> Result<S::Ok, S::Error> {
+        match state.extra.ob_type_lookup.is_type(value, ObType::Fraction) {
+            IsType::Exact | IsType::Subclass => infer_serialize_known(ObType::Fraction, value, serializer, state),
+            IsType::False => {
+                state.warn_fallback_ser::<S>(self.get_name(), value)?;
+                infer_serialize(value, serializer, state)
+            }
+        }
+    }
+
+    fn get_name(&self) -> &str {
+        Self::EXPECTED_TYPE
+    }
+}

--- a/pydantic-core/src/serializers/type_serializers/mod.rs
+++ b/pydantic-core/src/serializers/type_serializers/mod.rs
@@ -9,6 +9,7 @@ pub mod dict;
 pub mod enum_;
 pub mod float;
 pub mod format;
+pub mod fraction;
 pub mod function;
 pub mod generator;
 pub mod json;

--- a/pydantic-core/src/validators/fraction.rs
+++ b/pydantic-core/src/validators/fraction.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use pyo3::exceptions::{PyOverflowError, PyTypeError, PyValueError, PyZeroDivisionError};
+use pyo3::intern;
+use pyo3::sync::PyOnceLock;
+use pyo3::types::{IntoPyDict, PyDict, PyString, PyType};
+use pyo3::{PyTypeInfo, prelude::*};
+
+use crate::build_tools::is_strict;
+use crate::errors::ErrorTypeDefaults;
+use crate::errors::ValResult;
+use crate::errors::{ErrorType, Number, ToErrorValue, ValError};
+use crate::input::Input;
+
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+
+static FRACTION_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+
+pub fn get_fraction_type(py: Python<'_>) -> &Bound<'_, PyType> {
+    FRACTION_TYPE
+        .get_or_init(py, || {
+            py.import("fractions")
+                .and_then(|fraction_module| fraction_module.getattr("Fraction"))
+                .unwrap()
+                .extract()
+                .unwrap()
+        })
+        .bind(py)
+}
+
+fn validate_as_fraction(
+    py: Python,
+    schema: &Bound<'_, PyDict>,
+    key: &Bound<'_, PyString>,
+) -> PyResult<Option<Py<PyAny>>> {
+    match schema.get_item(key)? {
+        Some(value) => match value.validate_fraction(false, py) {
+            Ok(v) => Ok(Some(v.into_inner().unbind())),
+            Err(_) => Err(PyValueError::new_err(format!(
+                "'{key}' must be coercible to a Fraction instance",
+            ))),
+        },
+        None => Ok(None),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FractionValidator {
+    strict: bool,
+    le: Option<Py<PyAny>>,
+    lt: Option<Py<PyAny>>,
+    ge: Option<Py<PyAny>>,
+    gt: Option<Py<PyAny>>,
+}
+
+impl BuildValidator for FractionValidator {
+    const EXPECTED_TYPE: &'static str = "fraction";
+    fn build(
+        schema: &Bound<'_, PyDict>,
+        config: Option<&Bound<'_, PyDict>>,
+        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+    ) -> PyResult<Arc<CombinedValidator>> {
+        let py = schema.py();
+
+        Ok(CombinedValidator::Fraction(Self {
+            strict: is_strict(schema, config)?,
+            le: validate_as_fraction(py, schema, intern!(py, "le"))?,
+            lt: validate_as_fraction(py, schema, intern!(py, "lt"))?,
+            ge: validate_as_fraction(py, schema, intern!(py, "ge"))?,
+            gt: validate_as_fraction(py, schema, intern!(py, "gt"))?,
+        })
+        .into())
+    }
+}
+
+impl_py_gc_traverse!(FractionValidator { le, lt, ge, gt });
+
+impl Validator for FractionValidator {
+    fn validate<'py>(
+        &self,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Py<PyAny>> {
+        let fraction = input.validate_fraction(state.strict_or(self.strict), py)?.unpack(state);
+
+        if let Some(le) = &self.le
+            && !fraction.le(le)?
+        {
+            return Err(ValError::new(
+                ErrorType::LessThanEqual {
+                    le: Number::String(le.to_string()),
+                    context: Some([("le", le)].into_py_dict(py)?.into()),
+                },
+                input,
+            ));
+        }
+        if let Some(lt) = &self.lt
+            && !fraction.lt(lt)?
+        {
+            return Err(ValError::new(
+                ErrorType::LessThan {
+                    lt: Number::String(lt.to_string()),
+                    context: Some([("lt", lt)].into_py_dict(py)?.into()),
+                },
+                input,
+            ));
+        }
+        if let Some(ge) = &self.ge
+            && !fraction.ge(ge)?
+        {
+            return Err(ValError::new(
+                ErrorType::GreaterThanEqual {
+                    ge: Number::String(ge.to_string()),
+                    context: Some([("ge", ge)].into_py_dict(py)?.into()),
+                },
+                input,
+            ));
+        }
+        if let Some(gt) = &self.gt
+            && !fraction.gt(gt)?
+        {
+            return Err(ValError::new(
+                ErrorType::GreaterThan {
+                    gt: Number::String(gt.to_string()),
+                    context: Some([("gt", gt)].into_py_dict(py)?.into()),
+                },
+                input,
+            ));
+        }
+
+        Ok(fraction.into())
+    }
+
+    fn get_name(&self) -> &str {
+        Self::EXPECTED_TYPE
+    }
+}
+
+pub(crate) fn create_fraction<'py>(arg: &Bound<'py, PyAny>, input: impl ToErrorValue) -> ValResult<Bound<'py, PyAny>> {
+    let py = arg.py();
+    get_fraction_type(py)
+        .call1((arg,))
+        .map_err(|e| handle_fraction_new_error(input, e))
+}
+
+fn handle_fraction_new_error(input: impl ToErrorValue, error: PyErr) -> ValError {
+    Python::attach(|py| {
+        if error.matches(py, PyTypeError::type_object(py)).unwrap_or(false) {
+            ValError::new(ErrorTypeDefaults::FractionType, input)
+        } else if error
+            .matches(
+                py,
+                (
+                    PyValueError::type_object(py),
+                    PyZeroDivisionError::type_object(py),
+                    PyOverflowError::type_object(py),
+                ),
+            )
+            .unwrap_or(false)
+        {
+            ValError::new(ErrorTypeDefaults::FractionParsing, input)
+        } else {
+            // Let other exceptions bubble up
+            ValError::InternalErr(error)
+        }
+    })
+}

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -39,6 +39,7 @@ mod definitions;
 mod dict;
 mod enum_;
 mod float;
+pub(crate) mod fraction;
 mod frozenset;
 mod function;
 mod generator;
@@ -586,6 +587,8 @@ fn build_validator_inner(
         float::FloatBuilder,
         // decimals
         decimal::DecimalValidator,
+        // fractions
+        fraction::FractionValidator,
         // tuples
         tuple::TupleValidator,
         // list/arrays
@@ -749,6 +752,8 @@ pub enum CombinedValidator {
     ConstrainedFloat(float::ConstrainedFloatValidator),
     // decimals
     Decimal(decimal::DecimalValidator),
+    // fractions
+    Fraction(fraction::FractionValidator),
     // lists
     List(list::ListValidator),
     // sets - unique lists

--- a/pydantic-core/tests/test_errors.py
+++ b/pydantic-core/tests/test_errors.py
@@ -394,6 +394,8 @@ all_errors = [
     ('uuid_version', 'UUID version 42 expected', {'expected_version': 42}),
     ('decimal_type', 'Decimal input should be an integer, float, string or Decimal object', None),
     ('decimal_parsing', 'Input should be a valid decimal', None),
+    ('fraction_type', 'Fraction input should be an integer, float, string or Fraction object', None),
+    ('fraction_parsing', 'Input is not a valid fraction', None),
     ('decimal_max_digits', 'Decimal input should have no more than 42 digits in total', {'max_digits': 42}),
     ('decimal_max_digits', 'Decimal input should have no more than 1 digit in total', {'max_digits': 1}),
     ('decimal_max_places', 'Decimal input should have no more than 42 decimal places', {'decimal_places': 42}),

--- a/pydantic-core/tests/test_schema_functions.py
+++ b/pydantic-core/tests/test_schema_functions.py
@@ -310,6 +310,7 @@ all_schema_functions = [
     (core_schema.uuid_schema, args(), {'type': 'uuid'}),
     (core_schema.decimal_schema, args(), {'type': 'decimal'}),
     (core_schema.decimal_schema, args(multiple_of=5, gt=1.2), {'type': 'decimal', 'multiple_of': 5, 'gt': 1.2}),
+    (core_schema.fraction_schema, args(), {'type': 'fraction'}),
     (core_schema.complex_schema, args(), {'type': 'complex'}),
     (core_schema.invalid_schema, args(), {'type': 'invalid'}),
 ]

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -640,23 +640,6 @@ class GenerateSchema:
 
         return schema
 
-    def _fraction_schema(self) -> CoreSchema:
-        """Support for [`fractions.Fraction`][fractions.Fraction]."""
-        from ._validators import fraction_validator
-
-        # TODO: note, this is a fairly common pattern, re lax / strict for attempted type coercion,
-        # can we use a helper function to reduce boilerplate?
-        return core_schema.lax_or_strict_schema(
-            lax_schema=core_schema.no_info_plain_validator_function(fraction_validator),
-            strict_schema=core_schema.json_or_python_schema(
-                json_schema=core_schema.no_info_plain_validator_function(fraction_validator),
-                python_schema=core_schema.is_instance_schema(Fraction),
-            ),
-            # use str serialization to guarantee round trip behavior
-            serialization=core_schema.to_string_ser_schema(when_used='always'),
-            metadata={'pydantic_js_functions': [lambda _1, _2: {'type': 'string', 'format': 'fraction'}]},
-        )
-
     def _arbitrary_type_schema(self, tp: Any) -> CoreSchema:
         if not isinstance(tp, type):
             warnings.warn(
@@ -1083,7 +1066,7 @@ class GenerateSchema:
         elif obj is Url:
             return core_schema.url_schema()
         elif obj is Fraction:
-            return self._fraction_schema()
+            return core_schema.fraction_schema()
         elif obj is MultiHostUrl:
             return core_schema.multi_host_url_schema()
         elif obj is None or obj is NoneType:

--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -43,6 +43,7 @@ SEQUENCE_CONSTRAINTS = {*LENGTH_CONSTRAINTS, *FAIL_FAST}
 
 FLOAT_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *ALLOW_INF_NAN, *STRICT}
 DECIMAL_CONSTRAINTS = {'max_digits', 'decimal_places', *FLOAT_CONSTRAINTS}
+FRACTION_CONSTRAINTS = {*INEQUALITY, *STRICT}
 INT_CONSTRAINTS = {*NUMERIC_CONSTRAINTS, *ALLOW_INF_NAN, *STRICT}
 BOOL_CONSTRAINTS = STRICT
 UUID_CONSTRAINTS = STRICT
@@ -91,6 +92,7 @@ constraint_schema_pairings: list[tuple[set[str], tuple[str, ...]]] = [
     (ENUM_CONSTRAINTS, ('enum',)),
     (DECIMAL_CONSTRAINTS, ('decimal',)),
     (COMPLEX_CONSTRAINTS, ('complex',)),
+    (FRACTION_CONSTRAINTS, ('fraction',)),
 ]
 
 for constraints, schemas in constraint_schema_pairings:

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -11,7 +11,6 @@ import re
 import typing
 from collections.abc import Callable, Sequence
 from decimal import Decimal
-from fractions import Fraction
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import Any, TypeAlias, TypeVar, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -244,16 +243,6 @@ def ip_v6_interface_validator(input_value: Any, /) -> IPv6Interface:
         return IPv6Interface(input_value)
     except ValueError:
         raise PydanticCustomError('ip_v6_interface', 'Input is not a valid IPv6 interface')
-
-
-def fraction_validator(input_value: Any, /) -> Fraction:
-    if isinstance(input_value, Fraction):
-        return input_value
-
-    try:
-        return Fraction(input_value)
-    except ValueError:
-        raise PydanticCustomError('fraction_parsing', 'Input is not a valid fraction')
 
 
 def forbid_inf_nan_check(x: Any) -> Any:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -694,7 +694,24 @@ class GenerateJsonSchema:
 
         """
         json_schema: JsonSchemaValue = {'type': 'string', 'format': 'fraction'}
-        self.update_with_validations(json_schema, schema, self.ValidationsMapping.numeric)
+        if self.mode == 'validation':
+            le = schema.get('le')
+            ge = schema.get('ge')
+            lt = schema.get('lt')
+            gt = schema.get('gt')
+            json_schema = {
+                'anyOf': [
+                    self.float_schema(
+                        core_schema.float_schema(
+                            le=None if le is None else float(le),
+                            ge=None if ge is None else float(ge),
+                            lt=None if lt is None else float(lt),
+                            gt=None if gt is None else float(gt),
+                        )
+                    ),
+                    json_schema,
+                ],
+            }
         return json_schema
 
     def decimal_schema(self, schema: core_schema.DecimalSchema) -> JsonSchemaValue:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -683,6 +683,20 @@ class GenerateJsonSchema:
         json_schema = {k: v for k, v in json_schema.items() if v not in {math.inf, -math.inf}}
         return json_schema
 
+    def fraction_schema(self, schema: core_schema.FractionSchema) -> JsonSchemaValue:
+        """Generates a JSON schema that matches a fraction value.
+
+        Args:
+            schema: The core schema.
+
+        Returns:
+            The generated JSON schema.
+
+        """
+        json_schema: JsonSchemaValue = {'type': 'string', 'format': 'fraction'}
+        self.update_with_validations(json_schema, schema, self.ValidationsMapping.numeric)
+        return json_schema
+
     def decimal_schema(self, schema: core_schema.DecimalSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a decimal value.
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1883,17 +1883,6 @@ def test_invalid_schema_constraints(kwargs, type_, a):
         Foo(a=a)
 
 
-def test_fraction_validation():
-    class Model(BaseModel):
-        a: Fraction
-
-    with pytest.raises(ValidationError) as exc_info:
-        Model(a='wrong_format')
-    assert exc_info.value.errors(include_url=False) == [
-        {'type': 'fraction_parsing', 'loc': ('a',), 'msg': 'Input is not a valid fraction', 'input': 'wrong_format'}
-    ]
-
-
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 def test_string_success():
     class MoreStringsModel(BaseModel):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from enum import Enum, IntEnum
-from fractions import Fraction
 from numbers import Number
 from pathlib import Path
 from re import Pattern
@@ -7142,35 +7141,6 @@ def test_ser_ip_python_and_json() -> None:
     assert ta.dump_python(ip) == ip
     assert ta.dump_python(ip, mode='json') == '127.0.0.1'
     assert ta.dump_json(ip) == b'"127.0.0.1"'
-
-
-@pytest.mark.parametrize('input_data', ['1/3', 1.333, Fraction(1, 3), Decimal('1.333')])
-def test_fraction_validation_lax(input_data) -> None:
-    ta = TypeAdapter(Fraction)
-    fraction = ta.validate_python(input_data)
-    assert isinstance(fraction, Fraction)
-
-
-def test_fraction_validation_strict() -> None:
-    ta = TypeAdapter(Fraction, config=ConfigDict(strict=True))
-
-    assert ta.validate_python(Fraction(1 / 3)) == Fraction(1 / 3)
-
-    # only fractions accepted in strict mode
-    for lax_fraction in ['1/3', 1.333, Decimal('1.333')]:
-        with pytest.raises(ValidationError):
-            ta.validate_python(lax_fraction)
-
-
-def test_fraction_serialization() -> None:
-    ta = TypeAdapter(Fraction)
-    assert ta.dump_python(Fraction(1, 3)) == '1/3'
-    assert ta.dump_json(Fraction(1, 3)) == b'"1/3"'
-
-
-def test_fraction_json_schema() -> None:
-    ta = TypeAdapter(Fraction)
-    assert ta.json_schema() == {'type': 'string', 'format': 'fraction'}
 
 
 def test_annotated_metadata_any_order() -> None:

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -4,7 +4,7 @@ from typing import Annotated
 import annotated_types
 import pytest
 
-from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 
 class FractionSubclass(Fraction):
@@ -41,12 +41,6 @@ class FractionSubclass(Fraction):
     ],
 )
 def test_fraction(input_value, expected):
-    class Model(BaseModel):
-        v: Fraction
-
-    m = Model(v=input_value)
-    assert m.v == expected
-
     ta = TypeAdapter(Fraction)
     assert ta.validate_python(input_value) == expected
 
@@ -72,7 +66,7 @@ def test_fraction_validate_json(json_str, expected):
     'json_str,error',
     [
         ('"not a number"', ValidationError),
-        ('"1/0"', ZeroDivisionError),
+        ('"1/0"', ValidationError),
         (float('inf'), ValidationError),
         (float('nan'), ValidationError),
     ],
@@ -96,14 +90,6 @@ def test_fraction_validate_json_error(json_str, error):
     ],
 )
 def test_fraction_validation_error_strict(input_value):
-    class Model(BaseModel):
-        v: Fraction
-
-        model_config = ConfigDict(strict=True)
-
-    with pytest.raises(ValidationError):
-        Model(v=input_value)
-
     with pytest.raises(ValidationError):
         ta = TypeAdapter(Fraction)
         ta.validate_python(input_value, strict=True)
@@ -124,21 +110,21 @@ def test_fraction_strict_accepts_fraction(input_value):
 
 
 @pytest.mark.parametrize(
-    'input_value,error',
+    ['input', 'error_type'],
     [
-        ('not a number', ValidationError),
-        ('1/0', ZeroDivisionError),
-        (float('inf'), OverflowError),
-        (float('nan'), ValidationError),
-        ([1, 2], TypeError),
-        ({}, TypeError),
-        (None, TypeError),
+        ('wrong_format', 'fraction_parsing'),  # Raises `ValueError` internally
+        ('1/0', 'fraction_parsing'),  # Raises `ZeroDivisionError` internally
+        (float('inf'), 'fraction_parsing'),  # Raises `OverflowError` internally
+        (float('nan'), 'fraction_parsing'),  # Raises `ValueError` internally
+        (type, 'fraction_type'),  # Raises `TypeError` internally
     ],
 )
-def test_fraction_validation_error_non_strict(input_value, error):
-    with pytest.raises(error):
-        ta = TypeAdapter(Fraction)
-        ta.validate_python(input_value, strict=False)
+def test_fraction_validation_error(input: object, error_type: str):
+
+    ta = TypeAdapter(Fraction)
+
+    with pytest.raises(ValidationError, check=lambda e: e.errors()[0]['type'] == error_type):
+        ta.validate_python(input)
 
 
 @pytest.mark.parametrize(

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -4,7 +4,7 @@ from typing import Annotated
 import annotated_types
 import pytest
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import Field, TypeAdapter, ValidationError
 
 
 class FractionSubclass(Fraction):
@@ -60,6 +60,23 @@ def test_fraction(input_value, expected):
 def test_fraction_validate_json(json_str, expected):
     ta = TypeAdapter(Fraction)
     assert ta.validate_json(json_str) == expected
+
+
+@pytest.mark.parametrize(
+    'str,expected',
+    [
+        ('1/3', Fraction(1, 3)),
+        ('42.5', Fraction('42.5')),
+        ('0', Fraction(0)),
+        ('42', Fraction(42)),
+        ('42.5', Fraction('42.5')),
+        ('0/100', Fraction(0)),
+        ('-47e-2', Fraction(-47, 100)),
+    ],
+)
+def test_fraction_validate_strings(str, expected):
+    ta = TypeAdapter(Fraction)
+    assert ta.validate_strings(str) == expected
 
 
 @pytest.mark.parametrize(
@@ -199,3 +216,7 @@ def test_fraction_constraints_error(constraint, input_value):
 def test_fraction_json_schema():
     ta = TypeAdapter(Fraction)
     assert ta.json_schema() == {'type': 'string', 'format': 'fraction'}
+
+    ta = TypeAdapter(Annotated[Fraction, Field(ge=Fraction(1))])
+
+    assert ta.json_schema() == {'anyOf': [{'minimum': 1.0, 'type': 'number'}, {'format': 'fraction', 'type': 'string'}]}

--- a/tests/types/test_fraction.py
+++ b/tests/types/test_fraction.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from fractions import Fraction
 from typing import Annotated
 
@@ -21,6 +22,7 @@ class FractionSubclass(Fraction):
         ('42.123', Fraction('42.123')),
         (42.0, Fraction(42)),
         (42.5, Fraction('42.5')),
+        (Decimal('1.333'), Fraction('1.333')),
         (1e10, Fraction('1E10')),
         (Fraction('42.0'), Fraction(42)),
         (Fraction('42.5'), Fraction('42.5')),
@@ -102,6 +104,9 @@ def test_fraction_validate_json_error(json_str, error):
         (False),
         ('not a number'),
         ('1/0'),
+        ('1/3'),
+        (1.333),
+        (Decimal('1.333')),
         (float('inf')),
         (float('nan')),
     ],
@@ -215,7 +220,7 @@ def test_fraction_constraints_error(constraint, input_value):
 
 def test_fraction_json_schema():
     ta = TypeAdapter(Fraction)
-    assert ta.json_schema() == {'type': 'string', 'format': 'fraction'}
+    assert ta.json_schema(mode='serialization') == {'type': 'string', 'format': 'fraction'}
 
     ta = TypeAdapter(Annotated[Fraction, Field(ge=Fraction(1))])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Wrapping up https://github.com/pydantic/pydantic/pull/12724. Implementation written by @CloseChoice.

Fixes https://github.com/pydantic/pydantic/issues/13257.

I'm not adding a pattern for the JSON Schema, as I'd rather not make the same mistake as with `Decimal` (even if the regex pattern is presumably way simpler for fractions).

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
