### PR TITLE
fix: reset SerCheck level for collection item serializers in union context

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/dict.rs
@@ -15,8 +15,8 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerMode, TypeSerializer, infer_serialize,
-    infer_to_python, py_err_se_err,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerCheck, SerMode, TypeSerializer,
+    infer_serialize, infer_to_python, py_err_se_err,
 };
 
 #[derive(Debug)]
@@ -87,12 +87,14 @@ impl TypeSerializer for DictSerializer {
                         let key = {
                             // disable include/exclude for keys
                             let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
+                            let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                             match state.extra.mode {
                                 SerMode::Json => self.key_serializer.json_key(&key, state)?.into_py_any(py)?,
                                 _ => self.key_serializer.to_python(&key, state)?,
                             }
                         };
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                         let value = value_serializer.to_python(&value, state)?;
                         new_dict.set_item(key, value)?;
                     }
@@ -129,6 +131,7 @@ impl TypeSerializer for DictSerializer {
                 for (key, value) in py_dict.iter() {
                     if let Some(next_include_exclude) = self.filter.key_filter(&key, state).map_err(py_err_se_err)? {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                         let key = key_serializer.json_key(&key, state).map_err(py_err_se_err)?;
                         let value_serialize = PydanticSerializer::new(&value, value_serializer, state);
                         map.serialize_entry(&key, &value_serialize)?;

--- a/pydantic-core/src/serializers/type_serializers/list.rs
+++ b/pydantic-core/src/serializers/type_serializers/list.rs
@@ -14,7 +14,7 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, TypeSerializer, infer_serialize,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerCheck, TypeSerializer, infer_serialize,
     infer_to_python, py_err_se_err,
 };
 
@@ -64,6 +64,7 @@ impl TypeSerializer for ListSerializer {
                     let op_next = self.filter.index_filter(index, state, value.len().ok())?;
                     if let Some(next_include_exclude) = op_next {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                         items.push(item_serializer.to_python(&element, state)?);
                     }
                 }
@@ -102,6 +103,7 @@ impl TypeSerializer for ListSerializer {
                         .map_err(py_err_se_err)?;
                     if let Some(next_include_exclude) = op_next {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                         let item_serialize = PydanticSerializer::new(&element, item_serializer, state);
                         seq.serialize_element(&item_serialize)?;
                     }

--- a/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
+++ b/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
@@ -13,7 +13,8 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    BuildSerializer, CombinedSerializer, PydanticSerializer, SerMode, TypeSerializer, infer_serialize, infer_to_python,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SerCheck, SerMode, TypeSerializer, infer_serialize,
+    infer_to_python,
 };
 
 macro_rules! build_serializer {
@@ -63,6 +64,7 @@ macro_rules! build_serializer {
 
                         let mut items = Vec::with_capacity(py_set.len());
                         for element in py_set.iter() {
+                            let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                             items.push(item_serializer.to_python(&element, state)?);
                         }
                         match state.extra.mode {
@@ -97,6 +99,7 @@ macro_rules! build_serializer {
                         let item_serializer = self.item_serializer.as_ref();
 
                         for value in py_set.iter() {
+                            let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                             let item_serialize = PydanticSerializer::new(&value, item_serializer, state);
                             seq.serialize_element(&item_serialize)?;
                         }

--- a/pydantic-core/src/serializers/type_serializers/tuple.rs
+++ b/pydantic-core/src/serializers/type_serializers/tuple.rs
@@ -182,6 +182,7 @@ impl TupleSerializer {
                     };
                     if let Some(next_include_exclude) = self.filter.index_filter(index, state, Some(n_items))? {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
                         if let Err(e) = f(TupleSerializerEntry {
                             item: element,
                             serializer,

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -674,3 +674,51 @@ def test_validate_strings_with_incorrect_configuration():
 
     with pytest.raises(PydanticUserError, check=lambda e: e.code == 'validate-by-alias-and-name-false'):
         ta.validate_strings(1, by_alias=False, by_name=False)
+
+
+def test_union_serialization_with_dataclass():
+    """Regression test for https://github.com/pydantic/pydantic/issues/13327
+
+    When TypeAdapter is used with a union type like list[TestSchema] | DifferentTestSchema,
+    serialization should apply the schema filtering correctly, not fall back to raw inference.
+    """
+    from dataclasses import dataclass
+
+    @dataclass
+    class TestModel:
+        id: int
+        name: str
+        description: str | None = None
+        derived_from_id: int | None = None
+
+    class TestSchema(BaseModel):
+        derived_from_id: int | None = None
+
+    class DifferentTestSchema(BaseModel):
+        unique_field: str
+
+    objs = [
+        TestModel(id=1, name='Obj 1', description='First object'),
+        TestModel(id=2, name='Obj 2', description='Second object', derived_from_id=1),
+    ]
+
+    # list[TestSchema] alone should work fine
+    adapter_list = TypeAdapter(list[TestSchema])
+    result_list = adapter_list.dump_json(objs)
+    assert result_list == b'[{"derived_from_id":null},{"derived_from_id":1}]'
+
+    # Union type should serialize with the same schema filtering
+    adapter_union = TypeAdapter(list[TestSchema] | DifferentTestSchema)
+    result_union = adapter_union.dump_json(objs)
+    assert result_union == b'[{"derived_from_id":null},{"derived_from_id":1}]'
+
+    # dump_python should also work
+    result_python = adapter_union.dump_python(objs)
+    assert result_python == [{'derived_from_id': None}, {'derived_from_id': 1}]
+
+    # Test with Union syntax
+    from typing import Union
+
+    adapter_union2 = TypeAdapter(Union[list[TestSchema], DifferentTestSchema])
+    result_union2 = adapter_union2.dump_json(objs)
+    assert result_union2 == b'[{"derived_from_id":null},{"derived_from_id":1}]'


### PR DESCRIPTION
## Summary

When a union type like `list[TestSchema] | DifferentTestSchema` is used with TypeAdapter, serialization incorrectly falls back to raw inference (serializing all fields) instead of applying the schema filtering.

**Root cause**: The union serializer sets `SerCheck::Strict` for type disambiguation, which cascades into nested collection item serializers. The `ModelSerializer` then rejects objects that aren't exact type matches (e.g., dataclasses being serialized through BaseModel schemas).

**Fix**: Reset the check level to `SerCheck::None` when processing items inside collection serializers (list, tuple, set, frozenset, dict). The union check level is only needed for top-level type disambiguation — once inside a collection, items should be serialized using the schema's field definitions without strict type checking.

## Changes

### pydantic-core serializer fixes:
- `list.rs`: Reset check level to `SerCheck::None` when serializing list items
- `tuple.rs`: Reset check level in the tuple item serialization macro
- `set_frozenset.rs`: Reset check level when serializing set/frozenset items
- `dict.rs`: Reset check level when serializing dict keys and values

### Test:
- Added regression test `test_union_serialization_with_dataclass` in `tests/test_type_adapter.py`

## Reproduction

```python
from dataclasses import dataclass
from pydantic import BaseModel, TypeAdapter

@dataclass
class TestModel:
    id: int
    name: str
    derived_from_id: int | None = None

class TestSchema(BaseModel):
    derived_from_id: int | None = None

class DifferentTestSchema(BaseModel):
    unique_field: str

objs = [TestModel(id=1, name="Obj 1"), TestModel(id=2, name="Obj 2", derived_from_id=1)]

# Before fix: b'[{"id":1,"name":"Obj 1",...}]' (all fields, with warnings)
# After fix:  b'[{"derived_from_id":null},{"derived_from_id":1}]' (schema-filtered, no warnings)
TypeAdapter(list[TestSchema] | DifferentTestSchema).dump_json(objs)
```

Fixes #13327