### PR TITLE
fix: prevent inner unions in collections from incorrectly using top-level strict checking

### DIFF
--- a/pydantic-core/src/serializers/extra.rs
+++ b/pydantic-core/src/serializers/extra.rs
@@ -33,6 +33,10 @@ pub(crate) struct SerializationState<'py> {
     pub include_exclude: IncludeExclude<'py>,
     /// Global settings for the serialization process
     pub extra: Extra<'py>,
+    /// Whether we're inside a collection (list, dict, tuple, set) that has
+    /// reset the check level for items. This prevents inner unions from
+    /// incorrectly treating themselves as top-level unions.
+    pub in_collection: bool,
 }
 
 /// Values of include/exclude parameters passed to serialization functions
@@ -74,6 +78,7 @@ impl<'py> SerializationState<'py> {
             check: SerCheck::None,
             include_exclude: IncludeExclude { include, exclude },
             extra,
+            in_collection: false,
         })
     }
 
@@ -338,6 +343,7 @@ impl ExtraOwned {
                 exclude: self.exclude.as_ref().map(|m| m.bind(py).clone()),
             },
             extra,
+            in_collection: false,
         }
     }
 }

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -150,6 +150,7 @@ impl DataclassSerializer {
     ) -> Result<S::Ok, S::Error> {
         if self.allow_value(value, state)? {
             let state = &mut state.scoped_set(|s| &mut s.model, Some(value.clone()));
+            let state = &mut state.scoped_set(|s| &mut s.in_collection, false);
             if let CombinedSerializer::Fields(ref fields_serializer) = *self.serializer {
                 // Fast path uses known dataclass fields to avoid needing to create a dict of field values
                 fields_serializer.serialize_iterators(

--- a/pydantic-core/src/serializers/type_serializers/dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/dict.rs
@@ -15,8 +15,8 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerMode, TypeSerializer, infer_serialize,
-    infer_to_python, py_err_se_err,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerCheck, SerMode, TypeSerializer,
+    infer_serialize, infer_to_python, py_err_se_err,
 };
 
 #[derive(Debug)]
@@ -87,12 +87,16 @@ impl TypeSerializer for DictSerializer {
                         let key = {
                             // disable include/exclude for keys
                             let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
+                            let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                            let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                             match state.extra.mode {
                                 SerMode::Json => self.key_serializer.json_key(&key, state)?.into_py_any(py)?,
                                 _ => self.key_serializer.to_python(&key, state)?,
                             }
                         };
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                        let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                         let value = value_serializer.to_python(&value, state)?;
                         new_dict.set_item(key, value)?;
                     }
@@ -129,6 +133,8 @@ impl TypeSerializer for DictSerializer {
                 for (key, value) in py_dict.iter() {
                     if let Some(next_include_exclude) = self.filter.key_filter(&key, state).map_err(py_err_se_err)? {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                        let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                         let key = key_serializer.json_key(&key, state).map_err(py_err_se_err)?;
                         let value_serialize = PydanticSerializer::new(&value, value_serializer, state);
                         map.serialize_entry(&key, &value_serialize)?;

--- a/pydantic-core/src/serializers/type_serializers/list.rs
+++ b/pydantic-core/src/serializers/type_serializers/list.rs
@@ -14,7 +14,7 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, TypeSerializer, infer_serialize,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerCheck, TypeSerializer, infer_serialize,
     infer_to_python, py_err_se_err,
 };
 
@@ -64,6 +64,8 @@ impl TypeSerializer for ListSerializer {
                     let op_next = self.filter.index_filter(index, state, value.len().ok())?;
                     if let Some(next_include_exclude) = op_next {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                        let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                         items.push(item_serializer.to_python(&element, state)?);
                     }
                 }
@@ -102,6 +104,8 @@ impl TypeSerializer for ListSerializer {
                         .map_err(py_err_se_err)?;
                     if let Some(next_include_exclude) = op_next {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                        let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                         let item_serialize = PydanticSerializer::new(&element, item_serializer, state);
                         seq.serialize_element(&item_serialize)?;
                     }

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -176,6 +176,7 @@ impl ModelSerializer {
         let inner_value = self.get_inner_value(value, &state.extra)?;
 
         let state = &mut state.scoped_set(|s| &mut s.model, Some(value.clone()));
+        let state = &mut state.scoped_set(|s| &mut s.in_collection, false);
         do_serialize.serialize_no_infer(&self.serializer, &inner_value, state)
     }
 

--- a/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
+++ b/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
@@ -13,7 +13,8 @@ use crate::tools::SchemaDict;
 
 use super::any::AnySerializer;
 use super::{
-    BuildSerializer, CombinedSerializer, PydanticSerializer, SerMode, TypeSerializer, infer_serialize, infer_to_python,
+    BuildSerializer, CombinedSerializer, PydanticSerializer, SerCheck, SerMode, TypeSerializer, infer_serialize,
+    infer_to_python,
 };
 
 macro_rules! build_serializer {
@@ -63,6 +64,8 @@ macro_rules! build_serializer {
 
                         let mut items = Vec::with_capacity(py_set.len());
                         for element in py_set.iter() {
+                            let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                            let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                             items.push(item_serializer.to_python(&element, state)?);
                         }
                         match state.extra.mode {
@@ -97,6 +100,8 @@ macro_rules! build_serializer {
                         let item_serializer = self.item_serializer.as_ref();
 
                         for value in py_set.iter() {
+                            let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                            let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                             let item_serialize = PydanticSerializer::new(&value, item_serializer, state);
                             seq.serialize_element(&item_serialize)?;
                         }

--- a/pydantic-core/src/serializers/type_serializers/tuple.rs
+++ b/pydantic-core/src/serializers/type_serializers/tuple.rs
@@ -182,6 +182,8 @@ impl TupleSerializer {
                     };
                     if let Some(next_include_exclude) = self.filter.index_filter(index, state, Some(n_items))? {
                         let state = &mut state.scoped_include_exclude(next_include_exclude);
+                        let state = &mut state.scoped_set(|s| &mut s.check, SerCheck::None);
+                        let state = &mut state.scoped_set(|s| &mut s.in_collection, true);
                         if let Err(e) = f(TupleSerializerEntry {
                             item: element,
                             serializer,

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -315,7 +315,7 @@ impl TaggedUnionSerializer {
 
 /// Whether currently in a top-level union serialization
 fn in_top_level_union(state: &SerializationState<'_>) -> bool {
-    state.check == SerCheck::None
+    state.check == SerCheck::None && !state.in_collection
 }
 
 /// Check level to use for the first pass of union serialization

--- a/pydantic-core/tests/serializers/test_union.py
+++ b/pydantic-core/tests/serializers/test_union.py
@@ -1116,3 +1116,56 @@ def test_discriminated_union_ser_with_typed_dict() -> None:
 
     assert v.to_python({'type': 'a', 'a': 1}, warnings='error') == {'type': 'a', 'a': 1}
     assert v.to_python({'type': 'b', 'b': 'foo'}, warnings='error') == {'type': 'b', 'b': 'foo'}
+
+
+@dataclasses.dataclass
+class DataclassModel:
+    id: int
+    name: str
+    description: str | None = None
+    derived_from_id: int | None = None
+
+
+def test_union_serialization_with_dataclass_in_list():
+    """Test that union serialization works when a dataclass is serialized through
+    a model schema in a list union member (GitHub issue pydantic/pydantic#13327)."""
+    schema = core_schema.union_schema(
+        [
+            core_schema.list_schema(
+                core_schema.model_schema(
+                    BaseModel,
+                    core_schema.model_fields_schema(
+                        {
+                            'derived_from_id': core_schema.model_field(
+                                core_schema.with_default_schema(
+                                    core_schema.nullable_schema(core_schema.int_schema()),
+                                    default=None,
+                                )
+                            ),
+                        }
+                    ),
+                )
+            ),
+            core_schema.model_schema(
+                BaseModel,
+                core_schema.model_fields_schema(
+                    {
+                        'unique_field': core_schema.model_field(core_schema.str_schema()),
+                    }
+                ),
+            ),
+        ]
+    )
+
+    s = SchemaSerializer(schema)
+
+    objs = [
+        DataclassModel(id=1, name='Obj 1', description='First object'),
+        DataclassModel(id=2, name='Obj 2', description='Second object', derived_from_id=1),
+    ]
+
+    result = s.to_json(objs, warnings='none')
+    assert result == b'[{"derived_from_id":null},{"derived_from_id":1}]'
+
+    result = s.to_python(objs, warnings='none')
+    assert result == [{'derived_from_id': None}, {'derived_from_id': 1}]

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -674,3 +674,51 @@ def test_validate_strings_with_incorrect_configuration():
 
     with pytest.raises(PydanticUserError, check=lambda e: e.code == 'validate-by-alias-and-name-false'):
         ta.validate_strings(1, by_alias=False, by_name=False)
+
+
+def test_union_serialization_with_dataclass():
+    """Regression test for https://github.com/pydantic/pydantic/issues/13327
+
+    When TypeAdapter is used with a union type like list[TestSchema] | DifferentTestSchema,
+    serialization should apply the schema filtering correctly, not fall back to raw inference.
+    """
+    from dataclasses import dataclass
+
+    @dataclass
+    class TestModel:
+        id: int
+        name: str
+        description: str | None = None
+        derived_from_id: int | None = None
+
+    class TestSchema(BaseModel):
+        derived_from_id: int | None = None
+
+    class DifferentTestSchema(BaseModel):
+        unique_field: str
+
+    objs = [
+        TestModel(id=1, name='Obj 1', description='First object'),
+        TestModel(id=2, name='Obj 2', description='Second object', derived_from_id=1),
+    ]
+
+    # list[TestSchema] alone should work fine
+    adapter_list = TypeAdapter(list[TestSchema])
+    result_list = adapter_list.dump_json(objs)
+    assert result_list == b'[{"derived_from_id":null},{"derived_from_id":1}]'
+
+    # Union type should serialize with the same schema filtering
+    adapter_union = TypeAdapter(list[TestSchema] | DifferentTestSchema)
+    result_union = adapter_union.dump_json(objs)
+    assert result_union == b'[{"derived_from_id":null},{"derived_from_id":1}]'
+
+    # dump_python should also work
+    result_python = adapter_union.dump_python(objs)
+    assert result_python == [{'derived_from_id': None}, {'derived_from_id': 1}]
+
+    # Test with Union syntax
+    from typing import Union
+
+    adapter_union2 = TypeAdapter(Union[list[TestSchema], DifferentTestSchema])
+    result_union2 = adapter_union2.dump_json(objs)
+    assert result_union2 == b'[{"derived_from_id":null},{"derived_from_id":1}]'


### PR DESCRIPTION
Fixes #13327

## Problem
When using `TypeAdapter` with a union type like `list[TestSchema] | DifferentTestSchema`, serialization of inner items was incorrect. The union serializer inside containers (list, tuple, set, frozenset, dict) was incorrectly treating them as "top-level unions" because `in_top_level_union` checks `state.check == SerCheck::None`, but container serializers already reset `check` to `SerCheck::None` for items.

## Root Cause
The `in_top_level_union` function in `pydantic-core/src/serializers/union.rs` uses `state.check == SerCheck::None` as a proxy for "we're at the top level of a union". But container serializers (list, tuple, set, frozenset, dict) also set `SerCheck::None` for their items, causing nested unions to incorrectly use strict checking.

## Fix
Added a new field `in_collection` to the serialization state that tracks whether we're inside a container. When `in_collection` is true, the union serializer uses the standard strict/lax checking instead of the top-level union behavior.