### PR TITLE
fix: preserve pattern constraint for Annotated + BeforeValidator + Optional fields

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -213,7 +213,9 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         # in this recursive case with function-after or function-wrap, we should refactor
         # this is a bit challenging because we sometimes want to apply constraints to the inner schema,
         # whereas other times we want to wrap the existing schema with a new one that enforces a new constraint.
-        if schema_type in {'function-before', 'function-wrap', 'function-after'} and constraint == 'strict':
+        if schema_type in {'function-before', 'function-wrap', 'function-after'} and (
+            constraint in chain_schema_constraints or constraint == 'strict'
+        ):
             schema['schema'] = apply_known_metadata(annotation, schema['schema'])  # type: ignore  # schema is function schema
             return schema
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7265,3 +7265,57 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_annotated_optional_field_with_pattern_and_before_validator() -> None:
+    """https://github.com/pydantic/pydantic/issues/12417
+
+    When combining Annotated type with BeforeValidator and Optional Field with pattern constraint,
+    the pattern should be preserved in the JSON schema.
+    """
+    from typing import Optional
+
+    regex = r'^[\da-fA-F]{32}$'
+
+    def _convert_bytes_to_str(value: Union[str, bytes]) -> str:
+        if isinstance(value, bytes):
+            return value.decode('utf8')
+        return value
+
+    bytes_to_str = Annotated[str, BeforeValidator(_convert_bytes_to_str)]
+
+    class TestModel(BaseModel):
+        str_mandatory: str = Field(..., pattern=regex)
+        annotated_mandatory: bytes_to_str = Field(..., pattern=regex)
+        str_optional: Optional[str] = Field(None, pattern=regex)
+        annotated_optional: Optional[bytes_to_str] = Field(None, pattern=regex)
+
+    schema = TestModel.model_json_schema()
+
+    # str_mandatory should have pattern
+    assert schema['properties']['str_mandatory'] == {
+        'pattern': regex,
+        'title': 'Str Mandatory',
+        'type': 'string',
+    }
+
+    # annotated_mandatory should have pattern
+    assert schema['properties']['annotated_mandatory'] == {
+        'pattern': regex,
+        'title': 'Annotated Mandatory',
+        'type': 'string',
+    }
+
+    # str_optional should have pattern in the string branch
+    assert schema['properties']['str_optional'] == {
+        'anyOf': [{'pattern': regex, 'type': 'string'}, {'type': 'null'}],
+        'default': None,
+        'title': 'Str Optional',
+    }
+
+    # annotated_optional should also have pattern in the string branch
+    assert schema['properties']['annotated_optional'] == {
+        'anyOf': [{'pattern': regex, 'type': 'string'}, {'type': 'null'}],
+        'default': None,
+        'title': 'Annotated Optional',
+    }


### PR DESCRIPTION
## Change Summary

Fix JSON schema generation for `Annotated` types combined with `BeforeValidator` and `Optional` fields that have string constraints (like `pattern`).

## Related issue number

Fixes #12417

## Root Cause

When a field is typed as `Optional[Annotated[str, BeforeValidator(...)]]` with `Field(pattern=...)`, pydantic-core builds a `chain_schema` with two steps: the `function-before` validator as step 0, and a wrapping pattern-check as step 1. The JSON Schema generator's `chain_schema` handler only uses one step:

```python
def chain_schema(self, schema):
    step_index = 0 if self.mode == 'validation' else -1
    return self.generate_inner(schema['steps'][step_index])
```

In validation mode it picks step 0 — the `function-before` wrapper, which knows nothing about `pattern`. The constraint is silently dropped from the emitted JSON Schema.

## Fix

In `pydantic/_internal/_known_annotated_metadata.py`, extend the existing `strict` special-case in `apply_known_metadata` to also trigger for all constraints in `chain_schema_constraints`:

```python
# Before
if schema_type in {'function-before', 'function-wrap', 'function-after'} \
        and constraint == 'strict':
    schema['schema'] = apply_known_metadata(annotation, schema['schema'])
    return schema

# After
if schema_type in {'function-before', 'function-wrap', 'function-after'} \
        and (constraint in chain_schema_constraints or constraint == 'strict'):
    schema['schema'] = apply_known_metadata(annotation, schema['schema'])
    return schema
```

This pushes `pattern` (and the other string constraints like `strip_whitespace`, `to_lower`, `to_upper`, etc.) onto the inner `str` schema directly, so no `chain_schema` split is needed and the JSON Schema generator sees the constraint on the right node.

## Checklist

- [x] The pull request title is a good summary of the changes
- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable