### PR TITLE
fix: accept scientific notation in Decimal JSON schema pattern

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -701,6 +701,8 @@ class GenerateJsonSchema:
                 r'^(?!^[-+.]*$)[+-]?0*'  # check it is not empty string and not one or sequence of ".+-" characters.
             )
 
+            exponent_part = r'(?:[eE][+-]?\d+)?'
+
             # Case 1: Both max_digits and decimal_places are set
             if max_digits is not None and decimal_places is not None:
                 integer_places = max(0, max_digits - decimal_places)
@@ -711,6 +713,7 @@ class GenerateJsonSchema:
                     rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
                     rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
                     rf')'
+                    rf'{exponent_part}'
                 )
 
             # Case 2: Only max_digits is set
@@ -722,15 +725,16 @@ class GenerateJsonSchema:
                     rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
                     rf'\d*\.\d*0*$'
                     rf')'
+                    rf'{exponent_part}'
                 )
 
             # Case 3: Only decimal_places is set
             elif max_digits is None and decimal_places is not None:
-                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*$'
+                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*{exponent_part}$'
 
             # Case 4: Both are None (no restrictions)
             else:
-                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
+                pattern += rf'\d*\.?\d*{exponent_part}$'
 
             return pattern
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7177,6 +7177,12 @@ def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places
     assert re.fullmatch(pattern, invalid_decimal) is None
 
 
+@pytest.mark.parametrize('valid_decimal', ['1E-7', '1e-7', '1.23E+4', '1.23e+4', '1E7', '1e7', '1.23E4', '1.23e4'])
+def test_decimal_pattern_accepts_scientific_notation(valid_decimal, get_decimal_pattern) -> None:
+    pattern = get_decimal_pattern()
+    assert re.fullmatch(pattern, valid_decimal) is not None
+
+
 def test_union_format_primitive_type_array() -> None:
     class Sub(BaseModel):
         pass


### PR DESCRIPTION
## Summary

This PR fixes #13089 by adding support for scientific notation in the Decimal JSON schema pattern.

## Problem

The JSON schema pattern for Decimal fields (added in #11987) doesn't account for scientific notation. However, pydantic-core's serializer calls `str()` on Decimal objects, which outputs scientific notation for small/large values (e.g., `Decimal('0.0000001')` becomes `"1E-7"`). This means:

1. `model_dump_json()` produces values like `"1E-7"`
2. `model_json_schema(mode="serialization")` produces a pattern that rejects `"1E-7"`
3. Downstream consumers validating output against the schema (e.g., OpenAPI validators, codegen tools) reject valid serialized values

## Fix

Added optional exponent part `(?:[eE][+-]?\d+)?` to all Decimal pattern cases (constrained and unconstrained).

**Before:** `^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$`
**After:** `^(?!^[-+.]*$)[+-]?0*\d*\.?\d*(?:[eE][+-]?\d+)?$`

## Testing

- Added test `test_decimal_pattern_accepts_scientific_notation` to verify scientific notation is accepted
- Verified existing tests still pass (no regression)
- End-to-end verification: `model_dump_json()` output now validates against `model_json_schema()` for Decimal values in scientific notation

## Example

```python
from decimal import Decimal
from pydantic import BaseModel
import json, re

class MyModel(BaseModel):
    value: Decimal | None

schema = MyModel.model_json_schema(mode='serialization')
pattern = schema['properties']['value']['anyOf'][0]['pattern']

m = MyModel(value=Decimal('0.0000001'))
serialized = json.loads(m.model_dump_json())['value']  # '1E-7'

re.fullmatch(pattern, serialized)  # Now matches!
```