### PR TITLE
fix: allow __pydantic_init_subclass__ to receive custom kwargs

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -159,8 +159,25 @@ class ModelMetaclass(ABCMeta):
             namespace['__class_vars__'] = class_vars
             namespace['__private_attributes__'] = {**base_private_attributes, **private_attributes}
 
-            cls = cast('type[BaseModel]', super().__new__(mcs, cls_name, bases, namespace, **kwargs))
             BaseModel_ = import_cached_base_model()
+
+            # Check if any parent class defines a custom __init_subclass__ or __pydantic_init_subclass__.
+            has_custom_init_subclass = any(
+                '__init_subclass__' in base.__dict__ for base in bases if base is not BaseModel_
+            )
+            has_custom_pydantic_init_subclass = any(
+                '__pydantic_init_subclass__' in base.__dict__ for base in bases if base is not BaseModel_
+            )
+
+            if has_custom_init_subclass or not has_custom_pydantic_init_subclass:
+                # Pass kwargs to super().__new__() - either __init_subclass__ will handle them,
+                # or we want to maintain backward compatibility (TypeError if unknown kwargs)
+                cls = cast('type[BaseModel]', super().__new__(mcs, cls_name, bases, namespace, **kwargs))
+            else:
+                # Only __pydantic_init_subclass__ is custom, don't pass kwargs to super().__new__()
+                # to avoid TypeError in object.__init_subclass__().
+                # The kwargs will be passed to __pydantic_init_subclass__() instead.
+                cls = cast('type[BaseModel]', super().__new__(mcs, cls_name, bases, namespace))
 
             mro = cls.__mro__
             if Generic in mro and mro.index(Generic) < mro.index(BaseModel_):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1696,6 +1696,33 @@ def test_custom_init_subclass_params():
     assert NewModel.something == 2
 
 
+def test_pydantic_init_subclass_with_custom_kwargs():
+    """Test that __pydantic_init_subclass__ receives custom kwargs from class definition.
+
+    This is a regression test for https://github.com/pydantic/pydantic/issues/13300
+    """
+
+    class Event(BaseModel):
+        e_type: str
+
+        @classmethod
+        def __pydantic_init_subclass__(cls, event_type: str | None = None, **kwargs: object) -> None:
+            super().__pydantic_init_subclass__(**kwargs)
+            cls._event_type = event_type
+
+    class CreatedEvent(Event, event_type='created'):
+        pass
+
+    class DeletedEvent(Event, event_type='deleted'):
+        pass
+
+    assert CreatedEvent._event_type == 'created'
+    assert DeletedEvent._event_type == 'deleted'
+
+    e = CreatedEvent(e_type='test')
+    assert e.e_type == 'test'
+
+
 def test_recursive_model():
     class MyModel(BaseModel):
         field: Optional['MyModel']


### PR DESCRIPTION
## Problem

When a class defines `__pydantic_init_subclass__` with custom kwargs (but not `__init_subclass__`), passing those kwargs at class definition time raises TypeError.

**Example from issue #13300:**

```python
from pydantic import BaseModel

class Event(BaseModel):
    e_type: str

    @classmethod
    def __pydantic_init_subclass__(cls, event_type: str | None = None, **kwargs: object) -> None:
        super().__pydantic_init_subclass__(**kwargs)
        print(f'registered: {event_type}')

class CreatedEvent(Event, event_type='created'): ...
# TypeError: CreatedEvent.__init_subclass__() takes no keyword arguments
```

## Root Cause

Python's `type.__new__()` calls `__init_subclass__()` with kwargs, but `object.__init_subclass__()` doesn't accept any kwargs, causing TypeError.

## Fix

In `ModelMetaclass.__new__()`, check if any parent class defines a custom `__pydantic_init_subclass__`. If so, and no custom `__init_subclass__` is defined, don't pass kwargs to `super().__new__()` to avoid the TypeError. The kwargs are instead passed to `__pydantic_init_subclass__()` which is called later.

This maintains backward compatibility:
- Classes with custom `__init_subclass__` still work as before
- Classes with neither custom hook still get TypeError for unknown kwargs  
- Classes with only custom `__pydantic_init_subclass__` now receive the kwargs correctly

## Testing

Added `test_pydantic_init_subclass_with_custom_kwargs` test that verifies the fix.

All existing tests pass (251 passed, 26 skipped, 1 xfailed).

Fixes #13300
