### PR TITLE
fix: resolve AttributeError for nested pipeline operators

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -424,10 +424,20 @@ def _apply_step(step: _Step, s: cs.CoreSchema | None, handler: GetCoreSchemaHand
     elif isinstance(step, _Constraint):
         s = _apply_constraint(s, step.constraint)
     elif isinstance(step, _PipelineOr):
-        s = cs.union_schema([step.left.__get_pydantic_core_schema__(source_type, handler), step.right.__get_pydantic_core_schema__(source_type, handler)])
+        s = cs.union_schema(
+            [
+                step.left.__get_pydantic_core_schema__(source_type, handler),
+                step.right.__get_pydantic_core_schema__(source_type, handler),
+            ]
+        )
     else:
         assert isinstance(step, _PipelineAnd)
-        s = cs.chain_schema([step.left.__get_pydantic_core_schema__(source_type, handler), step.right.__get_pydantic_core_schema__(source_type, handler)])
+        s = cs.chain_schema(
+            [
+                step.left.__get_pydantic_core_schema__(source_type, handler),
+                step.right.__get_pydantic_core_schema__(source_type, handler),
+            ]
+        )
     return s
 
 

--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -424,10 +424,10 @@ def _apply_step(step: _Step, s: cs.CoreSchema | None, handler: GetCoreSchemaHand
     elif isinstance(step, _Constraint):
         s = _apply_constraint(s, step.constraint)
     elif isinstance(step, _PipelineOr):
-        s = cs.union_schema([handler(step.left), handler(step.right)])
+        s = cs.union_schema([step.left.__get_pydantic_core_schema__(source_type, handler), step.right.__get_pydantic_core_schema__(source_type, handler)])
     else:
         assert isinstance(step, _PipelineAnd)
-        s = cs.chain_schema([handler(step.left), handler(step.right)])
+        s = cs.chain_schema([step.left.__get_pydantic_core_schema__(source_type, handler), step.right.__get_pydantic_core_schema__(source_type, handler)])
     return s
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -501,7 +501,5 @@ def test_nested_or_and_operators() -> None:
     ta = TypeAdapter[int](Annotated[int, (validate_as(int) & validate_as(int)) | (validate_as(int) & validate_as(int))])
     assert ta.validate_python(42) == 42
 
-    ta = TypeAdapter[int](
-        Annotated[int, ((validate_as(int) | validate_as(int)) & validate_as(int)) | validate_as(int)]
-    )
+    ta = TypeAdapter[int](Annotated[int, ((validate_as(int) | validate_as(int)) & validate_as(int)) | validate_as(int)])
     assert ta.validate_python(42) == 42

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -475,3 +475,33 @@ def test_validate_as_ellipsis_preserves_other_steps() -> None:
     ta = TypeAdapter[float](Annotated[float, validate_as(str).transform(lambda v: v.split()[0]).validate_as(...)])
 
     assert ta.validate_python('12 ab') == 12.0
+
+
+def test_nested_or_and_operators() -> None:
+    """https://github.com/pydantic/pydantic/issues/13287"""
+    ta = TypeAdapter[int](Annotated[int, (validate_as(int) | validate_as(int)) & validate_as(int)])
+    assert ta.validate_python(42) == 42
+    with pytest.raises(ValidationError):
+        ta.validate_python('not_an_int')
+
+    ta = TypeAdapter[int](Annotated[int, validate_as(int) | validate_as(int) | validate_as(int)])
+    assert ta.validate_python(42) == 42
+
+    ta = TypeAdapter[int](Annotated[int, validate_as(int) & validate_as(int) & validate_as(int)])
+    assert ta.validate_python(42) == 42
+
+    ta = TypeAdapter[int](Annotated[int, (validate_as(int) | validate_as(int)) & (validate_as(int) | validate_as(int))])
+    assert ta.validate_python(42) == 42
+    with pytest.raises(ValidationError):
+        ta.validate_python('not_an_int')
+
+    ta = TypeAdapter[int](Annotated[int, (validate_as(int) & validate_as(int)) | validate_as(int)])
+    assert ta.validate_python(42) == 42
+
+    ta = TypeAdapter[int](Annotated[int, (validate_as(int) & validate_as(int)) | (validate_as(int) & validate_as(int))])
+    assert ta.validate_python(42) == 42
+
+    ta = TypeAdapter[int](
+        Annotated[int, ((validate_as(int) | validate_as(int)) & validate_as(int)) | validate_as(int)]
+    )
+    assert ta.validate_python(42) == 42


### PR DESCRIPTION
## Problem

Nested pipeline operators ( and ) cause AttributeError during schema generation:

```
AttributeError: '_Pipeline' object has no attribute '__dict__'
```

### Reproduction

```python
from typing import Annotated
from pydantic import BaseModel
from pydantic.experimental.pipeline import validate_as

class TmpBaseModel(BaseModel):
    some_int: Annotated[int, (validate_as(int) | validate_as(int)) & validate_as(int)]
```

## Root Cause

In `_apply_step`, when processing `_PipelineOr` and `_PipelineAnd` steps, the code passed raw `_Pipeline` instances to `handler()`. The handler chain (`_generate_schema_inner` → `match_type` → `_dataclass_schema`) tries to access `__dict__` on the `_Pipeline` dataclass, which uses `slots=True` and has no `__dict__`.

## Fix

Call `__get_pydantic_core_schema__` directly on nested `_Pipeline` instances instead of passing them to the handler.

## Tests

Added `test_nested_or_and_operators` covering all combinations of nested `|` and `&` operators.