### PR TITLE
Omit default fields from BaseModel __rich_repr__ output

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -1311,12 +1311,43 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             yield from ((k, v) for k, v in pydantic_extra.items())
         yield from computed_fields_repr_args
 
+    def __rich_repr__(self) -> _repr.RichReprResult:
+        """Used by Rich (https://rich.readthedocs.io/en/stable/pretty.html) to pretty print objects.
+
+        Fields with defaults are yielded as 3-tuples so Rich omits them when the value equals the default.
+        """
+        computed_fields_repr_args = [
+            (k, getattr(self, k)) for k, v in self.__pydantic_computed_fields__.items() if v.repr
+        ]
+
+        for k, v in self.__dict__.items():
+            field = self.__pydantic_fields__.get(k)
+            if field and field.repr:
+                if v is not self:
+                    field_repr = v
+                else:
+                    field_repr = self.__repr_recursion__(v)
+                if field.is_required():
+                    yield k, field_repr
+                else:
+                    default = field.get_default(call_default_factory=True, validated_data=self.__dict__)
+                    yield k, field_repr, default
+        try:
+            pydantic_extra = object.__getattribute__(self, '__pydantic_extra__')
+        except AttributeError:
+            pydantic_extra = None
+
+        if pydantic_extra is not None:
+            for k, v in pydantic_extra.items():
+                yield k, v
+        for k, v in computed_fields_repr_args:
+            yield k, v
+
     # take logic from `_repr.Representation` without the side effects of inheritance, see #5740
     __repr_name__ = _repr.Representation.__repr_name__
     __repr_recursion__ = _repr.Representation.__repr_recursion__
     __repr_str__ = _repr.Representation.__repr_str__
     __pretty__ = _repr.Representation.__pretty__
-    __rich_repr__ = _repr.Representation.__rich_repr__
 
     def __str__(self) -> str:
         return self.__repr_str__(' ')

--- a/tests/test_rich_repr.py
+++ b/tests/test_rich_repr.py
@@ -23,10 +23,33 @@ def test_rich_repr(User):
 
     assert rich_repr == [
         ('id', 22),
-        ('name', 'John Doe'),
-        ('signup_ts', None),
-        ('friends', []),
+        ('name', 'John Doe', 'John Doe'),
+        ('signup_ts', None, None),
+        ('friends', [], []),
     ]
+
+
+def test_rich_repr_non_default_fields(User):
+    user = User(id=22, name='Jane', friends=[1, 2])
+    rich_repr = list(user.__rich_repr__())
+
+    assert rich_repr == [
+        ('id', 22),
+        ('name', 'Jane', 'John Doe'),
+        ('signup_ts', None, None),
+        ('friends', [1, 2], []),
+    ]
+
+
+def test_rich_repr_with_rich(User):
+    pytest.importorskip('rich')
+    from rich.pretty import pretty_repr
+
+    user = User(id=22)
+    assert pretty_repr(user) == 'User(id=22)'
+
+    user = User(id=22, name='Jane')
+    assert pretty_repr(user) == "User(id=22, name='Jane')"
 
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')


### PR DESCRIPTION
## Summary

Fixes #12184  
Fixes #495

`BaseModel.__rich_repr__` now uses Rich's 3-tuple protocol for fields with defaults, allowing Rich to omit fields whose value equals the default when pretty-printing models.

Previously, every field with `repr=True` was always included in Rich output, which could be slow and noisy for large models with many default-valued fields. Rich supports yielding `(name, value, default)` so that keyword arguments are only displayed when `value != default`. This change adopts that behavior for Pydantic models.

### Behavior

- Required fields still yield `(name, value)` and are always shown.
- Optional fields yield `(name, value, default)`, using:
  ```python
  field.get_default(
      call_default_factory=True,
      validated_data=self.__dict__,
  )
  ```
  This ensures that static defaults, `default_factory`, and factories that depend on validated data are all handled correctly.
- `__repr__`, `__str__`, and `__pretty__` are unchanged and continue to show all fields with `repr=True`.
- `Color` and other `Representation` subclasses are unaffected.

## Example

```python
from pydantic import BaseModel


class User(BaseModel):
    id: int
    name: str = "John Doe"
    friends: list[int] = []


user = User(id=22)
```

### Before

```text
User(id=22, name='John Doe', friends=[])
```

### After

```text
User(id=22)
```

## Changes

- Add a `BaseModel.__rich_repr__` implementation in `pydantic/main.py`.
- Update `tests/test_rich_repr.py` with coverage for:
  - Rich's 3-tuple protocol
  - Non-default values
  - Rich integration via `pretty_repr`

## Test Plan

```bash
pytest tests/test_rich_repr.py
```

### Verified

- `repr()` and `str()` output are unchanged.
- Rich pretty output omits default-valued fields while still displaying non-default values.
- `default_factory` fields and `repr=False` fields behave correctly.
## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
