### PR TITLE
Preserve decorators when re-applying the dataclass decorator

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -145,7 +145,15 @@ def dataclass(
         # if config is not explicitly provided, try to read it from the type
         config_dict = config if config is not None else getattr(cls, '__pydantic_config__', None)
         config_wrapper = _config.ConfigWrapper(config_dict)
-        decorators = _decorators.DecoratorInfos.build(cls, replace_wrapped_methods=True)
+        # If the decorator is applied to an already existing Pydantic dataclass, the decorated methods
+        # (e.g. field validators and serializers) were already replaced by their plain functions during
+        # the first application, so rebuilding from scratch would discard them. We reuse the existing
+        # decorators instead. See https://github.com/pydantic/pydantic/issues/12934.
+        existing_decorators = cls.__dict__.get('__pydantic_decorators__')
+        if existing_decorators is not None:
+            decorators = existing_decorators
+        else:
+            decorators = _decorators.DecoratorInfos.build(cls, replace_wrapped_methods=True)
         decorators.update_from_config(config_wrapper)
 
         # Keep track of the original __doc__ so that we can restore it after applying the dataclasses decorator

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2352,6 +2352,41 @@ def test_pydantic_dataclass_preserves_metadata(dataclass_decorator: Callable[[An
     assert FooPydantic.__qualname__ == FooStd.__qualname__
 
 
+def test_pydantic_dataclass_applied_twice_preserves_decorators() -> None:
+    """Re-applying the decorator to an existing Pydantic dataclass should keep its decorators.
+
+    See https://github.com/pydantic/pydantic/issues/12934.
+    """
+
+    @pydantic.dataclasses.dataclass
+    class Model:
+        x: int = 0
+
+        @field_validator('x')
+        @classmethod
+        def x_must_be_positive(cls, v: int) -> int:
+            if v < 0:
+                raise ValueError('x must be positive')
+            return v
+
+        @field_serializer('x')
+        def serialize_x(self, v: int) -> str:
+            return f'x={v}'
+
+    ReDecorated = pydantic.dataclasses.dataclass(Model)
+
+    decorators = ReDecorated.__pydantic_decorators__
+    assert 'x_must_be_positive' in decorators.field_validators
+    assert 'serialize_x' in decorators.field_serializers
+
+    # The field validator should still run:
+    with pytest.raises(ValidationError):
+        ReDecorated(x=-1)
+
+    # The field serializer should still run:
+    assert TypeAdapter(ReDecorated).dump_python(ReDecorated(x=1)) == {'x': 'x=1'}
+
+
 def test_recursive_dataclasses_gh_4509(create_module) -> None:
     @create_module
     def module():


### PR DESCRIPTION
## Change Summary

Re-applying `@pydantic.dataclasses.dataclass` to a class that is **already** a Pydantic dataclass silently discarded its `__pydantic_decorators__` — field validators, field serializers, and computed fields were all lost.

The root cause: on the first application, the decorated methods (e.g. field validators) are replaced by their plain functions on the class. When the decorator runs a second time, `DecoratorInfos.build()` collects from those now-bare methods and finds nothing, so the rebuilt decorators are empty.

This PR reuses the existing `__pydantic_decorators__` when the class already has one (i.e. it is being re-decorated), instead of rebuilding from scratch. A regression test verifies that validators, serializers, and computed fields all survive re-decoration. The existing `test_pydantic_dataclass_preserves_metadata` test (which intentionally re-applies the decorator) continues to pass.

## Related issue number

fix #12934

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
