### PR TITLE
fix: respect explicit @computed_field(deprecated=...) over @deprecated() decorator

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -736,11 +736,15 @@ def set_deprecated_descriptors(cls: type[BaseModel]) -> None:
             setattr(cls, field, desc)
 
     for field, computed_field_info in cls.__pydantic_computed_fields__.items():
-        if (
-            (msg := computed_field_info.deprecation_message) is not None
-            # Avoid having two warnings emitted:
-            and not hasattr(unwrap_wrapped_function(computed_field_info.wrapped_property), '__deprecated__')
-        ):
+        if (msg := computed_field_info.deprecation_message) is not None:
+            # Avoid having two warnings emitted when the @deprecated() decorator
+            # was auto-detected (same object reference). If the user explicitly
+            # passed deprecated=... to @computed_field, the value differs from
+            # the underlying function's __deprecated__, so we still set the
+            # descriptor with the explicit message.
+            unwrapped = unwrap_wrapped_function(computed_field_info.wrapped_property)
+            if hasattr(unwrapped, '__deprecated__') and computed_field_info.deprecated is unwrapped.__deprecated__:
+                continue
             desc = _DeprecatedFieldDescriptor(msg, computed_field_info.wrapped_property)
             desc.__set_name__(cls, field)
             setattr(cls, field, desc)


### PR DESCRIPTION
When a computed field has both @computed_field(deprecated='X') and @deprecated('Y'), the explicit deprecated= parameter should take precedence over the decorator. Previously, the guard in set_deprecated_descriptors() skipped setting the _DeprecatedFieldDescriptor whenever the underlying function had __deprecated__, without distinguishing auto-detection from explicit override.

The fix uses an identity check: if the deprecated value stored on ComputedFieldInfo is the same object as the underlying function's __deprecated__, it was auto-detected and we skip to avoid double warnings. If its a different object, the user explicitly overrode it and we set the descriptor with the correct message.

Closes #13356

## Verification

- test_computed_field_deprecated passes (was already written, was failing on main with pytest >= 9.1.0)
- All tests in test_deprecated_fields.py pass (12/12)
- All tests in test_computed_fields.py pass (33/33, 2 skipped + 2 xfailed pre-existing)