### PR TITLE
Fix `test_computed_field_deprecated()` test failure

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -738,7 +738,11 @@ def set_deprecated_descriptors(cls: type[BaseModel]) -> None:
     for field, computed_field_info in cls.__pydantic_computed_fields__.items():
         if (
             (msg := computed_field_info.deprecation_message) is not None
-            # Avoid having two warnings emitted:
+            # If the property was already decorated with `@deprecated`, we avoid emitting the warning message
+            # from `@computed_field` and give priority to the other. Ideally, the deprecation message from
+            # `@computed_field` should take priority, but we can't safely unwrap (using `inspect.unwrap()`)
+            # to get the inner property decorated by `@deprecated`, as we might skip other user-defined decorators
+            # while doing so:
             and not hasattr(unwrap_wrapped_function(computed_field_info.wrapped_property), '__deprecated__')
         ):
             desc = _DeprecatedFieldDescriptor(msg, computed_field_info.wrapped_property)

--- a/tests/test_deprecated_fields.py
+++ b/tests/test_deprecated_fields.py
@@ -117,7 +117,7 @@ def test_computed_field_deprecated():
 
         @computed_field(deprecated='This is deprecated')
         @property
-        @deprecated('This is deprecated (this message is overridden)')
+        @deprecated('This is deprecated (this message is the one emitted)')
         def p2(self) -> int:
             return 1
 
@@ -153,10 +153,10 @@ def test_computed_field_deprecated():
 
     with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
         instance.p1
-    # TODO: This should be match='^This is deprecated$' instead, but the
-    # overriding mechanism has apparently never worked:
-    # https://github.com/pydantic/pydantic/issues/13356
-    with pytest.warns(DeprecationWarning, match=r'^This is deprecated \(this message is overridden\)$'):
+    # Ideally, the deprecation message from `@computed_field` should take priority,
+    # but we can't safely unwrap the decorated property from `@deprecated` (see note in
+    # `set_deprecated_descriptors()`):
+    with pytest.warns(DeprecationWarning, match=r'^This is deprecated \(this message is the one emitted\)$'):
         instance.p2
     with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
         instance.p4


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13356.

It would be theoretically possible to support this (by unwrapping until we get to the inner property without the wrapper introduced by `@deprecated`, and reconstructing the user defined wrappers if any), but not worth the effort (and it is quite uncommon for users to use both `@deprecated` and `@computed_field(deprecated=...)` together anyway). 

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
