### PR TITLE
Allow init false dataclass field assignment

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -225,6 +225,8 @@ def dataclass(
                     attr.__set__(instance, value)
                 elif isinstance(attr, functools.cached_property):
                     instance.__dict__.__setitem__(name, value)
+                elif name in inst_cls.__dataclass_fields__ and name not in inst_cls.__pydantic_fields__:
+                    original_setattr(instance, name, value)  # pyright: ignore[reportCallIssue]
                 else:
                     inst_cls.__pydantic_validator__.validate_assignment(instance, name, value)
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -151,6 +151,17 @@ def test_validate_assignment_error():
     ]
 
 
+def test_validate_assignment_allows_init_false_field_post_init_assignment():
+    @pydantic.dataclasses.dataclass(config=ConfigDict(validate_assignment=True))
+    class MyDataclass:
+        a: int = dataclasses.field(init=False)
+
+        def __post_init__(self):
+            self.a = 1
+
+    assert MyDataclass().a == 1
+
+
 def test_not_validate_assignment():
     @pydantic.dataclasses.dataclass
     class MyDataclass:


### PR DESCRIPTION
Summary
- Allow validate_assignment dataclasses to assign stdlib dataclass fields that are not part of Pydantic's field schema.
- Keep unknown attribute assignment on the existing validation path.
- Add a regression test for init=False fields assigned in __post_init__.

Closes #5470

Tests
- `.venv\Scripts\python.exe -m pytest tests/test_dataclasses.py -q -k "validate_assignment_allows_init_false_field_post_init_assignment or validate_assignment_extra_unknown_field_assigned_errors or validate_assignment_error"`
- `.venv\Scripts\python.exe -m ruff check pydantic/dataclasses.py tests/test_dataclasses.py`
- `git diff --check`