### PR TITLE
fix: allow wrap model validator handler to run twice under `__init__`

### DIFF
--- a/pydantic-core/src/validators/model.rs
+++ b/pydantic-core/src/validators/model.rs
@@ -121,12 +121,18 @@ impl Validator for ModelValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
+        let class = self.class.bind(py);
         if let Some(self_instance) = state.self_instance {
-            // in the case that self_instance is Some, we're calling validation from within `BaseModel.__init__`
-            return self.validate_init(py, self_instance, input, state);
+            // During `BaseModel.__init__`, `self_instance` is set and the input is normally the kwargs dict.
+            // If a wrap validator calls `handler` more than once, the second call may pass an already-built
+            // model instance (the output of the first call). In that case we must not use `validate_init`
+            // (which only accepts dict-like input); fall through to normal validation / revalidation.
+            // See https://github.com/pydantic/pydantic/issues/12730
+            if input_as_python_instance(input, class).is_none() {
+                return self.validate_init(py, self_instance, input, state);
+            }
         }
 
-        let class = self.class.bind(py);
         let generic_origin_class = self.generic_origin.as_ref().map(|go| go.bind(py));
 
         // if we're in strict mode, we require an exact instance of the class (from python, with JSON an object is ok)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3023,6 +3023,22 @@ def test_non_self_return_val_warns() -> None:
         assert c.name == 'name'
 
 
+def test_wrap_model_validator_handler_called_twice_via_init() -> None:
+    """Calling the wrap handler twice must work from `__init__`, not only `model_validate`.
+
+    See https://github.com/pydantic/pydantic/issues/12730
+    """
+
+    class MyModel(BaseModel):
+        @model_validator(mode='wrap')
+        @classmethod
+        def my_validator(cls, v, handler):
+            return handler(handler(v))
+
+    assert MyModel().model_dump() == {}
+    assert MyModel.model_validate({}).model_dump() == {}
+
+
 def test_wrap_val_called_once() -> None:
     """See https://github.com/pydantic/pydantic/issues/11505 for context.
 


### PR DESCRIPTION
## Summary
- Fixes [#12730](https://github.com/pydantic/pydantic/issues/12730): calling a wrap `model_validator` handler twice via `MyModel()` raised a confusing `model_type` error, while `model_validate` worked.
- In `ModelValidator::validate`, only use the `self_instance` / `validate_init` path when the input is **not** already an instance of the model class (adapted from the patch sketched by @Viicos on the issue).
- Adds a regression test covering both `__init__` and `model_validate`.

## Test plan
- [x] `pytest tests/test_validators.py::test_wrap_model_validator_handler_called_twice_via_init`
- Rebuilt local `pydantic-core` with `maturin develop --release`