### PR TITLE
fix: include runtime extra fields in model_dump() and model_dump_json()

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -500,7 +500,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A dictionary representation of the model.
         """
-        return self.__pydantic_serializer__.to_python(
+        result = self.__pydantic_serializer__.to_python(
             self,
             mode=mode,
             by_alias=by_alias,
@@ -517,6 +517,17 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             serialize_as_any=serialize_as_any,
             polymorphic_serialization=polymorphic_serialization,
         )
+        pydantic_extra = self.__pydantic_extra__
+        if pydantic_extra and self.model_config.get('extra') != 'allow':
+            for key, value in pydantic_extra.items():
+                if include is not None and key not in include:
+                    continue
+                if exclude is not None and key in exclude:
+                    continue
+                if exclude_none and value is None:
+                    continue
+                result[key] = value
+        return result
 
     def model_dump_json(
         self,
@@ -567,6 +578,27 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         Returns:
             A JSON string representation of the model.
         """
+        pydantic_extra = self.__pydantic_extra__
+        if pydantic_extra and self.model_config.get('extra') != 'allow':
+            import json
+
+            result = self.model_dump(
+                mode='json',
+                include=include,
+                exclude=exclude,
+                context=context,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+                exclude_computed_fields=exclude_computed_fields,
+                round_trip=round_trip,
+                warnings=warnings,
+                fallback=fallback,
+                serialize_as_any=serialize_as_any,
+                polymorphic_serialization=polymorphic_serialization,
+            )
+            return json.dumps(result, indent=indent, ensure_ascii=ensure_ascii)
         return self.__pydantic_serializer__.to_json(
             self,
             indent=indent,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2861,6 +2861,61 @@ def test_model_validate_strings_with_validate_fn_override() -> None:
     ]
 
 
+def test_model_dump_includes_runtime_extra_fields() -> None:
+    class ForbidModel(BaseModel, extra='forbid'):
+        a: int
+
+    class IgnoreModel(BaseModel):
+        a: int
+
+    class AllowModel(BaseModel, extra='allow'):
+        a: int
+
+    m = ForbidModel.model_validate({'a': 1, 'b': 'hello', 'c': None}, extra='allow')
+    assert m.model_extra == {'b': 'hello', 'c': None}
+    assert m.model_dump() == {'a': 1, 'b': 'hello', 'c': None}
+    assert m.model_dump(exclude={'b'}) == {'a': 1, 'c': None}
+    assert m.model_dump(include={'b'}) == {'b': 'hello'}
+    assert m.model_dump(exclude_none=True) == {'a': 1, 'b': 'hello'}
+
+    m2 = IgnoreModel.model_validate({'a': 1, 'b': 42}, extra='allow')
+    assert m2.model_dump() == {'a': 1, 'b': 42}
+
+    m3 = AllowModel.model_validate({'a': 1, 'b': 'test'})
+    assert m3.model_dump() == {'a': 1, 'b': 'test'}
+
+    m4 = ForbidModel.model_validate({'a': 1})
+    assert m4.model_dump() == {'a': 1}
+
+
+def test_model_dump_json_includes_runtime_extra_fields() -> None:
+    import json
+
+    class ForbidModel(BaseModel, extra='forbid'):
+        a: int
+
+    class IgnoreModel(BaseModel):
+        a: int
+
+    class AllowModel(BaseModel, extra='allow'):
+        a: int
+
+    m = ForbidModel.model_validate({'a': 1, 'b': 'hello', 'c': None}, extra='allow')
+    assert json.loads(m.model_dump_json()) == {'a': 1, 'b': 'hello', 'c': None}
+    assert json.loads(m.model_dump_json(exclude={'b'})) == {'a': 1, 'c': None}
+    assert json.loads(m.model_dump_json(include={'b'})) == {'b': 'hello'}
+    assert json.loads(m.model_dump_json(exclude_none=True)) == {'a': 1, 'b': 'hello'}
+
+    m2 = IgnoreModel.model_validate({'a': 1, 'b': 42}, extra='allow')
+    assert json.loads(m2.model_dump_json()) == {'a': 1, 'b': 42}
+
+    m3 = AllowModel.model_validate({'a': 1, 'b': 'test'})
+    assert json.loads(m3.model_dump_json()) == {'a': 1, 'b': 'test'}
+
+    m4 = ForbidModel.model_validate({'a': 1})
+    assert json.loads(m4.model_dump_json()) == {'a': 1}
+
+
 def test_pydantic_hooks() -> None:
     calls = []
 


### PR DESCRIPTION
Closes #12937.

## Summary

When `model_validate(..., extra='allow')` is called on a model whose class-level config is `extra='forbid'` or `extra='ignore'`, pydantic-core correctly stores the extra fields in `__pydantic_extra__`. However, the serializer is built from the class schema (which has `extra_fields_behavior` set to `'forbid'` or `'ignore'`), so it silently drops those fields during `model_dump()` and `model_dump_json()`.

```python
class A(BaseModel, extra='forbid'):
    a: int

a = A.model_validate({'a': 1, 'b': 'test'}, extra='allow')
print(a)              # A(a=1, b='test')  ✓
print(a.model_dump()) # {'a': 1}          ✗ — 'b' silently dropped
```

## Fix

After the serializer runs in `model_dump()`, if `__pydantic_extra__` contains fields the class-level schema would not have emitted, they are merged into the result. The `include`, `exclude`, and `exclude_none` filters are honoured.

For `model_dump_json()`, the same detection routes through `model_dump(mode='json')` + `json.dumps()` to correctly JSON-serialize the extra values.

Models with class-level `extra='allow'` are unaffected — the serializer already handles them correctly and this path is not taken.

## Tests

Two new test functions covering both `model_dump()` and `model_dump_json()` across `extra='forbid'`, `extra='ignore'`, and `extra='allow'` (control) configurations, with `include`, `exclude`, and `exclude_none` filter variants.