### PR TITLE
Remove stale `field_name` param from `apply_validators()` docstring

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2551,7 +2551,6 @@ def apply_validators(
     Args:
         schema: The schema to apply validators on.
         validators: An iterable of validators.
-        field_name: The name of the field if validators are being applied to a model field.
 
     Returns:
         The updated schema.


### PR DESCRIPTION
The `apply_validators` function in `pydantic/_internal/_generate_schema.py` has an `Args:` docstring that documents a `field_name` parameter, but the function's actual signature only accepts `schema` and `validators`. No caller passes a `field_name` argument. This removes the stale docstring entry so the documentation matches the real signature. Docs-only change, no behavior impact.