### PR TITLE
Fix `json_schema_extra` dict being dropped when a callable follows it in `Annotated`

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -524,6 +524,10 @@ class FieldInfo(_repr.Representation):
                                 **current_js_extra,
                             }
                         elif callable(current_js_extra):
+                            # The `callable` is ignored, so we keep the existing `dict`. This needs to be set
+                            # explicitly as `merged_kwargs` is otherwise overridden with `meta._attributes_set`
+                            # (which contains the `callable`) below.
+                            new_js_extra = existing_js_extra
                             warn(
                                 'Composing `dict` and `callable` type `json_schema_extra` is not supported. '
                                 'The `callable` type is being ignored. '

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6940,6 +6940,14 @@ def test_warn_on_mixed_compose() -> None:
         class Model2(BaseModel):
             field: Annotated[int, Field(json_schema_extra=lambda x: x.pop('a')), Field(json_schema_extra={'a': 'dict'})]  # type: ignore
 
+    # The warning promises the `callable` is ignored, so the `dict` must survive in both orderings.
+    # Previously, when the `dict` came first (`Model1`), it was silently dropped in favor of the ignored
+    # `callable`, which also made schema generation raise `KeyError` as the lambda ran against a schema
+    # that no longer contained `'a'`.
+    expected = {'a': 'dict', 'title': 'Field', 'type': 'integer'}
+    assert Model1.model_json_schema()['properties']['field'] == expected
+    assert Model2.model_json_schema()['properties']['field'] == expected
+
 
 def test_blank_title_is_respected() -> None:
     class Model(BaseModel):

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6941,9 +6941,6 @@ def test_warn_on_mixed_compose() -> None:
             field: Annotated[int, Field(json_schema_extra=lambda x: x.pop('a')), Field(json_schema_extra={'a': 'dict'})]  # type: ignore
 
     # The warning promises the `callable` is ignored, so the `dict` must survive in both orderings.
-    # Previously, when the `dict` came first (`Model1`), it was silently dropped in favor of the ignored
-    # `callable`, which also made schema generation raise `KeyError` as the lambda ran against a schema
-    # that no longer contained `'a'`.
     expected = {'a': 'dict', 'title': 'Field', 'type': 'integer'}
     assert Model1.model_json_schema()['properties']['field'] == expected
     assert Model2.model_json_schema()['properties']['field'] == expected


### PR DESCRIPTION
## Change Summary

`FieldInfo._construct` warns that composing a `dict` and a `callable` `json_schema_extra` is unsupported and that "the `callable` type is being ignored." That only held when the **callable came first**. When a **dict came first and a callable second**, the dict+callable branch emitted the warning but never set `new_js_extra`, so the later unconditional `merged_kwargs.update(meta._attributes_set)` overwrote the dict with the callable.

The result is the opposite of what the warning promises: the callable wins and the dict is silently dropped. It can also crash schema generation when the callable mutates a schema that no longer contains the dropped keys.

```python
from typing import Annotated
from pydantic import BaseModel, Field

class M(BaseModel):
    x: Annotated[
        int,
        Field(json_schema_extra={'from_dict': 1}),
        Field(json_schema_extra=lambda s: s.update({'from_callable': True})),
    ]

print(M.model_json_schema()['properties']['x'])
# before: {'from_callable': True, 'title': 'X', 'type': 'integer'}  -> dict silently lost
# after:  {'from_dict': 1, 'title': 'X', 'type': 'integer'}         -> callable ignored, as documented
```

With a mutating callable like `lambda s: s.pop('a')` (as used in the existing test), the old behaviour raises `KeyError` during `model_json_schema()` because the dict keys it expects were already dropped.

The fix keeps the existing `dict` in that branch (setting `new_js_extra = existing_js_extra`) so the `callable` is genuinely ignored, matching the warning and the already-correct reverse ordering.

## Related issue number

N/A — small, self-contained correctness fix. Happy to open a tracking issue if preferred.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**