### PR TITLE
Fix stale links in mypy and rich integration docs

### DIFF
--- a/docs/integrations/mypy.md
+++ b/docs/integrations/mypy.md
@@ -1,4 +1,4 @@
-Pydantic works well with [mypy](http://mypy-lang.org) right out of the box.
+Pydantic works well with [mypy](https://www.mypy-lang.org/) right out of the box.
 
 However, Pydantic also ships with a mypy plugin that adds a number of important Pydantic-specific
 features that improve its ability to type-check your code.

--- a/docs/integrations/rich.md
+++ b/docs/integrations/rich.md
@@ -1,4 +1,4 @@
-Pydantic models may be printed with the [Rich](https://github.com/willmcgugan/rich) library which will add additional formatting and color to the output. Here's an example:
+Pydantic models may be printed with the [Rich](https://github.com/Textualize/rich) library which will add additional formatting and color to the output. Here's an example:
 
 ![Printing Pydantic models with Rich](../img/rich_pydantic.png)
 


### PR DESCRIPTION
- `docs/integrations/mypy.md`: updates `http://mypy-lang.org` to `https://www.mypy-lang.org/` (HTTPS, matches URL already used in `docs/why.md`)
- `docs/integrations/rich.md`: updates `github.com/willmcgugan/rich` to `github.com/Textualize/rich` (Rich moved to the Textualize org)

Both old URLs redirect via 301 to the new locations.