### PR TITLE
[codex] Fix generic extra JSON schema

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -424,6 +424,8 @@ def collect_model_fields(  # noqa: C901
     pydantic_extra_info: PydanticExtraInfo | None = None
     if '__pydantic_extra__' in type_hints:
         ann, complete = type_hints['__pydantic_extra__']
+        if typevars_map:
+            ann = _generics.replace_types(ann, typevars_map)
         pydantic_extra_info = PydanticExtraInfo(
             annotation=ann,
             complete=complete,
@@ -467,10 +469,12 @@ def rebuild_model_fields(
                 rebuilt_fields[f_name] = new_field
 
         if cls.__pydantic_extra_info__ is not None and not cls.__pydantic_extra_info__.complete:
+            ann = _typing_extra.eval_type(
+                cls.__pydantic_extra_info__.annotation, *ns_resolver.types_namespace
+            )
+            ann = _generics.replace_types(ann, typevars_map)
             rebuilt_extra_info = PydanticExtraInfo(
-                annotation=_typing_extra.eval_type(
-                    cls.__pydantic_extra_info__.annotation, *ns_resolver.types_namespace
-                ),
+                annotation=ann,
                 complete=True,
             )
         else:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -3154,6 +3154,52 @@ def test_generic_with_allow_extra():
         data: T
 
 
+def test_generic_extra_validator_json_schema() -> None:
+    T = TypeVar('T')
+
+    class ExtraModel(BaseModel, Generic[T], extra='allow'):
+        __pydantic_extra__: dict[str, T] = Field(init=False)
+
+    assert ExtraModel[int].model_json_schema() == {
+        'additionalProperties': {'type': 'integer'},
+        'properties': {},
+        'title': 'ExtraModel[int]',
+        'type': 'object',
+    }
+
+    class Value(BaseModel):
+        x: int
+
+    class Wrapper(BaseModel, Generic[T]):
+        extra_model: ExtraModel[T]
+        values: dict[str, T]
+
+    value_qualname = Value.__qualname__
+    assert Wrapper[Value].model_json_schema() == {
+        '$defs': {
+            'ExtraModel_Value_': {
+                'additionalProperties': {'$ref': '#/$defs/Value'},
+                'properties': {},
+                'title': f'ExtraModel[{value_qualname}]',
+                'type': 'object',
+            },
+            'Value': {
+                'properties': {'x': {'title': 'X', 'type': 'integer'}},
+                'required': ['x'],
+                'title': 'Value',
+                'type': 'object',
+            },
+        },
+        'properties': {
+            'extra_model': {'$ref': '#/$defs/ExtraModel_Value_'},
+            'values': {'additionalProperties': {'$ref': '#/$defs/Value'}, 'title': 'Values', 'type': 'object'},
+        },
+        'required': ['extra_model', 'values'],
+        'title': f'Wrapper[{value_qualname}]',
+        'type': 'object',
+    }
+
+
 def test_generic_field():
     """Test for https://github.com/pydantic/pydantic/issues/10039.
 


### PR DESCRIPTION
## Summary

- Apply generic type variable substitution to explicit `__pydantic_extra__` annotations when collecting model fields.
- Preserve that substitution when rebuilding incomplete extra annotations.
- Add a regression test covering JSON schema generation for generic extra value types, including nested model references.

## Root Cause

`__pydantic_extra__` annotations were collected into `PydanticExtraInfo` without applying the model's `typevars_map`. For parametrized generic models like `ExtraModel[int]`, the extra value type stayed as `T`, so the generated core schema treated extra values as `Any`. JSON schema then emitted `additionalProperties: {}` and skipped referenced model definitions.

## Validation

- `.\.venv\Scripts\python -m pytest -q -o addopts= -o strict=false -o markers="thread_unsafe: tests that are not thread safe" --basetemp .pytest-tmp tests/test_generics.py::test_generic_extra_validator_json_schema tests/test_main.py::test_extra_validator_scalar tests/test_main.py::test_extra_validator_field tests/test_main.py::test_extra_validator_named tests/test_forward_ref.py::test_pydantic_extra_forward_ref_separate_module tests/test_forward_ref.py::test_pydantic_extra_forward_ref_separate_module_subclass tests/test_forward_ref.py::test_pydantic_extra_forward_ref_evaluated_pep585`
- `uvx ruff check pydantic/_internal/_fields.py tests/test_generics.py`