### PR TITLE
Support deferred annotations in `@validate_call` (#12620)

### DIFF
--- a/pydantic/_internal/_validate_call.py
+++ b/pydantic/_internal/_validate_call.py
@@ -85,7 +85,16 @@ class ValidateCallWrapper:
         )
         self.config_wrapper = ConfigWrapper(config)
         if not self.config_wrapper.defer_build:
-            self._create_validators()
+            try:
+                self._create_validators()
+            except NameError:
+                # A type annotation could not be resolved yet, e.g. a deferred
+                # annotation (`from __future__ import annotations`) referencing a
+                # name that is only defined after the decorated function. Mirror
+                # `BaseModel`'s behavior and defer building the validators until
+                # the function is first called, at which point the annotation can
+                # usually be resolved from the function's globals.
+                self.__pydantic_complete__ = False
         else:
             self.__pydantic_complete__ = False
 

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -1311,6 +1311,33 @@ def test_validate_call_defer_build() -> None:
         DeferBuildClass.cls_meth(x='not_an_int')
 
 
+def test_validate_call_deferred_annotation(create_module):
+    """`@validate_call` should support deferred annotations that are only
+    resolvable after the decorated function is defined.
+
+    https://github.com/pydantic/pydantic/issues/12620
+    """
+    module = create_module(
+        """
+from __future__ import annotations
+
+from pydantic import BaseModel, validate_call
+
+@validate_call(validate_return=True)
+def foo(x: MyModel) -> MyModel:
+    return x
+
+class MyModel(BaseModel):
+    x: int
+        """
+    )
+
+    assert module.foo({'x': 1}) == module.MyModel(x=1)
+
+    with pytest.raises(ValidationError):
+        module.foo({'x': 'not_an_int'})
+
+
 class _PickleTestModel(BaseModel):
     number: float
 


### PR DESCRIPTION
#### Reference issues/PRs

Closes #12620.

#### What does this implement/fix? Explain your changes.

`@validate_call` built the argument (and return) validators eagerly at decoration time. When an annotation is deferred — e.g. under `from __future__ import annotations`, or a string forward reference — and refers to a name defined *after* the decorated function, resolution failed with a bare `NameError`:

```python
from __future__ import annotations
from pydantic import validate_call, BaseModel

@validate_call
def f(x: Foo) -> None: ...   # NameError: name 'Foo' is not defined

class Foo(BaseModel): ...
```

`BaseModel` handles the analogous situation by deferring schema construction (and completing it later) rather than raising. `ValidateCallWrapper` already has a lazy path (used for `defer_build=True`) that builds the validators on first call, and it works for deferred annotations because the function's globals are resolved at call time.

This change routes the eager path into that same lazy path when annotation resolution fails: if `_create_validators()` raises `NameError` at decoration time, we set `__pydantic_complete__ = False` and let the first call build the validators, at which point the name is resolvable from the function's globals. A name that is genuinely never defined still raises `NameError` at call time.

#### Any other comments?

- Added a non-regression test (`test_validate_call_deferred_annotation`) that fails on `main` and passes here; full `tests/test_validate_call.py` passes locally (61 passed, 3 skipped), `ruff` clean.
- This addresses the `@validate_call` case from the issue. The broader "everything using `get_function_type_hints()`" surface could be handled separately by making that helper lenient; happy to expand scope if preferred.
