### PR TITLE
docs: fix validator quick link anchors

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -43,8 +43,8 @@ In its simplest form, a field validator is a callable taking the value to be val
 [annotated pattern](./fields.md#the-annotated-pattern) or using the
 [`@field_validator`][pydantic.field_validator] decorator, applied on a [class method][classmethod]:
 
-* ***After* validators**: run after Pydantic's internal validation. They are generally more type safe and thus easier to implement.
-{#field-after-validator}
+* <span id="field-after-validator"></span>***After* validators**: run after Pydantic's internal validation.
+  They are generally more type safe and thus easier to implement.
 
     === "Annotated pattern"
 
@@ -157,12 +157,11 @@ In its simplest form, a field validator is a callable taking the value to be val
 
             1. `'after'` is the default mode for the decorator, and can be omitted.
 
-* ***Before* validators**: run before Pydantic's internal parsing and validation (e.g. coercion of a `str` to an `int`).
+* <span id="field-before-validator"></span>***Before* validators**: run before Pydantic's internal parsing and validation (e.g. coercion of a `str` to an `int`).
   These are more flexible than [*after* validators](#field-after-validator), but they also have to deal with the raw input, which
   in theory could be any arbitrary object. You should also avoid mutating the value directly if you are raising a
   [validation error](#raising-validation-errors) later in your validator function, as the mutated value may be passed to other
   validators if using [unions](./unions.md).
-  {#field-before-validator}
 
     The value returned from this callable is then validated against the provided type annotation by Pydantic.
 
@@ -251,9 +250,8 @@ In its simplest form, a field validator is a callable taking the value to be val
         3. Pydantic still performs validation against the `int` type, no matter if our `ensure_list` validator
            did operations on the original input type.
 
-* ***Plain* validators**: act similarly to *before* validators but they **terminate validation immediately** after returning,
+* <span id="field-plain-validator"></span>***Plain* validators**: act similarly to *before* validators but they **terminate validation immediately** after returning,
   so no further validators are called and Pydantic does not do any of its internal validation against the field type.
-  {#field-plain-validator}
 
     === "Annotated pattern"
 
@@ -310,10 +308,9 @@ In its simplest form, a field validator is a callable taking the value to be val
 
         1. Although `'invalid'` shouldn't validate against the `int` type, Pydantic accepts the input.
 
-* ***Wrap* validators**: are the most flexible of all. You can run code before or after Pydantic and other validators
+* <span id="field-wrap-validator"></span>***Wrap* validators**: are the most flexible of all. You can run code before or after Pydantic and other validators
   process the input, or you can terminate validation immediately, either by returning the value early or by raising an
   error.
-  {#field-wrap-validator}
 
     Such validators must be defined with a **mandatory** extra *handler* parameter: a callable taking the value to be validated
     as an argument. Internally, this handler will delegate validation of the value to Pydantic. You are free to wrap the call
@@ -466,10 +463,9 @@ decorator.
 
 **Three** different types of model validators can be used:
 
-* ***After* validators**: run after the whole model has been validated. As such, they are defined as
+* <span id="model-after-validator"></span>***After* validators**: run after the whole model has been validated. As such, they are defined as
   *instance* methods and can be seen as post-initialization hooks. Important note: the validated instance
   should be returned.
-  {#model-after-validator}
 
     ```python
     from typing_extensions import Self
@@ -489,11 +485,10 @@ decorator.
             return self
     ```
 
-* ***Before* validators**: are run before the model is instantiated. These are more flexible than *after* validators,
+* <span id="model-before-validator"></span>***Before* validators**: are run before the model is instantiated. These are more flexible than *after* validators,
   but they also have to deal with the raw input, which in theory could be any arbitrary object. You should also avoid
   mutating the value directly if you are raising a [validation error](#raising-validation-errors) later in your validator
   function, as the mutated value may be passed to other validators if using [unions](./unions.md).
-  {#model-before-validator}
 
     ```python
     from typing import Any
@@ -519,10 +514,9 @@ decorator.
        this is not always the case. For instance, if the [`from_attributes`][pydantic.ConfigDict.from_attributes]
        configuration value is set, you might receive an arbitrary class instance for the `data` argument.
 
-* ***Wrap* validators**: are the most flexible of all. You can run code before or after Pydantic and
+* <span id="model-wrap-validator"></span>***Wrap* validators**: are the most flexible of all. You can run code before or after Pydantic and
   other validators process the input data, or you can terminate validation immediately, either by returning
   the data early or by raising an error.
-  {#model-wrap-validator}
 
     ```python {lint="skip"}
     import logging


### PR DESCRIPTION
Fixes pydantic/pydantic#13392.

## Summary

- replace unsupported anonymous validator anchors with explicit HTML `id` anchors
- keep the quick-link targets attached to the same validator list items
- remove the now-ignored `{#...}` anchor markers

I understand the submitted documentation change.

## Checks

- `git diff --check origin/main...HEAD`
- source check confirmed each validator quick-link target has a matching `id`
- generated `site/concepts/validators/index.html` includes all seven expected quick-link ids

Note: local `mkdocs build --strict` currently aborts on existing unrelated autorefs warnings in this checkout; the generated validator page was still inspected for the fixed anchors.
