### PR TITLE
Fix missing function body in `model_serializer` signatures example (docs)

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -949,7 +949,7 @@ def mod_ser(self, info: SerializationInfo): ...
 
 # an instance method with `mode='wrap'`
 @model_serializer(mode='wrap')
-def mod_ser(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo):
+def mod_ser(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo): ...
 
 # For all of these, you can also choose to omit the `info` argument, for example:
 @model_serializer(mode='plain')


### PR DESCRIPTION
## Change Summary

### (docs-only change)
In the "Unrecognized model_serializer signature" docs, the `mode='wrap'` example is missing its `...` body.
This PR adds the missing `...`. 
CI didn't catch this because the code block is marked `test="skip" lint="skip"`.

## Related issue number
None (simple change)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
