### PR TITLE
fix: add explicit stacklevel to 21 warnings.warn() calls

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -383,4 +383,4 @@ def check_deprecated(config_dict: ConfigDict) -> None:
         renamed_bullets = [f'* {k!r} has been renamed to {v!r}' for k, v in renamings.items()]
         removed_bullets = [f'* {k!r} has been removed' for k in sorted(deprecated_removed_keys)]
         message = '\n'.join(['Valid config keys have changed in V2:'] + renamed_bullets + removed_bullets)
-        warnings.warn(message, UserWarning)
+        warnings.warn(message, UserWarning, stacklevel=2)

--- a/pydantic/_internal/_core_metadata.py
+++ b/pydantic/_internal/_core_metadata.py
@@ -90,7 +90,7 @@ def update_core_metadata(
                     'Composing `dict` and `callable` type `json_schema_extra` is not supported.'
                     'The `callable` type is being ignored.'
                     "If you'd like support for this behavior, please open an issue on pydantic.",
-                    PydanticJsonSchemaWarning,
+                    PydanticJsonSchemaWarning, stacklevel=2,
                 )
         if callable(existing_pydantic_js_extra):
             # if ever there's a case of a callable, we'll just keep the last json schema extra spec

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -134,7 +134,7 @@ def complete_dataclass(
     if hasattr(cls, '__post_init_post_parse__'):
         warnings.warn(
             'Support for `__post_init_post_parse__` has been dropped, the method will not be called',
-            PydanticDeprecatedSince20,
+            PydanticDeprecatedSince20, stacklevel=2,
         )
 
     typevars_map = get_standard_typevars_map(cls)

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -323,7 +323,7 @@ def _add_custom_serialization_from_json_encoders(
 
         warnings.warn(
             f'`json_encoders` is deprecated. See https://pydantic.dev/docs/validation/{version_short()}/concepts/serialization/#custom-serializers for alternatives',
-            PydanticDeprecatedSince20,
+            PydanticDeprecatedSince20, stacklevel=2,
         )
 
         # TODO: in theory we should check that the schema accepts a serialization key
@@ -647,7 +647,7 @@ class GenerateSchema:
                 ' Pydantic will allow any object with no validation since we cannot even'
                 ' enforce that the input is an instance of the given type.'
                 ' To get rid of this error wrap the type with `pydantic.SkipValidation`.',
-                ArbitraryTypeWarning,
+                ArbitraryTypeWarning, stacklevel=2,
             )
             return core_schema.any_schema()
         return core_schema.is_instance_schema(tp)
@@ -930,12 +930,12 @@ class GenerateSchema:
             if issubclass(obj, BaseModelV1):
                 warnings.warn(
                     f'Mixing V1 models and V2 models (or constructs, like `TypeAdapter`) is not supported. Please upgrade `{obj.__name__}` to V2.',
-                    UserWarning,
+                    UserWarning, stacklevel=2,
                 )
             else:
                 warnings.warn(
                     '`__get_validators__` is deprecated and will be removed, use `__get_pydantic_core_schema__` instead.',
-                    PydanticDeprecatedSince20,
+                    PydanticDeprecatedSince20, stacklevel=2,
                 )
             return core_schema.chain_schema([core_schema.with_info_plain_validator_function(v) for v in validators()])
 
@@ -1463,7 +1463,7 @@ class GenerateSchema:
                         f'Item{"s" if plural else ""} {fields_repr} on TypedDict class {typed_dict_cls.__name__!r} '
                         f'{"are" if plural else "is"} using the `ReadOnly` qualifier. Pydantic will not protect items '
                         'from any mutation on dictionary instances.',
-                        UserWarning,
+                        UserWarning, stacklevel=2,
                     )
 
                 extra_behavior: core_schema.ExtraBehavior = 'ignore'
@@ -1484,13 +1484,13 @@ class GenerateSchema:
                         warnings.warn(
                             f"TypedDict class {typed_dict_cls.__qualname__!r} is closed, but 'extra' configuration "
                             "is set to `'allow'`. The 'extra' configuration value will be ignored.",
-                            category=TypedDictExtraConfigWarning,
+                            stacklevel=2, category=TypedDictExtraConfigWarning,
                         )
                     elif not typing_objects.is_noextraitems(extra_items) and config_extra == 'forbid':
                         warnings.warn(
                             f"TypedDict class {typed_dict_cls.__qualname__!r} allows extra items, but 'extra' configuration "
                             "is set to `'forbid'`. The 'extra' configuration value will be ignored.",
-                            category=TypedDictExtraConfigWarning,
+                            stacklevel=2, category=TypedDictExtraConfigWarning,
                         )
                     else:
                         extra_behavior = config_extra
@@ -2259,7 +2259,7 @@ class GenerateSchema:
                         'and can only be attached to a model field using `Annotated` metadata or by assignment. '
                         'This may have happened because an `Annotated` type alias using the `type` statement was '
                         'used, or if the `Field()` function was attached to a single member of a union type.',
-                        category=UnsupportedFieldAttributeWarning,
+                        stacklevel=2, category=UnsupportedFieldAttributeWarning,
                     )
 
                 if (
@@ -2270,7 +2270,7 @@ class GenerateSchema:
                     warnings.warn(
                         "A 'default_factory' taking validated data as an argument was provided to the `Field()` function, "
                         'but no validated data is available in the context it was used.',
-                        category=UnsupportedFieldAttributeWarning,
+                        stacklevel=2, category=UnsupportedFieldAttributeWarning,
                     )
 
             for field_metadata in metadata.metadata:

--- a/pydantic/deprecated/config.py
+++ b/pydantic/deprecated/config.py
@@ -20,7 +20,7 @@ class _ConfigMetaclass(type):
     def __getattr__(self, item: str) -> Any:
         try:
             obj = _config.config_defaults[item]
-            warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+            warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
             return obj
         except KeyError as exc:
             raise AttributeError(f"type object '{self.__name__}' has no attribute {exc}") from exc
@@ -37,7 +37,7 @@ class BaseConfig(metaclass=_ConfigMetaclass):
     def __getattr__(self, item: str) -> Any:
         try:
             obj = super().__getattribute__(item)
-            warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+            warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
             return obj
         except AttributeError as exc:
             try:
@@ -47,7 +47,7 @@ class BaseConfig(metaclass=_ConfigMetaclass):
                 raise AttributeError(str(exc)) from exc
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning)
+        warnings.warn(_config.DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
         return super().__init_subclass__(**kwargs)
 
 

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -528,14 +528,14 @@ class FieldInfo(_repr.Representation):
                                 'Composing `dict` and `callable` type `json_schema_extra` is not supported. '
                                 'The `callable` type is being ignored. '
                                 "If you'd like support for this behavior, please open an issue on pydantic.",
-                                UserWarning,
+                                UserWarning, stacklevel=2,
                             )
                     elif callable(existing_js_extra) and isinstance(current_js_extra, dict):
                         warn(
                             'Composing `dict` and `callable` type `json_schema_extra` is not supported. '
                             'The `callable` type is being ignored. '
                             "If you'd like support for this behavior, please open an issue on pydantic.",
-                            UserWarning,
+                            UserWarning, stacklevel=2,
                         )
 
                 # HACK: It is common for users to define "make model partial" (or similar) utilities, that
@@ -620,7 +620,7 @@ class FieldInfo(_repr.Representation):
                             'Composing `dict` and `callable` type `json_schema_extra` is not supported.'
                             'The `callable` type is being ignored.'
                             "If you'd like support for this behavior, please open an issue on pydantic.",
-                            PydanticJsonSchemaWarning,
+                            PydanticJsonSchemaWarning, stacklevel=2,
                         )
                 elif callable(json_schema_extra):
                     # if ever there's a case of a callable, we'll just keep the last json schema extra spec

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2489,7 +2489,7 @@ class GenerateJsonSchema:
         """This method simply emits PydanticJsonSchemaWarnings based on handling in the `warning_message` method."""
         message = self.render_warning_message(kind, detail)
         if message is not None:
-            warnings.warn(message, PydanticJsonSchemaWarning)
+            warnings.warn(message, PydanticJsonSchemaWarning, stacklevel=2)
 
     def render_warning_message(self, kind: JsonSchemaWarningKind, detail: str) -> str | None:
         """This method is responsible for ignoring warnings as desired, and for formatting the warning messages.
@@ -2794,7 +2794,7 @@ class Examples:
                     'Updating existing JSON Schema examples of type dict with examples of type list. '
                     'Only the existing examples values will be retained. Note that dict support for '
                     'examples is deprecated and will be removed in v3.0.',
-                    UserWarning,
+                    UserWarning, stacklevel=2,
                 )
                 json_schema['examples'] = to_jsonable_python(
                     [ex for value in examples.values() for ex in value] + self.examples
@@ -2809,7 +2809,7 @@ class Examples:
                     'Updating existing JSON Schema examples of type list with examples of type dict. '
                     'Only the examples values will be retained. Note that dict support for '
                     'examples is deprecated and will be removed in v3.0.',
-                    UserWarning,
+                    UserWarning, stacklevel=2,
                 )
                 json_schema['examples'] = to_jsonable_python(
                     examples + [ex for value in self.examples.values() for ex in value]


### PR DESCRIPTION
B028: Added `stacklevel=2` to all `warnings.warn()` calls missing it across 7 files.
Auto-fixed by ruff --unsafe-fixes.

Syntax verified. Test suite requires compiled pydantic-core which cannot be installed locally from this fork.