### PR TITLE
fix: accept Decimal in Field(multiple_of=...) type hints

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -68,7 +68,7 @@ class _FromFieldInfoInputs(TypedDict, total=False):
     ge: annotated_types.SupportsGe | None
     lt: annotated_types.SupportsLt | None
     le: annotated_types.SupportsLe | None
-    multiple_of: float | None
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None
     strict: bool | None
     min_length: int | None
     max_length: int | None
@@ -952,7 +952,7 @@ def Field(
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: float | None = _Unset,
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
@@ -992,7 +992,7 @@ def Field(
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: float | None = _Unset,
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
@@ -1035,7 +1035,7 @@ def Field(
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: float | None = _Unset,
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
@@ -1075,7 +1075,7 @@ def Field(  # pyright: ignore[reportOverlappingOverload]
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: float | None = _Unset,
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
@@ -1118,7 +1118,7 @@ def Field(
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: float | None = _Unset,
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
@@ -1157,7 +1157,7 @@ def Field(  # No default set
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: float | None = _Unset,
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
@@ -1197,7 +1197,7 @@ def Field(  # noqa: C901
     ge: annotated_types.SupportsGe | None = _Unset,
     lt: annotated_types.SupportsLt | None = _Unset,
     le: annotated_types.SupportsLe | None = _Unset,
-    multiple_of: float | None = _Unset,
+    multiple_of: annotated_types.SupportsDiv | annotated_types.SupportsMod | None = _Unset,
     allow_inf_nan: bool | None = _Unset,
     max_digits: int | None = _Unset,
     decimal_places: int | None = _Unset,
@@ -1255,6 +1255,8 @@ def Field(  # noqa: C901
         lt: Less than. If set, value must be less than this. Only applicable to numbers.
         le: Less than or equal. If set, value must be less than or equal to this. Only applicable to numbers.
         multiple_of: Value must be a multiple of this. Only applicable to numbers.
+            Accepts `int`, `float`, [`Decimal`][decimal.Decimal], or any type implementing
+            `__truediv__`/`__mod__` as described by [`annotated_types.MultipleOf`][].
         min_length: Minimum length for iterables.
         max_length: Maximum length for iterables.
         pattern: Pattern for strings (a regular expression).

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,8 @@
 import copy
+from decimal import Decimal
 from typing import Annotated, Any, Final, Generic, TypeVar
 
+import annotated_types
 import pytest
 from annotated_types import Gt
 from pydantic_core import PydanticUndefined
@@ -459,3 +461,32 @@ def test_default_factory_without_validated_data_unsupported() -> None:
 
     with pytest.raises(ValueError):
         FooBar.model_fields['a'].get_default(call_default_factory=True)
+
+
+def test_field_multiple_of_accepts_decimal() -> None:
+    """`Field(multiple_of=...)` should accept int, float, and Decimal values.
+
+    See https://github.com/pydantic/pydantic/issues/6885.
+    """
+    multiple = Decimal('0.05')
+    field_info = Field(max_digits=8, decimal_places=2, gt=0, multiple_of=multiple)
+    assert any(isinstance(m, annotated_types.MultipleOf) and m.multiple_of == multiple for m in field_info.metadata)
+
+    class Model(BaseModel):
+        amount: Decimal = Field(max_digits=8, decimal_places=2, gt=0, multiple_of=multiple)
+        count: int = Field(multiple_of=5)
+        ratio: float = Field(multiple_of=0.5)
+
+    m = Model(amount='1.00', count=10, ratio=1.5)
+    assert m.amount == Decimal('1.00')
+    assert m.count == 10
+    assert m.ratio == 1.5
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(amount='1.03', count=10, ratio=1.5)
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'multiple_of'
+    assert exc_info.value.errors(include_url=False)[0]['ctx'] == {'multiple_of': multiple}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(amount='1.00', count=7, ratio=1.5)
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'multiple_of'

--- a/tests/typechecking/fields.py
+++ b/tests/typechecking/fields.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from pydantic import BaseModel, Field, PrivateAttr
 
 
@@ -43,3 +45,9 @@ class Model(BaseModel):
     f15: int = Field(default_factory=str, validate_default=True)
     f16: int = Field(default='1', validate_default=False)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
     f17: int = Field(default_factory=str, validate_default=False)  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+    # `multiple_of` accepts int, float, and Decimal (see https://github.com/pydantic/pydantic/issues/6885):
+    f18: int = Field(multiple_of=5)
+    f19: float = Field(multiple_of=0.5)
+    f20: Decimal = Field(multiple_of=Decimal('0.01'))
+    f21: Decimal = Field(max_digits=8, decimal_places=2, gt=0, multiple_of=Decimal('0.01'))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

`Field(multiple_of=...)` already accepts `Decimal` at runtime, but the public type hints only allowed `float | None`, so type checkers rejected valid usages such as:

```python
from decimal import Decimal
from pydantic import Field

Field(max_digits=8, decimal_places=2, gt=0, multiple_of=Decimal('0.01'))
```

This updates `multiple_of` annotations on `Field` / `FieldInfo` inputs to `annotated_types.SupportsDiv | annotated_types.SupportsMod | None`, matching `annotated_types.MultipleOf` and the existing protocol-based typing for `gt` / `ge` / `lt` / `le`. `int`, `float`, and `Decimal` are all accepted by static checkers as a result.

Also adds runtime coverage in `tests/test_fields.py` and type-checking coverage in `tests/typechecking/fields.py`.

## Related issue number

Fixes #6885

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
