### PR TITLE
Use latest sentinel implementation from typing-extensions 4.16

### DIFF
--- a/docs/concepts/experimental.md
+++ b/docs/concepts/experimental.md
@@ -537,7 +537,6 @@ As such, the following limitations currently apply:
   [1.1.402](https://github.com/microsoft/pyright/releases/tag/1.1.402)
   or greater, and the `enableExperimentalFeatures` type evaluation setting
   should be enabled.
-* Pickling of models containing `MISSING` as a value is not supported.
 
 !!! note
     When [applying constraints](./fields.md#field-constraints) to a union containing the `MISSING` sentinel,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'typing-extensions>=4.15.0',
+    'typing-extensions>=4.16.0',
     'annotated-types>=0.6.0',
     # Keep this in sync with the version in the `check_pydantic_core_version()` function:
     'pydantic-core==2.48.0',

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -2,7 +2,6 @@ import pickle
 from typing import Annotated
 
 import pytest
-import typing_extensions
 from annotated_types import Ge
 from pydantic_core import MISSING, PydanticSerializationUnexpectedValue
 
@@ -54,11 +53,6 @@ class ModelPickle(BaseModel):
     f: int | MISSING = MISSING
 
 
-@pytest.mark.xfail(
-    # Unreleased typing-extensions has the final sentinel implementation with pickle support:
-    condition=not hasattr(typing_extensions, 'sentinel'),
-    reason="PEP 661 sentinels aren't picklable yet in the experimental typing-extensions implementation",
-)
 def test_missing_sentinel_pickle() -> None:
     m = ModelPickle()
     m_reconstructed = pickle.loads(pickle.dumps(m))

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "python_full_version >= '3.15'",
+    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "(python_full_version >= '3.12' and python_full_version < '3.15' and implementation_name != 'cpython') or (python_full_version == '3.12.*' and implementation_name == 'cpython') or (python_full_version == '3.14.*' and implementation_name == 'cpython')",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -2550,7 +2550,7 @@ requires-dist = [
     { name = "annotated-types", specifier = ">=0.6.0" },
     { name = "email-validator", marker = "extra == 'email'", specifier = ">=2.0.0" },
     { name = "pydantic-core", editable = "pydantic-core" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
+    { name = "typing-extensions", specifier = ">=4.16.0" },
     { name = "typing-inspection", specifier = ">=0.4.4" },
     { name = "tzdata", marker = "sys_platform == 'win32' and extra == 'timezone'" },
 ]
@@ -2844,8 +2844,8 @@ name = "pyodide-build"
 version = "0.39.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "python_full_version >= '3.15'",
+    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "(python_full_version >= '3.12' and python_full_version < '3.15' and implementation_name != 'cpython') or (python_full_version == '3.12.*' and implementation_name == 'cpython') or (python_full_version == '3.14.*' and implementation_name == 'cpython')",
 ]
 dependencies = [
@@ -3469,8 +3469,8 @@ name = "rpds-py"
 version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "python_full_version >= '3.15'",
+    "python_full_version == '3.13.*' and implementation_name == 'cpython'",
     "(python_full_version >= '3.12' and python_full_version < '3.15' and implementation_name != 'cpython') or (python_full_version == '3.12.*' and implementation_name == 'cpython') or (python_full_version == '3.14.*' and implementation_name == 'cpython')",
     "python_full_version == '3.11.*'",
 ]
@@ -3940,11 +3940,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

- Bumps the minimum `typing-extensions` to 4.16.0 to bring the latest changes after the final version of PEP 661 was implemented, which among other things makes the object pickable.

- Update the documentation and unconditionally enable the pickling test.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

- related to https://github.com/pydantic/pydantic/issues/12090
- part of https://github.com/pydantic/pydantic/issues/13173
- maybe blocked until https://github.com/python/mypy/pull/21454 (or https://github.com/python/mypy/pull/21647) is merged and released

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
