### PR TITLE
Stop dependabot suggesting strum updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,11 @@ updates:
       rust-deps:
         patterns:
           - '*'
-        # pyo3 updates will require jiter updates, we'll handle them manually anyway
         exclude-patterns:
+          # pyo3 updates will require jiter updates, we'll handle them manually anyway
           - 'pyo3*'
+          # strum updates will require speedate updates
+          - 'strum'
+          - 'strum_macros'
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Change Summary

Given that `strum` can only update with `speedate`, turn this off here for now. (We should maybe remove speedate's public dependency on `strum`, but that's a future problem.)

## Related issue number

N/A

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
