### PR TITLE
Remove duplicated `schema_generator` and `mode` entries in `TypeAdapter.json_schema` docstring

### DIFF
--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -716,8 +716,6 @@ class TypeAdapter(Generic[T]):
             schema_generator: To override the logic used to generate the JSON schema, as a subclass of
                 `GenerateJsonSchema` with your desired modifications
             mode: The mode in which to generate the schema.
-            schema_generator: The generator class used for creating the schema.
-            mode: The mode to use for schema generation.
 
         Returns:
             The JSON schema for the model as a dictionary.


### PR DESCRIPTION
The `TypeAdapter.json_schema` docstring listed `schema_generator` and `mode` twice each in its `Args:` section, with conflicting phrasings for each. This removes the stray duplicate pair, keeping the fuller descriptions that appear first. Docstring-only change; no behavior change.