### PR TITLE
fix(json-schema): handle non-UTF-8 bytes default instead of UnicodeDecodeError

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2351,7 +2351,7 @@ class GenerateJsonSchema:
             )
         except PydanticSchemaGenerationError:
             raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}')
-        except ValueError as exc:
+        except UnicodeDecodeError as exc:
             # e.g. a non-UTF-8 `bytes` default under `ser_json_bytes='utf8'` raises a `UnicodeDecodeError`.
             # Re-raise as a `PydanticSerializationError` so the caller can gracefully exclude the default.
             raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}') from exc
@@ -2363,7 +2363,8 @@ class GenerateJsonSchema:
                 bytes_mode=config.ser_json_bytes,
                 by_alias=self.by_alias,
             )
-        except ValueError as exc:
+        except UnicodeDecodeError as exc:
+            # Same non-UTF-8 `bytes` case reached via the `_type_has_config` branch above.
             raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}') from exc
 
     def update_with_validations(

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2351,10 +2351,20 @@ class GenerateJsonSchema:
             )
         except PydanticSchemaGenerationError:
             raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}')
+        except ValueError as exc:
+            # e.g. a non-UTF-8 `bytes` default under `ser_json_bytes='utf8'` raises a `UnicodeDecodeError`.
+            # Re-raise as a `PydanticSerializationError` so the caller can gracefully exclude the default.
+            raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}') from exc
 
-        return pydantic_core.to_jsonable_python(
-            default, timedelta_mode=config.ser_json_timedelta, bytes_mode=config.ser_json_bytes, by_alias=self.by_alias
-        )
+        try:
+            return pydantic_core.to_jsonable_python(
+                default,
+                timedelta_mode=config.ser_json_timedelta,
+                bytes_mode=config.ser_json_bytes,
+                by_alias=self.by_alias,
+            )
+        except ValueError as exc:
+            raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}') from exc
 
     def update_with_validations(
         self, json_schema: JsonSchemaValue, core_schema: CoreSchema, mapping: dict[str, str]

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1427,6 +1427,31 @@ def test_non_serializable_default(type_, default_value, properties):
     assert model_schema.get('required') is None
 
 
+def test_non_utf8_bytes_default():
+    # A non-UTF-8 `bytes` default cannot be encoded under the default `ser_json_bytes='utf8'`
+    # serialization mode. This should gracefully exclude the default (with a warning) rather than
+    # leaking a raw `UnicodeDecodeError`.
+    class Model(BaseModel):
+        x: bytes = b'\xff\xfe'
+
+    with pytest.warns(
+        PydanticJsonSchemaWarning,
+        match=(
+            'Default value .* is not JSON serializable; excluding default from JSON schema '
+            r'\[non-serializable-default\]'
+        ),
+    ):
+        model_schema = Model.model_json_schema()
+    assert 'default' not in model_schema['properties']['x']
+
+    # With a `bytes` serialization mode that can represent arbitrary bytes, the default is encoded.
+    class Base64Model(BaseModel):
+        model_config = ConfigDict(ser_json_bytes='base64')
+        x: bytes = b'\xff\xfe'
+
+    assert Base64Model.model_json_schema()['properties']['x']['default'] == '__4='
+
+
 def test_callable_fallback_with_non_serializable_default():
     class Model(BaseModel):
         callback: int | Callable[[int], int] = lambda x: x


### PR DESCRIPTION
## What's broken
A model field with a non-UTF-8 `bytes` default (e.g. `b'\xff\xfe'`) raises a raw `UnicodeDecodeError` from `model_json_schema()` under the default `ser_json_bytes='utf8'` serialization mode.

```python
class M(BaseModel):
    x: bytes = b'\xff\xfe'
M.model_json_schema()  # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff ...
```

## Why it happens
`GenerateJsonSchema.encode_default` only caught `PydanticSchemaGenerationError`, so the `UnicodeDecodeError` (a `ValueError`) escaped before reaching the caller's existing graceful-degradation path (which catches `PydanticSerializationError`, warns `non-serializable-default`, and omits the default).

## Fix
Catch `ValueError` in `encode_default` and re-raise as `PydanticSerializationError`, so a non-encodable bytes default is handled consistently with other non-serializable defaults (warn + omit). Behavior unchanged for `base64` mode or valid UTF-8 bytes.

## Test
Added `test_non_utf8_bytes_default`. Fails before (raw UnicodeDecodeError / DID NOT WARN), passes after; full `test_json_schema.py` still green (530 passed).
