### PR TITLE
Fix JSON Schema keys for wrapped numeric constraints

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from copy import copy
+from decimal import Decimal
 from functools import lru_cache, partial
+from math import isinf
+from numbers import Real
 from typing import TYPE_CHECKING, Any
 
 from pydantic_core import CoreSchema, PydanticCustomError, ValidationError, to_jsonable_python
@@ -20,6 +23,13 @@ FAIL_FAST = {'fail_fast'}
 LENGTH_CONSTRAINTS = {'min_length', 'max_length'}
 INEQUALITY = {'le', 'ge', 'lt', 'gt'}
 NUMERIC_CONSTRAINTS = {'multiple_of', *INEQUALITY}
+JSON_SCHEMA_NUMERIC_CONSTRAINTS = {
+    'multiple_of': 'multipleOf',
+    'le': 'maximum',
+    'ge': 'minimum',
+    'lt': 'exclusiveMaximum',
+    'gt': 'exclusiveMinimum',
+}
 ALLOW_INF_NAN = {'allow_inf_nan'}
 
 STR_CONSTRAINTS = {
@@ -104,6 +114,63 @@ def as_jsonable_value(v: Any) -> Any:
     if type(v) not in (int, str, float, bytes, bool, type(None)):
         return to_jsonable_python(v)
     return v
+
+
+def _json_schema_numeric_value(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        value = float(value)
+    elif isinstance(value, (int, float)):
+        pass
+    elif isinstance(value, Real):
+        value = float(value)
+    else:
+        return None
+    if isinstance(value, float) and isinf(value):
+        return None
+    return value
+
+
+def _strip_function_wrappers(schema: CoreSchema) -> CoreSchema:
+    while schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
+        schema = schema['schema']  # type: ignore
+    return schema
+
+
+def _apply_json_schema_constraint_update(
+    metadata: dict[str, Any], schema: CoreSchema, constraint: str, value: Any
+) -> None:
+    json_schema_key = JSON_SCHEMA_NUMERIC_CONSTRAINTS.get(constraint)
+    if json_schema_key is None:
+        return
+    json_schema_value = _json_schema_numeric_value(value)
+    if json_schema_value is None:
+        return
+
+    inner_schema_type = _strip_function_wrappers(schema)['type']
+    if inner_schema_type in {'decimal', 'fraction'}:
+
+        def update_numeric_branch(
+            json_schema: dict[str, Any],
+            json_schema_key: str = json_schema_key,
+            json_schema_value: int | float = json_schema_value,
+        ) -> None:
+            for choice in json_schema.get('anyOf', ()):
+                if isinstance(choice, dict) and choice.get('type') == 'number':
+                    choice[json_schema_key] = json_schema_value
+                    return
+
+        metadata['pydantic_js_extra'] = update_numeric_branch
+        return
+
+    if (existing_json_schema_updates := metadata.get('pydantic_js_updates')) is not None:
+        metadata['pydantic_js_updates'] = {
+            **existing_json_schema_updates,
+            **{json_schema_key: json_schema_value},
+        }
+    else:
+        metadata['pydantic_js_updates'] = {json_schema_key: json_schema_value}
 
 
 def expand_grouped_metadata(annotations: Iterable[Any]) -> Iterable[Any]:
@@ -266,13 +333,15 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:
-                js_constraint_key = constraint
+                js_constraint_key = None
 
             schema = cs.no_info_after_validator_function(
                 partial(NUMERIC_VALIDATOR_LOOKUP[constraint], **{constraint: value}), schema
             )
             metadata = schema.get('metadata', {})
-            if (existing_json_schema_updates := metadata.get('pydantic_js_updates')) is not None:
+            if js_constraint_key is None:
+                _apply_json_schema_constraint_update(metadata, schema, constraint, value)
+            elif (existing_json_schema_updates := metadata.get('pydantic_js_updates')) is not None:
                 metadata['pydantic_js_updates'] = {
                     **existing_json_schema_updates,
                     **{js_constraint_key: as_jsonable_value(value)},

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2111,6 +2111,58 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
     assert Foo.model_json_schema(mode='validation') == expected_schema
 
 
+@pytest.mark.parametrize(
+    'constraint,value,json_schema_key',
+    [
+        ('gt', 2, 'exclusiveMinimum'),
+        ('ge', 2, 'minimum'),
+        ('lt', 5, 'exclusiveMaximum'),
+        ('le', 5, 'maximum'),
+        ('multiple_of', 5, 'multipleOf'),
+    ],
+)
+def test_numeric_constraint_after_validator_uses_json_schema_key(
+    constraint: str, value: int, json_schema_key: str
+) -> None:
+    schema = TypeAdapter(
+        Annotated[int, BeforeValidator(lambda value: value), Field(**{constraint: value})]
+    ).json_schema()
+
+    assert schema == {'type': 'integer', json_schema_key: value}
+    assert constraint not in schema
+
+
+def test_decimal_constraint_after_validator_matches_direct_json_schema() -> None:
+    direct_schema = TypeAdapter(Annotated[Decimal, Field(gt=Decimal('9.5'))]).json_schema()
+    wrapped_schema = TypeAdapter(
+        Annotated[Decimal, BeforeValidator(lambda value: value), Field(gt=Decimal('9.5'))]
+    ).json_schema()
+
+    assert wrapped_schema == direct_schema
+
+
+@pytest.mark.parametrize(
+    'field_type,constraint,value',
+    [
+        (date, 'gt', date(2020, 1, 1)),
+        (datetime, 'lt', datetime(2020, 1, 1)),
+        (timedelta, 'le', timedelta(days=1)),
+    ],
+)
+def test_temporal_constraint_after_validator_omits_numeric_json_schema_keywords(
+    field_type: Any, constraint: str, value: Any
+) -> None:
+    direct_schema = TypeAdapter(Annotated[field_type, Field(**{constraint: value})]).json_schema()
+    wrapped_schema = TypeAdapter(
+        Annotated[field_type, BeforeValidator(lambda value: value), Field(**{constraint: value})]
+    ).json_schema()
+
+    assert wrapped_schema == direct_schema
+    for json_schema_key in ('exclusiveMinimum', 'minimum', 'exclusiveMaximum', 'maximum', 'multipleOf'):
+        assert json_schema_key not in wrapped_schema
+    assert constraint not in wrapped_schema
+
+
 # ADDTESTS: add test cases to check max_digits and decimal_places constrains
 @pytest.mark.parametrize(
     'kwargs,type_,expected_extra',

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -117,10 +117,13 @@ def test_missing_sentinel_constraints_pushdown() -> None:
 
     assert js_schema['properties']['f1'] == {'minimum': 1, 'title': 'F1', 'type': 'integer'}
     assert js_schema['properties']['f2'] == {'minimum': 1, 'title': 'F2', 'type': 'integer'}
-    # Note: 'ge' is still wrong (see https://github.com/pydantic/pydantic/issues/11576)
-    assert js_schema['properties']['f3'] == {'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'ge': 1, 'title': 'F3'}
+    assert js_schema['properties']['f3'] == {
+        'anyOf': [{'type': 'integer'}, {'type': 'string'}],
+        'minimum': 1,
+        'title': 'F3',
+    }
     assert js_schema['properties']['f4'] == {
-        'anyOf': [{'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'ge': 1}, {'type': 'null'}],
+        'anyOf': [{'anyOf': [{'type': 'integer'}, {'type': 'string'}], 'minimum': 1}, {'type': 'null'}],
         'title': 'F4',
     }
 


### PR DESCRIPTION
## Summary

When a numeric Field constraint is applied after a validator in an Annotated type, Pydantic can fall back to a validator wrapper and attach JSON Schema updates through metadata. That path used raw constraint names like lt and ge, so the generated JSON Schema could include invalid Pydantic keys instead of canonical JSON Schema keywords.

This change maps gt, ge, lt, le, and multiple_of to exclusiveMinimum, minimum, exclusiveMaximum, maximum, and multipleOf on the fallback path. Decimal schemas keep matching the direct generator path by placing the keyword on the number branch inside anyOf. Temporal constraints continue to validate at runtime, but they are not emitted as numeric JSON Schema keywords because the direct date, datetime, and timedelta schemas do not emit them either.

tests/test_missing_sentinel.py had an assertion that documented the old wrong ge output for this issue. I updated it to expect minimum now that the shared fallback path emits canonical keys.

## Tests

tests/test_json_schema.py
tests/test_missing_sentinel.py
tests/test_annotated.py
tests/test_types.py
Full test suite excluding benchmarks, mypy, plugin, and pydantic_core: 5755 passed.

Fixes #11576
