### PR TITLE
Remove `RootModel` iteration example

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -1426,30 +1426,6 @@ print(PetsByName.model_validate({'Otis': 'dog', 'Milo': 'cat'}))
 #> root={'Otis': 'dog', 'Milo': 'cat'}
 ```
 
-If you want to access items in the `root` field directly or to iterate over the items, you can implement
-custom `__iter__` and `__getitem__` functions, as shown in the following example.
-
-```python
-from pydantic import RootModel
-
-
-class Pets(RootModel):
-    root: list[str]
-
-    def __iter__(self):
-        return iter(self.root)
-
-    def __getitem__(self, item):
-        return self.root[item]
-
-
-pets = Pets.model_validate(['dog', 'cat'])
-print(pets[0])
-#> dog
-print([pet for pet in pets])
-#> ['dog', 'cat']
-```
-
 You can also create subclasses of the parametrized root model directly:
 
 ```python


### PR DESCRIPTION
## Summary

- Removed the `RootModel` example that overrides `__iter__` and `__getitem__`.
- Kept the surrounding `RootModel` examples for validation, JSON schema, and subclassing parametrized root models.

## Why

The removed example was called out in #8872 because overriding `__iter__` on a `RootModel` can be type-confusing and too specific for the main docs. A maintainer also suggested removing these examples rather than adding a type-ignore workaround.

## Validation

- `DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/opt/homebrew/opt/cairo/lib:$DYLD_FALLBACK_LIBRARY_PATH" PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/cairo/lib/pkgconfig:$PKG_CONFIG_PATH" uv run --group docs mkdocs build --strict`

Refs #8872.
