### PR TITLE
docs: note generic model pickling requirements

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -807,6 +807,11 @@ you would expect if you were to declare a distinct type for each parametrization
     Internally, Pydantic creates subclasses of the generic model at runtime when the generic model class is parametrized.
     These classes are cached, so there should be minimal overhead introduced by the use of generics models.
 
+!!! note "Pickling parametrized generic models"
+    If you need to pickle instances of a parametrized generic model, make sure the parametrized class is created
+    at module global scope. For example, evaluate or assign `Response[int]` at the module level before pickling
+    instances of that type. This lets `pickle` resolve the runtime-created class by its generated qualified name.
+
 To inherit from a generic model and preserve the fact that it is generic, the subclass must also inherit from
 [`Generic`][typing.Generic]:
 


### PR DESCRIPTION
## Change Summary

Adds a short note to the generic models docs explaining that parametrized generic model classes should be created at module global scope when their instances need to be pickled.

## Related issue number

Refs #9390

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist or are not required for this docs-only change
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## Validation

* Reproduced that parametrizing a generic model inside a function can fail to pickle.
* Reproduced that creating the parametrized generic model at module global scope allows pickling to resolve the generated class name.
* `DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:/opt/homebrew/opt/cairo/lib:$DYLD_FALLBACK_LIBRARY_PATH" PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/cairo/lib/pkgconfig:$PKG_CONFIG_PATH" uv run --group docs mkdocs build --strict`
