### PR TITLE
Fix timezone offset ignored in temporal seconds/milliseconds serialization

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -14,6 +14,7 @@ use crate::serializers::SerializationState;
 use crate::serializers::config::{FromConfig, TemporalMode};
 
 pub(crate) fn datetime_to_seconds(dt: DateTime) -> f64 {
+    // time_to_seconds applies tz_offset so aware datetimes become true POSIX timestamps.
     dt.date.timestamp() as f64 + time_to_seconds(dt.time)
 }
 
@@ -29,18 +30,31 @@ pub(crate) fn date_to_milliseconds(date: Date) -> f64 {
     date.timestamp_ms() as f64
 }
 
+/// Seconds since midnight, accounting for timezone offset when present.
+///
+/// `tz_offset` is seconds east of UTC (Python `utcoffset` convention). Subtracting
+/// it yields absolute time rather than wall-clock local time, matching
+/// `datetime.timestamp()` for aware datetimes (see pydantic#13423).
 pub(crate) fn time_to_seconds(time: Time) -> f64 {
-    f64::from(time.hour) * 3600.0
+    let mut seconds = f64::from(time.hour) * 3600.0
         + f64::from(time.minute) * 60.0
         + f64::from(time.second)
-        + f64::from(time.microsecond) / 1_000_000.0
+        + f64::from(time.microsecond) / 1_000_000.0;
+    if let Some(tz_offset) = time.tz_offset {
+        seconds -= f64::from(tz_offset);
+    }
+    seconds
 }
 
 pub(crate) fn time_to_milliseconds(time: Time) -> f64 {
-    f64::from(time.hour) * 3_600_000.0
+    let mut milliseconds = f64::from(time.hour) * 3_600_000.0
         + f64::from(time.minute) * 60_000.0
         + f64::from(time.second) * 1_000.0
-        + f64::from(time.microsecond) / 1_000.0
+        + f64::from(time.microsecond) / 1_000.0;
+    if let Some(tz_offset) = time.tz_offset {
+        milliseconds -= f64::from(tz_offset) * 1_000.0;
+    }
+    milliseconds
 }
 
 fn downcast_date_reject_datetime<'a, 'py>(py_date: &'a Bound<'py, PyAny>) -> PyResult<&'a Bound<'py, PyDate>> {

--- a/pydantic-core/tests/serializers/test_datetime.py
+++ b/pydantic-core/tests/serializers/test_datetime.py
@@ -363,3 +363,74 @@ def test_union_time_respects_downcasts_correctly():
 
     s = SchemaSerializer(core_schema.union_schema(choices=[core_schema.time_schema(), test_custom_ser_schema]))
     assert s.to_python('foo') is None
+
+
+@pytest.mark.parametrize(
+    'dt,mode,expected',
+    [
+        # EST is UTC-5: 2026-07-09T12:00:00-05:00 == 2026-07-09T17:00:00Z
+        (
+            datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5))),
+            'seconds',
+            1783616400.0,
+        ),
+        (
+            datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5))),
+            'milliseconds',
+            1783616400000.0,
+        ),
+        (
+            datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc),
+            'seconds',
+            1783598400.0,
+        ),
+        (
+            datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone(timedelta(hours=2))),
+            'seconds',
+            1783591200.0,
+        ),
+        (
+            datetime(2026, 7, 9, 12, 0, 0, 500_000, tzinfo=timezone(timedelta(hours=-5))),
+            'seconds',
+            1783616400.5,
+        ),
+        # Naive datetimes are treated as wall-clock / UTC-equivalent (unchanged).
+        (
+            datetime(2026, 7, 9, 12, 0, 0),
+            'seconds',
+            1783598400.0,
+        ),
+    ],
+)
+def test_config_datetime_applies_tz_offset(dt: datetime, mode: str, expected: float):
+    """Regression for https://github.com/pydantic/pydantic/issues/13423.
+
+    `ser_json_temporal='seconds'/'milliseconds'` must produce the true POSIX
+    timestamp for timezone-aware datetimes, not the wall-clock time treated as UTC.
+    """
+    s = SchemaSerializer(core_schema.datetime_schema(), config={'ser_json_temporal': mode})
+    assert s.to_python(dt, mode='json') == expected
+    assert float(s.to_json(dt)) == expected
+    # Also matches Python's datetime.timestamp() for aware values.
+    if dt.tzinfo is not None:
+        scale = 1.0 if mode == 'seconds' else 1000.0
+        assert s.to_python(dt, mode='json') == pytest.approx(dt.timestamp() * scale)
+
+
+@pytest.mark.parametrize(
+    't,mode,expected',
+    [
+        # 12:00 EST (UTC-5) is 17:00 UTC → 61200 seconds since midnight UTC.
+        (time(12, 0, 0, tzinfo=timezone(timedelta(hours=-5))), 'seconds', 61200.0),
+        (time(12, 0, 0, tzinfo=timezone(timedelta(hours=-5))), 'milliseconds', 61200000.0),
+        (time(12, 0, 0, tzinfo=timezone.utc), 'seconds', 43200.0),
+        (time(12, 0, 0, tzinfo=timezone(timedelta(hours=2))), 'seconds', 36000.0),
+        # Naive time is wall-clock seconds since midnight (unchanged).
+        (time(12, 0, 0), 'seconds', 43200.0),
+    ],
+)
+def test_config_time_applies_tz_offset(t: time, mode: str, expected: float):
+    """Regression for https://github.com/pydantic/pydantic/issues/13423 for `time`."""
+    s = SchemaSerializer(core_schema.time_schema(), config={'ser_json_temporal': mode})
+    assert s.to_python(t, mode='json') == expected
+    assert float(s.to_json(t)) == expected

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -742,6 +742,23 @@ def test_datetime_from_date_str():
             b'1704070861000.023',
             'milliseconds',
         ),
+        # Aware datetimes must apply tz_offset when serializing to unix timestamps
+        # (https://github.com/pydantic/pydantic/issues/13423).
+        (
+            datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5))),
+            b'1783616400.0',
+            'seconds',
+        ),
+        (
+            datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5))),
+            b'1783616400000.0',
+            'milliseconds',
+        ),
+        (
+            datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc),
+            b'1783598400.0',
+            'seconds',
+        ),
     ],
 )
 def test_config_datetime(dt: datetime, expected_to_json, mode):


### PR DESCRIPTION
## Change Summary

When serializing timezone-aware `datetime`/`time` values with `temporal_mode` / `ser_json_temporal` set to `seconds` or `milliseconds`, the timezone offset was ignored and the wall-clock time was treated as UTC. That produced incorrect unix timestamps (wrong by exactly the offset).

**Example (before):**
```python
>>> from datetime import datetime, timezone, timedelta
>>> import pydantic_core
>>> est = timezone(timedelta(hours=-5))
>>> aware = datetime(2026, 7, 9, 12, 0, 0, tzinfo=est)  # == 17:00 UTC
>>> float(pydantic_core.to_json(aware, temporal_mode="seconds"))
1783598400.0  # wrong: same as 12:00 UTC
>>> aware.timestamp()
1783616400.0  # correct
```

**Fix:** subtract `Time.tz_offset` (seconds east of UTC) when converting to float seconds/milliseconds, matching Python's `datetime.timestamp()` and speedate's `timestamp_tz()` semantics.

## Related issue number

Fixes #13423

## Prior art

- No existing open PR addresses this.
- Introduced with the `seconds`/`milliseconds` temporal modes in [pydantic-core#1743](https://github.com/pydantic/pydantic-core/pull/1743) / pydantic#12068; the conversion never applied `tz_offset`.
- Related but separate: #13422 (`timedelta_mode`/`temporal_mode` independence) is an API-design issue, not fixed here.
- #12937 (extra fields not dumped) is a different serialization complaint under design discussion; not this bug.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
