### PR TITLE
Use `object` instead of `Any` for `obj` and `context` parameters of `BaseModel` validation methods

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -721,12 +721,12 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     @classmethod
     def model_validate(
         cls,
-        obj: Any,
+        obj: object,
         *,
         strict: bool | None = None,
         extra: ExtraValues | None = None,
         from_attributes: bool | None = None,
-        context: Any | None = None,
+        context: object | None = None,
         by_alias: bool | None = None,
         by_name: bool | None = None,
     ) -> Self:
@@ -774,7 +774,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         *,
         strict: bool | None = None,
         extra: ExtraValues | None = None,
-        context: Any | None = None,
+        context: object | None = None,
         by_alias: bool | None = None,
         by_name: bool | None = None,
     ) -> Self:


### PR DESCRIPTION
Annotate `obj` and `context` as `object` instead of `Any` in `BaseModel.model_validate()`, `model_validate_json()` and `model_validate_strings()`.

`object` accepts the same arguments at call sites, but is the more precise annotation for "any value is allowed" and avoids `Any` spreading into type-checked caller code.

The `TypeAdapter.validate_*` counterparts still use `Any`; happy to align them here or in a follow-up if preferred.