### PR TITLE
Fix `__hash__` in `WithJsonSchema` and `Examples` to hash the mode value

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2744,7 +2744,7 @@ class WithJsonSchema:
             return self.json_schema.copy()
 
     def __hash__(self) -> int:
-        return hash(type(self.mode))
+        return hash(self.mode)
 
 
 class Examples:
@@ -2818,7 +2818,7 @@ class Examples:
         return json_schema
 
     def __hash__(self) -> int:
-        return hash(type(self.mode))
+        return hash(self.mode)
 
 
 def _get_all_json_refs(item: Any) -> set[JsonRef]:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5670,19 +5670,6 @@ def test_examples_annotation() -> None:
     }
 
 
-def test_with_json_schema_and_examples_hash_depends_on_mode() -> None:
-    # WithJsonSchema and Examples used to hash `type(self.mode)`, collapsing every
-    # instance into a single bucket regardless of mode (the same slip that was
-    # fixed for UuidVersion and PathType in #12827). The hash now reflects the
-    # mode value, so instances differing only by mode no longer collide.
-    val = WithJsonSchema({'type': 'integer'}, mode='validation')
-    ser = WithJsonSchema({'type': 'integer'}, mode='serialization')
-    assert hash(val) != hash(ser)
-    assert hash(val) == hash(WithJsonSchema({'type': 'integer'}, mode='validation'))
-
-    assert hash(Examples([1], mode='validation')) != hash(Examples([1], mode='serialization'))
-
-
 @pytest.mark.skip_json_schema_validation(reason='Uses old examples format, planned for removal in v3.0.')
 def test_examples_annotation_dict() -> None:
     with pytest.warns(PydanticDeprecatedSince29):

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5670,6 +5670,19 @@ def test_examples_annotation() -> None:
     }
 
 
+def test_with_json_schema_and_examples_hash_depends_on_mode() -> None:
+    # WithJsonSchema and Examples used to hash `type(self.mode)`, collapsing every
+    # instance into a single bucket regardless of mode (the same slip that was
+    # fixed for UuidVersion and PathType in #12827). The hash now reflects the
+    # mode value, so instances differing only by mode no longer collide.
+    val = WithJsonSchema({'type': 'integer'}, mode='validation')
+    ser = WithJsonSchema({'type': 'integer'}, mode='serialization')
+    assert hash(val) != hash(ser)
+    assert hash(val) == hash(WithJsonSchema({'type': 'integer'}, mode='validation'))
+
+    assert hash(Examples([1], mode='validation')) != hash(Examples([1], mode='serialization'))
+
+
 @pytest.mark.skip_json_schema_validation(reason='Uses old examples format, planned for removal in v3.0.')
 def test_examples_annotation_dict() -> None:
     with pytest.warns(PydanticDeprecatedSince29):


### PR DESCRIPTION
## Change Summary

`WithJsonSchema.__hash__` and `Examples.__hash__` in `pydantic/json_schema.py` were both implemented as:

```python
def __hash__(self) -> int:
    return hash(type(self.mode))
```

`self.mode` is `Literal['validation', 'serialization'] | None`, so `hash(type(self.mode))` hashes the *type* (`str` or `NoneType`) rather than the value. Every instance with a string mode collapses into the same hash bucket regardless of whether it is `'validation'` or `'serialization'`:

```python
>>> from pydantic.json_schema import WithJsonSchema
>>> a = WithJsonSchema({'type': 'integer'}, mode='validation')
>>> b = WithJsonSchema({'type': 'integer'}, mode='serialization')
>>> a == b, hash(a) == hash(b)
(False, True)
```

This is the same slip that was fixed for `UuidVersion` and `PathType` in #12827 — these two `json_schema.py` annotations were missed. This changes both to `hash(self.mode)`, mirroring that fix (the non-hashable `json_schema` / `examples` fields stay out of the hash, exactly as before).

## Related issue number

Follow-up to #12827 (same `hash(type(...))` mistake in the sibling annotations). No open issue — found while reading that commit.

## Checklist

* [x] The pull request title is a good summary of the changes.
* [x] Code style is correct (`ruff` check and format are clean).
* [x] A regression test is added: `tests/test_json_schema.py::test_with_json_schema_and_examples_hash_depends_on_mode`.
