### PR TITLE
Improve JSON schema generation for timedelta

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -860,9 +860,47 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        if self._config.ser_json_timedelta == 'float':
-            return {'type': 'number'}
-        return {'type': 'string', 'format': 'duration'}
+        json_schema_float = {'type': 'number', 'format': 'duration'}
+        json_schema_iso = {
+            'type': 'string', 
+            'format': 'duration',
+            'pattern': r'^[+-]?P(?:(?:\d+Y)?(?:\d+M)?(?:\d+D)?(?:T(?=.)(?:\d+H)?(?:\d+M)?(?:\d+(?:\.\d+)?S)?)?|\d+W)$',
+            }
+        json_schema_string = {
+            'type': 'string',
+            'format': 'duration',
+            'pattern': r'^[+-]?(?:(?:\d+:)?(?:[0-5]?\d):)?(?:[0-5]?\d)(?:\.\d{1,3})?$',
+
+        }
+        json_schema_string_prefix = {
+            'type': 'string', 
+            'format': 'duration',
+            'pattern': r'^[+-]?(?:\d+\s*,?\s*[Dd](?:[Aa][Yy][Ss])?\s*,?\s*)?\d{1,2}:[0-5]\d:[0-5]\d(?:\.\d{1,3})?$',
+            }
+        le = schema.get('le')
+        ge = schema.get('ge')
+        lt = schema.get('lt')
+        gt = schema.get('gt')
+        self.update_with_validations(
+            json_schema_float,  
+            core_schema.float_schema(
+            le=None if le is None else le.total_seconds(),
+            ge=None if ge is None else ge.total_seconds(),
+            lt=None if lt is None else lt.total_seconds(),
+            gt=None if gt is None else gt.total_seconds(),
+        ), self.ValidationsMapping.numeric)
+        if not json_schema_float.get('description'):
+            json_schema_float['description'] = 'Duration in seconds.'
+        if not json_schema_iso.get('description'):
+            json_schema_iso['description'] = 'Duration in ISO 8601.'
+        if self.mode == 'serialization': 
+            if self._config.ser_json_timedelta == 'float':
+                return json_schema_float
+            return json_schema_iso
+        else:
+            return {
+                'description': 'Duration in seconds or ISO 8601 duration string.',
+                'anyOf': [json_schema_float, json_schema_iso, json_schema_string, json_schema_string_prefix]}
 
     def literal_schema(self, schema: core_schema.LiteralSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a literal value.

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -814,7 +814,33 @@ def test_list_union_dict(field_type, expected_schema):
         (datetime, {'type': 'string', 'format': 'date-time'}),
         (date, {'type': 'string', 'format': 'date'}),
         (time, {'type': 'string', 'format': 'time'}),
-        (timedelta, {'type': 'string', 'format': 'duration'}),
+        (timedelta, {'anyOf': 
+            [
+                {
+                    'description': 'Duration in seconds.', 
+                    'format': 'duration', 
+                    'type': 'number'
+                }, 
+                {
+                    'description': 'Duration in ISO 8601.', 
+                    'format': 'duration', 
+                    'pattern': r'^[+-]?P(?:(?:\d+Y)?(?:\d+M)?(?:\d+D)?(?:T(?=.)(?:\d+H)?(?:\d+M)?(?:\d+(?:\.\d+)?S)?)?|\d+W)$', 
+                    'type': 'string'
+                }, 
+                {
+                    'format': 'duration', 
+                    'pattern': r'^[+-]?(?:(?:\d+:)?(?:[0-5]?\d):)?(?:[0-5]?\d)(?:\.\d{1,3})?$', 
+                    'type': 'string'
+                }, 
+                {
+                    'format': 'duration', 
+                    'pattern': r'^[+-]?(?:\d+\s*,?\s*[Dd](?:[Aa][Yy][Ss])?\s*,?\s*)?\d{1,2}:[0-5]\d:[0-5]\d(?:\.\d{1,3})?$', 
+                    'type': 'string'
+                }
+            ], 
+            'description': 'Duration in seconds or ISO 8601 duration string.'
+        }
+        )
     ],
 )
 def test_date_types(field_type, expected_schema):
@@ -1847,12 +1873,28 @@ def test_model_default():
         'type': 'object',
     }
 
-
 @pytest.mark.parametrize(
     'ser_json_timedelta,properties',
     [
-        ('float', {'duration': {'default': 300.0, 'title': 'Duration', 'type': 'number'}}),
-        ('iso8601', {'duration': {'default': 'PT5M', 'format': 'duration', 'title': 'Duration', 'type': 'string'}}),
+        ('float', {
+            'duration': {
+                'default': 300.0, 
+                'description': 'Duration in seconds.', 
+                'title': 'Duration', 
+                'type': 'number',
+                'format': 'duration',
+            }},
+        ),
+        ('iso8601', {
+            'duration': {
+                'default': 'PT5M', 
+                'description': 'Duration in ISO 8601.', 
+                'title': 'Duration', 
+                'type': 'string',
+                'format': 'duration',
+                'pattern': r'^[+-]?P(?:(?:\d+Y)?(?:\d+M)?(?:\d+D)?(?:T(?=.)(?:\d+H)?(?:\d+M)?(?:\d+(?:\.\d+)?S)?)?|\d+W)$',
+            }}, 
+        )
     ],
 )
 def test_model_default_timedelta(ser_json_timedelta: Literal['float', 'iso8601'], properties: dict[str, Any]):
@@ -1893,8 +1935,18 @@ def test_model_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], properti
 @pytest.mark.parametrize(
     'ser_json_timedelta,properties',
     [
-        ('float', {'duration': {'default': 300.0, 'title': 'Duration', 'type': 'number'}}),
-        ('iso8601', {'duration': {'default': 'PT5M', 'format': 'duration', 'title': 'Duration', 'type': 'string'}}),
+        ('float', {'duration': {'default': 300.0, 'description': 'Duration in seconds.', 'format': 'duration', 'title': 'Duration', 'type': 'number'}}),
+        ('iso8601', {
+            'duration': {
+                'default': 'PT5M', 
+                'description': 'Duration in ISO 8601.', 
+                'format': 'duration',
+                'pattern': r'^[+-]?P(?:(?:\d+Y)?(?:\d+M)?(?:\d+D)?(?:T(?=.)(?:\d+H)?(?:\d+M)?(?:\d+(?:\.\d+)?S)?)?|\d+W)$', 
+                'title': 'Duration', 
+                'type': 'string',
+            }
+        }
+        ),
     ],
 )
 def test_dataclass_default_timedelta(ser_json_timedelta: Literal['float', 'iso8601'], properties: dict[str, Any]):
@@ -1933,8 +1985,18 @@ def test_dataclass_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], prop
 @pytest.mark.parametrize(
     'ser_json_timedelta,properties',
     [
-        ('float', {'duration': {'default': 300.0, 'title': 'Duration', 'type': 'number'}}),
-        ('iso8601', {'duration': {'default': 'PT5M', 'format': 'duration', 'title': 'Duration', 'type': 'string'}}),
+        ('float', {'duration': {'default': 300.0, 'description': 'Duration in seconds.', 'format': 'duration', 'title': 'Duration', 'type': 'number'}}),
+        ('iso8601', {
+            'duration': {
+                'default': 'PT5M', 
+                'description': 'Duration in ISO 8601.', 
+                'format': 'duration',
+                'pattern': r'^[+-]?P(?:(?:\d+Y)?(?:\d+M)?(?:\d+D)?(?:T(?=.)(?:\d+H)?(?:\d+M)?(?:\d+(?:\.\d+)?S)?)?|\d+W)$', 
+                'title': 'Duration', 
+                'type': 'string'
+            }
+        }
+        ),
     ],
 )
 def test_typeddict_default_timedelta(ser_json_timedelta: Literal['float', 'iso8601'], properties: dict[str, Any]):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
add new types of 'duration formats' to 'json_schema',  in 'validation mode' json schema consists of 'anyOf' shemas


in serialization mode, the schema still depends on `ser_json_timedelta` (`float` or `iso8601`).

<!-- Please give a short summary of the changes. -->

## Related issue number
Fixes #13360

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
