### PR TITLE
Fix aware datetime numeric serialization #13423

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -13,12 +13,15 @@ use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 use crate::serializers::config::{FromConfig, TemporalMode};
 
+const MILLISECONDS_PER_SECOND: f64 = 1_000.0;
+
 pub(crate) fn datetime_to_seconds(dt: DateTime) -> f64 {
-    dt.date.timestamp() as f64 + time_to_seconds(dt.time)
+    dt.date.timestamp() as f64 + time_to_seconds(dt.time) - f64::from(dt.time.tz_offset.unwrap_or(0))
 }
 
 pub(crate) fn datetime_to_milliseconds(dt: DateTime) -> f64 {
     dt.date.timestamp_ms() as f64 + time_to_milliseconds(dt.time)
+        - f64::from(dt.time.tz_offset.unwrap_or(0)) * MILLISECONDS_PER_SECOND
 }
 
 pub(crate) fn date_to_seconds(date: Date) -> f64 {

--- a/pydantic-core/tests/serializers/test_datetime.py
+++ b/pydantic-core/tests/serializers/test_datetime.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, time, timedelta, timezone
 
 import pytest
 
-from pydantic_core import SchemaSerializer, core_schema
+from pydantic_core import SchemaSerializer, core_schema, to_json
 
 
 def test_datetime():
@@ -192,6 +192,24 @@ def test_config_datetime(
         ),
     ):
         assert s.to_json({dt: 'foo'}) == expected_to_json_dict
+
+
+@pytest.mark.parametrize('mode, multiplier', [('seconds', 1), ('milliseconds', 1_000)])
+@pytest.mark.parametrize(
+    'dt',
+    [
+        datetime(2024, 1, 1, 12, tzinfo=timezone.utc),
+        datetime(2024, 1, 1, 12, 0, 0, 123_456, tzinfo=tz(hours=-5)),
+        datetime(2024, 1, 1, 0, 30, tzinfo=tz(hours=2)),
+    ],
+)
+def test_aware_datetime_numeric_serialization_uses_utc_timestamp(dt: datetime, mode: str, multiplier: int):
+    expected = dt.timestamp() * multiplier
+    serializer = SchemaSerializer(core_schema.datetime_schema(), config={'ser_json_temporal': mode})
+
+    assert float(to_json(dt, temporal_mode=mode)) == expected
+    assert serializer.to_python(dt, mode='json') == expected
+    assert float(serializer.to_json(dt)) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -753,6 +753,23 @@ def test_config_datetime(dt: datetime, expected_to_json, mode):
     assert ta.dump_json(instance) == expected_to_json
 
 
+@pytest.mark.parametrize('mode, multiplier', [('seconds', 1), ('milliseconds', 1_000)])
+@pytest.mark.parametrize(
+    'dt',
+    [
+        datetime(2024, 1, 1, 12, tzinfo=timezone.utc),
+        datetime(2024, 1, 1, 12, 0, 0, 123_456, tzinfo=timezone(timedelta(hours=-5))),
+        datetime(2024, 1, 1, 0, 30, tzinfo=timezone(timedelta(hours=2))),
+    ],
+)
+def test_config_aware_datetime_numeric_serialization_uses_utc_timestamp(
+    dt: datetime, mode: str, multiplier: int
+):
+    ta = TypeAdapter(datetime, config={'ser_json_temporal': mode})
+
+    assert float(ta.dump_json(dt)) == dt.timestamp() * multiplier
+
+
 @pytest.mark.parametrize(
     'dt,expected_to_json,mode',
     [


### PR DESCRIPTION
fix #13423 

This pull request improves the handling and testing of timezone-aware datetime serialization, ensuring that numeric serialization (to seconds or milliseconds) always uses the UTC timestamp. The main changes include corrections to the serialization logic and the addition of comprehensive tests to verify correct UTC-based output for various timezones and modes.

**Datetime serialization logic improvements:**

* Fixed the `datetime_to_seconds` and `datetime_to_milliseconds` functions in `datetime_etc.rs` to properly adjust for timezone offsets, ensuring that numeric serialization always uses UTC timestamps.

**Testing enhancements:**

* Added new parameterized tests in `test_datetime.py` and `tests/test_datetime.py` to verify that timezone-aware datetime objects are serialized to their correct UTC numeric representations in both seconds and milliseconds modes. [[1]](diffhunk://#diff-606d75258351c623832b3b892d01b3ef1e702de23bb902ffede3f5b7afd6a707R197-R214) [[2]](diffhunk://#diff-065ff88740a4a42f629dec5199a2207d52a80028c9c9ab01b932b3a7d7241a93R756-R772)
* Updated imports in `test_datetime.py` to include `to_json` for direct serialization testing.