### PR TITLE
Fix pre-commit installation command in contributor guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,11 +73,11 @@ git clone git@github.com:<your username>/pydantic.git
 cd pydantic
 
 # Install UV and pre-commit
-# We use pipx here, for other options see:
+# We use uv here, for other options see:
 # https://docs.astral.sh/uv/getting-started/installation/
 # https://pre-commit.com/#install
 curl -LsSf https://astral.sh/uv/install.sh | sh
-uvx install pre-commit
+uv tool install pre-commit
 
 # Install pydantic, dependencies, test dependencies and doc dependencies
 make install


### PR DESCRIPTION
## Summary

Correct the pre-commit installation command in the contributor setup guide.

## Why this helps

The documented `uvx install pre-commit` command treats `install` as a package command rather than a uv subcommand, so new contributors cannot use it to install pre-commit. The corrected command uses uv’s tool installation interface.

## Changes made

- Replace `uvx install pre-commit` with `uv tool install pre-commit`.
- Correct the adjacent comment to say the setup uses uv rather than pipx.

## Testing

- `uv tool install --help`
- `uvx pre-commit run --files docs/contributing.md`
- `git diff --check`

## Related issue

No related issue; this is a focused documentation correction.