### PR TITLE
Do not ignore timezone offset when using `'seconds'/'milliseconds'` `temporal_mode`

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -14,11 +14,11 @@ use crate::serializers::SerializationState;
 use crate::serializers::config::{FromConfig, TemporalMode};
 
 pub(crate) fn datetime_to_seconds(dt: DateTime) -> f64 {
-    dt.date.timestamp() as f64 + time_to_seconds(dt.time)
+    dt.timestamp_tz() as f64 + f64::from(dt.time.microsecond) / 1_000_000.0
 }
 
 pub(crate) fn datetime_to_milliseconds(dt: DateTime) -> f64 {
-    dt.date.timestamp_ms() as f64 + time_to_milliseconds(dt.time)
+    dt.timestamp_tz() as f64 * 1_000.0 + f64::from(dt.time.microsecond) / 1_000.0
 }
 
 pub(crate) fn date_to_seconds(date: Date) -> f64 {

--- a/pydantic-core/tests/serializers/test_datetime.py
+++ b/pydantic-core/tests/serializers/test_datetime.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, time, timedelta, timezone
+from typing import Literal
 
 import pytest
 
@@ -192,6 +193,62 @@ def test_config_datetime(
         ),
     ):
         assert s.to_json({dt: 'foo'}) == expected_to_json_dict
+
+
+@pytest.mark.parametrize(
+    ['dt', 'expected', 'expected_json', 'expected_key', 'mode'],
+    [
+        (datetime(2026, 1, 1, tzinfo=timezone.utc), 1767225600.0, b'1767225600.0', '1767225600', 'seconds'),
+        (
+            datetime(2026, 1, 1, tzinfo=timezone.utc),
+            1767225600000.0,
+            b'1767225600000.0',
+            '1767225600000',
+            'milliseconds',
+        ),
+        (datetime(2026, 1, 1, tzinfo=tz(hours=-5)), 1767243600.0, b'1767243600.0', '1767243600', 'seconds'),
+        (
+            datetime(2026, 1, 1, tzinfo=tz(hours=-5)),
+            1767243600000.0,
+            b'1767243600000.0',
+            '1767243600000',
+            'milliseconds',
+        ),
+        (datetime(2026, 1, 1, tzinfo=tz(hours=2, minutes=30)), 1767216600.0, b'1767216600.0', '1767216600', 'seconds'),
+        (
+            datetime(2026, 1, 1, 1, 1, 1, 23, tzinfo=tz(hours=-5)),
+            1767247261.000023,
+            b'1767247261.000023',
+            '1767247261.000023',
+            'seconds',
+        ),
+        (
+            datetime(2026, 1, 1, 1, 1, 1, 23, tzinfo=tz(hours=-5)),
+            1767247261000.023,
+            b'1767247261000.023',
+            '1767247261000.023',
+            'milliseconds',
+        ),
+    ],
+)
+def test_config_datetime_tz_aware(
+    dt: datetime, expected: float, expected_json: bytes, expected_key: str, mode: Literal['seconds', 'milliseconds']
+):
+    """https://github.com/pydantic/pydantic/issues/13423"""
+    if mode == 'seconds':
+        assert expected == dt.timestamp()
+
+    s = SchemaSerializer(core_schema.datetime_schema(), config={'ser_json_temporal': mode})
+    assert s.to_python(dt) == dt
+    assert s.to_python(dt, mode='json') == expected
+    assert s.to_json(dt) == expected_json
+
+    key_s = SchemaSerializer(
+        core_schema.dict_schema(core_schema.datetime_schema(), core_schema.str_schema()),
+        config={'ser_json_temporal': mode},
+    )
+    assert key_s.to_python({dt: 'foo'}, mode='json') == {expected_key: 'foo'}
+    assert key_s.to_json({dt: 'foo'}) == f'{{"{expected_key}":"foo"}}'.encode()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13423.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
