### PR TITLE
Make model rebuilding logic thread safe

### DIFF
--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -330,9 +330,13 @@ def rebuild_dataclass(
         return None
 
     for attr in ('__pydantic_core_schema__', '__pydantic_validator__', '__pydantic_serializer__'):
-        if attr in cls.__dict__ and not isinstance(getattr(cls, attr), _mock_val_ser.MockValSer):
+        if attr in cls.__dict__ and not isinstance(
+            getattr(cls, attr), (_mock_val_ser.MockCoreSchema, _mock_val_ser.MockValSer)
+        ):
             # Deleting the validator/serializer is necessary as otherwise they can get reused in
             # pydantic-core. Same applies for the core schema that can be reused in schema generation.
+            # We do so only if they aren't mock instances, otherwise concurrent reads of these attributes
+            # (e.g. when instantiating the dataclass in another thread) can resolve them from the parent class.
             delattr(cls, attr)
 
     cls.__pydantic_complete__ = False

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -8,6 +8,7 @@ from __future__ import annotations as _annotations
 
 import operator
 import sys
+import threading
 import types
 import warnings
 from collections.abc import Generator, Mapping
@@ -77,6 +78,14 @@ TupleGenerator: TypeAlias = Generator[tuple[str, Any], None, None]
 IncEx: TypeAlias = set[int] | set[str] | Mapping[int, Union['IncEx', bool]] | Mapping[str, Union['IncEx', bool]]
 
 _object_setattr = _model_construction.object_setattr
+
+# Rebuilding a model isn't thread-safe (the class attributes are mutated during the rebuild,
+# while other threads may be reading them to perform validation/serialization), so `model_rebuild()`
+# calls are serialized using this lock. The lock is reentrant, as rebuilding a model can trigger the
+# rebuild of another one (e.g. when a generic origin is rebuilt during parametrization in
+# `__class_getitem__()`). For the same reason, the lock is global and not per-class: two threads
+# holding their own class's lock could otherwise request the other's and deadlock.
+_rebuild_lock = threading.RLock()
 
 
 def _check_frozen(model_cls: type[BaseModel], name: str, value: Any) -> None:
@@ -681,42 +690,52 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             Returns `None` if the schema is already "complete" and rebuilding was not required.
             If rebuilding _was_ required, returns `True` if rebuilding was successful, otherwise `False`.
         """
-        already_complete = cls.__pydantic_complete__
-        if already_complete and not force:
+        # As the rebuild lock is global (not per model class), avoid needlessly holding it if the model is
+        # already complete:
+        if cls.__pydantic_complete__ and not force:
             return None
 
-        cls.__pydantic_complete__ = False
+        with _rebuild_lock:
+            # Re-check inside the lock, as another thread may have rebuilt the model while we were waiting:
+            already_complete = cls.__pydantic_complete__
+            if already_complete and not force:
+                return None
 
-        for attr in ('__pydantic_core_schema__', '__pydantic_validator__', '__pydantic_serializer__'):
-            if attr in cls.__dict__ and not isinstance(getattr(cls, attr), _mock_val_ser.MockValSer):
-                # Deleting the validator/serializer is necessary as otherwise they can get reused in
-                # pydantic-core. We do so only if they aren't mock instances, otherwise — as `model_rebuild()`
-                # isn't thread-safe — concurrent model instantiations can lead to the parent validator being used.
-                # Same applies for the core schema that can be reused in schema generation.
-                delattr(cls, attr)
+            cls.__pydantic_complete__ = False
 
-        if _types_namespace is not None:
-            rebuild_ns = _types_namespace
-        elif _parent_namespace_depth > 0:
-            rebuild_ns = _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth, force=True) or {}
-        else:
-            rebuild_ns = {}
+            for attr in ('__pydantic_core_schema__', '__pydantic_validator__', '__pydantic_serializer__'):
+                if attr in cls.__dict__ and not isinstance(getattr(cls, attr), _mock_val_ser.MockValSer):
+                    # Deleting the validator/serializer is necessary as otherwise they can get reused in
+                    # pydantic-core. We do so only if they aren't mock instances, otherwise concurrent model
+                    # instantiations — which read these attributes without holding the rebuild lock — can
+                    # lead to the parent validator being used. Same applies for the core schema that can be
+                    # reused in schema generation.
+                    delattr(cls, attr)
 
-        parent_ns = _model_construction.unpack_lenient_weakvaluedict(cls.__pydantic_parent_namespace__) or {}
+            if _types_namespace is not None:
+                rebuild_ns = _types_namespace
+            elif _parent_namespace_depth > 0:
+                rebuild_ns = (
+                    _typing_extra.parent_frame_namespace(parent_depth=_parent_namespace_depth, force=True) or {}
+                )
+            else:
+                rebuild_ns = {}
 
-        ns_resolver = _namespace_utils.NsResolver(
-            parent_namespace={**rebuild_ns, **parent_ns},
-        )
+            parent_ns = _model_construction.unpack_lenient_weakvaluedict(cls.__pydantic_parent_namespace__) or {}
 
-        return _model_construction.complete_model_class(
-            cls,
-            _config.ConfigWrapper(cls.model_config, check=False),
-            ns_resolver,
-            raise_errors=raise_errors,
-            # If the model was already complete, we don't need to call the hook again.
-            call_on_complete_hook=not already_complete,
-            is_force_rebuild=force,
-        )
+            ns_resolver = _namespace_utils.NsResolver(
+                parent_namespace={**rebuild_ns, **parent_ns},
+            )
+
+            return _model_construction.complete_model_class(
+                cls,
+                _config.ConfigWrapper(cls.model_config, check=False),
+                ns_resolver,
+                raise_errors=raise_errors,
+                # If the model was already complete, we don't need to call the hook again.
+                call_on_complete_hook=not already_complete,
+                is_force_rebuild=force,
+            )
 
     @classmethod
     def model_validate(

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -704,12 +704,14 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             cls.__pydantic_complete__ = False
 
             for attr in ('__pydantic_core_schema__', '__pydantic_validator__', '__pydantic_serializer__'):
-                if attr in cls.__dict__ and not isinstance(getattr(cls, attr), _mock_val_ser.MockValSer):
+                if attr in cls.__dict__ and not isinstance(
+                    getattr(cls, attr), (_mock_val_ser.MockCoreSchema, _mock_val_ser.MockValSer)
+                ):
                     # Deleting the validator/serializer is necessary as otherwise they can get reused in
-                    # pydantic-core. We do so only if they aren't mock instances, otherwise concurrent model
-                    # instantiations — which read these attributes without holding the rebuild lock — can
-                    # lead to the parent validator being used. Same applies for the core schema that can be
-                    # reused in schema generation.
+                    # pydantic-core. Same applies for the core schema that can be reused in schema generation.
+                    # We do so only if they aren't mock instances, otherwise concurrent reads of these attributes
+                    # — performed without holding the rebuild lock (e.g. when instantiating the model) — can
+                    # resolve them from the parent class.
                     delattr(cls, attr)
 
             if _types_namespace is not None:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -79,13 +79,17 @@ IncEx: TypeAlias = set[int] | set[str] | Mapping[int, Union['IncEx', bool]] | Ma
 
 _object_setattr = _model_construction.object_setattr
 
-# Rebuilding a model isn't thread-safe (the class attributes are mutated during the rebuild,
-# while other threads may be reading them to perform validation/serialization), so `model_rebuild()`
-# calls are serialized using this lock. The lock is reentrant, as rebuilding a model can trigger the
-# rebuild of another one (e.g. when a generic origin is rebuilt during parametrization in
-# `__class_getitem__()`). For the same reason, the lock is global and not per-class: two threads
-# holding their own class's lock could otherwise request the other's and deadlock.
 _rebuild_lock = threading.RLock()
+"""
+A lock used to make model rebuilds thread-safe when first instantiating an incomplete model.
+
+Rebuilding a model isn't thread-safe (the class attributes are mutated during the rebuild,
+while other threads may be reading them to perform validation/serialization), so `model_rebuild()`
+calls are serialized using this lock. The lock is reentrant, as rebuilding a model can trigger the
+rebuild of another one (e.g. when a generic origin is rebuilt during parametrization in
+`__class_getitem__()`). For the same reason, the lock is global and not per-class: two threads
+holding their own class's lock could otherwise request the other's and deadlock.
+"""
 
 
 def _check_frozen(model_cls: type[BaseModel], name: str, value: Any) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2589,8 +2589,11 @@ def test_model_rebuild_already_rebuilt_by_other_thread():
     assert not Model.__pydantic_complete__
 
     results: dict[str, bool | None] = {}
+    t2_started = threading.Event()
 
     def rebuild(key: str) -> None:
+        if key == 't2':
+            t2_started.set()
         results[key] = Model.model_rebuild(_types_namespace={'Gate': Gate})
 
     # The first thread acquires the rebuild lock and waits in schema generation:
@@ -2602,9 +2605,9 @@ def test_model_rebuild_already_rebuilt_by_other_thread():
     # so the second thread is guaranteed to pass the unlocked completeness check and block on the lock:
     t2 = threading.Thread(target=rebuild, args=('t2',), daemon=True)
     t2.start()
-    # Give the second thread time to pass the unlocked completeness check and block on the
-    # lock, so that the *locked* completeness recheck is the early return taken:
-    time.sleep(0.1)
+    assert t2_started.wait(timeout=10)
+    assert t2.is_alive()
+    assert 't2' not in results
 
     resume_schema_gen.set()
     t1.join(timeout=10)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,8 @@ import json
 import platform
 import re
 import sys
+import threading
+import time
 import typing
 import warnings
 from collections import defaultdict
@@ -2539,6 +2541,80 @@ def test_model_rebuild_localns():
 
     with pytest.raises(PydanticUndefinedAnnotation, match="name 'Model' is not defined"):
         C.model_rebuild(_types_namespace={'A': A})
+
+
+@pytest.mark.timeout(5)
+def test_model_rebuild_nested_during_parametrization():
+    T = TypeVar('T')
+
+    class Model(BaseModel):
+        b: Optional['Box[Leaf]'] = None
+
+    class Box(BaseModel, Generic[T]):
+        leaf: Optional['Leaf'] = None
+
+    class Leaf(BaseModel):
+        x: int = 0
+
+    assert not Model.__pydantic_complete__
+    assert not Box.__pydantic_complete__
+
+    # Rebuilding `Model` evaluates `Box[Leaf]`, and `__class_getitem__` then calls
+    # `Box.model_rebuild()` on the same thread. Any locking added to the rebuild logic
+    # must support this reentrancy:
+    m = Model(b={'leaf': {'x': 1}})
+    assert m.b.leaf.x == 1
+    assert Model.__pydantic_complete__
+
+
+def test_model_rebuild_already_rebuilt_by_other_thread():
+    schema_gen_entered = threading.Event()
+    resume_schema_gen = threading.Event()
+    hook_calls: list[type] = []
+
+    class Model(BaseModel):
+        x: 'Gate'
+
+        @classmethod
+        def __pydantic_on_complete__(cls) -> None:
+            hook_calls.append(cls)
+
+    class Gate:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type, handler):
+            schema_gen_entered.set()
+            resume_schema_gen.wait(timeout=10)
+            return core_schema.int_schema()
+
+    assert not Model.__pydantic_complete__
+
+    results: dict[str, bool | None] = {}
+
+    def rebuild(key: str) -> None:
+        results[key] = Model.model_rebuild(_types_namespace={'Gate': Gate})
+
+    # The first thread acquires the rebuild lock and waits in schema generation:
+    t1 = threading.Thread(target=rebuild, args=('t1',), daemon=True)
+    t1.start()
+    assert schema_gen_entered.wait(timeout=10)
+
+    # While the first thread is waiting on `resume_schema_gen`, `Model` can't become complete,
+    # so the second thread is guaranteed to pass the unlocked completeness check and block on the lock:
+    t2 = threading.Thread(target=rebuild, args=('t2',), daemon=True)
+    t2.start()
+    # Give the second thread time to pass the unlocked completeness check and block on the
+    # lock, so that the *locked* completeness recheck is the early return taken:
+    time.sleep(0.1)
+
+    resume_schema_gen.set()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+    assert not t1.is_alive()
+    assert not t2.is_alive()
+
+    assert results == {'t1': True, 't2': None}
+    assert hook_calls == [Model]
+    assert Model(x=1).x == 1
 
 
 def test_model_rebuild_zero_depth():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2566,6 +2566,7 @@ def test_model_rebuild_nested_during_parametrization():
     assert Model.__pydantic_complete__
 
 
+@pytest.mark.skipif(sys.platform == 'emscripten', reason='no threading on emscripten')
 def test_model_rebuild_already_rebuilt_by_other_thread():
     schema_gen_entered = threading.Event()
     resume_schema_gen = threading.Event()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,6 @@ import platform
 import re
 import sys
 import threading
-import time
 import typing
 import warnings
 from collections import defaultdict


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Revival of https://github.com/pydantic/pydantic/pull/11851, to fix https://github.com/pydantic/pydantic/issues/13419.

iirc, in https://github.com/pydantic/pydantic/pull/11851 I had to put the lock on every path instantiating models (e.g. `BaseModel.__init__()`) because without https://github.com/pydantic/pydantic/pull/11890 -- the alternative implementation to this revived PR -- concurrent instantiation attempts would result in parent validators being used. This is now safe to lock directly inside `model_rebuild()`.

To prevent race conditions on the core schema, I also included `MockCoreSchema` in the `isinstance()` check, which was probably missed in https://github.com/pydantic/pydantic/pull/11890.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
