### PR TITLE
docs: expand guidance on troubleshooting validation failures in production

### DIFF
--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -184,6 +184,26 @@ print(Model.model_config)
 
     [MRO]: https://docs.python.org/3/glossary.html#term-method-resolution-order
 
+## Plugin settings
+
+The [`plugin_settings`][pydantic.ConfigDict.plugin_settings] configuration value passes options to
+Pydantic plugins — code that hooks into validation, usually for tooling that observes it rather than for
+changing validation behaviour. Its value is a dictionary keyed by plugin name, so a given plugin reads
+only its own entry.
+
+The main plugin in use today is [Logfire](../integrations/logfire.md)'s, which records validations for
+observability. You can tune what it records per model — for instance, recording only failures for one
+particular model:
+
+```python {test="skip"}
+from pydantic import BaseModel
+
+
+class User(BaseModel, plugin_settings={'logfire': {'record': 'failure'}}):
+    name: str
+    email: str
+```
+
 ## Configuration propagation
 
 When using types that support configuration as field annotations, configuration may not be propagated:

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -187,15 +187,15 @@ print(Model.model_config)
 ## Plugin settings
 
 The [`plugin_settings`][pydantic.ConfigDict.plugin_settings] configuration value passes options to
-Pydantic plugins — code that hooks into validation, usually for tooling that observes it rather than for
-changing validation behaviour. Its value is a dictionary keyed by plugin name, so a given plugin reads
+Pydantic plugins (code that hooks into validation, usually for tooling that observes it rather than for
+changing validation behaviour). Its value is a dictionary keyed by plugin name, so a given plugin reads
 only its own entry.
 
 The main plugin in use today is [Logfire](../integrations/logfire.md)'s, which records validations for
-observability. You can tune what it records per model — for instance, recording only failures for one
+observability. You can tune what it records per model, for instance recording only failures for one
 particular model:
 
-```python {test="skip"}
+```python
 from pydantic import BaseModel
 
 

--- a/docs/concepts/dataclasses.md
+++ b/docs/concepts/dataclasses.md
@@ -218,6 +218,10 @@ except pydantic.ValidationError as e:
     """
 ```
 
+Because a Pydantic dataclass validates its inputs just like a model, the same observability applies: if
+you use [Logfire](../integrations/logfire.md), validations of Pydantic dataclasses are
+[recorded alongside model validations](../errors/troubleshooting.md), input included.
+
 The decorator can also be applied directly on a stdlib dataclass, in which case a new subclass will be created:
 
 ```python

--- a/docs/concepts/experimental.md
+++ b/docs/concepts/experimental.md
@@ -146,8 +146,8 @@ Partial validation allows you to validate an incomplete JSON string, or a Python
 Partial validation is particularly helpful when processing the output of an LLM, where the model streams structured responses, and you may wish to begin validating the stream while you're still receiving data (e.g. to show partial data to users).
 
 Streaming pipelines like this can be fiddly to debug after the fact. If you run one in production,
-[Logfire](../integrations/logfire.md) records each validation in the context of the surrounding request,
-which makes it easier to reconstruct how a given stream was handled.
+[Logfire](../integrations/logfire.md) can record each validation in the context of the surrounding
+request, which makes it easier to reconstruct how a given stream was handled.
 
 !!! warning
     Partial validation is an experimental feature and may change in future versions of Pydantic. The current implementation should be considered a proof of concept at this time and has a number of [limitations](#limitations-of-partial-validation).

--- a/docs/concepts/experimental.md
+++ b/docs/concepts/experimental.md
@@ -145,6 +145,10 @@ Partial validation allows you to validate an incomplete JSON string, or a Python
 
 Partial validation is particularly helpful when processing the output of an LLM, where the model streams structured responses, and you may wish to begin validating the stream while you're still receiving data (e.g. to show partial data to users).
 
+Streaming pipelines like this can be fiddly to debug after the fact. If you run one in production,
+[Logfire](../integrations/logfire.md) records each validation in the context of the surrounding request,
+which makes it easier to reconstruct how a given stream was handled.
+
 !!! warning
     Partial validation is an experimental feature and may change in future versions of Pydantic. The current implementation should be considered a proof of concept at this time and has a number of [limitations](#limitations-of-partial-validation).
 

--- a/docs/concepts/json.md
+++ b/docs/concepts/json.md
@@ -95,6 +95,11 @@ print(dog_dict)
     This feature is particularly beneficial for validating LLM outputs.
     We've written some blog posts about this topic, which you can find on [our website](https://pydantic.dev/articles).
 
+    Even carefully prompted models produce output that fails validation some fraction of the time. If
+    you're validating LLM output in production, [Logfire](../integrations/logfire.md) can record just
+    the failures (`logfire.instrument_pydantic(record='failure')`), so you can see which generations
+    didn't match your schema, and why.
+
 In future versions of Pydantic, we expect to expand support for this feature through either Pydantic's other JSON validation functions
 ([`pydantic.main.BaseModel.model_validate_json`][pydantic.main.BaseModel.model_validate_json] and
 [`pydantic.type_adapter.TypeAdapter.validate_json`][pydantic.type_adapter.TypeAdapter.validate_json]) or model configuration. Stay tuned 🚀!

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -557,6 +557,12 @@ except ValidationError as e:
     """
 ```
 
+In an example like this one, the offending `data` is right there in the code. In a running application
+it usually isn't — the exception says which fields failed, but the input that produced it is whatever a
+user, API, or job happened to send at the time. If you need to see that input as well,
+[Logfire can record failed validations](../errors/troubleshooting.md) together with the data that
+caused them.
+
 ## Arbitrary class instances
 
 (Formerly known as "ORM Mode"/`from_orm()`).

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -558,7 +558,7 @@ except ValidationError as e:
 ```
 
 In an example like this one, the offending `data` is right there in the code. In a running application
-it usually isn't — the exception says which fields failed, but the input that produced it is whatever a
+it usually isn't. The exception says which fields failed, but the input that produced it is whatever a
 user, API, or job happened to send at the time. If you need to see that input as well,
 [Logfire can record failed validations](../errors/troubleshooting.md) together with the data that
 caused them.

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -134,7 +134,7 @@ is used and can't be serialized to JSON, a [`PydanticSerializationError`][pydant
 is raised.
 
 A serialization error like this often only shows up when a particular object reaches the point of being
-serialized — commonly when building a response — so it can be easy to miss until it happens in
+serialized (commonly when building a response), so it can be easy to miss until it happens in
 production. Like any exception, it's captured by [Logfire](../integrations/logfire.md) if you've
 instrumented your application, in the context of the request that triggered it, and grouped with other
 occurrences so you can tell a one-off from a recurring problem.

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -133,6 +133,12 @@ variety of types ([date and time types][datetime], [`UUID`][uuid.UUID] objects, 
 is used and can't be serialized to JSON, a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError] exception
 is raised.
 
+A serialization error like this often only shows up when a particular object reaches the point of being
+serialized — commonly when building a response — so it can be easy to miss until it happens in
+production. Like any exception, it's captured by [Logfire](../integrations/logfire.md) if you've
+instrumented your application, in the context of the request that triggered it, and grouped with other
+occurrences so you can tell a one-off from a recurring problem.
+
 !!! info "See also"
     The [`TypeAdapter.dump_json()`][pydantic.TypeAdapter.dump_json] method, useful when *not* dealing with Pydantic models.
 

--- a/docs/concepts/strict_mode.md
+++ b/docs/concepts/strict_mode.md
@@ -45,7 +45,7 @@ except ValidationError as exc:
 
 One caveat when enabling strict mode on models an existing application relies on: inputs that were
 being quietly coerced will start failing. If you can't audit every caller, it helps to watch validation
-failures while you roll the change out — [Logfire](../integrations/logfire.md) counts successful and
+failures while you roll the change out. [Logfire](../integrations/logfire.md) counts successful and
 failed validations as metrics, and records the inputs that were rejected.
 
 Strict mode can be enabled in various ways:

--- a/docs/concepts/strict_mode.md
+++ b/docs/concepts/strict_mode.md
@@ -43,6 +43,11 @@ except ValidationError as exc:
     """
 ```
 
+One caveat when enabling strict mode on models an existing application relies on: inputs that were
+being quietly coerced will start failing. If you can't audit every caller, it helps to watch validation
+failures while you roll the change out — [Logfire](../integrations/logfire.md) counts successful and
+failed validations as metrics, and records the inputs that were rejected.
+
 Strict mode can be enabled in various ways:
 
 * [As a validation parameter](#as-a-validation-parameter), such as when using [`model_validate()`][pydantic.BaseModel.model_validate],

--- a/docs/concepts/type_adapter.md
+++ b/docs/concepts/type_adapter.md
@@ -86,6 +86,11 @@ print(items)
 [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] is capable of parsing data into any of the types Pydantic can
 handle as fields of a [`BaseModel`][pydantic.main.BaseModel].
 
+Data parsed this way often comes from a source you don't control — like the API call in the example
+above — so validation can fail long after the code has shipped. If your application is
+[instrumented with Logfire](../integrations/logfire.md), validations performed through a `TypeAdapter`
+are recorded just like model validations.
+
 !!! info "Performance considerations"
     When creating an instance of [`TypeAdapter`][pydantic.type_adapter.TypeAdapter], the provided type must be analyzed and converted into a pydantic-core
     schema. This comes with some non-trivial overhead, so it is recommended to create a `TypeAdapter` for a given type

--- a/docs/concepts/type_adapter.md
+++ b/docs/concepts/type_adapter.md
@@ -86,10 +86,10 @@ print(items)
 [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] is capable of parsing data into any of the types Pydantic can
 handle as fields of a [`BaseModel`][pydantic.main.BaseModel].
 
-Data parsed this way often comes from a source you don't control — like the API call in the example
-above — so validation can fail long after the code has shipped. If your application is
-[instrumented with Logfire](../integrations/logfire.md), validations performed through a `TypeAdapter`
-are recorded just like model validations.
+Data parsed this way often comes from a source you don't control, like the API call in the example
+above, so validation can fail long after the code has shipped. A `TypeAdapter` raises the same
+structured errors as a model, so tooling that records validation failures in production, such as
+[Logfire](../integrations/logfire.md), captures these too.
 
 !!! info "Performance considerations"
     When creating an instance of [`TypeAdapter`][pydantic.type_adapter.TypeAdapter], the provided type must be analyzed and converted into a pydantic-core

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -474,6 +474,11 @@ recursion.
 Discriminated unions help to simplify error messages in this case, as validation errors are only produced for
 the case with a matching discriminator value.
 
+Making sense of a union failure means working out which member *should* have matched, and that's hard to
+do without the input in front of you. When the failure happens in a deployed service,
+[Logfire records the per-member errors next to the offending input](../errors/troubleshooting.md), so
+you can make that comparison after the fact.
+
 You can also customize the error type, message, and context for a `Discriminator` by passing
 these specifications as parameters to the `Discriminator` constructor, as seen in the example below.
 

--- a/docs/concepts/validation_decorator.md
+++ b/docs/concepts/validation_decorator.md
@@ -403,6 +403,10 @@ Currently upon validation failure, a standard Pydantic [`ValidationError`][pydan
 (see [model error handling](models.md#error-handling) for details). This is also true for missing required arguments,
 where Python normally raises a [`TypeError`][].
 
+The error names the argument that was rejected, but the traceback won't show you what value the caller
+actually passed. If that matters for your debugging, [Logfire](../errors/troubleshooting.md) records
+decorated calls together with their arguments when validation fails.
+
 ### Performance
 
 We've made a big effort to make Pydantic as performant as possible. While the inspection of the decorated

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -34,6 +34,10 @@ The [`ErrorDetails`][pydantic_core.ErrorDetails] object is a dictionary. It cont
 The first item in the [`loc`][pydantic_core.ErrorDetails.loc] list will be the field where the error occurred, and if the field is a
 [sub-model](../concepts/models.md#nested-models), subsequent items will be present to indicate the nested location of the error.
 
+Accessing errors this way requires a `try`/`except` around the validation call. For validations spread
+across a running service, [Logfire](troubleshooting.md) records the same structured error list on each
+failure — together with the input that produced it — without wrapping each call.
+
 As a demonstration:
 
 ```python

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -36,7 +36,7 @@ The first item in the [`loc`][pydantic_core.ErrorDetails.loc] list will be the f
 
 Accessing errors this way requires a `try`/`except` around the validation call. For validations spread
 across a running service, [Logfire](troubleshooting.md) records the same structured error list on each
-failure — together with the input that produced it — without wrapping each call.
+failure, together with the input that produced it, without wrapping each call.
 
 As a demonstration:
 

--- a/docs/errors/troubleshooting.md
+++ b/docs/errors/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting Validation Errors with Logfire
 
 When a [`ValidationError`][pydantic_core.ValidationError] is raised, the message tells you *what* went
-wrong — which field, which rule, and the value that triggered it. In production, the hard part is
+wrong: which field, which rule, and the value that triggered it. In production, the hard part is
 usually everything the message *can't* show you: which input caused it, where that data came from, how
 often it happens, and what else your application was doing at the time. By the time you read the log,
 the payload that failed is often already gone.
@@ -9,7 +9,7 @@ the payload that failed is often already gone.
 ## Have Logfire explain the error
 
 Open a failed validation span in [Pydantic Logfire](../integrations/logfire.md) and it explains the
-failure in plain language (currently in beta) — reading the structured errors and, for each field,
+failure in plain language (currently in beta), reading the structured errors and, for each field,
 telling you what was expected and what it received, including the messages from your own
 [custom validators](../concepts/validators.md#raising-validation-errors). You get to the fix without
 memorising every `pydantic-core` error code.
@@ -20,10 +20,10 @@ memorising every `pydantic-core` error code.
 
 ## Getting started
 
-If you find yourself troubleshooting Pydantic validation errors, you need a system that records them as
-they happen — capturing the input alongside the error. Logfire is that system: built by the same team as
-Pydantic, its integration captures every validation as it runs, so you can open the one that failed
-instead of reconstructing it from logs after the fact.
+Troubleshooting validation errors in production is much easier when something records them as they
+happen, capturing the input alongside the error. Logfire's Pydantic integration does this: it records
+each validation as it runs, so you can open the one that failed instead of reconstructing it from logs
+after the fact.
 
 If you haven't set it up yet, follow the three-step
 [getting started guide](https://logfire.pydantic.dev/docs/), then instrument your models:
@@ -55,19 +55,19 @@ User(name='Anne', country_code='USA', dob='not-a-date')  # (2)!
 
 Once instrumented, each failed validation shows up in the live view, recorded with:
 
-* **Its input** — the exact data passed to validation, so you don't have to reconstruct the payload from
+* **Its input**: the exact data passed to validation, so you don't have to reconstruct the payload from
   logs or guess what your model received.
-* **Its context** — a span alongside the surrounding request, task, or trace, so you can follow bad data
+* **Its context**: a span alongside the surrounding request, task, or trace, so you can follow bad data
   back to its source.
-* **A queryable history** — every failure is stored, so you can ask "which field fails most often?"
+* **A queryable history**: every failure is stored, so you can ask "which field fails most often?"
   or "did this error spike after the last deploy?" in SQL.
-* **No extra logging code** — one `logfire.instrument_pydantic()` call covers all your models; you don't
+* **No extra logging code**: one `logfire.instrument_pydantic()` call covers all your models; you don't
   wrap each `model_validate` in a `try`/`except`.
 
 Recording the input naturally raises the question of sensitive data, since the failing payload may
 contain it. The Logfire SDK
-[scrubs common sensitive values](https://logfire.pydantic.dev/docs/how-to-guides/scrubbing/) — things
-that look like passwords, tokens, or other secrets — from spans before they leave your machine, and you
+[scrubs common sensitive values](https://logfire.pydantic.dev/docs/how-to-guides/scrubbing/) (things
+that look like passwords, tokens, or other secrets) from spans before they leave your machine, and you
 can extend the rules for your own fields.
 
 ![A failed Pydantic validation recorded in the Logfire live view](../img/logfire-validation-live-view.png)
@@ -75,8 +75,8 @@ can extend the rules for your own fields.
 ## Reading the error from the trace
 
 Beyond the plain-language explanation, each failed validation span shows the raw structured
-[`errors()`][pydantic_core.ValidationError.errors] list next to the input that produced it — the field
-path (`loc`), the machine-readable `type`, and the offending value — so you can see which field failed
+[`errors()`][pydantic_core.ValidationError.errors] list next to the input that produced it: the field
+path (`loc`), the machine-readable `type`, and the offending value, so you can see which field failed
 and with what value without parsing the rendered message string by hand.
 
 ![A Pydantic validation failure in the Logfire live view, with the structured errors captured on the span](../img/logfire-validation-error-trace.png)
@@ -87,30 +87,26 @@ A single trace tells you about one failure. Often the more useful question is wh
 something recurring. Logfire
 [groups repeated exceptions into issues](https://logfire.pydantic.dev/docs/guides/web-ui/issues/), so a
 validation that fails a thousand times shows up as one entry with a count and a first-seen time, rather
-than a thousand lines to scroll through — which makes it easy to tell a genuine spike from background
+than a thousand lines to scroll through, which makes it easy to tell a genuine spike from background
 noise.
 
 Once you know which failures matter, you don't have to keep watching for them. Logfire
 [alerts](https://logfire.pydantic.dev/docs/guides/web-ui/alerts/) run a SQL query on a schedule and
-notify you (for example, in Slack) when it matches — "validation failures for this model crossed a
-threshold" — so the next occurrence finds you instead of a user reporting it.
+notify you (for example, in Slack) when it matches. A rule like "validation failures for this model
+crossed a threshold" means the next occurrence finds you instead of a user reporting it.
 
 ## Debugging with an AI coding agent
 
-If you use an AI coding agent, you can point it at the [Logfire MCP
-server](https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/), which lets the agent query your
-telemetry directly — including the input and errors from a failed validation — so it can investigate a
-failure against your real data rather than a guess. There's also an [installable Logfire
-skill](https://logfire.pydantic.dev/docs/how-to-guides/skills/) that gives agents current guidance on
-instrumenting a codebase in the first place.
+If you debug with an AI coding agent, the [Logfire MCP
+server](https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/) lets the agent query your telemetry
+directly, including the input and errors from a failed validation, so it can investigate against your
+real data instead of guessing.
 
 ## Learn more
 
-* [Pydantic Logfire integration](../integrations/logfire.md) — how to install and configure Logfire
+* [Pydantic Logfire integration](../integrations/logfire.md): how to install and configure Logfire
   with Pydantic.
-* [Logfire documentation](https://logfire.pydantic.dev/docs/) — the full Logfire docs.
-* [Why Logfire for Pydantic](https://logfire.pydantic.dev/docs/why-logfire/pydantic/) — a deeper look
-  at the Pydantic integration.
+* [Logfire documentation](https://logfire.pydantic.dev/docs/): the full Logfire docs.
 
 For a reference of the individual error types you may encounter, see
 [Validation Errors](validation_errors.md) and [Usage Errors](usage_errors.md).

--- a/docs/errors/troubleshooting.md
+++ b/docs/errors/troubleshooting.md
@@ -64,6 +64,12 @@ Once instrumented, each failed validation shows up in the live view, recorded wi
 * **No extra logging code** — one `logfire.instrument_pydantic()` call covers all your models; you don't
   wrap each `model_validate` in a `try`/`except`.
 
+Recording the input naturally raises the question of sensitive data, since the failing payload may
+contain it. The Logfire SDK
+[scrubs common sensitive values](https://logfire.pydantic.dev/docs/how-to-guides/scrubbing/) — things
+that look like passwords, tokens, or other secrets — from spans before they leave your machine, and you
+can extend the rules for your own fields.
+
 ![A failed Pydantic validation recorded in the Logfire live view](../img/logfire-validation-live-view.png)
 
 ## Reading the error from the trace
@@ -74,6 +80,29 @@ path (`loc`), the machine-readable `type`, and the offending value — so you ca
 and with what value without parsing the rendered message string by hand.
 
 ![A Pydantic validation failure in the Logfire live view, with the structured errors captured on the span](../img/logfire-validation-error-trace.png)
+
+## From one failure to the pattern
+
+A single trace tells you about one failure. Often the more useful question is whether it's a one-off or
+something recurring. Logfire
+[groups repeated exceptions into issues](https://logfire.pydantic.dev/docs/guides/web-ui/issues/), so a
+validation that fails a thousand times shows up as one entry with a count and a first-seen time, rather
+than a thousand lines to scroll through — which makes it easy to tell a genuine spike from background
+noise.
+
+Once you know which failures matter, you don't have to keep watching for them. Logfire
+[alerts](https://logfire.pydantic.dev/docs/guides/web-ui/alerts/) run a SQL query on a schedule and
+notify you (for example, in Slack) when it matches — "validation failures for this model crossed a
+threshold" — so the next occurrence finds you instead of a user reporting it.
+
+## Debugging with an AI coding agent
+
+If you use an AI coding agent, you can point it at the [Logfire MCP
+server](https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/), which lets the agent query your
+telemetry directly — including the input and errors from a failed validation — so it can investigate a
+failure against your real data rather than a guess. There's also an [installable Logfire
+skill](https://logfire.pydantic.dev/docs/how-to-guides/skills/) that gives agents current guidance on
+instrumenting a codebase in the first place.
 
 ## Learn more
 

--- a/docs/examples/custom_validators.md
+++ b/docs/examples/custom_validators.md
@@ -287,3 +287,8 @@ except ValidationError as e:
 Note that if the context property is not included in `model_validate`, then `info.context` will be `None` and the forbidden passwords list will not get added to the context in the above implementation. As such, `validate_user_passwords` would not carry out the desired password validation.
 
 More details about validation context can be found in the [validators documentation](../concepts/validators.md#validation-context).
+
+The messages you write in these `raise ValueError(...)` calls are worth crafting: they're what you'll
+read when the rule eventually rejects real data. They also carry through to tooling that consumes the
+structured errors — [Logfire's explanations of failed validations](../errors/troubleshooting.md), for
+example, include the messages from your custom validators.

--- a/docs/examples/custom_validators.md
+++ b/docs/examples/custom_validators.md
@@ -290,5 +290,5 @@ More details about validation context can be found in the [validators documentat
 
 The messages you write in these `raise ValueError(...)` calls are worth crafting: they're what you'll
 read when the rule eventually rejects real data. They also carry through to tooling that consumes the
-structured errors — [Logfire's explanations of failed validations](../errors/troubleshooting.md), for
+structured errors: [Logfire's explanations of failed validations](../errors/troubleshooting.md), for
 example, include the messages from your custom validators.

--- a/docs/examples/files.md
+++ b/docs/examples/files.md
@@ -132,7 +132,7 @@ print(people)
 [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] is a Pydantic construct used to validate data against a single type.
 
 With two records, spotting a bad one is easy. In a pipeline processing files with thousands of records,
-the error's `loc` gives you the index of the failing one — and if the pipeline runs unattended,
+the error's `loc` gives you the index of the failing one, and if the pipeline runs unattended,
 [Logfire](../errors/troubleshooting.md) records each failed validation with its input, so you can find
 the offending record after the run.
 

--- a/docs/examples/files.md
+++ b/docs/examples/files.md
@@ -131,6 +131,11 @@ print(people)
 1. We use [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] to validate a list of `Person` objects.
 [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] is a Pydantic construct used to validate data against a single type.
 
+With two records, spotting a bad one is easy. In a pipeline processing files with thousands of records,
+the error's `loc` gives you the index of the failing one — and if the pipeline runs unattended,
+[Logfire](../errors/troubleshooting.md) records each failed validation with its input, so you can find
+the offending record after the run.
+
 ## JSON lines files
 
 Similar to validating a list of objects from a `.json` file, you can validate a list of objects from a `.jsonl` file.

--- a/docs/examples/orms.md
+++ b/docs/examples/orms.md
@@ -50,7 +50,7 @@ print(pydantic_model.model_dump(by_alias=True))
 
 Validating ORM objects can surface a less obvious class of failure: rows written before a constraint
 was added, or columns that allow `NULL` where your model doesn't. These only fail when the offending
-row is actually read, which may be long after a deploy —
+row is actually read, which may be long after a deploy, and
 [recording failed validations](../errors/troubleshooting.md) tells you which rows they were.
 
 <!-- TODO: add examples for Django with Pydantic models -->

--- a/docs/examples/orms.md
+++ b/docs/examples/orms.md
@@ -48,4 +48,9 @@ print(pydantic_model.model_dump(by_alias=True))
     The example above works because aliases have priority over field names for
     field population. Accessing `SQLModel`'s `metadata` attribute would lead to a `ValidationError`.
 
+Validating ORM objects can surface a less obvious class of failure: rows written before a constraint
+was added, or columns that allow `NULL` where your model doesn't. These only fail when the offending
+row is actually read, which may be long after a deploy —
+[recording failed validations](../errors/troubleshooting.md) tells you which rows they were.
+
 <!-- TODO: add examples for Django with Pydantic models -->

--- a/docs/examples/pydantic_ai.md
+++ b/docs/examples/pydantic_ai.md
@@ -34,3 +34,9 @@ result = agent.run_sync('List the 3 largest cities in Japan')
 print(result.output)
 #> [City(name='Tokyo', country='Japan', population=13960000), ...]
 ```
+
+When validation fails — say the model returns a country your validator rejects — Pydantic AI feeds the
+validation errors back to the model and asks it to retry. To see this happening in a real application,
+instrument it with [Logfire](../integrations/logfire.md), which supports both
+[Pydantic AI](https://ai.pydantic.dev/logfire/) and Pydantic validation itself: each agent run shows the
+output the model produced, the errors your validators raised, and the retry that followed.

--- a/docs/examples/pydantic_ai.md
+++ b/docs/examples/pydantic_ai.md
@@ -35,8 +35,8 @@ print(result.output)
 #> [City(name='Tokyo', country='Japan', population=13960000), ...]
 ```
 
-When validation fails — say the model returns a country your validator rejects — Pydantic AI feeds the
+When validation fails (say the model returns a country your validator rejects), Pydantic AI feeds the
 validation errors back to the model and asks it to retry. To see this happening in a real application,
-instrument it with [Logfire](../integrations/logfire.md), which supports both
-[Pydantic AI](https://ai.pydantic.dev/logfire/) and Pydantic validation itself: each agent run shows the
-output the model produced, the errors your validators raised, and the retry that followed.
+instrument it with [Logfire](../integrations/logfire.md), which records
+[Pydantic AI](https://ai.pydantic.dev/logfire/) runs and the validations inside them: each agent run
+shows the output the model produced, the errors your validators raised, and the retry that followed.

--- a/docs/examples/queues.md
+++ b/docs/examples/queues.md
@@ -164,6 +164,19 @@ To test this example:
 1. Run the receiver script in one terminal to start the consumer.
 2. Run the sender script in another terminal to send messages.
 
+One thing to keep in mind with consumers like this: if `model_validate_json` raises a
+[`ValidationError`][pydantic_core.ValidationError], the message that caused it may no longer be on the
+queue by the time you investigate, making the failure hard to reproduce. It's worth recording failed
+validations as they happen — for example with [Logfire](../errors/troubleshooting.md), which captures
+the message body alongside the error:
+
+```python {test="skip"}
+import logfire
+
+logfire.configure()
+logfire.instrument_pydantic(record='failure')
+```
+
 ## ARQ
 
 ARQ is a fast Redis-based job queue for Python.

--- a/docs/examples/queues.md
+++ b/docs/examples/queues.md
@@ -167,7 +167,7 @@ To test this example:
 One thing to keep in mind with consumers like this: if `model_validate_json` raises a
 [`ValidationError`][pydantic_core.ValidationError], the message that caused it may no longer be on the
 queue by the time you investigate, making the failure hard to reproduce. It's worth recording failed
-validations as they happen — for example with [Logfire](../errors/troubleshooting.md), which captures
+validations as they happen, for example with [Logfire](../errors/troubleshooting.md), which captures
 the message body alongside the error:
 
 ```python {test="skip"}

--- a/docs/examples/requests.md
+++ b/docs/examples/requests.md
@@ -70,4 +70,10 @@ pprint([u.name for u in users])
 
 1. Note, we're querying the `/users/` endpoint here to get a list of users.
 
+When you validate responses like this, a [`ValidationError`][pydantic_core.ValidationError] is often
+the first sign that an API you depend on has changed its response format. The useful questions at that
+point are *what did the response actually contain*, and *when did this start* —
+[recording failed validations with Logfire](../errors/troubleshooting.md) answers both, since each
+failure is stored with the data that triggered it.
+
 <!-- TODO: httpx, flask, Django rest framework, FastAPI -->

--- a/docs/examples/requests.md
+++ b/docs/examples/requests.md
@@ -72,7 +72,7 @@ pprint([u.name for u in users])
 
 When you validate responses like this, a [`ValidationError`][pydantic_core.ValidationError] is often
 the first sign that an API you depend on has changed its response format. The useful questions at that
-point are *what did the response actually contain*, and *when did this start* —
+point are *what did the response actually contain*, and *when did this start*:
 [recording failed validations with Logfire](../errors/troubleshooting.md) answers both, since each
 failure is stored with the data that triggered it.
 

--- a/docs/integrations/aws_lambda.md
+++ b/docs/integrations/aws_lambda.md
@@ -114,3 +114,9 @@ If you're still struggling with installing `pydantic` for your AWS Lambda, you m
 ### Validating `event` and `context` data
 
 Check out our [blog post](https://pydantic.dev/articles/lambda-intro) to learn more about how to use `pydantic` to validate `event` and `context` data in AWS Lambda functions.
+
+Validation failures are particularly awkward to debug in Lambda: you can't attach a debugger, and the
+event that caused the failure disappears with the invocation. If you validate `event` data with
+Pydantic, it pairs well with [Logfire](../integrations/logfire.md), which has an
+[AWS Lambda integration](https://logfire.pydantic.dev/docs/integrations/aws-lambda/) and records each
+failed validation along with the payload that caused it.

--- a/docs/integrations/aws_lambda.md
+++ b/docs/integrations/aws_lambda.md
@@ -116,7 +116,7 @@ If you're still struggling with installing `pydantic` for your AWS Lambda, you m
 Check out our [blog post](https://pydantic.dev/articles/lambda-intro) to learn more about how to use `pydantic` to validate `event` and `context` data in AWS Lambda functions.
 
 Validation failures are particularly awkward to debug in Lambda: you can't attach a debugger, and the
-event that caused the failure disappears with the invocation. If you validate `event` data with
-Pydantic, it pairs well with [Logfire](../integrations/logfire.md), which has an
-[AWS Lambda integration](https://logfire.pydantic.dev/docs/integrations/aws-lambda/) and records each
-failed validation along with the payload that caused it.
+event that caused the failure disappears with the invocation. If you record validations with
+[Logfire](../integrations/logfire.md), each failed validation is stored with the payload that caused
+it, and its [AWS Lambda integration](https://logfire.pydantic.dev/docs/integrations/aws-lambda/)
+captures the surrounding invocation.

--- a/docs/integrations/datamodel_code_generator.md
+++ b/docs/integrations/datamodel_code_generator.md
@@ -109,10 +109,10 @@ More information can be found on the
 ## Catching drift from the source schema
 
 A model generated from an OpenAPI or JSON Schema document is a snapshot of that contract. When the
-upstream data stops matching it — a field changes type, a new required field appears — the mismatch
+upstream data stops matching it (a field changes type, a new required field appears), the mismatch
 surfaces as a [`ValidationError`][pydantic_core.ValidationError] at runtime, often the first sign the
 source has drifted from the schema you generated against.
 
 If you [record validations with Logfire](../errors/troubleshooting.md), those failures are stored with
-the payload that caused them, so you can see *what* changed and *when* it started — useful when you
+the payload that caused them, so you can see *what* changed and *when* it started, useful when you
 don't own the schema and can't regenerate the models until you know what moved.

--- a/docs/integrations/datamodel_code_generator.md
+++ b/docs/integrations/datamodel_code_generator.md
@@ -105,3 +105,14 @@ class Person(BaseModel):
 
 More information can be found on the
 [official documentation](https://datamodel-code-generator.koxudaxi.dev/).
+
+## Catching drift from the source schema
+
+A model generated from an OpenAPI or JSON Schema document is a snapshot of that contract. When the
+upstream data stops matching it — a field changes type, a new required field appears — the mismatch
+surfaces as a [`ValidationError`][pydantic_core.ValidationError] at runtime, often the first sign the
+source has drifted from the schema you generated against.
+
+If you [record validations with Logfire](../errors/troubleshooting.md), those failures are stored with
+the payload that caused them, so you can see *what* changed and *when* it started — useful when you
+don't own the schema and can't regenerate the models until you know what moved.

--- a/docs/integrations/devtools.md
+++ b/docs/integrations/devtools.md
@@ -49,5 +49,9 @@ Will output in your terminal:
 
 {{ devtools_example }}
 
+`debug()` is a development-time tool: it prints to the terminal of a process you're watching. The
+closest equivalent for a deployed application is [Logfire](logfire.md) — also built by the Pydantic
+team — where models and validations show up as structured output you can browse and query.
+
 !!! note
     `python-devtools` doesn't yet support Python 3.13.

--- a/docs/integrations/devtools.md
+++ b/docs/integrations/devtools.md
@@ -50,8 +50,8 @@ Will output in your terminal:
 {{ devtools_example }}
 
 `debug()` is a development-time tool: it prints to the terminal of a process you're watching. The
-closest equivalent for a deployed application is [Logfire](logfire.md) — also built by the Pydantic
-team — where models and validations show up as structured output you can browse and query.
+closest equivalent for a deployed application is [Logfire](logfire.md), where models and validations
+show up as structured output you can browse and query.
 
 !!! note
     `python-devtools` doesn't yet support Python 3.13.

--- a/docs/integrations/llms.md
+++ b/docs/integrations/llms.md
@@ -12,3 +12,9 @@ Two formats are available:
 As of today, these files *cannot* be natively leveraged by LLM frameworks or IDEs. Alternatively,
 a [MCP server](https://modelcontextprotocol.io/) can be implemented to properly parse the `llms.txt`
 file.
+
+Where `llms.txt` gives an AI tool the Pydantic *documentation*, the
+[Logfire MCP server](https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/) gives it your
+application's *runtime data*: an agent can query the traces, metrics, and recorded validations from your
+own service and, for example, pull up the input behind a `ValidationError` while it's helping you fix
+it. Logfire is built by the Pydantic team.

--- a/docs/integrations/llms.md
+++ b/docs/integrations/llms.md
@@ -17,4 +17,4 @@ Where `llms.txt` gives an AI tool the Pydantic *documentation*, the
 [Logfire MCP server](https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/) gives it your
 application's *runtime data*: an agent can query the traces, metrics, and recorded validations from your
 own service and, for example, pull up the input behind a `ValidationError` while it's helping you fix
-it. Logfire is built by the Pydantic team.
+it.

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -221,3 +221,12 @@ dumped = model.model_dump()  # (2)!
    [`SchemaSerializer.to_python`][pydantic_core.SchemaSerializer.to_python] method.
    `pydantic-core` will read the instance's `__dict__` attribute and built the appropriate result
    (again, following the core schema of the model).
+
+### The plugin hook around validation
+
+Pydantic wraps the `SchemaValidator` in a plugin layer: when plugins are installed, each of the
+`validate_python`, `validate_json`, and `validate_strings` calls can be intercepted, letting a plugin
+observe the input, result, and any error for every validation. This is the mechanism behind
+observability tooling such as [Logfire](../integrations/logfire.md), which uses it to record validations
+without any per-call instrumentation. Plugins are configured per model through the
+[`plugin_settings`][pydantic.ConfigDict.plugin_settings] configuration value.

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -57,7 +57,6 @@ def on_page_markdown(markdown: str, page: Page, config: MkDocsConfig, files: Fil
     """
     markdown = upgrade_python(markdown)
     markdown = insert_json_output(markdown)
-    markdown = add_error_troubleshooting_footer(markdown, page)
     if md := render_index(markdown, page):
         return md
     if md := render_why(markdown, page):
@@ -77,35 +76,6 @@ def on_page_markdown(markdown: str, page: Page, config: MkDocsConfig, files: Fil
 
 
 # End definition of MkDocs hooks
-
-
-# Pages that describe Pydantic validation errors and should show the shared
-# "troubleshoot with Logfire" footer. The troubleshooting page itself is excluded
-# so it doesn't link to itself.
-ERROR_PAGES_WITH_FOOTER = {
-    'errors/errors.md',
-    'errors/validation_errors.md',
-    'errors/usage_errors.md',
-}
-
-TROUBLESHOOTING_FOOTER = """
-
----
-
-A `ValidationError` names the field and rule that failed, but not the input that triggered it.
-[Logfire](troubleshooting.md), built by the team behind Pydantic, records the input and the structured
-errors for each validation, so you can trace a failure back to the exact payload.
-"""
-
-
-def add_error_troubleshooting_footer(markdown: str, page: Page) -> str:
-    """Append a shared footer linking to the Logfire troubleshooting page.
-
-    This is added to every page that describes a Pydantic validation error.
-    """
-    if page.file.src_uri in ERROR_PAGES_WITH_FOOTER:
-        return markdown + TROUBLESHOOTING_FOOTER
-    return markdown
 
 
 def add_changelog() -> None:

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -85,6 +85,10 @@ def dataclass(
 
     This function should be used similarly to `dataclasses.dataclass`.
 
+    Validation of a Pydantic dataclass works the same way as validation of a `BaseModel`, including how
+    failures are recorded by [Logfire](../integrations/logfire.md) if you use it — see
+    [Troubleshooting validation errors](../errors/troubleshooting.md).
+
     Args:
         _cls: The target `dataclass`.
         init: Included for signature compatibility with `dataclasses.dataclass`, and is passed through to

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -85,8 +85,9 @@ def dataclass(
 
     This function should be used similarly to `dataclasses.dataclass`.
 
-    Validation of a Pydantic dataclass works the same way as validation of a `BaseModel`, including how
-    failures are recorded by [Logfire](../integrations/logfire.md) if you use it — see
+    A Pydantic dataclass validates its inputs like a `BaseModel` does, and a failed validation can leave
+    you without the input that caused it. [Logfire](../integrations/logfire.md) records dataclass
+    validations the same way as model validations, input included — see
     [Troubleshooting validation errors](../errors/troubleshooting.md).
 
     Args:

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -456,6 +456,11 @@ def field_validator(  # noqa: D417
 
     For more in depth examples, see [Field Validators](../concepts/validators.md#field-validators).
 
+    Errors raised in a field validator become part of the model's
+    [`ValidationError`][pydantic_core.ValidationError]. In a running application,
+    [Logfire](../integrations/logfire.md) can record the input each failed validation rejected — see
+    [Troubleshooting validation errors](../errors/troubleshooting.md).
+
     Args:
         *fields: The field names the validator should apply to.
         mode: Specifies whether to validate the fields before or after validation.
@@ -709,6 +714,11 @@ def model_validator(
     ```
 
     For more in depth examples, see [Model Validators](../concepts/validators.md#model-validators).
+
+    Cross-field rules like the one above tend to fail on combinations of values you didn't anticipate.
+    To see the combination that failed in a running application, record validations with
+    [Logfire](../integrations/logfire.md) (see
+    [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
     Args:
         mode: A required string literal that specifies the validation mode.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -834,10 +834,6 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     ) -> Self:
         """Validate the given object with string data against the Pydantic model.
 
-        Like the other validation methods, validations performed here can be recorded by
-        [Logfire](../integrations/logfire.md), including the string data a failed validation received —
-        see [Troubleshooting validation errors](../errors/troubleshooting.md).
-
         Args:
             obj: The object containing string data to validate.
             strict: Whether to enforce types strictly.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -788,10 +788,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         Validate the given JSON data against the Pydantic model.
 
-        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
-        fields were rejected but not the input behind them — instrument your app with
-        [Logfire](../integrations/logfire.md) to record that input too, and debug production failures straight
-        from the trace (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
+        A [`ValidationError`][pydantic_core.ValidationError] raised here names the failing fields, but
+        not the JSON document they came from. Recording validations with
+        [Logfire](../integrations/logfire.md) keeps the offending input alongside the error — see
+        [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             json_data: The JSON data to validate.
@@ -834,10 +834,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     ) -> Self:
         """Validate the given object with string data against the Pydantic model.
 
-        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
-        fields were rejected but not the input behind them — instrument your app with
-        [Logfire](../integrations/logfire.md) to record that input too, and debug production failures straight
-        from the trace (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
+        Like the other validation methods, validations performed here can be recorded by
+        [Logfire](../integrations/logfire.md), including the string data a failed validation received —
+        see [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             obj: The object containing string data to validate.

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -408,10 +408,9 @@ class TypeAdapter(Generic[T]):
     ) -> T:
         """Validate a Python object against the model.
 
-        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
-        fields were rejected but not the input behind them — instrument your app with
-        [Logfire](../integrations/logfire.md) to record that input too, and debug production failures straight
-        from the trace (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
+        `TypeAdapter` validations are recorded by [Logfire](../integrations/logfire.md) the same way as
+        model validations, so a failure here can be traced back to the object that caused it — see
+        [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             object: The Python object to validate against the model.
@@ -469,10 +468,10 @@ class TypeAdapter(Generic[T]):
 
         Validate a JSON string or bytes against the model.
 
-        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
-        fields were rejected but not the input behind them — instrument your app with
-        [Logfire](../integrations/logfire.md) to record that input too, and debug production failures straight
-        from the trace (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
+        JSON validated this way often comes from an external source, where a
+        [`ValidationError`][pydantic_core.ValidationError] can be the first sign that the source changed
+        shape. [Logfire](../integrations/logfire.md) records the document that failed together with the
+        errors — see [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             data: The JSON data to validate against the model.
@@ -521,10 +520,9 @@ class TypeAdapter(Generic[T]):
     ) -> T:
         """Validate object contains string data against the model.
 
-        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
-        fields were rejected but not the input behind them — instrument your app with
-        [Logfire](../integrations/logfire.md) to record that input too, and debug production failures straight
-        from the trace (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
+        As with the other validation methods, failed validations here can be recorded with
+        [Logfire](../integrations/logfire.md), input included — see
+        [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             obj: The object contains string data to validate.

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -408,9 +408,10 @@ class TypeAdapter(Generic[T]):
     ) -> T:
         """Validate a Python object against the model.
 
-        `TypeAdapter` validations are recorded by [Logfire](../integrations/logfire.md) the same way as
-        model validations, so a failure here can be traced back to the object that caused it — see
-        [Troubleshooting validation errors](../errors/troubleshooting.md).
+        A failure here names the fields that were rejected, but not the object they came from. If you
+        record validations with [Logfire](../integrations/logfire.md), that object is kept alongside the
+        error — `TypeAdapter` validations are captured the same way as model validations (see
+        [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
         Args:
             object: The Python object to validate against the model.
@@ -519,10 +520,6 @@ class TypeAdapter(Generic[T]):
         by_name: bool | None = None,
     ) -> T:
         """Validate object contains string data against the model.
-
-        As with the other validation methods, failed validations here can be recorded with
-        [Logfire](../integrations/logfire.md), input included — see
-        [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             obj: The object contains string data to validate.

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -94,10 +94,10 @@ def validate_call(
 
     Usage may be either as a plain decorator `@validate_call` or with arguments `@validate_call(...)`.
 
-    If a decorated call fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
-    argument was rejected but not its value — instrument your app with [Logfire](../integrations/logfire.md) to
-    record each call with its arguments, and debug production failures straight from the trace (see
-    [Troubleshooting validation errors](../errors/troubleshooting.md)).
+    When a decorated call fails, the [`ValidationError`][pydantic_core.ValidationError] names the rejected
+    argument, but the traceback won't show the value the caller passed.
+    [Logfire](../integrations/logfire.md) records failing calls along with their arguments — see
+    [Troubleshooting validation errors](../errors/troubleshooting.md).
 
     Args:
         func: The function to be decorated.


### PR DESCRIPTION
Weave contextual pointers to the Logfire troubleshooting guide into the
pages where validation failures naturally come up: error handling in
models and unions, external data in the requests/queues/files/ORM
examples, LLM output validation, strict mode rollout, AWS Lambda, and
the validation decorator.

Also replace the injected footer on the error pages with an inline note
in the error handling docs, and rephrase the repeated docstring notes on
the validation methods so each is specific to its method.