### PR TITLE
Add __hash__ to NameEmail to restore hashability

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1094,6 +1094,9 @@ class NameEmail(_repr.Representation):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, NameEmail) and (self.name, self.email) == (other.name, other.email)
 
+    def __hash__(self) -> int:
+        return hash((self.name, self.email))
+
     @classmethod
     def __get_pydantic_json_schema__(
         cls, core_schema: core_schema.CoreSchema, handler: _schema_generation_shared.GetJsonSchemaHandler

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ClickHouseDsn,
     CockroachDsn,
+    ConfigDict,
     Field,
     FileUrl,
     FtpUrl,
@@ -1045,6 +1046,23 @@ def test_name_email_serialization():
 
     obj = json.loads(m.model_dump_json())
     Model(email=obj['email'])
+
+
+@pytest.mark.skipif(not email_validator, reason='email_validator not installed')
+def test_name_email_hashable():
+    a = NameEmail('foo bar', 'foobaR@example.com')
+    b = NameEmail('foo bar', 'foobaR@example.com')
+    c = NameEmail('foo bar', 'different@example.com')
+
+    assert hash(a) == hash(b)
+    assert {a, b, c} == {a, c}
+
+    class Model(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        v: NameEmail
+
+    assert hash(Model(v=a)) == hash(Model(v=b))
 
 
 def test_specialized_urls() -> None:


### PR DESCRIPTION
## Change Summary

`NameEmail` defines `__eq__` but not `__hash__`. Python automatically sets `__hash__ = None` on any class that defines `__eq__` without also defining `__hash__`, so `NameEmail` instances are silently unhashable — they can't be put in a `set`, used as a `dict` key, or contribute to a `frozen=True` model's hash.

```python
from pydantic import BaseModel, NameEmail, ConfigDict

class Model(BaseModel):
    model_config = ConfigDict(frozen=True)
    v: NameEmail

m = Model(v='foo bar <foo@example.com>')
hash(m)  # TypeError: unhashable type: 'NameEmail'
{NameEmail('a', 'a@example.com'), NameEmail('b', 'b@example.com')}  # TypeError
```

The sibling `_BaseUrl`/`_BaseMultiHostUrl` classes in the same file (`pydantic/networks.py`) already pair `__eq__` with a matching `__hash__` (hashing the underlying value). This just restores the same symmetry for `NameEmail`, which is exactly the kind of small, immutable value type (a `name`/`email` pair) that should support hashing.

```python
def __hash__(self) -> int:
    return hash((self.name, self.email))
```

## Related issue number

No existing issue. The template asks for one unless the change is trivial — this is a small
regression fix with a clear before/after, but happy to open one first if you'd rather have the
discussion there; say the word and I'll close this and reopen after.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable — no doc change needed (restores documented behaviour)
* [x] My PR is ready to review

## How I verified this

- Added `test_name_email_hashable` to `tests/test_networks.py`, covering: two equal `NameEmail`s hash the same, a set correctly dedupes them, and a `frozen=True` model wrapping a `NameEmail` is hashable.
- Confirmed the new test fails on the current code (`TypeError: unhashable type: 'NameEmail'`) and passes after the fix.
- Ran the full `tests/test_networks.py` suite: 304 passed, 1 skipped, 1 xfailed — no regressions.
- `ruff check` / `ruff format --check` clean; pre-commit (including the Typecheck hook) passes.

---

I used AI assistance (Claude) to help investigate and draft this fix, but I personally reviewed the root cause, wrote/ran the regression test, and reviewed the final diff before submitting. Happy to answer any questions.
