### PR TITLE
List `typing-inspection` in install dependencies

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -17,6 +17,7 @@ Pydantic has a few dependencies:
 * [`pydantic-core`](https://pypi.org/project/pydantic-core/): Core validation logic for Pydantic written in Rust.
 * [`typing-extensions`](https://pypi.org/project/typing-extensions/): Backport of the standard library [typing][] module.
 * [`annotated-types`](https://pypi.org/project/annotated-types/): Reusable constraint types to use with [`typing.Annotated`][].
+* [`typing-inspection`](https://pypi.org/project/typing-inspection/): Runtime typing introspection tools.
 
 If you've got Python 3.10+ and `pip` installed, you're good to go.
 


### PR DESCRIPTION
Hi, and thank you for Pydantic.

Small docs fix. `docs/install.md` says "Pydantic has a few dependencies:" and lists three, but `pyproject.toml` declares four required runtime dependencies — `typing-inspection>=0.4.2` is missing from the docs list:

```toml
# pyproject.toml [project].dependencies
'typing-extensions>=4.15.0',
'annotated-types>=0.6.0',
'pydantic-core==2.47.0',
'typing-inspection>=0.4.2',   # ← not listed in docs/install.md
```

This PR adds the `typing-inspection` bullet so the docs match the actual dependencies. Feel free to reword the description.

For transparency: I used AI assistance to spot and draft this; I verified `install.md` and `pyproject.toml` against the current source myself.
