### PR TITLE
fix: `Gt` constraint silently dropped in experimental pipeline API on numeric type mismatch

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -486,6 +486,10 @@ def _apply_constraint(  # noqa: C901
     """Apply a single constraint to a schema."""
     if isinstance(constraint, annotated_types.Gt):
         gt = constraint.gt
+
+        def check_gt(v: Any) -> bool:
+            return v > gt
+
         if s and s['type'] in {'int', 'float', 'decimal'}:
             s = s.copy()
             if s['type'] == 'int' and isinstance(gt, int):
@@ -494,11 +498,9 @@ def _apply_constraint(  # noqa: C901
                 s['gt'] = gt
             elif s['type'] == 'decimal' and isinstance(gt, Decimal):
                 s['gt'] = gt
+            else:
+                s = _check_func(check_gt, f'> {gt}', s)
         else:
-
-            def check_gt(v: Any) -> bool:
-                return v > gt
-
             s = _check_func(check_gt, f'> {gt}', s)
     elif isinstance(constraint, annotated_types.Ge):
         ge = constraint.ge

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -40,6 +40,10 @@ def test_parse_str_with_pattern() -> None:
         (int, validate_as(...).gt(0), [1, 2, 100], [0, -1]),
         (float, validate_as(...).gt(0.0), [0.1, 1.8], [0.0, -1.0]),
         (Decimal, validate_as(...).gt(Decimal(0.0)), [Decimal(1)], [Decimal(0.0), Decimal(-1.0)]),
+        # `gt` value type differs from the schema type: the constraint must still be enforced
+        (float, validate_as(float).gt(0), [1.0, 2.5], [0.0, -1.0]),
+        (Decimal, validate_as(Decimal).gt(0), [Decimal(1)], [Decimal(0), Decimal(-1)]),
+        (int, validate_as(int).gt(0.5), [1, 2], [0, -3]),
         (int, validate_as(...).lt(5), [2, 4], [5, 6, 100]),
         (float, validate_as(...).lt(1.0), [0.5, 0.0], [1.0, 100.0]),
         (Decimal, validate_as(...).lt(Decimal(1.0)), [Decimal(0.5)], [Decimal(1.0), Decimal(5.0)]),


### PR DESCRIPTION
## Change Summary

In `pydantic/experimental/pipeline.py`, `_apply_constraint()` handles each `annotated_types` comparison constraint by setting a native core-schema field (`gt`/`ge`/`lt`/...) when the schema is numeric and the value type matches, and otherwise falling back to a function validator.

The `Gt` branch is the **only** comparison constraint that placed its fallback `check_gt` inside an `else:`:

```python
if isinstance(constraint, annotated_types.Gt):
    gt = constraint.gt
    if s and s['type'] in {'int', 'float', 'decimal'}:
        s = s.copy()
        if s['type'] == 'int' and isinstance(gt, int):
            s['gt'] = gt
        elif s['type'] == 'float' and isinstance(gt, float):
            s['gt'] = gt
        elif s['type'] == 'decimal' and isinstance(gt, Decimal):
            s['gt'] = gt
    else:                       # <-- only runs for non-numeric schemas
        def check_gt(v): return v > gt
        s = _check_func(check_gt, f'> {gt}', s)
```

When the schema is numeric (`int`/`float`/`decimal`) but the constraint value's type does **not** match the schema type, none of the inner `isinstance` branches set `s['gt']`, and — because the fallback lives in the `else:` — `check_gt` is skipped as well. The `gt` bound is silently dropped and the field accepts values it should reject.

The sibling branches (`Ge`, `Lt`, `Le`, `MultipleOf`) do **not** wrap their `check_*` validator in an `else:`; they always apply it, so they enforce the bound even on a type mismatch. This makes `Gt` uniquely broken.

## Failing scenario

```python
from typing import Annotated
from decimal import Decimal
from pydantic import TypeAdapter
from pydantic.experimental.pipeline import validate_as

TypeAdapter(Annotated[float, validate_as(float).gt(0)]).validate_python(-5.0)
# returns -5.0  (should raise: 0 is an int, schema type is float)

TypeAdapter(Annotated[Decimal, validate_as(Decimal).gt(0)]).validate_python(Decimal(-5))
# returns Decimal('-5')  (should raise)

TypeAdapter(Annotated[int, validate_as(int).gt(0.5)]).validate_python(-3)
# returns -3  (should raise)
```

The equivalent `.ge(0)` / `.lt(0)` / `.le(0)` / `.multiple_of(...)` all correctly reject the same mismatched inputs. Since users routinely write integer literals like `.gt(0)` on float/decimal fields, this is a realistic silent validation bypass.

## Fix

Apply the `check_gt` fallback whenever the native `gt` constraint was not set (a type mismatch, or a non-numeric schema), while keeping the matching-type fast path that sets the native `gt` on the core schema. Deliberately **not** always wrapping in an after-validator: doing so would change the schema type to `function-after` and hide the numeric type from subsequently chained constraints, so `Annotated[int, validate_as(int).gt(0).lt(100)]` would lose its `exclusiveMaximum`. The fast path is preserved, so JSON-schema chaining still emits both `exclusiveMinimum` and `exclusiveMaximum`.

## Tests

Adds mismatched value/schema-type regression cases to the existing parametrized `test_ge_le_gt_lt` in `tests/test_pipeline.py`. These fail before the change and pass after; the full `tests/test_pipeline.py` suite passes.
