### PR TITLE
Fix `model_construct` to honor `validation_alias` over `alias`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -341,7 +341,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         fields_set = set()
 
         for name, field in cls.__pydantic_fields__.items():
-            if field.alias is not None and field.alias in values:
+            if field.validation_alias is None and field.alias is not None and field.alias in values:
                 fields_values[name] = values.pop(field.alias)
                 fields_set.add(name)
 

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -97,6 +97,21 @@ def test_construct_with_validation_aliases():
     assert my_model.model_dump() == {'x': 1}
 
 
+def test_construct_with_alias_and_distinct_validation_alias():
+    # When a field sets both `alias` and a distinct `validation_alias`, the
+    # `validation_alias` fully overrides `alias` for input, so `model_construct`
+    # (which builds from validation-shaped data) must use the validation alias
+    # and ignore the plain alias, matching validation.
+    class MyModel(BaseModel):
+        x: int = Field(alias='al', validation_alias='va')
+
+    assert MyModel.model_construct(va=2).x == 2
+    # both keys present -> validation_alias wins
+    assert MyModel.model_construct(al=1, va=2).x == 2
+    # only the plain alias -> ignored, just like validation rejects it
+    assert 'x' not in MyModel.model_construct(al=1).model_fields_set
+
+
 def test_large_any_str():
     class Model(BaseModel):
         a: bytes


### PR DESCRIPTION
## Change Summary

When a field sets both `alias` and a **distinct** `validation_alias`, the `validation_alias` fully overrides `alias` for input — validation accepts only the validation alias and rejects the plain alias. `BaseModel.model_construct` did not follow this: it checked `field.alias` *before* `validation_alias`, so it accepted a key that validation rejects and, when both keys were present, picked the wrong one. Since `model_construct` builds from "trusted or pre-validated data" (i.e. validation-input-shaped), it should accept the same keys validation does.

### Reproduction (before this PR)

```python
from pydantic import BaseModel, Field

class M(BaseModel):
    x: int = Field(alias='al', validation_alias='va')

M(al=1, va=2).x                    # 2   (validation uses validation_alias)
M.model_construct(al=1, va=2).x    # 1   ✗ should be 2
M.model_construct(al=1).x          # 1   ✗ M(al=1) raises ValidationError; 'al' isn't a valid input key
```

### Fix

Gate the `alias` branch on `validation_alias` being unset, so that whenever a `validation_alias` is present the (existing) validation-alias branch handles the field — mirroring validation. The common `Field(alias=...)`-only case is unchanged (`validation_alias is None`, so the alias branch still runs), and `AliasChoices` / `AliasPath` handling is unaffected.

## Related issues

None found (searched issues/PRs for `model_construct` + `validation_alias`/`alias` precedence).

## Checklist

- [x] The pull request title is a good summary of the changes
- [x] Unit tests for the changes exist (`test_construct_with_alias_and_distinct_validation_alias` in `tests/test_construction.py`, fails without the fix)
- [x] Existing `test_construction.py` + `test_aliases.py` suites pass (56 passed, no regression)
- [x] No documentation changes needed
