### PR TITLE
Include extra field names in serialization warnings

### DIFF
--- a/pydantic-core/src/serializers/fields.rs
+++ b/pydantic-core/src/serializers/fields.rs
@@ -295,6 +295,9 @@ impl GeneralFieldsSerializer {
         extras_serializer: &Arc<CombinedSerializer>,
         map: &mut Map,
     ) -> Result<(), Map::Error> {
+        // Match declared fields: expose the extra key as `field_name` so
+        // serialization warnings / custom serializers report a useful name.
+        let state = &mut state.scoped_set_field_name(Some(key.as_py_str().bind(value.py()).clone()));
         if let Some(next_include_exclude) = self.filter.key_filter(key.as_py_str().bind(value.py()), state)?
             && !exclude_field_by_value(
                 value,

--- a/pydantic-core/tests/serializers/test_model.py
+++ b/pydantic-core/tests/serializers/test_model.py
@@ -1174,9 +1174,59 @@ def test_extra_custom_serializer():
     s = SchemaSerializer(schema)
 
     m = Model()
+    m.__dict__ = {}
     m.__pydantic_extra__ = {'extra': 'extra'}
 
     assert s.to_python(m) == {'extra': 'extra bam!'}
+    assert s.to_python(m, mode='json') == {'extra': 'extra bam!'}
+    assert s.to_json(m) == b'{"extra":"extra bam!"}'
+
+
+def test_extra_fields_schema_used_for_json_and_warnings():
+    """Regression for pydantic/pydantic#12385.
+
+    Typed `__pydantic_extra__` / `extras_schema` must drive serialization for extra
+    fields on both the Python and JSON paths, including warnings.
+    """
+
+    class Model:
+        __slots__ = ('__pydantic_extra__', '__dict__')
+        __pydantic_extra__: dict[str, Any]
+
+    schema = core_schema.model_schema(
+        Model,
+        core_schema.model_fields_schema(
+            {
+                'a': core_schema.model_field(core_schema.int_schema()),
+            },
+            extra_behavior='allow',
+            extras_schema=core_schema.int_schema(),
+        ),
+        extra_behavior='allow',
+    )
+    s = SchemaSerializer(schema)
+
+    m = Model()
+    m.__dict__ = {'a': 1}
+    m.__pydantic_extra__ = {'extra': 'not_an_int'}
+
+    with pytest.warns(
+        UserWarning,
+        match=r"Expected `int` - serialized value may not be as expected \[field_name='extra', input_value='not_an_int', input_type=str\]",
+    ):
+        assert s.to_python(m) == {'a': 1, 'extra': 'not_an_int'}
+
+    with pytest.warns(
+        UserWarning,
+        match=r"Expected `int` - serialized value may not be as expected \[field_name='extra', input_value='not_an_int', input_type=str\]",
+    ):
+        assert s.to_python(m, mode='json') == {'a': 1, 'extra': 'not_an_int'}
+
+    with pytest.warns(
+        UserWarning,
+        match=r"Expected `int` - serialized value may not be as expected \[field_name='extra', input_value='not_an_int', input_type=str\]",
+    ):
+        assert s.to_json(m) == b'{"a":1,"extra":"not_an_int"}'
 
 
 def test_no_warn_on_exclude() -> None:

--- a/pydantic-core/tests/serializers/test_typed_dict.py
+++ b/pydantic-core/tests/serializers/test_typed_dict.py
@@ -342,6 +342,39 @@ def test_extra_custom_serializer():
     m = {'extra': 'extra'}
 
     assert s.to_python(m) == {'extra': 'extra bam!'}
+    assert s.to_python(m, mode='json') == {'extra': 'extra bam!'}
+    assert s.to_json(m) == b'{"extra":"extra bam!"}'
+
+
+def test_extra_fields_schema_used_for_json_and_warnings():
+    """Regression for pydantic/pydantic#12385 on typed dict extras."""
+    s = SchemaSerializer(
+        core_schema.typed_dict_schema(
+            {
+                'a': core_schema.typed_dict_field(core_schema.int_schema()),
+            },
+            extra_behavior='allow',
+            extras_schema=core_schema.int_schema(),
+        )
+    )
+
+    with pytest.warns(
+        UserWarning,
+        match=r"Expected `int` - serialized value may not be as expected \[field_name='extra', input_value='not_an_int', input_type=str\]",
+    ):
+        assert s.to_python({'a': 1, 'extra': 'not_an_int'}) == {'a': 1, 'extra': 'not_an_int'}
+
+    with pytest.warns(
+        UserWarning,
+        match=r"Expected `int` - serialized value may not be as expected \[field_name='extra', input_value='not_an_int', input_type=str\]",
+    ):
+        assert s.to_python({'a': 1, 'extra': 'not_an_int'}, mode='json') == {'a': 1, 'extra': 'not_an_int'}
+
+    with pytest.warns(
+        UserWarning,
+        match=r"Expected `int` - serialized value may not be as expected \[field_name='extra', input_value='not_an_int', input_type=str\]",
+    ):
+        assert s.to_json({'a': 1, 'extra': 'not_an_int'}) == b'{"a":1,"extra":"not_an_int"}'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

Set `field_name` for extra keys during serialization so typed extras behave like declared fields in warnings and field-aware serializers. Add regression tests that wrong-type values in `__pydantic_extra__` / typed-dict extras warn on both Python and JSON paths (`to_python`, `mode='json'`, `to_json`), covering the MRE from #12385.

The shared extras serializer path for JSON was already unified with Python dumps in the DoSerialize fields work; this PR locks that behavior with tests and makes extra-field names show up in warning messages.

## Related issue number

Fixes #12385

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
