### PR TITLE
Fix `Interval` zero bounds silently dropped in pipeline API

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -613,13 +613,13 @@ def _apply_constraint(  # noqa: C901
         else:
             raise NotImplementedError('Constraining to a specific timezone is not yet supported')
     elif isinstance(constraint, annotated_types.Interval):
-        if constraint.ge:
+        if constraint.ge is not None:
             s = _apply_constraint(s, annotated_types.Ge(constraint.ge))
-        if constraint.gt:
+        if constraint.gt is not None:
             s = _apply_constraint(s, annotated_types.Gt(constraint.gt))
-        if constraint.le:
+        if constraint.le is not None:
             s = _apply_constraint(s, annotated_types.Le(constraint.le))
-        if constraint.lt:
+        if constraint.lt is not None:
             s = _apply_constraint(s, annotated_types.Lt(constraint.lt))
         assert s is not None
     elif isinstance(constraint, annotated_types.Predicate):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -83,7 +83,6 @@ def test_parse_multipleOf(type_: Any, pipeline: Any, valid_cases: list[Any], inv
     [
         (int, validate_as(int).constrain(Interval(ge=0, le=10)), [0, 5, 10], [-5, 11]),
         (float, validate_as(float).constrain(Interval(gt=0.0, lt=10.0)), [0.1, 9.9], [0.0, -5.0, 10.0]),
-        # Zero bounds must not be silently dropped (truthiness vs. `is not None`) on any of the four sides.
         (int, validate_as(int).constrain(Interval(gt=0)), [1, 100], [0, -5]),
         (int, validate_as(int).constrain(Interval(le=0)), [0, -5], [1]),
         (int, validate_as(int).constrain(Interval(lt=0)), [-5], [0, 1]),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -81,8 +81,12 @@ def test_parse_multipleOf(type_: Any, pipeline: Any, valid_cases: list[Any], inv
 @pytest.mark.parametrize(
     'type_, pipeline, valid_cases, invalid_cases',
     [
-        (int, validate_as(int).constrain(Interval(ge=0, le=10)), [0, 5, 10], [11]),
-        (float, validate_as(float).constrain(Interval(gt=0.0, lt=10.0)), [0.1, 9.9], [10.0]),
+        (int, validate_as(int).constrain(Interval(ge=0, le=10)), [0, 5, 10], [-5, 11]),
+        (float, validate_as(float).constrain(Interval(gt=0.0, lt=10.0)), [0.1, 9.9], [0.0, -5.0, 10.0]),
+        # Zero bounds must not be silently dropped (truthiness vs. `is not None`) on any of the four sides.
+        (int, validate_as(int).constrain(Interval(gt=0)), [1, 100], [0, -5]),
+        (int, validate_as(int).constrain(Interval(le=0)), [0, -5], [1]),
+        (int, validate_as(int).constrain(Interval(lt=0)), [-5], [0, 1]),
         (
             Decimal,
             validate_as(Decimal).constrain(Interval(ge=Decimal('1.0'), lt=Decimal('10.0'))),


### PR DESCRIPTION
Fixes #13450.

## Change Summary

In `pydantic/experimental/pipeline.py`, `_apply_constraint()` handles `annotated_types.Interval` by delegating to the individual comparison constraints, but it checks each bound for truthiness instead of `is not None`:

```python
elif isinstance(constraint, annotated_types.Interval):
    if constraint.ge:
        s = _apply_constraint(s, annotated_types.Ge(constraint.ge))
    ...
```

Since `0` is falsy, a bound of exactly zero is silently skipped and the constraint is never applied. `Interval(ge=0, le=10)` happily accepts `-5`; `Interval(gt=0)` accepts `0` and negative values; etc. All four bounds (`ge`, `gt`, `le`, `lt`) are affected.

## Fix

Change the four checks to `is not None`.

## Tests

Extended the existing `test_interval_constraints` parametrization in `tests/test_pipeline.py` with cases that pin a zero bound on each of `ge`/`gt`/`le`/`lt`. These fail on `main` and pass with the fix; the full `tests/test_pipeline.py` suite (69 tests) passes.

Related to #13450 (see the issue for the full reproduction table).