### PR TITLE
Fix RootModel model_dump typing signature

### DIFF
--- a/pydantic/root_model.py
+++ b/pydantic/root_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations as _annotations
 
+from collections.abc import Callable
 from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
@@ -123,7 +124,7 @@ class RootModel(BaseModel, Generic[RootModelRootType], metaclass=_RootModelMetac
             mode: Literal['json', 'python'] | str = 'python',
             include: Any = None,
             exclude: Any = None,
-            context: dict[str, Any] | None = None,
+            context: Any | None = None,
             by_alias: bool | None = None,
             exclude_unset: bool = False,
             exclude_defaults: bool = False,
@@ -131,7 +132,9 @@ class RootModel(BaseModel, Generic[RootModelRootType], metaclass=_RootModelMetac
             exclude_computed_fields: bool = False,
             round_trip: bool = False,
             warnings: bool | Literal['none', 'warn', 'error'] = True,
+            fallback: Callable[[Any], Any] | None = None,
             serialize_as_any: bool = False,
+            polymorphic_serialization: bool | None = None,
         ) -> Any:
             """This method is included just to get a more accurate return type for type checkers.
             It is included in this `if TYPE_CHECKING:` block since no override is actually necessary.

--- a/tests/typechecking/root_model.py
+++ b/tests/typechecking/root_model.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 from typing_extensions import assert_type
 
-from pydantic import RootModel
+from pydantic import BaseModel, RootModel, SerializationInfo, model_serializer
 
 IntRootModel = RootModel[int]
 
@@ -17,3 +19,33 @@ class StrRootModel(RootModel[str]):
 str_root_model = StrRootModel(root='a')
 
 assert_type(str_root_model.root, str)
+
+
+class ContextRoot(RootModel[str]):
+    @model_serializer
+    def serialize_root(self, info: SerializationInfo) -> str:
+        return f'{info.context}:{self.root}'
+
+
+class Unknown:
+    pass
+
+
+class Base(BaseModel):
+    x: int
+
+
+class Sub(Base):
+    y: int
+
+
+ContextRoot(root='value').model_dump(context='prefix')
+
+RootModel[Any](root=Unknown()).model_dump(
+    mode='json',
+    fallback=lambda _: 'fallback',
+)
+
+RootModel[list[Base]](root=[Sub(x=1, y=2)]).model_dump(
+    polymorphic_serialization=True,
+)


### PR DESCRIPTION
## Change Summary

- Align the type-checking-only `RootModel.model_dump()` signature with `BaseModel.model_dump()` for `context`, `fallback`, and `polymorphic_serialization`.
- Add focused type-checking regressions covering all three supported arguments.

No runtime serialization behavior changes.

## Related issue number

Fix #13453

## Validation

- `make test-typechecking-mypy`
- `make test-typechecking-pyright`
- `make test-typechecking-pyrefly`
- `uv run pytest tests/test_root_model.py -k 'dump' -q`
- `uv run ruff check pydantic/root_model.py tests/typechecking/root_model.py`
- `uv run ruff format --check pydantic/root_model.py tests/typechecking/root_model.py`
- `git diff --check`

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**