### PR TITLE
fix: prevent computed field names from leaking into extras when extra="allow"

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -872,6 +872,22 @@ class GenerateSchema:
 
                 schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
                 schema = apply_model_validators(schema, model_validators, 'outer')
+
+                # When extra='allow' and the model has computed fields, a value
+                # passed at init/validation whose key matches a computed field
+                # name leaks into ``__pydantic_extra__``.  During serialization
+                # both the extra value and the computed value are emitted,
+                # producing inconsistent results (duplicate JSON keys etc.).
+                # Wrap the schema with an after-validator that drops such
+                # entries so the computed field is the single source of truth.
+                if computed_fields and core_config.get('extra_fields_behavior') == 'allow':
+                    ref = schema.get('ref')  # type: ignore[union-attr]
+                    schema = core_schema.no_info_after_validator_function(
+                        _remove_computed_field_names_from_extras, schema
+                    )
+                    if ref is not None:
+                        schema['ref'] = ref  # type: ignore[union-attr]
+
                 return self.defs.create_definition_reference_schema(schema)
 
     def _resolve_self_type(self, obj: Any) -> Any:
@@ -2590,6 +2606,31 @@ def _convert_to_aliases(
         return alias
 
 
+def _remove_computed_field_names_from_extras(model: Any) -> Any:
+    """After-validator that removes computed field names from ``__pydantic_extra__``.
+
+    When ``extra='allow'`` and a value whose key matches a computed field name is
+    passed at validation time, pydantic-core stores it in ``__pydantic_extra__``.
+    During serialization both the extra value and the computed value are emitted,
+    producing inconsistent results (duplicate JSON keys, ``exclude_none`` showing
+    the stale extra value, etc.).  This validator silently drops such entries so
+    that the computed field is the single source of truth, matching the behaviour
+    already seen when ``extra='ignore'``.
+    """
+    extra = getattr(model, '__pydantic_extra__', None)
+    if extra:
+        computed_field_names = type(model).__pydantic_computed_fields__.keys() if hasattr(type(model), '__pydantic_computed_fields__') else ()
+        computed_names: set[str] = set(computed_field_names)
+        if computed_names:
+            fields_set = getattr(model, '__pydantic_fields_set__', None)
+            for key in list(extra):
+                if key in computed_names:
+                    del extra[key]
+                    if fields_set is not None:
+                        fields_set.discard(key)
+    return model
+
+
 def apply_model_validators(
     schema: core_schema.CoreSchema,
     validators: Iterable[Decorator[ModelValidatorDecoratorInfo]],
@@ -2930,3 +2971,4 @@ class _ModelTypeStack:
             return self._stack[-1]
         else:
             return None
+

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -388,6 +388,12 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             _fields_set = fields_set
 
         _extra: dict[str, Any] | None = values if cls.model_config.get('extra') == 'allow' else None
+        if _extra is not None:
+            # Drop computed field names that leaked into extras so that
+            # serialization is consistent (computed field is the source of truth).
+            computed_field_names = cls.__pydantic_computed_fields__.keys() if cls.__pydantic_computed_fields__ else ()
+            if computed_field_names:
+                _extra = {k: v for k, v in _extra.items() if k not in computed_field_names}
         _object_setattr(m, '__dict__', fields_values)
         _object_setattr(m, '__pydantic_fields_set__', _fields_set)
         if not cls.__pydantic_root_model__:
@@ -1898,3 +1904,4 @@ def create_model(  # noqa: C901
 
 
 __getattr__ = getattr_migration(__name__)
+


### PR DESCRIPTION
Fixes #12709

When `extra='allow'` and a `@computed_field` has the same name as a value passed to `__init__`, `model_validate`, `model_validate_json`, or `model_validate_strings`, the value was stored in `__pydantic_extra__`. During serialization, both the extra value and the computed value were emitted, producing inconsistent results:

- `model_dump_json()` produced **duplicate JSON keys** (e.g. `{"favorite_color":"red","favorite_color":null}`)
- `model_dump(exclude_none=True)` showed the **stale extra value** instead of the computed value
- `model_dump()` showed the computed value (dict last-write-wins), creating an inconsistency with `exclude_none`

This PR silently drops computed field names from `__pydantic_extra__` after validation, making the computed field the single source of truth — matching the behavior already seen when `extra='ignore'` (the default), where computed field names in input data are silently dropped.

## Approach

Two changes, both Python-side (no pydantic-core/Rust changes):

1. **`pydantic/_internal/_generate_schema.py`**: When a model has both `extra='allow'` and computed fields, the model's core schema is wrapped with a `no_info_after_validator_function` that removes computed field names from `__pydantic_extra__` after validation. This covers all validation entry points since they all use the same core schema.
2. **`pydantic/main.py`**: In `model_construct`, computed field names are filtered from `_extra` before assignment, since `model_construct` bypasses validation.

The previous attempt (#12848) was closed because its approach would need to live in core (Rust). This approach is Python-side and covers all entry points.

## AI usage

Per the [AI policy](https://github.com/pydantic/pydantic/blob/main/CONTRIBUTING.md) in CONTRIBUTING.md, I certify that I fully understand the code being submitted. The fix was developed by reproducing the bug, tracing the validation and serialization paths, and the approach (after-validator cleanup) was chosen because it covers all validation entry points from Python without touching pydantic-core internals.