### PR TITLE
fix: use an explicit tuple serializer for named tuples

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1543,19 +1543,30 @@ class GenerateSchema:
                     for field_name, annotation in annotations.items()
                 }
 
+            parameter_schemas = [
+                self._generate_parameter_schema(
+                    field_name,
+                    annotation,
+                    source=AnnotationSource.NAMED_TUPLE,
+                    default=namedtuple_cls._field_defaults.get(field_name, Parameter.empty),
+                )
+                for field_name, annotation in annotations.items()
+            ]
             arguments_schema = core_schema.arguments_schema(
-                [
-                    self._generate_parameter_schema(
-                        field_name,
-                        annotation,
-                        source=AnnotationSource.NAMED_TUPLE,
-                        default=namedtuple_cls._field_defaults.get(field_name, Parameter.empty),
-                    )
-                    for field_name, annotation in annotations.items()
-                ],
+                parameter_schemas,
                 metadata={'pydantic_js_prefer_positional_arguments': True},
             )
-            schema = core_schema.call_schema(arguments_schema, namedtuple_cls, ref=namedtuple_ref)
+            # Serialize named tuples using an explicit tuple serializer built from the field schemas.
+            # Without it, the `'call'` schema falls back to an `AnySerializer` that relies on type
+            # inference, which uses the (possibly incomplete) `__pydantic_serializer__` of the field
+            # types and breaks when a field type is built with `defer_build=True` (see #13448).
+            serialization = core_schema.plain_serializer_function_ser_schema(
+                _serialize_namedtuple,
+                return_schema=core_schema.tuple_schema([parameter['schema'] for parameter in parameter_schemas]),
+            )
+            schema = core_schema.call_schema(
+                arguments_schema, namedtuple_cls, ref=namedtuple_ref, serialization=serialization
+            )
             return self.defs.create_definition_reference_schema(schema)
 
     def _generate_parameter_schema(
@@ -2635,6 +2646,15 @@ def apply_model_validators(
     if ref:
         schema['ref'] = ref  # type: ignore
     return schema
+
+
+def _serialize_namedtuple(value: Any) -> tuple[Any, ...]:
+    """Serialize a named tuple instance as a plain tuple.
+
+    Used as the serialization function of the `'call'` schema generated for named tuples, so that
+    the explicit tuple serializer (and not an `AnySerializer`) is used (see #13448).
+    """
+    return tuple(value)
 
 
 def wrap_default(field_info: FieldInfo, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:

--- a/tests/test_types_namedtuple.py
+++ b/tests/test_types_namedtuple.py
@@ -254,3 +254,20 @@ def test_namedtuple_inheritance_with_annotations():
             'input': 'c',
         }
     ]
+
+
+def test_namedtuple_serialization_with_deferred_build_field():
+    """https://github.com/pydantic/pydantic/issues/13448"""
+
+    class Lazy(BaseModel, defer_build=True):
+        x: int
+
+    class NT(NamedTuple):
+        bar: Lazy
+
+    class Model(BaseModel):
+        nt: NT
+
+    m = Model(nt=[{'x': 1}])
+    assert m.model_dump() == {'nt': ({'x': 1},)}
+    assert m.model_dump_json() == '{"nt":[{"x":1}]}'


### PR DESCRIPTION
## Summary

Fixes a serialization crash when a `NamedTuple` field contains a model built with `defer_build=True`.

## Root cause

`NamedTuple` types are generated as a `'call'` core schema. pydantic-core has no dedicated serializer for `'call'` schemas, so it falls back to an `AnySerializer` that uses runtime type inference. Inference looks up the field type's `__pydantic_serializer__` and assumes it is complete. When the field type was built with `defer_build=True` and not rebuilt, that serializer is still a `MockValSer`, so `model_dump()` raises `TypeError: 'MockValSer' object is not an instance of 'SchemaSerializer'`.

## Fix

Attach an explicit tuple serialization schema to the `NamedTuple` `'call'` schema, built from the same per-field schemas already used for validation. Serialization then uses a proper tuple serializer (and the inlined field serializers) instead of `AnySerializer` type inference, so a deferred-build field type no longer matters. This is the focused fix outlined in the issue (stop relying on `AnySerializer`).

## Test before/after

Added `test_namedtuple_serialization_with_deferred_build_field`.

- Before: fails with `TypeError: 'MockValSer' object is not an instance of 'SchemaSerializer'`.
- After: `model_dump()` -> `{'nt': ({'x': 1},)}`, `model_dump_json()` -> `{"nt":[{"x":1}]}`, matching a non-deferred `NamedTuple`.

Closes #13448
