### PR TITLE
Fix `multiple_of` on floats wrongly rejecting valid values in pipeline API

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -572,19 +572,28 @@ def _apply_constraint(  # noqa: C901
         s = _check_func(check_len, f'length >= {min_len} and length <= {max_len}', s)
     elif isinstance(constraint, annotated_types.MultipleOf):
         multiple_of = constraint.multiple_of
+        native_constraint_applied = False
         if s and s['type'] in {'int', 'float', 'decimal'}:
             s = s.copy()
             if s['type'] == 'int' and isinstance(multiple_of, int):
                 s['multiple_of'] = multiple_of
+                native_constraint_applied = True
             elif s['type'] == 'float' and isinstance(multiple_of, float):
                 s['multiple_of'] = multiple_of
+                native_constraint_applied = True
             elif s['type'] == 'decimal' and isinstance(multiple_of, Decimal):
                 s['multiple_of'] = multiple_of
+                native_constraint_applied = True
 
-        def check_multiple_of(v: Any) -> bool:
-            return v % multiple_of == 0
+        # Only fall back to an exact Python `%` check when the native (tolerant) constraint could not be
+        # applied. Layering the exact check on top of the native one diverges for floats, where e.g.
+        # `0.3 % 0.1 != 0`, wrongly rejecting values the native `multiple_of` accepts.
+        if not native_constraint_applied:
 
-        s = _check_func(check_multiple_of, f'% {multiple_of} == 0', s)
+            def check_multiple_of(v: Any) -> bool:
+                return v % multiple_of == 0
+
+            s = _check_func(check_multiple_of, f'% {multiple_of} == 0', s)
     elif isinstance(constraint, annotated_types.Timezone):
         tz = constraint.tz
 

--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -594,6 +594,8 @@ def _apply_constraint(  # noqa: C901
                 return v % multiple_of == 0
 
             s = _check_func(check_multiple_of, f'% {multiple_of} == 0', s)
+
+        assert s is not None
     elif isinstance(constraint, annotated_types.Timezone):
         tz = constraint.tz
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -61,6 +61,9 @@ def test_ge_le_gt_lt(
     [
         (int, validate_as(int).multiple_of(5), [5, 20, 0], [18, 7]),
         (float, validate_as(float).multiple_of(2.5), [2.5, 5.0, 7.5], [3.0, 1.1]),
+        # `multiple_of` on floats must agree with the native constraint, which tolerates float
+        # imprecision (e.g. `0.3 % 0.1 != 0`), instead of applying an exact Python `%` check.
+        (float, validate_as(float).multiple_of(0.1), [0.1, 0.2, 0.3, 0.5, 1.0], [0.15, 0.25, 0.35]),
         (
             Decimal,
             validate_as(Decimal).multiple_of(Decimal('1.5')),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import datetime
+import math
 from collections.abc import Callable
 from decimal import Decimal
 from typing import Annotated, Any
 
 import pytest
 import pytz
-from annotated_types import Interval
+from annotated_types import Interval, MultipleOf
 
 from pydantic import TypeAdapter, ValidationError
 from pydantic.experimental.pipeline import _Pipeline, transform, validate_as  # pyright: ignore[reportPrivateUsage]
@@ -79,6 +80,28 @@ def test_parse_multipleOf(type_: Any, pipeline: Any, valid_cases: list[Any], inv
     for y in invalid_cases:
         with pytest.raises(ValueError):
             ta.validate_python(y)
+
+
+def test_multiple_of_float_matches_native_constraint() -> None:
+    """`multiple_of` on floats defers to the native constraint, including for non-finite values.
+
+    pydantic-core's `multiple_of` tolerates float imprecision and lets `nan`/`inf` through, so the
+    pipeline API matches it rather than layering a stricter Python `%` check on top.
+    """
+    pipe = TypeAdapter[float](Annotated[float, validate_as(float).multiple_of(0.1)])
+    native = TypeAdapter[float](Annotated[float, MultipleOf(0.1)])
+
+    for value in [0.1, 0.2, 0.3, 0.5, 1.0, math.inf, -math.inf]:
+        assert pipe.validate_python(value) == native.validate_python(value) == value
+
+    assert math.isnan(pipe.validate_python(math.nan))
+    assert math.isnan(native.validate_python(math.nan))
+
+    for value in [0.15, 0.25, 0.35]:
+        with pytest.raises(ValidationError):
+            native.validate_python(value)
+        with pytest.raises(ValidationError):
+            pipe.validate_python(value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

In `pydantic/experimental/pipeline.py`, the `MultipleOf` branch of `_apply_constraint()` sets the native `multiple_of` core-schema constraint on numeric schemas, but then *also* layers an exact Python `v % multiple_of == 0` after-validator on top of it:

```python
if s and s['type'] in {'int', 'float', 'decimal'}:
    s = s.copy()
    if s['type'] == 'float' and isinstance(multiple_of, float):
        s['multiple_of'] = multiple_of
    ...

def check_multiple_of(v: Any) -> bool:
    return v % multiple_of == 0

s = _check_func(check_multiple_of, f'% {multiple_of} == 0', s)   # always applied
```

pydantic-core's native `multiple_of` tolerates floating-point imprecision, but the exact Python `%` check does not. For floats the two disagree, so the pipeline rejects valid multiples that the equivalent native constraint accepts:

```python
from typing import Annotated
from annotated_types import MultipleOf
from pydantic import TypeAdapter
from pydantic.experimental.pipeline import validate_as

native = TypeAdapter(Annotated[float, MultipleOf(0.1)])
pipe   = TypeAdapter(Annotated[float, validate_as(float).multiple_of(0.1)])

native.validate_python(0.3)   # -> 0.3
pipe.validate_python(0.3)     # ValidationError!  (0.3 % 0.1 != 0 in float math)
pipe.validate_python(0.5)     # ValidationError!
```

### Fix

Only fall back to the exact Python check when the native constraint could **not** be applied (a non-numeric schema, or a bound whose Python type doesn't match the schema type). When the native `multiple_of` is set, it is the single source of truth, so the redundant — and, for floats, incorrect — Python check is no longer layered on top. `int` and `Decimal` behaviour is unchanged.

## Related issue number

<!-- no separate issue; happy to open one if preferred -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

---

### Behaviour change: non-finite floats

Deferring to the native constraint also means `nan`/`inf`/`-inf` are now **accepted** by `validate_as(float).multiple_of(...)`, where the old exact `%` check rejected them (`nan % 0.1` is `nan`, which fails `== 0`). This matches `Annotated[float, MultipleOf(0.1)]`, which accepts them today — so it is the same parity fix, just less obvious. It is covered explicitly by `test_multiple_of_float_matches_native_constraint`.

Rejecting non-finite values for `multiple_of` may well be worth doing, but it would be a divergence from the native constraint if done only here, so it probably belongs in pydantic-core where every API benefits. Thanks to @Sanjays2402 for catching it.
