### PR TITLE
Clean up `_internal/_utils.py`: dead slot, return annotation, typos

### DIFF
--- a/pydantic/_internal/_utils.py
+++ b/pydantic/_internal/_utils.py
@@ -50,7 +50,7 @@ IMMUTABLE_NON_COLLECTIONS_TYPES: set[type[Any]] = {
     CodeType,
     # note: including ModuleType will differ from behaviour of deepcopy by not producing error.
     # It might be not a good idea in general, but considering that this function used only internally
-    # against default values of fields, this will allow to actually have a field with module as default value
+    # against default values of fields, this will allow one to actually have a field with module as default value
     ModuleType,
     NotImplemented.__class__,
     Ellipsis.__class__,
@@ -171,7 +171,7 @@ def unique_list(
 class ValueItems(_repr.Representation):
     """Class for more convenient calculation of excluded or included fields on values."""
 
-    __slots__ = ('_items', '_type')
+    __slots__ = ('_items',)
 
     def __init__(self, value: Any, items: AbstractSetIntStr | MappingIntStrAny) -> None:
         items = self._coerce_items(items)
@@ -322,7 +322,7 @@ else:
         def value(self) -> Any:
             return self.get_value()
 
-        def __get__(self, instance: Any, owner: type[Any]) -> None:
+        def __get__(self, instance: Any, owner: type[Any]) -> Any:
             if instance is None:
                 return self.value
             raise AttributeError(f'{self.name!r} attribute of {owner.__name__!r} is class-only')
@@ -379,7 +379,7 @@ def get_first_not_none(a: Any, b: Any) -> Any:
 class SafeGetItemProxy:
     """Wrapper redirecting `__getitem__` to `get` with a sentinel value as default
 
-    This makes is safe to use in `operator.itemgetter` when some keys may be missing
+    This makes it safe to use in `operator.itemgetter` when some keys may be missing
     """
 
     wrapped: Mapping[str, Any]


### PR DESCRIPTION
## Change Summary

Small, no-behaviour-change cleanups in `pydantic/_internal/_utils.py`:

- **Dead `__slots__` entry.** `ValueItems` declares `__slots__ = ('_items', '_type')`, but `_type` is never assigned or read anywhere in the class (a leftover from the V1 `ValueItems`). Removed it.
- **Incorrect return annotation.** `LazyClassAttribute.__get__` is annotated `-> None` but actually returns `self.value` (any value). Annotated it `-> Any`.
- **Two typos:** `This makes is safe to use` -> `This makes it safe to use` (`SafeGetItemProxy` docstring), and `this will allow to actually have` -> `this will allow one to actually have` (comment).

## Related issue number

<!-- trivial cleanup; no separate issue -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist  <!-- existing tests/test_utils.py (159 passed) cover ValueItems/LazyClassAttribute; no behaviour change -->
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**