### PR TITLE
Fix grammar typos in docs and pydantic skill

### DIFF
--- a/.agents/skills/pydantic/SKILL.md
+++ b/.agents/skills/pydantic/SKILL.md
@@ -10,7 +10,7 @@ to understand how validation (and serialization) should be performed. It is most
 when dealing with external untrusted data, for example when defining an HTTP API.
 
 It is generally *not* recommended to use Pydantic to define classes that are instantiated within the user code.
-By doing so, you will loose flexibility (e.g. can't use types not supported by Pydantic, harder to perform
+By doing so, you will lose flexibility (e.g. can't use types not supported by Pydantic, harder to perform
 post init changes). It is usually better to use vanilla classes (or standard library dataclasses) in this case,
 as a static type checker will already catch type mismatches.
 

--- a/docs/concepts/config.md
+++ b/docs/concepts/config.md
@@ -46,7 +46,7 @@ On Pydantic models, configuration can be specified in two ways:
 
   Unlike the [`model_config`][pydantic.BaseModel.model_config] class attribute,
   static type checkers will recognize class arguments. For `frozen`, any instance
-  mutation will be flagged as an type checking error.
+  mutation will be flagged as a type checking error.
 
 ## Configuration on Pydantic dataclasses
 

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -615,7 +615,7 @@ print(m.model_dump())  # (1)!
 ### Polymorphic serialization
 
 /// version-added | v2.13
-Polymorphic serialization was added as an better alternative to the [serialize as any](#serializing-as-any) behavior, and only
+Polymorphic serialization was added as a better alternative to the [serialize as any](#serializing-as-any) behavior, and only
 applies to Pydantic models and Pydantic dataclasses.
 ///
 

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -806,7 +806,7 @@ Pydantic provides a few special utilities that can be used to customize validati
     1. Note that the validation of the second item is skipped. If it has the wrong type it will emit a
        warning during serialization.
 
-* [`ValidateAs`][pydantic.functional_validators.ValidateAs] can be used to validate an custom type from a
+* [`ValidateAs`][pydantic.functional_validators.ValidateAs] can be used to validate a custom type from a
   type natively supported by Pydantic. This is particularly useful when using custom types with multiple fields.
 
     ```python {lint="skip"}


### PR DESCRIPTION
## Change Summary

Fixes four small grammar typos (all `codespell`-clean, so not caught by existing CI):

- `docs/concepts/config.md`: "flagged as **an** type checking error" -> "**a** type checking error"
- `docs/concepts/validators.md`: "validate **an** custom type" -> "validate **a** custom type"
- `docs/concepts/serialization.md`: "added as **an** better alternative" -> "added as **a** better alternative"
- `.agents/skills/pydantic/SKILL.md`: "you will **loose** flexibility" -> "you will **lose** flexibility"

## Related issue number

<!-- trivial docs fix; no separate issue -->

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist  <!-- docs/grammar only -->
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**