### PR TITLE
Enforce Gt constraint in pipeline API when the bound type does not match the schema

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -486,15 +486,23 @@ def _apply_constraint(  # noqa: C901
     """Apply a single constraint to a schema."""
     if isinstance(constraint, annotated_types.Gt):
         gt = constraint.gt
+        applied = False
         if s and s['type'] in {'int', 'float', 'decimal'}:
             s = s.copy()
             if s['type'] == 'int' and isinstance(gt, int):
                 s['gt'] = gt
+                applied = True
             elif s['type'] == 'float' and isinstance(gt, float):
                 s['gt'] = gt
+                applied = True
             elif s['type'] == 'decimal' and isinstance(gt, Decimal):
                 s['gt'] = gt
-        else:
+                applied = True
+
+        # Fall back to a check function whenever the constraint could not be applied natively
+        # (non-numeric schema, or a bound whose type does not match the schema). Without this the
+        # constraint was silently dropped for e.g. a float schema with an int bound.
+        if not applied:
 
             def check_gt(v: Any) -> bool:
                 return v > gt

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -28,6 +28,21 @@ def test_parse_str_with_pattern() -> None:
         ta_pattern.validate_python('POTATO')
 
 
+def test_gt_constraint_with_mismatched_numeric_bound_type() -> None:
+    # A numeric pipeline whose ``gt`` bound has a different Python type than the schema
+    # (e.g. a ``float`` schema with an ``int`` bound) must still enforce the constraint.
+    # Previously the ``Gt`` branch dropped it entirely in this case, unlike ge/lt/le.
+    ta_float = TypeAdapter[float](Annotated[float, validate_as(float).gt(0)])
+    assert ta_float.validate_python(1.0) == 1.0
+    with pytest.raises(ValidationError):
+        ta_float.validate_python(-5.0)
+
+    ta_decimal = TypeAdapter[Decimal](Annotated[Decimal, validate_as(Decimal).gt(0)])
+    assert ta_decimal.validate_python(Decimal(1)) == Decimal(1)
+    with pytest.raises(ValidationError):
+        ta_decimal.validate_python(Decimal(-3))
+
+
 @pytest.mark.parametrize(
     'type_, pipeline, valid_cases, invalid_cases',
     [


### PR DESCRIPTION
## Change Summary

In the experimental pipeline API, a `gt` constraint is silently dropped when the bound's
Python type doesn't match a numeric schema — e.g. `validate_as(float).gt(0)` (a `float` schema
with an `int` bound) accepts `-5.0` with no error.

In `_apply_constraint` (`pydantic/experimental/pipeline.py`) the `Gt` branch attaches the
`_check_func` fallback only inside an `else` taken for **non-numeric** schemas:

```python
if s and s['type'] in {'int', 'float', 'decimal'}:
    s = s.copy()
    if s['type'] == 'int' and isinstance(gt, int):
        s['gt'] = gt
    elif s['type'] == 'float' and isinstance(gt, float):
        s['gt'] = gt
    elif s['type'] == 'decimal' and isinstance(gt, Decimal):
        s['gt'] = gt
else:
    ...
    s = _check_func(check_gt, f'> {gt}', s)
```

For a numeric schema with a mismatched bound type, none of the inner branches set the native
`s['gt']`, and the `else` is skipped — so no constraint is applied at all (missing from the
core schema, from any check function, and from the JSON schema).

`ge`/`lt`/`le` don't have this hole because they run their check function unconditionally.
Simply mirroring that here would regress JSON-schema fidelity for exact-type chains
(`validate_as(int).gt(0).lt(100)` would lose `exclusiveMaximum`, because wrapping the exact-type
case in a function hides the `int` schema from the following `.lt`). So instead this tracks
whether the native constraint was applied and only falls back to the check function when it
wasn't:

```python
applied = False
if s and s['type'] in {'int', 'float', 'decimal'}:
    s = s.copy()
    if ... exact type ...:
        s['gt'] = gt
        applied = True
if not applied:
    def check_gt(v): return v > gt
    s = _check_func(check_gt, f'> {gt}', s)
```

Exact-type bounds keep the native (introspectable) constraint; mismatched or non-numeric bounds
are enforced via the check function.

## Related issues

None.

## Tests

`tests/test_pipeline.py::test_gt_constraint_with_mismatched_numeric_bound_type` — `float`/`int`
and `Decimal`/`int` cross-type bounds now reject out-of-range values (fails against current code,
which accepts `-5.0`). Full `test_pipeline.py` suite (70 tests) passes, including `test_json_schema`
(the `gt(0).lt(100)` case keeps both `exclusiveMinimum` and `exclusiveMaximum`), `test_ge_le_gt_lt`,
and `test_interval_constraints`. `ruff check`/`ruff format` clean.
