### PR TITLE
Fix uv `cache-keys` for `pydantic-core`

### DIFF
--- a/pydantic-core/pyproject.toml
+++ b/pydantic-core/pyproject.toml
@@ -158,11 +158,12 @@ fix = ["create", "fix"]
 required-version = '>=0.7.2'
 cache-keys = [
     { file = "pyproject.toml" },
-    { file = "setup.py" },
-    { file = "setup.cfg" },
     { file = "Cargo.toml" },
     { file = "Cargo.lock" },
-    { file = "**/*.rs" },
+    { file = "build.rs" },
+    { dir = ".cargo" },
+    { dir = "src" },
+    { dir = "python" },
     { env = "MATURIN_PEP517_ARGS" },
     { env = "RUSTFLAGS" }
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- Do not glob all rust files in the dir, as in CI after building `pydantic-core` we have new rust files in `target/`, so subsequent `uv` invocations needlessly rebuild `pydantic-core`.
- Add more entries to rebuild if necessary.

Reference: https://docs.astral.sh/uv/reference/settings/#cache-keys

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
