### PR TITLE
Reject control characters in `NameEmail` display names

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1343,7 +1343,8 @@ def validate_email(value: str) -> tuple[str, str]:
     if m:
         unquoted_name, quoted_name, value = m.groups()
         name = unquoted_name or quoted_name
-        if name is not None and any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
+        # HTAB is valid FWS in an RFC 5322 display name; other C0 controls, DEL and C1 controls are rejected:
+        if name is not None and any(c != '\t' and (ord(c) < 0x20 or 0x7F <= ord(c) <= 0x9F) for c in name):
             raise PydanticCustomError(
                 'value_error',
                 'value is not a valid email address: {reason}',

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1343,6 +1343,12 @@ def validate_email(value: str) -> tuple[str, str]:
     if m:
         unquoted_name, quoted_name, value = m.groups()
         name = unquoted_name or quoted_name
+        if name is not None and any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
+            raise PydanticCustomError(
+                'value_error',
+                'value is not a valid email address: {reason}',
+                {'reason': 'The display name contains control characters'},
+            )
 
     email = value.strip()
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1088,6 +1088,7 @@ class NameEmail(_repr.Representation):
     __slots__ = 'name', 'email'
 
     def __init__(self, name: str, email: str):
+        _validate_display_name(name)
         self.name = name
         self.email = email
 
@@ -1311,6 +1312,24 @@ A somewhat arbitrary but very generous number compared to what is allowed by mos
 """
 
 
+def _validate_display_name(name: str) -> None:
+    """Reject display names that cannot be safely re-emitted in RFC 5322 name-addr form."""
+    # HTAB is valid FWS in an RFC 5322 display name; other C0 controls, DEL and C1 controls are rejected:
+    if any(c != '\t' and (ord(c) < 0x20 or 0x7F <= ord(c) <= 0x9F) for c in name):
+        raise PydanticCustomError(
+            'value_error',
+            'value is not a valid email address: {reason}',
+            {'reason': 'The display name contains control characters'},
+        )
+    # An embedded '"' would prematurely terminate the quoted form produced by `NameEmail.__str__`:
+    if '"' in name:
+        raise PydanticCustomError(
+            'value_error',
+            'value is not a valid email address: {reason}',
+            {'reason': 'The display name contains an unescaped double quote'},
+        )
+
+
 def validate_email(value: str) -> tuple[str, str]:
     """Email address validation using [email-validator](https://pypi.org/project/email-validator/).
 
@@ -1343,13 +1362,8 @@ def validate_email(value: str) -> tuple[str, str]:
     if m:
         unquoted_name, quoted_name, value = m.groups()
         name = unquoted_name or quoted_name
-        # HTAB is valid FWS in an RFC 5322 display name; other C0 controls, DEL and C1 controls are rejected:
-        if name is not None and any(c != '\t' and (ord(c) < 0x20 or 0x7F <= ord(c) <= 0x9F) for c in name):
-            raise PydanticCustomError(
-                'value_error',
-                'value is not a valid email address: {reason}',
-                {'reason': 'The display name contains control characters'},
-            )
+        if name is not None:
+            _validate_display_name(name)
 
     email = value.strip()
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1314,9 +1314,9 @@ A somewhat arbitrary but very generous number compared to what is allowed by mos
 """
 
 
-_display_name_specials = frozenset('()<>[]:;@\\,')
-"""RFC 5322 specials (except `.`, kept bare for compatibility, and DQUOTE, rejected at validation)
-that make a display name unsafe to emit outside a quoted string."""
+_display_name_specials = frozenset('()<>[]:;@,')
+"""RFC 5322 specials (except `.`, kept bare for compatibility, and DQUOTE and backslash, rejected
+at validation) that make a display name unsafe to emit outside a quoted string."""
 
 
 def _validate_display_name(name: str) -> None:
@@ -1334,6 +1334,14 @@ def _validate_display_name(name: str) -> None:
             'value_error',
             'value is not a valid email address: {reason}',
             {'reason': 'The display name contains an unescaped double quote'},
+        )
+    # A '\' in the quoted form starts an RFC 5322 quoted-pair, escaping the following character
+    # (including the closing DQUOTE), and quoted-pairs are not processed when parsing:
+    if '\\' in name:
+        raise PydanticCustomError(
+            'value_error',
+            'value is not a valid email address: {reason}',
+            {'reason': 'The display name contains a backslash'},
         )
 
 

--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1133,7 +1133,9 @@ class NameEmail(_repr.Representation):
             return input_value
 
     def __str__(self) -> str:
-        if '@' in self.name:
+        # A bare name containing RFC 5322 specials would parse as address-list, group or comment
+        # syntax rather than as a display name, so it must be emitted in the quoted form:
+        if not _display_name_specials.isdisjoint(self.name):
             return f'"{self.name}" <{self.email}>'
 
         return f'{self.name} <{self.email}>'
@@ -1310,6 +1312,11 @@ MAX_EMAIL_LENGTH = 2048
 """Maximum length for an email.
 A somewhat arbitrary but very generous number compared to what is allowed by most implementations.
 """
+
+
+_display_name_specials = frozenset('()<>[]:;@\\,')
+"""RFC 5322 specials (except `.`, kept bare for compatibility, and DQUOTE, rejected at validation)
+that make a display name unsafe to emit outside a quoted string."""
 
 
 def _validate_display_name(name: str) -> None:

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -971,6 +971,16 @@ def test_address_valid(value, name, email):
         ('foobar <foobar@example.com>>', None),
         ('foobar <<foobar<@example.com>', None),
         ('foobar <>', None),
+        pytest.param(
+            '"Alice\r\nBcc: victim@example.com" <alice@example.com>',
+            'The display name contains control characters',
+            id='crlf-in-display-name',
+        ),
+        pytest.param(
+            '"a\x00b" <alice@example.com>',
+            'The display name contains control characters',
+            id='nul-in-display-name',
+        ),
         pytest.param('foobar <' + 'a' * 4096 + '@example.com>', 'Length must not exceed 2048 characters', id='long'),
     ],
 )

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -938,6 +938,9 @@ def test_json():
         ('first.last <first.last@example.com>', 'first.last', 'first.last@example.com'),
         ("Shaquille O'Neal <shaq@example.com>", "Shaquille O'Neal", 'shaq@example.com'),
         ('Homer J. Simpson <homer@thesimpsons.com>', 'Homer J. Simpson', 'homer@thesimpsons.com'),
+        pytest.param(
+            '"Alice\tSmith" <alice@example.com>', 'Alice\tSmith', 'alice@example.com', id='htab-in-display-name'
+        ),
     ],
 )
 def test_address_valid(value, name, email):
@@ -980,6 +983,11 @@ def test_address_valid(value, name, email):
             '"a\x00b" <alice@example.com>',
             'The display name contains control characters',
             id='nul-in-display-name',
+        ),
+        pytest.param(
+            '"Alice\x85Bcc: victim@example.com" <alice@example.com>',
+            'The display name contains control characters',
+            id='c1-in-display-name',
         ),
         pytest.param('foobar <' + 'a' * 4096 + '@example.com>', 'Length must not exceed 2048 characters', id='long'),
     ],

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -941,6 +941,9 @@ def test_json():
         pytest.param(
             '"Alice\tSmith" <alice@example.com>', 'Alice\tSmith', 'alice@example.com', id='htab-in-display-name'
         ),
+        pytest.param(
+            '"Smith, Alice" <alice@example.com>', 'Smith, Alice', 'alice@example.com', id='comma-in-quoted-name'
+        ),
     ],
 )
 def test_address_valid(value, name, email):
@@ -1075,6 +1078,19 @@ def test_name_email_rejects_unsafe_display_names():
         NameEmail('Alice\r\nBcc: victim@example.com', 'alice@example.com')
     with pytest.raises(PydanticCustomError, match='The display name contains an unescaped double quote'):
         NameEmail('a@b.com" <evil@x.com>, x', 'real@r.com')
+
+
+@pytest.mark.skipif(not email_validator, reason='email_validator not installed')
+def test_name_email_quotes_names_containing_specials():
+    # A bare `,`, `<` or `>` in an unquoted display name splits or terminates the address list
+    # when the serialized form is re-parsed, e.g. by `email.utils.getaddresses`:
+    assert str(NameEmail('Smith, Alice', 'alice@example.com')) == '"Smith, Alice" <alice@example.com>'
+    assert str(NameEmail('Alice <bob', 'alice@example.com')) == '"Alice <bob" <alice@example.com>'
+    assert str(NameEmail('Homer J. Simpson', 'homer@thesimpsons.com')) == 'Homer J. Simpson <homer@thesimpsons.com>'
+
+    ta = TypeAdapter(NameEmail)
+    for name in ('Smith, Alice', 'Alice <bob', 'x>', 'a; b', 'c (d)'):
+        assert ta.validate_python(str(NameEmail(name, 'alice@example.com'))) == NameEmail(name, 'alice@example.com')
 
 
 def test_specialized_urls() -> None:

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -989,6 +989,11 @@ def test_address_valid(value, name, email):
             'The display name contains control characters',
             id='c1-in-display-name',
         ),
+        pytest.param(
+            '"a@b.com" <evil@x.com>, x" <real@r.com>',
+            'The display name contains an unescaped double quote',
+            id='quote-in-display-name',
+        ),
         pytest.param('foobar <' + 'a' * 4096 + '@example.com>', 'Length must not exceed 2048 characters', id='long'),
     ],
 )
@@ -1063,6 +1068,13 @@ def test_name_email_serialization():
 
     obj = json.loads(m.model_dump_json())
     Model(email=obj['email'])
+
+
+def test_name_email_rejects_unsafe_display_names():
+    with pytest.raises(PydanticCustomError, match='The display name contains control characters'):
+        NameEmail('Alice\r\nBcc: victim@example.com', 'alice@example.com')
+    with pytest.raises(PydanticCustomError, match='The display name contains an unescaped double quote'):
+        NameEmail('a@b.com" <evil@x.com>, x', 'real@r.com')
 
 
 def test_specialized_urls() -> None:

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -997,6 +997,11 @@ def test_address_valid(value, name, email):
             'The display name contains an unescaped double quote',
             id='quote-in-display-name',
         ),
+        pytest.param(
+            '"Alice\\" <alice@example.com>',
+            'The display name contains a backslash',
+            id='backslash-in-display-name',
+        ),
         pytest.param('foobar <' + 'a' * 4096 + '@example.com>', 'Length must not exceed 2048 characters', id='long'),
     ],
 )
@@ -1078,6 +1083,8 @@ def test_name_email_rejects_unsafe_display_names():
         NameEmail('Alice\r\nBcc: victim@example.com', 'alice@example.com')
     with pytest.raises(PydanticCustomError, match='The display name contains an unescaped double quote'):
         NameEmail('a@b.com" <evil@x.com>, x', 'real@r.com')
+    with pytest.raises(PydanticCustomError, match='The display name contains a backslash'):
+        NameEmail('Alice\\', 'alice@example.com')
 
 
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')


### PR DESCRIPTION
## Change Summary

The pretty-email parser in `validate_email` pulls the display name out of the quoted `"name" <addr>` form with `[^"]`, so it accepts control characters. A validated `NameEmail` can then hold raw CR/LF, and `NameEmail.__str__` writes them straight back into the `name <addr>` form used for RFC 5322 headers, so `"Alice\r\nBcc: victim@example.com" <alice@example.com>` round-trips into a header-injection payload.

- reject display names containing C0 controls or DEL where the name is extracted, before it reaches `NameEmail`
- the address half was already covered by email-validator, so only the display name was left unchecked
- valid names, including the unicode and dotted cases from #13206, are unaffected

## Related issue number

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
