### PR TITLE
Fix `multiple_of` raising `TypeError` instead of failing validation in pipeline API

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -582,7 +582,12 @@ def _apply_constraint(  # noqa: C901
                 s['multiple_of'] = multiple_of
 
         def check_multiple_of(v: Any) -> bool:
-            return v % multiple_of == 0
+            try:
+                return v % multiple_of == 0
+            except TypeError:
+                # The value and the bound aren't compatible operands (e.g. a `float` value against a
+                # `Decimal` bound), so the value can't be shown to be a multiple of it.
+                return False
 
         s = _check_func(check_multiple_of, f'% {multiple_of} == 0', s)
     elif isinstance(constraint, annotated_types.Timezone):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -79,6 +79,20 @@ def test_parse_multipleOf(type_: Any, pipeline: Any, valid_cases: list[Any], inv
 
 
 @pytest.mark.parametrize(
+    'type_, pipeline, value',
+    [
+        (float, validate_as(float).multiple_of(Decimal('0.1')), 0.3),
+        (Decimal, validate_as(Decimal).multiple_of(0.1), Decimal('0.3')),
+    ],
+)
+def test_multiple_of_incompatible_operands(type_: Any, pipeline: Any, value: Any) -> None:
+    """A bound the value can't be combined with fails validation instead of raising `TypeError`."""
+    ta = TypeAdapter[Any](Annotated[type_, pipeline])
+    with pytest.raises(ValidationError):
+        ta.validate_python(value)
+
+
+@pytest.mark.parametrize(
     'type_, pipeline, valid_cases, invalid_cases',
     [
         (int, validate_as(int).constrain(Interval(ge=0, le=10)), [0, 5, 10], [-5, 11]),

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any
 import pytest
 import pytz
 from annotated_types import Interval
+from dirty_equals import HasRepr
 
 from pydantic import TypeAdapter, ValidationError
 from pydantic.experimental.pipeline import _Pipeline, transform, validate_as  # pyright: ignore[reportPrivateUsage]
@@ -88,8 +89,20 @@ def test_parse_multipleOf(type_: Any, pipeline: Any, valid_cases: list[Any], inv
 def test_multiple_of_incompatible_operands(type_: Any, pipeline: Any, value: Any) -> None:
     """A bound the value can't be combined with fails validation instead of raising `TypeError`."""
     ta = TypeAdapter[Any](Annotated[type_, pipeline])
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         ta.validate_python(value)
+
+    # Assert on the `multiple_of` predicate specifically, so this stays tied to the constraint that
+    # failed rather than passing on any unrelated validation error.
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'value_error',
+            'loc': (),
+            'msg': 'Value error, Expected % 0.1 == 0',
+            'input': value,
+            'ctx': {'error': HasRepr(repr(ValueError('Expected % 0.1 == 0')))},
+        }
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

The `MultipleOf` fallback in `_apply_constraint()` applies `v % multiple_of == 0` as a Python validator. When the value and the bound aren't compatible operands, the `%` propagates a `TypeError` out of validation instead of producing a validation error:

```python
from decimal import Decimal
from typing import Annotated
from pydantic import TypeAdapter
from pydantic.experimental.pipeline import validate_as

TypeAdapter(Annotated[float, validate_as(float).multiple_of(Decimal('0.1'))]).validate_python(0.3)
# TypeError: unsupported operand type(s) for %: 'float' and 'decimal.Decimal'

TypeAdapter(Annotated[Decimal, validate_as(Decimal).multiple_of(0.1)]).validate_python(Decimal('0.3'))
# TypeError: unsupported operand type(s) for %: 'decimal.Decimal' and 'float'
```

Both directions of the `float`/`Decimal` combination are affected. These are exactly the cases the native core-schema constraint declines to handle (the bound's type doesn't match the schema type), so they fall through to the Python check.

Scope note: only `multiple_of` is affected. The `Gt`/`Ge`/`Lt`/`Le` fallbacks use comparison operators, and Python compares `float` and `Decimal` natively, so they already behave correctly.

### Fix

Treat incompatible operands as "not a multiple" and return `False`, so the value fails with a normal `ValidationError` carrying the existing `Expected % <multiple_of> == 0` message rather than crashing the validator.

An alternative would be to coerce the bound to the value's type, but that trades a crash for silent precision decisions, so I opted for the conservative reading. Happy to change it if you'd prefer coercion.

## Related issue number

Found while reviewing [#13473](https://github.com/pydantic/pydantic/pull/13473); this is independent of that PR and is present on `main` today. The two touch the same branch, so whichever lands second will need a trivial rebase.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**