### PR TITLE
Fix `field_title_generator` not applying to inherited fields in subcl…

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -129,7 +129,7 @@ def _apply_field_title_generator_to_field_info(
     field_name: str,
     field_info: FieldInfo,
 ):
-    if field_info.title is None:
+    if 'title' not in field_info._attributes_set:
         title = title_generator(field_name, field_info)
         if not isinstance(title, str):
             raise TypeError(f'field_title_generator {title_generator} must return str, not {title.__class__}')

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1581,6 +1581,7 @@ class ComputedFieldInfo:
         alias: The alias of the property to be used during serialization.
         alias_priority: The priority of the alias. This affects whether an alias generator is used.
         title: Title of the computed field to include in the serialization JSON schema.
+        title_priority: The priority of the title. This affects whether a field title generator is used.
         field_title_generator: A callable that takes a field name and returns title for it.
         description: Description of the computed field to include in the serialization JSON schema.
         deprecated: A deprecation message, an instance of `warnings.deprecated` or the `typing_extensions.deprecated` backport,
@@ -1597,6 +1598,7 @@ class ComputedFieldInfo:
     alias_priority: int | None
     exclude_if: Callable[[Any], bool] | None
     title: str | None
+    title_priority: int | None
     field_title_generator: Callable[[str, ComputedFieldInfo], str] | None
     description: str | None
     deprecated: Deprecated | str | bool | None
@@ -1613,6 +1615,7 @@ class ComputedFieldInfo:
             alias_priority=self.alias_priority,
             exclude_if=self.exclude_if,
             title=self.title,
+            title_priority=self.title_priority,
             field_title_generator=self.field_title_generator,
             description=self.description,
             deprecated=self.deprecated,
@@ -1635,8 +1638,10 @@ class ComputedFieldInfo:
     def _update_from_config(self, config_wrapper: ConfigWrapper, name: str) -> None:
         """Update the instance from the configuration set on the class this computed field belongs to."""
         title_generator = self.field_title_generator or config_wrapper.field_title_generator
-        if title_generator is not None and self.title is None:
+        if title_generator is not None and (self.title_priority is None or self.title_priority <= 1):
             self.title = title_generator(name, self)
+            if self.title_priority is None or self.title_priority <= 1:
+                self.title_priority = 1
         if config_wrapper.alias_generator is not None:
             self._apply_alias_generator(config_wrapper.alias_generator, name)
 
@@ -1885,6 +1890,7 @@ def computed_field(
         # if the function isn't already decorated with `@property` (or another descriptor), then we wrap it now
         f = _decorators.ensure_property(f)
         alias_priority = (alias_priority or 2) if alias is not None else None
+        title_priority = 2 if title is not None else None
 
         if repr is None:
             repr_: bool = not _wrapped_property_is_private(property_=f)
@@ -1898,6 +1904,7 @@ def computed_field(
             alias_priority,
             exclude_if,
             title,
+            title_priority,
             field_title_generator,
             description,
             deprecated,

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -137,6 +137,77 @@ def test_model_config_field_title_generator(field_title_generator):
     }
 
 
+def test_field_title_generator_inheritance():
+    class Model(BaseModel):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'a')
+
+        a: int
+
+    class Sub(Model):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'b')
+
+        b: int
+
+    assert Sub.model_fields['a'].title == 'ab'
+    assert Sub.model_fields['b'].title == 'bb'
+
+    assert Model.model_fields['a'].title == 'aa'
+
+
+def test_field_title_generator_inheritance_explicit_title_not_overridden():
+    class Model(BaseModel):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'a')
+
+        a: int = Field(title='Explicit A')
+        c: int
+
+    class Sub(Model):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'b')
+
+        b: int
+
+    assert Sub.model_fields['a'].title == 'Explicit A'
+    assert Sub.model_fields['b'].title == 'bb'
+    assert Sub.model_fields['c'].title == 'cb'
+
+
+def test_computed_field_title_generator_inheritance():
+    class Model(BaseModel):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'a')
+
+        a: int
+
+        @computed_field
+        def c(self) -> int:
+            return self.a
+
+    class Sub(Model):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'b')
+
+        b: int
+
+    assert Sub.model_computed_fields['c'].title == 'cb'
+    assert Model.model_computed_fields['c'].title == 'ca'
+
+
+def test_computed_field_title_generator_inheritance_explicit_title_not_overridden():
+    class Model(BaseModel):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'a')
+
+        a: int
+
+        @computed_field(title='Explicit C')
+        def c(self) -> int:
+            return self.a
+
+    class Sub(Model):
+        model_config = ConfigDict(field_title_generator=lambda name, _: name + 'b')
+
+        b: int
+
+    assert Sub.model_computed_fields['c'].title == 'Explicit C'
+
+
 @pytest.mark.parametrize('model_title_generator', MODEL_TITLE_GENERATORS)
 def test_dataclass_model_title_generator(model_title_generator):
     @pydantic.dataclasses.dataclass(config=ConfigDict(model_title_generator=model_title_generator))


### PR DESCRIPTION
please review 
Subclass config is merged with the parent's, so a subclass overriding `field_title_generator` is expected to affect all its fields, including ones inherited from the parent. Previously, inherited `FieldInfo`/`ComputedFieldInfo` instances already had a `title` computed by the parent's generator, and the "only generate if unset" guard treated that the same as a user-provided title, silently skipping regeneration.

`FieldInfo` now tracks this via `_attributes_set` (mirroring how `alias_generator` already distinguishes user-set aliases). `ComputedFieldInfo` gains a `title_priority` field for the same purpose, mirroring the existing `alias_priority` mechanism.

## Change Summary

- `pydantic/_internal/_fields.py`: `_apply_field_title_generator_to_field_info` now skips generation only when `title` was explicitly set by the user (checked via `'title' not in field_info._attributes_set`) instead of just `title is None`. This lets a subclass's `field_title_generator` regenerate titles for fields inherited from a parent class, consistent with how config merging already works for other values (e.g. `str_to_lower`, `alias_generator`).
- `pydantic/fields.py`: `ComputedFieldInfo` gains a `title_priority` field (mirroring the existing `alias_priority`), fixing the identical bug for `@computed_field` properties.
- `tests/test_titles.py`: added regression tests for both regular fields and computed fields — a subclass's generator now applies to inherited fields, while an explicitly-set `title=...` is still never overridden.

## Related issue number

fix #13486

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
