### PR TITLE
Return `NotImplemented` from URL ordering comparisons with foreign types

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -241,16 +241,24 @@ class _BaseUrl:
         return self.__class__ is other.__class__ and self._url == other._url
 
     def __lt__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url < other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url < other._url
 
     def __gt__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url > other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url > other._url
 
     def __le__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url <= other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url <= other._url
 
     def __ge__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url >= other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url >= other._url
 
     def __hash__(self) -> int:
         return hash(self._url)

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,4 +1,5 @@
 import json
+import operator
 from typing import Annotated, Any
 
 import pytest
@@ -1180,6 +1181,27 @@ def test_any_url_comparison() -> None:
     assert second_url > first_url
     assert first_url <= second_url
     assert second_url >= first_url
+
+
+@pytest.mark.parametrize('other', ['https://a.com', 5, None, HttpUrl('https://a.com')])
+def test_any_url_ordering_not_implemented(other: Any) -> None:
+    """Ordering against a different type is unsupported, rather than silently `False`."""
+    url = AnyUrl('https://a.com')
+
+    for op in (operator.lt, operator.gt, operator.le, operator.ge):
+        with pytest.raises(TypeError):
+            op(url, other)
+
+
+def test_any_url_ordering_is_consistent() -> None:
+    """`sorted()` on mixed URL types raises instead of returning a meaningless order."""
+    with pytest.raises(TypeError):
+        sorted([AnyUrl('https://z.com'), HttpUrl('https://b.com')])
+
+    # Equality is unaffected: unlike ordering, comparing against another type is well defined.
+    assert AnyUrl('https://a.com') != HttpUrl('https://a.com')
+    assert AnyUrl('https://a.com') != 'https://a.com'
+    assert AnyUrl('https://a.com') == AnyUrl('https://a.com')
 
 
 def test_max_length_base_url() -> None:


### PR DESCRIPTION
## Change Summary

The ordering comparisons on `_BaseUrl` (`__lt__`, `__gt__`, `__le__`, `__ge__`) returned `False` when the other operand was a different class, rather than `NotImplemented`. Returning `False` from all four breaks the ordering contract in two visible ways:

```python
from pydantic import AnyUrl, HttpUrl

a, b = AnyUrl('https://a.com'), HttpUrl('https://b.com')

a < b    # False
a >= b   # False   ← both False is impossible for a total order

sorted([AnyUrl('https://z.com'), HttpUrl('https://b.com')])
# ['https://z.com/', 'https://b.com/']  — silently unsorted, no TypeError
```

Comparing against an unrelated type such as `str` or `int` had the same problem: `AnyUrl(...) < 'x'` returned `False` instead of raising.

Returning `NotImplemented` when the classes differ lets Python try the reflected operation and then raise `TypeError` if neither side can order the pair — the standard protocol for rich comparisons. Same-class ordering is unchanged.

`__eq__` is deliberately left as-is: equality against a foreign type is well defined and correctly returns `False`, so it should keep doing so. Only the four ordering methods were wrong.

## Related issues

No existing issue or PR — found none open or closed covering URL ordering.

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable
* [x] `pydantic-cli` / changes are backwards compatible where possible
