### PR TITLE
Compare `SecretStr`/`SecretBytes` values in constant time

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 import base64
 import dataclasses as _dataclasses
+import hmac
 import re
 from collections.abc import Callable, Hashable, Iterator
 from datetime import date, datetime
@@ -1557,7 +1558,18 @@ class _SecretBase(Generic[SecretType]):
         return self._secret_value
 
     def __eq__(self, other: Any) -> bool:
-        return isinstance(other, self.__class__) and self.get_secret_value() == other.get_secret_value()
+        if not isinstance(other, self.__class__):
+            return False
+        self_value = self.get_secret_value()
+        other_value = other.get_secret_value()
+        # Compare str/bytes payloads in constant time so verifying a secret (e.g. a token or
+        # password submitted by a client) against a stored one doesn't leak the length of the
+        # matching prefix through timing.
+        if isinstance(self_value, str) and isinstance(other_value, str):
+            return hmac.compare_digest(self_value.encode(), other_value.encode())
+        if isinstance(self_value, (bytes, bytearray)) and isinstance(other_value, (bytes, bytearray)):
+            return hmac.compare_digest(self_value, other_value)
+        return self_value == other_value
 
     def __hash__(self) -> int:
         return hash(self.get_secret_value())

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import collections
+import hmac
 import ipaddress
 import itertools
 import json
@@ -4804,6 +4805,25 @@ def test_secretbytes_equality():
     assert SecretBytes(b'123') != SecretBytes(b'321')
     assert SecretBytes(b'123') != b'123'
     assert SecretBytes(b'123') is not SecretBytes(b'123')
+
+
+@pytest.mark.thread_unsafe
+def test_secret_constant_time_comparison(mocker):
+    spy = mocker.spy(hmac, 'compare_digest')
+
+    # str/bytes secrets are compared with a constant-time function
+    assert SecretStr('abc') == SecretStr('abc')
+    assert SecretStr('abc') != SecretStr('abcd')
+    assert SecretStr('naïve') == SecretStr('naïve')  # non-ASCII round-trips through the byte compare
+    assert SecretBytes(b'abc') == SecretBytes(b'abc')
+    assert SecretBytes(b'abc') != SecretBytes(b'abd')
+    assert spy.call_count == 5
+
+    # other Secret payload types fall back to plain equality
+    spy.reset_mock()
+    assert Secret[int](1) == Secret[int](1)
+    assert Secret[int](1) != Secret[int](2)
+    assert spy.call_count == 0
 
 
 def test_secretbytes_idempotent():


### PR DESCRIPTION
## Change Summary

`_SecretBase.__eq__` (shared by `Secret`, `SecretStr`, and `SecretBytes`) compared the wrapped secret with `==`:

- for `str`/`bytes` payloads that comparison short-circuits at the first differing byte and checks length first, so verifying a client-supplied secret against a stored one leaks the length of the matching prefix by timing
- `SecretStr`/`SecretBytes` are documented for passwords and tokens, where an equality check against an incoming value is a natural verification step
- the `str`/`bytes` paths now go through `hmac.compare_digest` (encoding `str` to utf-8 so non-ASCII secrets still round-trip); other `Secret[T]` payloads keep plain `==`

Equality semantics are unchanged. Added a regression test that asserts the constant-time path is taken for `str`/`bytes` and that non-str/bytes payloads still use `==`.

## Related issue number

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
