### PR TITLE
Return NotImplemented from _BaseUrl ordering comparisons

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -241,16 +241,24 @@ class _BaseUrl:
         return self.__class__ is other.__class__ and self._url == other._url
 
     def __lt__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url < other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url < other._url
 
     def __gt__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url > other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url > other._url
 
     def __le__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url <= other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url <= other._url
 
     def __ge__(self, other: Any) -> bool:
-        return self.__class__ is other.__class__ and self._url >= other._url
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self._url >= other._url
 
     def __hash__(self) -> int:
         return hash(self._url)

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,4 +1,5 @@
 import json
+import operator
 from typing import Annotated, Any
 
 import pytest
@@ -1180,6 +1181,20 @@ def test_any_url_comparison() -> None:
     assert second_url > first_url
     assert first_url <= second_url
     assert second_url >= first_url
+
+
+def test_any_url_comparison_incompatible_type() -> None:
+    # Ordering against an incomparable type must raise ``TypeError`` (Python's
+    # rich-comparison contract), not silently return ``False``.
+    url = AnyUrl('https://a.com')
+    for op in (operator.lt, operator.gt, operator.le, operator.ge):
+        with pytest.raises(TypeError):
+            op(url, 5)
+    # Different Url subclasses are not orderable with each other either.
+    with pytest.raises(TypeError):
+        url < HttpUrl('https://a.com')
+    with pytest.raises(TypeError):
+        HttpUrl('https://a.com') > url
 
 
 def test_max_length_base_url() -> None:


### PR DESCRIPTION
### Change Summary

The ordering comparisons on `_BaseUrl` (the base of `AnyUrl`, `HttpUrl`, `PostgresDsn`, etc.) return `False` instead of `NotImplemented` when compared against an incomparable object, violating Python's rich-comparison contract.

```python
def __lt__(self, other: Any) -> bool:
    return self.__class__ is other.__class__ and self._url < other._url
```

When `other` is a different type, `self.__class__ is other.__class__` is `False`, so the whole expression short-circuits to `False` for **all four** operators.

```python
from pydantic import AnyUrl
a = AnyUrl('http://a.com')
a < 5    # -> False   (every other type raises TypeError here)
a > 5    # -> False
a <= 5   # -> False
a >= 5   # -> False   (so `a` is simultaneously not <, >, <=, >= to 5)
```

A well-behaved type returns `NotImplemented` (not `False`) from rich-comparison methods when it doesn't know how to compare, so Python can try the reflected operation and, failing that, raise `TypeError`. The current behaviour silently succeeds and breaks total ordering — e.g. `sorted([some_url, 5])` won't raise and gives meaningless results, and it hides accidental cross-type comparisons. It also means two different `Url` subclasses are silently unorderable-but-not-erroring.

### Fix

Return `NotImplemented` when the classes differ, then perform the comparison:

```python
def __lt__(self, other: Any) -> bool:
    if self.__class__ is not other.__class__:
        return NotImplemented
    return self._url < other._url
```

Applied to all four ordering operators. `__eq__` is intentionally left as-is (returning `False` for different classes is the conventional behaviour for equality). Same-type ordering and sorting are unchanged.

### Tests

Existing `test_any_url_comparison` (same-type ordering) still passes untouched. Added `test_any_url_comparison_incompatible_type` asserting that `< > <= >=` against an incomparable value raise `TypeError`, and that two different `Url` subclasses are not orderable. Full `tests/test_networks.py` passes locally; `ruff check`/`ruff format` clean.

<!-- Disclosure: an AI coding assistant helped locate this and draft the change; I reviewed it, reproduced the behaviour, and verified the fix and tests. -->
