### PR TITLE
Add support for `datetime.timezone` as a field type

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -689,6 +689,47 @@ print(m.model_dump_json())
 #> {"td":"P3DT12H30M5S"}
 ```
 
+### Timezones
+
+Standard library type: [`datetime.timezone`][].
+
+<h4>Validation</h4>
+
+* [`timezone`][datetime.timezone] instances are validated as is.
+* The string `'UTC'` and UTC-offset strings such as `'UTC+05:00'`, `'+05:00'` or `'-08:30'` (as accepted by the
+  [`%z` strptime directive](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)) are
+  validated into the corresponding fixed-offset [`timezone`][datetime.timezone].
+
+The [`tzinfo`][datetime.tzinfo] abstract base class and named timezones (such as [`ZoneInfo`][zoneinfo.ZoneInfo]) are
+not covered here; annotate the field with the concrete type you want instead.
+
+<h4>Serialization</h4>
+
+In [Python mode](../concepts/serialization.md#python-mode), [`timezone`][datetime.timezone] instances are serialized as is.
+
+In [JSON mode](../concepts/serialization.md#json-mode), they are serialized as `'UTC'` or a `'UTC±HH:MM[:SS]'`
+offset string. A custom [`timezone`][datetime.timezone] name is dropped in favor of the offset so that the value round-trips.
+
+<h4>Example</h4>
+
+```python
+from datetime import timezone
+
+from pydantic import BaseModel
+
+
+class Model(BaseModel):
+    tz: timezone
+
+
+m = Model(tz='UTC+05:00')
+
+print(m.model_dump())
+#> {'tz': datetime.timezone(datetime.timedelta(seconds=18000))}
+print(m.model_dump_json())
+#> {"tz":"UTC+05:00"}
+```
+
 <!-- old anchor added for backwards compatibility -->
 <!-- markdownlint-disable-next-line no-empty-links -->
 [](){#enum}

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1132,6 +1132,8 @@ class GenerateSchema:
             return self._call_schema(obj)  # pyright: ignore[reportArgumentType]
         elif obj is ZoneInfo:
             return self._zoneinfo_schema()
+        elif obj is datetime.timezone:
+            return self._timezone_schema()
 
         # dataclasses.is_dataclass coerces dc instances to types, but we only handle
         # the case of a dc type here
@@ -1698,6 +1700,21 @@ class GenerateSchema:
         return core_schema.no_info_plain_validator_function(
             validate_str_is_valid_iana_tz,
             serialization=core_schema.to_string_ser_schema(),
+            metadata=metadata,
+        )
+
+    def _timezone_schema(self) -> core_schema.CoreSchema:
+        """Generate schema for a datetime.timezone object."""
+        from ._validators import serialize_timezone, validate_timezone
+
+        metadata = {'pydantic_js_functions': [lambda _1, _2: {'type': 'string', 'format': 'timezone'}]}
+        return core_schema.no_info_plain_validator_function(
+            validate_timezone,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                serialize_timezone,
+                return_schema=core_schema.str_schema(),
+                when_used='json-unless-none',
+            ),
             metadata=metadata,
         )
 

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -6,6 +6,7 @@ Import of this module is deferred since it contains imports of many standard lib
 from __future__ import annotations as _annotations
 
 import collections.abc
+import datetime
 import math
 import re
 import typing
@@ -481,6 +482,32 @@ def validate_str_is_valid_iana_tz(value: Any, /) -> ZoneInfo:
         return ZoneInfo(value)
     except (ZoneInfoNotFoundError, ValueError, TypeError):
         raise PydanticCustomError('zoneinfo_str', 'invalid timezone: {value}', {'value': value})
+
+
+def validate_timezone(value: Any, /) -> datetime.timezone:
+    """Validate a `datetime.timezone`, either passed directly or as a `'UTC'`/UTC-offset string."""
+    if isinstance(value, datetime.timezone):
+        return value
+    if isinstance(value, str):
+        if value.upper() == 'UTC':
+            return datetime.timezone.utc
+        offset_str = value[3:] if value[:3].upper() == 'UTC' else value
+        try:
+            offset = datetime.datetime.strptime(offset_str, '%z').utcoffset()
+        except ValueError:
+            offset = None
+        if offset is not None:
+            return datetime.timezone(offset)
+    raise PydanticCustomError('timezone_parsing', 'Input is not a valid timezone: {value}', {'value': value})
+
+
+def serialize_timezone(value: datetime.timezone, /) -> str:
+    """Serialize a `datetime.timezone` to its offset name (`'UTC'` or `'UTC±HH:MM[:SS]'`).
+
+    The timezone is rebuilt from its UTC offset so that any custom name is dropped in favor of
+    the offset, which is what round-trips through `validate_timezone`.
+    """
+    return datetime.timezone(value.utcoffset(None)).tzname(None)
 
 
 NUMERIC_VALIDATOR_LOOKUP: dict[str, Callable] = {

--- a/tests/test_types_timezone.py
+++ b/tests/test_types_timezone.py
@@ -1,0 +1,114 @@
+from datetime import timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+
+class TimezoneModel(BaseModel):
+    tz: timezone
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        pytest.param('UTC', timezone.utc, id='utc-str'),
+        pytest.param('utc', timezone.utc, id='utc-str-lowercase'),
+        pytest.param('Z', timezone.utc, id='z-str'),
+        pytest.param('UTC+05:00', timezone(timedelta(hours=5)), id='utc-offset-str'),
+        pytest.param('UTC-08:30', timezone(timedelta(hours=-8, minutes=-30)), id='utc-negative-offset-str'),
+        pytest.param('+05:00', timezone(timedelta(hours=5)), id='bare-offset-str'),
+        pytest.param('-08:30', timezone(timedelta(hours=-8, minutes=-30)), id='bare-negative-offset-str'),
+        pytest.param('UTC+05:00:30', timezone(timedelta(hours=5, seconds=30)), id='sub-minute-offset-str'),
+    ],
+)
+def test_timezone_valid_inputs(value, expected):
+    assert TimezoneModel(tz=value).tz == expected
+
+
+def test_timezone_object_is_passed_through():
+    tz = timezone(timedelta(hours=3))
+    assert TimezoneModel(tz=tz).tz is tz
+
+
+def test_timezone_python_mode_serialization_keeps_object():
+    tz = timezone(timedelta(hours=3))
+    assert TimezoneModel(tz=tz).model_dump()['tz'] is tz
+
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        pytest.param('not-a-timezone', id='garbage-str'),
+        pytest.param('', id='empty-str'),
+        pytest.param('UTCfoo', id='utc-prefixed-garbage'),
+        pytest.param(b'+05:00', id='bytes'),
+        pytest.param(5, id='int'),
+        pytest.param(None, id='none'),
+        pytest.param(timedelta(hours=5), id='timedelta'),
+    ],
+)
+def test_timezone_invalid_inputs(value):
+    with pytest.raises(ValidationError):
+        TimezoneModel(tz=value)
+
+
+@pytest.mark.parametrize(
+    'tz,expected',
+    [
+        pytest.param(timezone.utc, 'UTC', id='utc'),
+        pytest.param(timezone(timedelta(hours=5)), 'UTC+05:00', id='positive'),
+        pytest.param(timezone(timedelta(hours=-8, minutes=-30)), 'UTC-08:30', id='negative'),
+        # A custom name is dropped in favor of the offset so the value round-trips.
+        pytest.param(timezone(timedelta(hours=5, minutes=30), 'EST'), 'UTC+05:30', id='named-serializes-to-offset'),
+        pytest.param(timezone(timedelta(hours=5, seconds=30)), 'UTC+05:00:30', id='sub-minute'),
+    ],
+)
+def test_timezone_serialization(tz, expected):
+    assert TimezoneModel(tz=tz).model_dump_json() == f'{{"tz":"{expected}"}}'
+
+
+@pytest.mark.parametrize(
+    'tz',
+    [
+        timezone.utc,
+        timezone(timedelta(hours=5)),
+        timezone(timedelta(hours=-8, minutes=-30)),
+        timezone(timedelta(hours=5, minutes=30), 'EST'),
+        timezone(timedelta(hours=5, seconds=30)),
+        timezone(timedelta(seconds=-30)),
+    ],
+)
+def test_timezone_round_trip(tz):
+    ta = TypeAdapter(timezone)
+    assert ta.validate_json(ta.dump_json(tz)).utcoffset(None) == tz.utcoffset(None)
+
+
+def test_timezone_parsing_fails_for_invalid_strs():
+    with pytest.raises(ValidationError) as exc_info:
+        TimezoneModel(tz='not-a-timezone')
+    assert exc_info.value.errors() == [
+        {
+            'type': 'timezone_parsing',
+            'loc': ('tz',),
+            'msg': 'Input is not a valid timezone: not-a-timezone',
+            'input': 'not-a-timezone',
+            'ctx': {'value': 'not-a-timezone'},
+        }
+    ]
+
+
+def test_timezone_rejects_non_timezone_tzinfo():
+    # A ZoneInfo is a tzinfo but not a datetime.timezone; the field is scoped to timezone.
+    with pytest.raises(ValidationError):
+        TimezoneModel(tz=ZoneInfo('America/Los_Angeles'))
+
+
+def test_timezone_json_schema():
+    assert TimezoneModel.model_json_schema() == {
+        'type': 'object',
+        'title': 'TimezoneModel',
+        'properties': {'tz': {'type': 'string', 'format': 'timezone', 'title': 'Tz'}},
+        'required': ['tz'],
+    }


### PR DESCRIPTION
## Change Summary

Adds support for `datetime.timezone` as a field type (pure Python), mirroring the existing `ZoneInfo` support in #9896.

A `datetime.timezone` field:
- validates from a `datetime.timezone` instance, or from a `'UTC'` / UTC-offset string (`'UTC+05:00'`, `'+05:00'`, `'-08:30'`, `'Z'`, as accepted by the `%z` strptime directive);
- serializes in JSON mode to `'UTC'` or a `'UTC±HH:MM[:SS]'` offset string (and passes the object through unchanged in Python mode, like `ZoneInfo`);
- exposes a JSON-schema `format: 'timezone'`.

Per @davidhewitt's note on the issue, this is scoped to `datetime.timezone` only; the `tzinfo` ABC (which he flagged as likely needing `pydantic-core`) is intentionally left out.

A custom `timezone` name is dropped in favor of the offset on serialization, since a fixed-offset name is arbitrary and can't be reconstructed from JSON; this keeps the value round-trippable.

## Related issue number

Closes #8895

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
