### PR TITLE
Raise TypeError for invalid serializer index keys

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -2,13 +2,11 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use pyo3::PyTraverseError;
-use pyo3::exceptions::{PyAttributeError, PyRecursionError, PyRuntimeError};
+use pyo3::exceptions::{PyAttributeError, PyRecursionError, PyRuntimeError, PyTypeError};
 use pyo3::gc::PyVisit;
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
-
-use pyo3::types::PyString;
+use pyo3::types::{PyDict, PyInt, PyString};
 
 use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
@@ -474,6 +472,9 @@ impl SerializationCallable {
         let state = &mut self.extra_owned.to_state(py);
 
         if let Some(index_key) = index_key {
+            if !index_key.is_instance_of::<PyInt>() && !index_key.is_instance_of::<PyString>() {
+                return Err(PyTypeError::new_err("`index_key` must be an `int`, `str` or `None`"));
+            }
             let filter = if let Ok(index) = index_key.extract::<usize>() {
                 self.filter.index_filter(index, state, None)?
             } else {

--- a/pydantic-core/tests/serializers/test_functions.py
+++ b/pydantic-core/tests/serializers/test_functions.py
@@ -358,6 +358,21 @@ def test_function_wrap():
     assert s.to_json('foo') == b'"result=3 repr=SerializationCallable(serializer=int)"'
 
 
+def test_function_wrap_invalid_index_key():
+    def f(value, serializer, info):
+        return serializer(value, info)
+
+    s = SchemaSerializer(
+        core_schema.int_schema(serialization=core_schema.wrap_serializer_function_ser_schema(f, info_arg=True))
+    )
+
+    with pytest.raises(
+        PydanticSerializationError,
+        match=r'Error calling function `f`: TypeError: `index_key` must be an `int`, `str` or `None`',
+    ):
+        s.to_python(1)
+
+
 def test_function_wrap_return_scheam():
     def f(value, serializer):
         if value == 42:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -513,6 +513,21 @@ def test_model_serializer_wrap_info():
     assert m.model_dump_json(exclude={'a'}) == '{"b":"boom","info":"mode=json exclude={\'a\'}"}'
 
 
+def test_model_serializer_wrap_rejects_info_as_index_key():
+    class MyModel(BaseModel):
+        value: int
+
+        @model_serializer(mode='wrap')
+        def _serialize(self, handler, info):
+            return handler(self, info)
+
+    with pytest.raises(
+        PydanticSerializationError,
+        match=r'Error calling function `_serialize`: TypeError: `index_key` must be an `int`, `str` or `None`',
+    ):
+        MyModel(value=1).model_dump(include={'value'})
+
+
 def test_model_serializer_plain_json_return_type():
     class MyModel(BaseModel):
         a: int


### PR DESCRIPTION
## Change Summary

- Validate `SerializerFunctionWrapHandler` index keys against its documented `int | str | None` contract.
- Raise a clear `TypeError` when serializer info (or another unsupported object) is accidentally forwarded as the index key, rather than surfacing `PydanticOmit`.
- Add regression coverage in both pydantic-core and Pydantic's model serializer tests.

Valid integer sequence indexes and string mapping keys retain their existing include/exclude behavior.

## Related issue number

Related to #11862. Assignment was requested in the issue before opening this PR; I will change this to a closing reference once assigned.

## Test report

- `uv run --project pydantic-core pytest pydantic-core\tests\serializers\test_functions.py -q` — 31 passed, 2 skipped
- `uv run pytest tests\test_serialize.py -q` — 89 passed, 1 skipped
- `cargo fmt --all -- --check` — passed
- `cargo clippy --tests -- -D warnings` — passed
- Ruff check and format checks for changed Python tests — passed

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable (the public protocol already documents the accepted types)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**