### PR TITLE
Raise explicit `TypeError` on invalid `index_key` serialization wrap handler

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -15,7 +15,7 @@ use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::extra::IncludeExclude;
 use crate::tools::SchemaDict;
-use crate::tools::{function_name, py_err, py_error_type};
+use crate::tools::{function_name, py_err, py_error_type, safe_repr};
 use crate::{PydanticOmit, PydanticSerializationUnexpectedValue};
 
 use super::format::WhenUsed;
@@ -481,7 +481,7 @@ impl SerializationCallable {
             } else {
                 return Err(PyTypeError::new_err(format!(
                     "'index_key' is expected to be an integer or a string, got '{}'",
-                    index_key.repr()?
+                    safe_repr(index_key),
                 )));
             };
             if let Some(next_include_exclude) = filter {

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -2,13 +2,13 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use pyo3::PyTraverseError;
-use pyo3::exceptions::{PyAttributeError, PyRecursionError, PyRuntimeError};
+use pyo3::exceptions::{PyAttributeError, PyRecursionError, PyRuntimeError, PyTypeError};
 use pyo3::gc::PyVisit;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use pyo3::types::PyString;
+use pyo3::types::{PyInt, PyString};
 
 use crate::definitions::DefinitionsBuilder;
 use crate::py_gc::PyGcTraverse;
@@ -476,8 +476,13 @@ impl SerializationCallable {
         if let Some(index_key) = index_key {
             let filter = if let Ok(index) = index_key.extract::<usize>() {
                 self.filter.index_filter(index, state, None)?
-            } else {
+            } else if index_key.is_instance_of::<PyString>() || index_key.is_instance_of::<PyInt>() {
                 self.filter.key_filter(index_key, state)?
+            } else {
+                return Err(PyTypeError::new_err(format!(
+                    "'index_key' is expected to be an integer or a string, got '{}'",
+                    index_key.repr()?
+                )));
             };
             if let Some(next_include_exclude) = filter {
                 let state = &mut state.scoped_include_exclude(next_include_exclude);

--- a/pydantic/functional_serializers.py
+++ b/pydantic/functional_serializers.py
@@ -97,50 +97,41 @@ class WrapSerializer:
     from datetime import datetime, timezone
     from typing import Annotated, Any
 
-    from pydantic import BaseModel, WrapSerializer
+    from pydantic import (
+        BaseModel,
+        SerializationInfo,
+        SerializerFunctionWrapHandler,
+        WrapSerializer,
+    )
 
-    class EventDatetime(BaseModel):
-        start: datetime
-        end: datetime
-
-    def convert_to_utc(value: Any, handler, info) -> dict[str, datetime]:
+    def convert_to_utc(
+        value: Any, handler: SerializerFunctionWrapHandler, info: SerializationInfo
+    ):
         # Note that `handler` can actually help serialize the `value` for
         # further custom serialization in case it's a subclass.
-        partial_result = handler(value, info)
+        serialized = handler(value)
         if info.mode == 'json':
-            return {
-                k: datetime.fromisoformat(v).astimezone(timezone.utc)
-                for k, v in partial_result.items()
-            }
-        return {k: v.astimezone(timezone.utc) for k, v in partial_result.items()}
+            return datetime.fromisoformat(serialized).astimezone(timezone.utc)
+        else:
+            return serialized.astimezone(timezone.utc)
 
-    UTCEventDatetime = Annotated[EventDatetime, WrapSerializer(convert_to_utc)]
+    UTCDatetime = Annotated[datetime, WrapSerializer(convert_to_utc)]
 
     class EventModel(BaseModel):
-        event_datetime: UTCEventDatetime
+        event_datetime: UTCDatetime
 
-    dt = EventDatetime(
-        start='2024-01-01T07:00:00-08:00', end='2024-01-03T20:00:00+06:00'
-    )
-    event = EventModel(event_datetime=dt)
+    event = EventModel(event_datetime='2024-01-01T07:00:00-08:00')
     print(event.model_dump())
     '''
     {
-        'event_datetime': {
-            'start': datetime.datetime(
-                2024, 1, 1, 15, 0, tzinfo=datetime.timezone.utc
-            ),
-            'end': datetime.datetime(
-                2024, 1, 3, 14, 0, tzinfo=datetime.timezone.utc
-            ),
-        }
+        'event_datetime': datetime.datetime(
+            2024, 1, 1, 15, 0, tzinfo=datetime.timezone.utc
+        )
     }
     '''
 
     print(event.model_dump_json())
-    '''
-    {"event_datetime":{"start":"2024-01-01T15:00:00Z","end":"2024-01-03T14:00:00Z"}}
-    '''
+    #> {"event_datetime":"2024-01-01T15:00:00Z"}
     ```
 
     Attributes:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1419,3 +1419,21 @@ def test_serialization_info_properties() -> None:
         'round_trip',
     ):
         assert getattr(m.model_dump(**{property: True})['f'], property) is True, f'{property!r} check failed'
+
+
+def test_model_serializer_index_key_type_error() -> None:
+    """https://github.com/pydantic/pydantic/issues/11862"""
+
+    class Model(BaseModel):
+        f: int
+
+        @model_serializer(mode='wrap')
+        def _serialize(self, handler: SerializerFunctionWrapHandler):
+            return handler(self, b'not_a_valid_type_for_index_key')
+
+    m = Model(f=1)
+    with pytest.raises(
+        PydanticSerializationError,
+        match="Error calling function `_serialize`: TypeError: 'index_key' is expected to be an integer or a string, got 'b'not_a_valid_type_for_index_key''",
+    ):
+        m.model_dump(include={'f'})


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/11862.

Marking as a change as we had a docstring example wrongly passing `info` for `index_key` (same as the reported issue). It was harmless until now, but with this PR an explicit exception is raised, and some users might have copied the wrong docstring example so I think we should document this change.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
