### PR TITLE
Keep chained pipeline constraints in the JSON schema

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -502,49 +502,82 @@ def _apply_constraint(  # noqa: C901
             s = _check_func(check_gt, f'> {gt}', s)
     elif isinstance(constraint, annotated_types.Ge):
         ge = constraint.ge
+        native_constraint_applied = False
         if s and s['type'] in {'int', 'float', 'decimal'}:
             s = s.copy()
             if s['type'] == 'int' and isinstance(ge, int):
                 s['ge'] = ge
+                native_constraint_applied = True
             elif s['type'] == 'float' and isinstance(ge, float):
                 s['ge'] = ge
+                native_constraint_applied = True
             elif s['type'] == 'decimal' and isinstance(ge, Decimal):
                 s['ge'] = ge
+                native_constraint_applied = True
 
-        def check_ge(v: Any) -> bool:
-            return v >= ge
+        # Only fall back to a function validator when the native constraint could not be applied.
+        # Layering one on top of a native constraint wraps the schema in `function-after`, which
+        # hides the numeric type from every constraint chained after this one - they can no longer
+        # set their own native field, so the bound survives only inside an opaque callable and
+        # disappears from the generated JSON schema.
+        if not native_constraint_applied:
 
-        s = _check_func(check_ge, f'>= {ge}', s)
+            def check_ge(v: Any) -> bool:
+                return v >= ge
+
+            s = _check_func(check_ge, f'>= {ge}', s)
     elif isinstance(constraint, annotated_types.Lt):
         lt = constraint.lt
+        native_constraint_applied = False
         if s and s['type'] in {'int', 'float', 'decimal'}:
             s = s.copy()
             if s['type'] == 'int' and isinstance(lt, int):
                 s['lt'] = lt
+                native_constraint_applied = True
             elif s['type'] == 'float' and isinstance(lt, float):
                 s['lt'] = lt
+                native_constraint_applied = True
             elif s['type'] == 'decimal' and isinstance(lt, Decimal):
                 s['lt'] = lt
+                native_constraint_applied = True
 
-        def check_lt(v: Any) -> bool:
-            return v < lt
+        # Only fall back to a function validator when the native constraint could not be applied.
+        # Layering one on top of a native constraint wraps the schema in `function-after`, which
+        # hides the numeric type from every constraint chained after this one - they can no longer
+        # set their own native field, so the bound survives only inside an opaque callable and
+        # disappears from the generated JSON schema.
+        if not native_constraint_applied:
 
-        s = _check_func(check_lt, f'< {lt}', s)
+            def check_lt(v: Any) -> bool:
+                return v < lt
+
+            s = _check_func(check_lt, f'< {lt}', s)
     elif isinstance(constraint, annotated_types.Le):
         le = constraint.le
+        native_constraint_applied = False
         if s and s['type'] in {'int', 'float', 'decimal'}:
             s = s.copy()
             if s['type'] == 'int' and isinstance(le, int):
                 s['le'] = le
+                native_constraint_applied = True
             elif s['type'] == 'float' and isinstance(le, float):
                 s['le'] = le
+                native_constraint_applied = True
             elif s['type'] == 'decimal' and isinstance(le, Decimal):
                 s['le'] = le
+                native_constraint_applied = True
 
-        def check_le(v: Any) -> bool:
-            return v <= le
+        # Only fall back to a function validator when the native constraint could not be applied.
+        # Layering one on top of a native constraint wraps the schema in `function-after`, which
+        # hides the numeric type from every constraint chained after this one - they can no longer
+        # set their own native field, so the bound survives only inside an opaque callable and
+        # disappears from the generated JSON schema.
+        if not native_constraint_applied:
 
-        s = _check_func(check_le, f'<= {le}', s)
+            def check_le(v: Any) -> bool:
+                return v <= le
+
+            s = _check_func(check_le, f'<= {le}', s)
     elif isinstance(constraint, annotated_types.Len):
         min_len = constraint.min_length
         max_len = constraint.max_length

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from decimal import Decimal
 from typing import Annotated, Any
 
+import annotated_types
 import pytest
 import pytz
 from annotated_types import Interval
@@ -490,3 +491,76 @@ def test_validate_as_ellipsis_preserves_other_steps() -> None:
     ta = TypeAdapter[float](Annotated[float, validate_as(str).transform(lambda v: v.split()[0]).validate_as(...)])
 
     assert ta.validate_python('12 ab') == 12.0
+
+
+@pytest.mark.parametrize(
+    'pipeline, expected',
+    [
+        pytest.param(
+            validate_as(int).ge(1).le(100),
+            {'type': 'integer', 'minimum': 1, 'maximum': 100},
+            id='ge-then-le',
+        ),
+        pytest.param(
+            validate_as(int).le(100).ge(1),
+            {'type': 'integer', 'minimum': 1, 'maximum': 100},
+            id='le-then-ge',
+        ),
+        pytest.param(
+            validate_as(int).lt(100).gt(1),
+            {'type': 'integer', 'exclusiveMinimum': 1, 'exclusiveMaximum': 100},
+            id='lt-then-gt',
+        ),
+        pytest.param(
+            validate_as(int).gt(1).lt(100),
+            {'type': 'integer', 'exclusiveMinimum': 1, 'exclusiveMaximum': 100},
+            id='gt-then-lt',
+        ),
+        pytest.param(
+            validate_as(int).ge(1).le(100).multiple_of(5),
+            {'type': 'integer', 'minimum': 1, 'maximum': 100, 'multipleOf': 5},
+            id='ge-le-multiple_of',
+        ),
+        pytest.param(
+            validate_as(int).constrain(annotated_types.Interval(ge=1, le=100)),
+            {'type': 'integer', 'minimum': 1, 'maximum': 100},
+            id='interval',
+        ),
+    ],
+)
+def test_chained_constraints_survive_in_json_schema(pipeline: Any, expected: dict[str, Any]) -> None:
+    """Every bound in a chain must reach the JSON schema, not just the first.
+
+    A constraint that layers a function validator on top of an already-applied
+    native constraint wraps the schema in `function-after`. Every constraint
+    chained after it then sees a non-numeric schema type, cannot set its own
+    native field, and survives only inside an opaque callable - so validation
+    stays correct while the published schema silently loses the bound.
+    """
+    assert TypeAdapter[Any](Annotated[int, pipeline]).json_schema() == expected
+
+
+def test_chained_constraints_match_the_equivalent_plain_annotation() -> None:
+    """The pipeline API and plain `Annotated` must publish the same schema."""
+    via_pipeline = TypeAdapter[Any](Annotated[int, validate_as(int).ge(1).le(100)]).json_schema()
+    via_annotated = TypeAdapter[Any](Annotated[int, annotated_types.Ge(1), annotated_types.Le(100)]).json_schema()
+
+    assert via_pipeline == via_annotated
+
+
+@pytest.mark.parametrize(
+    'pipeline, accepted, rejected',
+    [
+        (validate_as(int).ge(1).le(100), [1, 50, 100], [0, 101]),
+        (validate_as(int).le(100).ge(1), [1, 50, 100], [0, 101]),
+        (validate_as(int).lt(100).gt(1), [2, 50, 99], [1, 100]),
+    ],
+)
+def test_chained_constraints_still_validate(pipeline: Any, accepted: list[int], rejected: list[int]) -> None:
+    """Guard the other direction: the bounds must keep being enforced."""
+    ta = TypeAdapter[Any](Annotated[int, pipeline])
+    for value in accepted:
+        assert ta.validate_python(value) == value
+    for value in rejected:
+        with pytest.raises(ValueError):
+            ta.validate_python(value)


### PR DESCRIPTION
## Change Summary

In the experimental pipeline API, chaining constraints silently drops every bound after the first from the generated JSON schema. Validation stays correct, so the divergence is easy to miss.

```python
TypeAdapter(Annotated[int, validate_as(int).ge(1).le(100)]).json_schema()
# {'minimum': 1, 'type': 'integer'}      <- maximum is gone

TypeAdapter(Annotated[int, annotated_types.Ge(1), annotated_types.Le(100)]).json_schema()
# {'maximum': 100, 'minimum': 1, 'type': 'integer'}   <- control
```

`_apply_constraint()`'s `Ge`, `Lt` and `Le` branches apply their fallback function validator unconditionally, including when the native core-schema field was just set. `_check_func` wraps the schema in `function-after`, so the next constraint in the chain sees a non-numeric schema type, cannot set its own native field, and survives only inside an opaque callable that JSON-schema generation cannot read.

This applies the fallback only when the native constraint could not be — the same shape #13473 introduces for `MultipleOf` (there, to avoid a float parity problem) and #13446 for `Gt`. Those two PRs each fix one branch for unrelated reasons; between them `Ge`, `Lt` and `Le` are left as they are. Scoped deliberately to those three so it does not conflict with either.

Before and after, all bounds non-zero so this is not #13450:

| expression | before | after |
|---|---|---|
| `.ge(1).le(100)` | `{minimum: 1}` | `{minimum: 1, maximum: 100}` |
| `.le(100).ge(1)` | `{maximum: 100}` | `{minimum: 1, maximum: 100}` |
| `.lt(100).gt(1)` | `{exclusiveMaximum: 100}` | `{exclusiveMinimum: 1, exclusiveMaximum: 100}` |
| `.ge(1).le(100).multiple_of(5)` | `{minimum: 1}` | `{minimum: 1, maximum: 100, multipleOf: 5}` |
| `Interval(ge=1, le=100)` | `{minimum: 1}` | `{minimum: 1, maximum: 100}` |
| `.gt(1).lt(100)` *(control)* | both | both |

Validation behaviour is unchanged in every case — the bounds were always enforced, just invisibly.

## Related issue number

fix #13507

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable

## Tests

`tests/test_pipeline.py` gains three cases: a parametrised schema check over the chains above, an equivalence check against the plain-`Annotated` spelling, and a validation guard so the bounds cannot be quietly lost in the other direction.

I checked the tests actually gate the change rather than just passing alongside it: reverting `pipeline.py` to `main` while keeping the new tests fails 6 of them, including the `gt`-control staying green. `tests/test_pipeline.py` is 79/79 with the fix; `test_pipeline.py`, `test_json_schema.py` and `test_types.py` together are 1545 passed (the two `test_iterable_any` failures are pre-existing on clean `main`). `ruff check` and `ruff format --check` are clean.