### PR TITLE
Reject trailing data in `ByteSize` strings

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2100,7 +2100,7 @@ class ByteSize(int):
     }
     byte_sizes.update({k.lower()[0]: v for k, v in byte_sizes.items() if 'i' not in k})
 
-    byte_string_pattern = r'^\s*(\d*\.?\d+)\s*(\w+)?'
+    byte_string_pattern = r'^\s*(\d*\.?\d+)\s*(\w+)?\s*$'
     byte_string_re = re.compile(byte_string_pattern, re.IGNORECASE)
 
     @classmethod

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1351,14 +1351,14 @@ def test_byte_size_type():
         'properties': {
             'a': {
                 'anyOf': [
-                    {'pattern': '^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?', 'type': 'string'},
+                    {'pattern': '^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?\\s*$', 'type': 'string'},
                     {'minimum': 0, 'type': 'integer'},
                 ],
                 'title': 'A',
             },
             'b': {
                 'anyOf': [
-                    {'pattern': '^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?', 'type': 'string'},
+                    {'pattern': '^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?\\s*$', 'type': 'string'},
                     {'minimum': 0, 'type': 'integer'},
                 ],
                 'default': 1000000,
@@ -1366,7 +1366,7 @@ def test_byte_size_type():
             },
             'c': {
                 'anyOf': [
-                    {'pattern': '^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?', 'type': 'string'},
+                    {'pattern': '^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?\\s*$', 'type': 'string'},
                     {'minimum': 0, 'type': 'integer'},
                 ],
                 'default': '1MB',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -5068,6 +5068,20 @@ def test_bytesize_raises():
         m.size.to('1ZiB')
 
 
+@pytest.mark.parametrize('size', ['1KB junk', '1.5 MiB extra', '  12  kb  trailing'])
+def test_bytesize_rejects_trailing_data(size):
+    """Trailing data after the value/unit must be rejected, not silently ignored."""
+
+    class Model(BaseModel):
+        size: ByteSize
+
+    with pytest.raises(ValidationError, match='parse value'):
+        Model(size=size)
+
+    # surrounding whitespace remains valid
+    assert Model(size='  1MB  ').size == 1_000_000
+
+
 def test_deque_success():
     class Model(BaseModel):
         v: deque


### PR DESCRIPTION
## Change Summary

`ByteSize.byte_string_pattern` is anchored only at the start (`^`), and `_validate` matches it with `re.match`, so any trailing data after the value and unit is silently ignored:

```python
ta = TypeAdapter(ByteSize)
ta.validate_python('1KB junk')            # -> 1000
ta.validate_python('1.5 MiB extra')       # -> 1572864
ta.validate_python('  12  kb  trailing')  # -> 12000
```

Malformed input is accepted with a plausible-looking value — the worst failure mode for a config parser.

The fix anchors the pattern with `\s*$` so trailing garbage is rejected, while surrounding whitespace stays valid (symmetric with the existing leading `^\s*`):

```python
ta.validate_python('1KB junk')   # -> ValidationError: could not parse value and unit from byte string
ta.validate_python('  1MB  ')    # -> 1000000  (still fine)
```

The same `byte_string_pattern` feeds the string branch of the core/JSON schema, so the generated `pattern` is corrected in lockstep (existing `test_byte_size_type` assertion updated).

## Related issue number

N/A — found by review; no existing issue.

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**