### PR TITLE
Make `NameEmail` hashable

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -1094,6 +1094,9 @@ class NameEmail(_repr.Representation):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, NameEmail) and (self.name, self.email) == (other.name, other.email)
 
+    def __hash__(self) -> int:
+        return hash((self.name, self.email))
+
     @classmethod
     def __get_pydantic_json_schema__(
         cls, core_schema: core_schema.CoreSchema, handler: _schema_generation_shared.GetJsonSchemaHandler

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1034,6 +1034,19 @@ def test_name_email():
     ]
 
 
+def test_name_email_hashable():
+    # `NameEmail` defines `__eq__` but historically not `__hash__`, which made it
+    # unhashable (unusable as a dict key / set member) despite being an immutable
+    # value object like every sibling type (`AnyUrl`, `SecretStr`, ...).
+    a = NameEmail('foo bar', 'foobaR@example.com')
+    b = NameEmail('foo bar', 'foobaR@example.com')
+    c = NameEmail('foo bar', 'different@example.com')
+
+    assert hash(a) == hash(b)
+    assert {a, b, c} == {a, c}
+    assert {a: 1}[b] == 1
+
+
 @pytest.mark.skipif(not email_validator, reason='email_validator not installed')
 def test_name_email_serialization():
     class Model(BaseModel):


### PR DESCRIPTION
## Change Summary

`NameEmail` defines `__eq__` but no `__hash__`, so Python sets `__hash__ = None` and instances are unhashable:

```python
>>> NameEmail.__hash__
None
>>> hash(NameEmail('a', 'a@b.com'))
TypeError: unhashable type: 'NameEmail'
```

This means a `NameEmail` can't be a dict key or go in a `set`. It's an immutable value object (`__slots__ = 'name', 'email'`), and every sibling type (`AnyUrl`, `SecretStr`, `Color`, ...) is hashable — so this reads as an oversight rather than a design choice.

Add `__hash__` derived from the same `(name, email)` fields `__eq__` compares, keeping the hash/eq invariant (equal objects hash equally). Mirrors the recently-fixed `__hash__` handling on `WithJsonSchema`/`Examples` (#13428).

## Related issue number

N/A — found by review; no existing issue.

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**