### PR TITLE
Omit `propertyNames` for non-string enum dict keys

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1132,11 +1132,19 @@ class GenerateJsonSchema:
         else:  # for `dict[str, Any]`, we allow any key and any value, since `str` is the default key type
             json_schema['additionalProperties'] = True
 
+        keys_core_schema = schema.get('keys_schema', {})
+        # A non-string enum is serialized as a string when used as a key, so a
+        # reference to its schema would reject the JSON we ourselves produce.
+        # `dict[int, Any]` gets no `propertyNames` for the same reason.
+        keys_ref_is_applicable = not (
+            keys_core_schema.get('type') == 'enum' and keys_core_schema.get('sub_type', 'str') != 'str'
+        )
+
         if (
             # The len check indicates that constraints are probably present:
             (keys_schema.get('type') == 'string' and len(keys_schema) > 1)
             # If this is a definition reference schema, it most likely has constraints:
-            or '$ref' in keys_schema
+            or ('$ref' in keys_schema and keys_ref_is_applicable)
         ):
             keys_schema.pop('type', None)
             json_schema['propertyNames'] = keys_schema

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1780,6 +1780,26 @@ def test_enum_dict():
     }
 
 
+def test_int_enum_dict_key_no_property_names():
+    """A non-string enum key is serialized as a string, so referencing its
+    schema in `propertyNames` would reject our own output. See #11967.
+    """
+
+    class MyEnum(IntEnum):
+        FOO = 1
+        BAR = 2
+
+    class MyModel(BaseModel):
+        enum_dict: dict[MyEnum, str]
+
+    schema = MyModel.model_json_schema()
+    assert 'propertyNames' not in schema['properties']['enum_dict']
+
+    # the emitted JSON must satisfy the emitted schema
+    instance = json.loads(MyModel(enum_dict={MyEnum.FOO: 'a'}).model_dump_json())
+    assert instance == {'enum_dict': {'1': 'a'}}
+
+
 def test_property_names_constraint():
     class MyModel(BaseModel):
         my_dict: dict[Annotated[str, StringConstraints(max_length=1)], str]


### PR DESCRIPTION
This addresses the invalid JSON Schema reported in #11967. I am not assigned to
that issue, so I have not used a closing keyword here. Happy for it to be linked
or for this to be closed if you would rather someone else take it.

## Problem

`dict[SomeIntEnum, T]` produces a schema that rejects the model's own output:

```python
class I(IntEnum):
    one = 1

class M(BaseModel):
    i: dict[I, float]

M.model_json_schema()['properties']['i']['propertyNames']  # {'$ref': '#/$defs/I'}  ->  {'enum': [1], 'type': 'integer'}
M(i={I.one: 1.0}).model_dump_json()                        # {"i":{"1":1.0}}
```

Validating that output against that schema fails with `'1' is not one of [1]`,
because JSON object keys are strings.

## Cause

In `GenerateJsonSchema.dict_schema`, `propertyNames` is emitted whenever the key
schema is a `$ref`, on the assumption (stated in the comment just above) that a
referenced key schema is a constrained string. The `keys_schema.pop('type', None)`
guard cannot help for a `$ref`, since the `type: integer` lives in the referenced
`$defs` entry rather than in the dict being popped from.

`dict[int, float]` already emits no `propertyNames` at all, so integer-keyed
dicts are handled correctly when the key type is not an enum.

## Change

Skip that branch when the core key schema is an enum whose `sub_type` is not
`str`, which is the same outcome `dict[int, float]` already gets. String enums
are unaffected, so the existing `test_enum_dict` expectations are unchanged.

## Tests

Added `test_int_enum_dict_key_no_property_names`, which asserts no
`propertyNames` is emitted and that the serialized output has the string key.
It fails on main.

- `tests/test_json_schema.py`: 530 passed
- `tests/test_json_schema.py tests/test_generics.py`: 652 passed, 7 skipped, 5 xfailed
- `ruff check` and `ruff format --check` clean; pyright reports one error in this
  file that is present on main unchanged
