### PR TITLE
perf: serialize tagged unions directly

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -205,7 +205,6 @@ impl TypeSerializer for TaggedUnionSerializer {
             if let Some(serializer_index) = serializer_index {
                 let choice = &self.choices.choices[serializer_index];
                 let state = &mut scoped_check_level(state, initial_check_level(state));
-                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
                 return choice.serde_serialize(value, serializer, state);
             }
         }

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -196,6 +196,20 @@ impl TypeSerializer for TaggedUnionSerializer {
         serializer: S,
         state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
+        if let Some(tag) = self.get_discriminator_value(value) {
+            let serializer_index = match self.lookup.get(&tag) {
+                Ok(Some(&serializer_index)) => Some(serializer_index),
+                Ok(None) => None,
+                Err(err) => return Err(serde::ser::Error::custom(err.to_string())),
+            };
+            if let Some(serializer_index) = serializer_index {
+                let choice = &self.choices.choices[serializer_index];
+                let state = &mut scoped_check_level(state, initial_check_level(state));
+                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
+                return choice.serde_serialize(value, serializer, state);
+            }
+        }
+
         match self.tagged_union_serialize(
             value,
             |comb_serializer, state| comb_serializer.to_python(value, state),

--- a/pydantic-core/tests/serializers/test_union.py
+++ b/pydantic-core/tests/serializers/test_union.py
@@ -673,6 +673,8 @@ def test_tagged_union() -> None:
     model_b = ModelB(field=1)
     assert s.to_python(model_a) == {'field': 1, 'tag': 'a'}
     assert s.to_python(model_b) == {'field': 1, 'tag': 'b'}
+    assert s.to_json(model_a, include={'field'}) == b'{"field":1}'
+    assert s.to_json(model_a, exclude={'field'}) == b'{"tag":"a"}'
 
 
 def test_union_float_int() -> None:

--- a/tests/benchmarks/test_model_serialization.py
+++ b/tests/benchmarks/test_model_serialization.py
@@ -1,8 +1,33 @@
+from typing import Literal
+
 import pytest
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, JsonValue
 
 from .shared import ComplexModel, NestedModel, OuterModel, SimpleModel
+
+
+class _UnionStringDataA(BaseModel):
+    buffer: str
+    encoding: Literal['a']
+
+
+class _UnionStringDataB(BaseModel):
+    buffer: str
+    encoding: Literal['b']
+
+
+class _UnionJsonData(BaseModel):
+    buffer: JsonValue
+    encoding: Literal['json']
+
+
+class _DiscriminatedUnionModel(BaseModel):
+    data: _UnionStringDataA | _UnionStringDataB | _UnionJsonData = Field(discriminator='encoding')
+
+
+class _ConcreteUnionModel(BaseModel):
+    data: _UnionJsonData
 
 
 @pytest.mark.benchmark(group='model_serialization')
@@ -37,4 +62,18 @@ def test_list_of_models_serialization(benchmark):
 @pytest.mark.benchmark(group='model_serialization')
 def test_model_json_serialization(benchmark):
     model = ComplexModel(field1='test', field2=[{'a': 1, 'b': 2.2}, {'c': 3, 'd': 4.4}], field3=['test', 1, 2, 'test2'])
+    benchmark(model.model_dump_json)
+
+
+@pytest.mark.benchmark(group='model_serialization_union')
+def test_model_json_serialization_discriminated_union(benchmark):
+    inner = _UnionJsonData.model_construct(buffer=[1.0] * 100_000, encoding='json')
+    model = _DiscriminatedUnionModel.model_construct(data=inner)
+    benchmark(model.model_dump_json)
+
+
+@pytest.mark.benchmark(group='model_serialization_union')
+def test_model_json_serialization_concrete(benchmark):
+    inner = _UnionJsonData.model_construct(buffer=[1.0] * 100_000, encoding='json')
+    model = _ConcreteUnionModel.model_construct(data=inner)
     benchmark(model.model_dump_json)


### PR DESCRIPTION
## Summary

- Serialize the selected branch of a tagged union directly during JSON serialization.
- Avoid converting the selected value to an intermediate Python object before serializing it.
- Preserve existing fallback behavior when the discriminator cannot select a branch.
- Preserve nested include/exclude selections for the selected branch.

Related to #12912

## Benchmark

For a 100,000-element JSON payload inside a three-variant discriminated union on Linux x86_64:

- Concrete model: ~53.6 ms → ~52.1 ms
- Discriminated union: ~137.4 ms → ~51.8 ms

The discriminated-union path now performs approximately like the concrete model path.

## Testing

- 106 union serializer tests
- 802 serializer tests
- Added include/exclude regression coverage
- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`
