### PR TITLE
Use constant-time comparison for `SecretStr` and `SecretBytes` types

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1584,7 +1584,7 @@ class Secret(_SecretBase[SecretType]):
     """A generic base class used for defining a field with sensitive information that you do not want to be visible in logging or tracebacks.
 
     You may either directly parametrize `Secret` with a type, or subclass from `Secret` with a parametrized type. The benefit of subclassing
-    is that you can define a custom `_display()` method, which will be used for [`repr()`][] and [`str()`][str] methods. The examples below demonstrate both
+    is that you can define a custom `_display()` method, which will be used for [`repr()`][repr] and [`str()`][str] methods. The examples below demonstrate both
     ways of using `Secret` to create a new secret type.
 
     1. Directly parametrizing `Secret` with a type:

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations as _annotations
 import base64
 import dataclasses as _dataclasses
 import re
+import secrets
 from collections.abc import Callable, Hashable, Iterator
 from datetime import date, datetime
 from decimal import Decimal
@@ -1583,7 +1584,7 @@ class Secret(_SecretBase[SecretType]):
     """A generic base class used for defining a field with sensitive information that you do not want to be visible in logging or tracebacks.
 
     You may either directly parametrize `Secret` with a type, or subclass from `Secret` with a parametrized type. The benefit of subclassing
-    is that you can define a custom `_display` method, which will be used for `repr()` and `str()` methods. The examples below demonstrate both
+    is that you can define a custom `_display()` method, which will be used for [`repr()`][] and [`str()`][str] methods. The examples below demonstrate both
     ways of using `Secret` to create a new secret type.
 
     1. Directly parametrizing `Secret` with a type:
@@ -1632,7 +1633,7 @@ class Secret(_SecretBase[SecretType]):
     #> 2022-01-01
     ```
 
-    The value returned by the `_display` method will be used for `repr()` and `str()`.
+    The value returned by the `_display()` method will be used for [`repr()`][repr] and [`str()`][str].
 
     You can enforce constraints on the underlying type through annotations:
     For example:
@@ -1683,6 +1684,11 @@ class Secret(_SecretBase[SecretType]):
 
     1. The input value is not greater than 0, so it raises a validation error.
     2. The input value is not an integer, so it raises a validation error because the `SecretPosInt` type has strict mode enabled.
+
+    Two `Secret` types compare equal if the secret values are equal. For the [`SecretStr`][pydantic.types.SecretStr] and
+    [`SecretBytes`][pydantic.types.SecretBytes] implementations, constant-time comparison is achieved
+    (using [`secrets.compare_digest()`][secrets.compare_digest]). If you need constant-time comparison on your `Secret`
+    subclass, you can do so by overriding [`__eq__()`][object.__eq__].
     """
 
     def _display(self) -> str | bytes:
@@ -1813,7 +1819,10 @@ class SecretStr(_SecretField[str]):
     """A string used for storing sensitive information that you do not want to be visible in logging or tracebacks.
 
     When the secret value is nonempty, it is displayed as `'**********'` instead of the underlying value in
-    calls to `repr()` and `str()`. If the value _is_ empty, it is displayed as `''`.
+    calls to [`repr()`][repr] and [`str()`][str]. If the value _is_ empty, it is displayed as `''`.
+
+    Two `SecretStr` types compare equal if the secret values are equal. Constant-time comparison is achieved
+    (using [`secrets.compare_digest()`][secrets.compare_digest]).
 
     ```python
     from pydantic import BaseModel, SecretStr
@@ -1835,7 +1844,7 @@ class SecretStr(_SecretField[str]):
     As seen above, by default, [`SecretStr`][pydantic.types.SecretStr] (and [`SecretBytes`][pydantic.types.SecretBytes])
     will be serialized as `**********` when serializing to json.
 
-    You can use the [`field_serializer`][pydantic.functional_serializers.field_serializer] to dump the
+    You can use a [field serializer](../concepts/serialization.md#field-serializers) to dump the
     secret as plain-text when serializing to json.
 
     ```python
@@ -1872,6 +1881,15 @@ class SecretStr(_SecretField[str]):
     def __len__(self) -> int:
         return len(self._secret_value)
 
+    def __hash__(self) -> int:
+        return hash(self.get_secret_value())
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+
+        return secrets.compare_digest(self.get_secret_value(), other.get_secret_value())
+
     def _display(self) -> str:
         return _secret_display(self._secret_value)
 
@@ -1879,9 +1897,11 @@ class SecretStr(_SecretField[str]):
 class SecretBytes(_SecretField[bytes]):
     """A bytes used for storing sensitive information that you do not want to be visible in logging or tracebacks.
 
-    It displays `b'**********'` instead of the string value on `repr()` and `str()` calls.
     When the secret value is nonempty, it is displayed as `b'**********'` instead of the underlying value in
-    calls to `repr()` and `str()`. If the value _is_ empty, it is displayed as `b''`.
+    calls to [`repr()`][repr] and [`str()`][str]. If the value _is_ empty, it is displayed as `b''`.
+
+    Two `SecretBytes` types compare equal if the secret values are equal. Constant-time comparison is achieved
+    (using [`secrets.compare_digest()`][secrets.compare_digest]).
 
     ```python
     from pydantic import BaseModel, SecretBytes
@@ -1904,6 +1924,15 @@ class SecretBytes(_SecretField[bytes]):
 
     def __len__(self) -> int:
         return len(self._secret_value)
+
+    def __hash__(self) -> int:
+        return hash(self.get_secret_value())
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+
+        return secrets.compare_digest(self.get_secret_value(), other.get_secret_value())
 
     def _display(self) -> bytes:
         return _secret_display(self._secret_value).encode()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Replaces https://github.com/pydantic/pydantic/pull/13497.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
