### PR TITLE
Fix access of annotations in `safe_get_annotations()` in Python <= 3.13

### DIFF
--- a/pydantic/_internal/_typing_extra.py
+++ b/pydantic/_internal/_typing_extra.py
@@ -294,7 +294,10 @@ def safe_get_annotations(obj: Any) -> dict[str, Any]:
     if sys.version_info >= (3, 14):
         return annotationlib.get_annotations(obj, format=annotationlib.Format.FORWARDREF)
     else:
-        return getattr(obj, '__annotations__', {})
+        if isinstance(obj, type):
+            return obj.__dict__.get('__annotations__', {})
+        else:
+            return getattr(obj, '__annotations__', {})
 
 
 def get_model_type_hints(

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -51,6 +51,7 @@ from pydantic import (
     validator,
 )
 from pydantic._internal._model_construction import ModelMetaclass
+from pydantic._internal._typing_extra import safe_get_annotations
 from pydantic.fields import Field, computed_field
 from pydantic.functional_serializers import (
     field_serializer,
@@ -3161,3 +3162,23 @@ def test_model_fields_set_includes_extra_after_assignment():
     m.extra_after_init = 3
     assert m.model_fields_set == {'field', 'extra_at_init', 'extra_after_init'}
     assert m.model_extra == {'extra_at_init': 2, 'extra_after_init': 3}
+
+
+def test_safe_get_annotations_from_dict() -> None:
+    """https://github.com/pydantic/pydantic/issues/13520"""
+
+    class Meta(type):
+        pass
+
+    Meta.__annotations__
+
+    class Base(metaclass=Meta):
+        pass
+
+    class Main(Base):
+        f: int
+
+    class Sub(Main):
+        pass
+
+    assert safe_get_annotations(Sub) == {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13520. Regression in https://github.com/pydantic/pydantic/pull/13070.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
