### PR TITLE
Fix prebuilt validator/serializer reuse being disabled by plugins and model validators/serializers

### DIFF
--- a/pydantic-core/src/serializers/polymorphism_trampoline.rs
+++ b/pydantic-core/src/serializers/polymorphism_trampoline.rs
@@ -17,7 +17,7 @@ use crate::serializers::{
 /// inner serializer may just be a function serializer and so cannot handle polymorphism itself.
 #[derive(Debug)]
 pub struct PolymorphismTrampoline {
-    class: Py<PyType>,
+    pub(crate) class: Py<PyType>,
     /// Inner serializer used when the type is not a subclass (responsible for any fallback etc)
     pub(crate) serializer: Arc<CombinedSerializer>,
     /// Whether polymorphic serialization is enabled from config

--- a/pydantic-core/src/serializers/prebuilt.rs
+++ b/pydantic-core/src/serializers/prebuilt.rs
@@ -1,17 +1,38 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
+use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyType};
 
 use crate::SchemaSerializer;
+use crate::common::prebuilt::get_prebuilt;
 use crate::serializers::SerializationState;
-use crate::{common::prebuilt::get_prebuilt, serializers::polymorphism_trampoline::PolymorphismTrampoline};
+use crate::tools::SchemaDict;
 
 use super::shared::{CombinedSerializer, TypeSerializer};
 
-#[derive(Debug)]
 pub struct PrebuiltSerializer {
+    /// Keeps the referenced `SchemaSerializer` alive (and with it, `serializer`). This is also the
+    /// only field reported to the garbage collector: the contents of `serializer` are owned (and
+    /// traversed) by the `SchemaSerializer`, so they must not be traversed a second time here.
     schema_serializer: Py<SchemaSerializer>,
+    /// The polymorphism trampoline around the `model`/`dataclass` serializer of the referenced
+    /// class, found by walking the schema serializer's tree from the root (see
+    /// `find_class_serializer`).
+    serializer: Arc<CombinedSerializer>,
+}
+
+#[allow(clippy::missing_fields_in_debug)] // `schema_serializer` is deliberately omitted
+impl std::fmt::Debug for PrebuiltSerializer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Note: the delegated serializer is deliberately not expanded: it is owned by another
+        // `SchemaSerializer`, and expanding it per reference can result in exponentially large
+        // output with highly interconnected models.
+        f.debug_struct("PrebuiltSerializer")
+            .field("serializer", &self.serializer.get_name())
+            .finish()
+    }
 }
 
 impl PrebuiltSerializer {
@@ -19,33 +40,89 @@ impl PrebuiltSerializer {
         get_prebuilt(type_, schema, "__pydantic_serializer__", |py_any| {
             let schema_serializer = py_any.extract::<Py<SchemaSerializer>>()?;
 
-            let mut serializer = schema_serializer.get().serializer.as_ref();
-
-            // it is very likely that the prebuilt serializer is a polymorphism trampoline, peek
-            // through it for the sake of the check below
-            if let CombinedSerializer::PolymorphismTrampoline(PolymorphismTrampoline {
-                serializer: inner_serializer,
-                ..
-            }) = serializer
-            {
-                serializer = inner_serializer.as_ref();
-            }
-
-            // don't allow wrap serializers as prebuilt serializers (leads to double wrapping)
-            if matches!(serializer, CombinedSerializer::FunctionWrap(_)) {
+            let class: Bound<'_, PyType> = schema.get_as_req(intern!(schema.py(), "cls"))?;
+            let Some(serializer) = find_class_serializer(schema_serializer.get().serializer.clone(), &class) else {
                 return Ok(None);
-            }
+            };
 
-            Ok(Some(Self { schema_serializer }.into()))
+            Ok(Some(
+                Self {
+                    schema_serializer,
+                    serializer,
+                }
+                .into(),
+            ))
         })
     }
+}
+
+/// Walk a class's prebuilt serializer tree from the root to the polymorphism trampoline around
+/// the class's own `model`/`dataclass` serializer, which is what a schema *referencing* the class
+/// compiles by reference rather than inline (the serializer of a `model`/`dataclass` schema is
+/// always built wrapped in a trampoline):
+///
+/// - a recursive class stores its schema in a definition, making the root of its own tree a
+///   reference to that definition — resolve it (the class is complete, so the definition is
+///   filled);
+/// - a `'wrap'` model serializer is applied *around* the `model`/`dataclass` serializer (under
+///   the trampoline). A referencing schema embeds the class's full core schema (including the
+///   `serialization` key), so the wrap function serializer is compiled inline before the
+///   `model`/`dataclass` schema (with the `serialization` key removed) is reached. Delegating to
+///   it would apply the wrap function a second time, so strip it, along with the trampoline
+///   wrapping it.
+///
+/// If the walk moves past any of those but does not end at the trampoline around the
+/// `model`/`dataclass` serializer of the referenced class itself, the class serializes in some
+/// non-standard way (e.g. a custom `__get_pydantic_core_schema__` wrapping the model schema), and
+/// `None` is returned so that the referencing schema conservatively compiles the class's schema
+/// inline instead. Delegating to anything else (e.g. a bare model serializer) could also skip the
+/// polymorphic subclass dispatch that inline compilation would preserve.
+///
+/// A root that is none of the above (e.g. a `'plain'` model serializer, which — unlike a `'wrap'`
+/// one — cannot double-apply, or a hand-built schema whose serializer is a plain function
+/// serializer) is delegated to wholesale, preserving the longstanding behavior that
+/// `__pydantic_serializer__` stands in for the class wherever it is referenced.
+fn find_class_serializer(
+    mut target: Arc<CombinedSerializer>,
+    class: &Bound<'_, PyType>,
+) -> Option<Arc<CombinedSerializer>> {
+    let mut walked = false;
+    // Bounded to guard against reference cycles, which a hand-built schema can produce.
+    for _ in 0..64 {
+        target = match target.as_ref() {
+            CombinedSerializer::Recursive(definition_ref_serializer) => {
+                definition_ref_serializer.resolved_serializer()?
+            }
+            CombinedSerializer::PolymorphismTrampoline(trampoline) if trampoline.class.bind(class.py()).is(class) => {
+                match trampoline.serializer.as_ref() {
+                    // The final target: the trampoline around the class's `model`/`dataclass`
+                    // serializer.
+                    CombinedSerializer::Model(_) | CombinedSerializer::Dataclass(_) => return Some(target.clone()),
+                    // Descend through a nested trampoline (the builder can apply the trampoline
+                    // twice) or into a `'wrap'` model serializer so that it can be stripped;
+                    // a trampoline around anything else (e.g. a `'plain'` model serializer) is
+                    // left intact for the wholesale delegation below.
+                    CombinedSerializer::PolymorphismTrampoline(_) | CombinedSerializer::FunctionWrap(_) => {
+                        trampoline.serializer.clone()
+                    }
+                    _ if walked => return None,
+                    _ => return Some(target.clone()),
+                }
+            }
+            CombinedSerializer::FunctionWrap(function_serializer) => function_serializer.inner_serializer().clone(),
+            _ if walked => return None,
+            _ => return Some(target.clone()),
+        };
+        walked = true;
+    }
+    None
 }
 
 impl_py_gc_traverse!(PrebuiltSerializer { schema_serializer });
 
 impl TypeSerializer for PrebuiltSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
-        self.schema_serializer.get().serializer.to_python_no_infer(value, state)
+        self.serializer.to_python_no_infer(value, state)
     }
 
     fn json_key<'a, 'py>(
@@ -53,7 +130,7 @@ impl TypeSerializer for PrebuiltSerializer {
         key: &'a Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
-        self.schema_serializer.get().serializer.json_key_no_infer(key, state)
+        self.serializer.json_key_no_infer(key, state)
     }
 
     fn serde_serialize<'py, S: serde::ser::Serializer>(
@@ -62,17 +139,14 @@ impl TypeSerializer for PrebuiltSerializer {
         serializer: S,
         state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
-        self.schema_serializer
-            .get()
-            .serializer
-            .serde_serialize_no_infer(value, serializer, state)
+        self.serializer.serde_serialize_no_infer(value, serializer, state)
     }
 
     fn get_name(&self) -> &str {
-        self.schema_serializer.get().serializer.get_name()
+        self.serializer.get_name()
     }
 
     fn retry_with_lax_check(&self) -> bool {
-        self.schema_serializer.get().serializer.retry_with_lax_check()
+        self.serializer.retry_with_lax_check()
     }
 }

--- a/pydantic-core/src/serializers/type_serializers/definitions.rs
+++ b/pydantic-core/src/serializers/type_serializers/definitions.rs
@@ -73,6 +73,15 @@ impl BuildSerializer for DefinitionRefSerializer {
     }
 }
 
+impl DefinitionRefSerializer {
+    /// The serializer this reference points to, if the definition has been filled and is still
+    /// alive (always the case for references inside a fully built `SchemaSerializer`).
+    #[allow(clippy::redundant_closure_for_method_calls)] // `Option::cloned` is ambiguous here
+    pub fn resolved_serializer(&self) -> Option<Arc<CombinedSerializer>> {
+        self.definition.read(|serializer| serializer.cloned())
+    }
+}
+
 impl_py_gc_traverse!(DefinitionRefSerializer {});
 
 impl TypeSerializer for DefinitionRefSerializer {

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -334,6 +334,13 @@ pub struct FunctionWrapSerializer {
     info_arg: bool,
 }
 
+impl FunctionWrapSerializer {
+    /// The serializer that the function wraps, used by `PrebuiltSerializer`.
+    pub fn inner_serializer(&self) -> &Arc<CombinedSerializer> {
+        &self.serializer
+    }
+}
+
 impl BuildSerializer for FunctionWrapSerializer {
     const EXPECTED_TYPE: &'static str = "function-wrap";
 

--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -461,6 +461,13 @@ pub struct DataclassValidator {
     slots: bool,
 }
 
+impl DataclassValidator {
+    /// The dataclass, used by `PrebuiltValidator`.
+    pub fn class(&self) -> &Py<PyType> {
+        &self.class
+    }
+}
+
 impl BuildValidator for DataclassValidator {
     const EXPECTED_TYPE: &'static str = "dataclass";
 

--- a/pydantic-core/src/validators/definitions.rs
+++ b/pydantic-core/src/validators/definitions.rs
@@ -52,6 +52,13 @@ impl DefinitionRefValidator {
     pub fn new(definition: DefinitionRef<Arc<CombinedValidator>>) -> Self {
         Self { definition }
     }
+
+    /// The validator this reference points to, if the definition has been filled and is still
+    /// alive (always the case for references inside a fully built `SchemaValidator`).
+    #[allow(clippy::redundant_closure_for_method_calls)] // `Option::cloned` is ambiguous here
+    pub fn resolved_validator(&self) -> Option<Arc<CombinedValidator>> {
+        self.definition.read(|validator| validator.cloned())
+    }
 }
 
 impl BuildValidator for DefinitionRefValidator {

--- a/pydantic-core/src/validators/function.rs
+++ b/pydantic-core/src/validators/function.rs
@@ -167,6 +167,11 @@ pub struct FunctionAfterValidator {
 impl_build!(FunctionAfterValidator, "function-after");
 
 impl FunctionAfterValidator {
+    /// The validator that the function is applied after, used by `PrebuiltValidator`.
+    pub fn inner_validator(&self) -> &Arc<CombinedValidator> {
+        &self.validator
+    }
+
     fn _validate<'py, I: Input<'py> + ?Sized>(
         &self,
         call: impl FnOnce(&I, &mut ValidationState<'_, 'py>) -> ValResult<Py<PyAny>>,
@@ -331,6 +336,11 @@ impl BuildValidator for FunctionWrapValidator {
 }
 
 impl FunctionWrapValidator {
+    /// The validator that the function wraps, used by `PrebuiltValidator`.
+    pub fn inner_validator(&self) -> &Arc<CombinedValidator> {
+        &self.validator
+    }
+
     fn _validate<'py>(
         &self,
         handler: &Bound<'_, PyAny>,

--- a/pydantic-core/src/validators/model.rs
+++ b/pydantic-core/src/validators/model.rs
@@ -64,6 +64,13 @@ pub struct ModelValidator {
     name: String,
 }
 
+impl ModelValidator {
+    /// The model class, used by `PrebuiltValidator`.
+    pub fn class(&self) -> &Py<PyType> {
+        &self.class
+    }
+}
+
 impl BuildValidator for ModelValidator {
     const EXPECTED_TYPE: &'static str = "model";
 

--- a/pydantic-core/src/validators/prebuilt.rs
+++ b/pydantic-core/src/validators/prebuilt.rs
@@ -1,31 +1,119 @@
+use std::sync::Arc;
+
+use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyType};
 
 use crate::common::prebuilt::get_prebuilt;
 use crate::errors::ValResult;
 use crate::input::Input;
+use crate::tools::SchemaDict;
 
 use super::ValidationState;
 use super::{CombinedValidator, SchemaValidator, Validator};
 
-#[derive(Debug)]
 pub struct PrebuiltValidator {
+    /// Keeps the referenced `SchemaValidator` alive (and with it, `validator`). This is also the
+    /// only field reported to the garbage collector: the contents of `validator` are owned (and
+    /// traversed) by the `SchemaValidator`, so they must not be traversed a second time here.
     schema_validator: Py<SchemaValidator>,
+    /// The `model`/`dataclass` validator of the referenced class, found by walking the schema
+    /// validator's tree from the root (see `find_class_validator`).
+    validator: Arc<CombinedValidator>,
+}
+
+#[allow(clippy::missing_fields_in_debug)] // `schema_validator` is deliberately omitted
+impl std::fmt::Debug for PrebuiltValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Note: the delegated validator is deliberately not expanded: it is owned by another
+        // `SchemaValidator`, and expanding it per reference can result in exponentially large
+        // output with highly interconnected models.
+        f.debug_struct("PrebuiltValidator")
+            .field("validator", &self.validator.get_name())
+            .finish()
+    }
 }
 
 impl PrebuiltValidator {
     pub fn try_get_from_schema(type_: &str, schema: &Bound<'_, PyDict>) -> PyResult<Option<CombinedValidator>> {
         get_prebuilt(type_, schema, "__pydantic_validator__", |py_any| {
-            let schema_validator = py_any.extract::<Py<SchemaValidator>>()?;
-            if matches!(
-                schema_validator.get().validator.as_ref(),
-                CombinedValidator::FunctionWrap(_) | CombinedValidator::FunctionAfter(_)
-            ) {
+            let schema_validator: Py<SchemaValidator> = match py_any.extract() {
+                Ok(schema_validator) => schema_validator,
+                // If any Pydantic plugin is installed, `__pydantic_validator__` is a
+                // `pydantic.plugin._schema_validator.PluggableSchemaValidator` wrapping the actual
+                // `SchemaValidator`. Plugin callbacks only fire on the top-level validation entry
+                // points (`validate_python()`, etc.) and never on nested validation of a sub-model,
+                // so reusing the wrapped validator is behavior-preserving:
+                Err(_) => match py_any.getattr(intern!(py_any.py(), "_schema_validator")) {
+                    Ok(inner) => match inner.extract() {
+                        Ok(schema_validator) => schema_validator,
+                        Err(_) => return Ok(None),
+                    },
+                    Err(_) => return Ok(None),
+                },
+            };
+
+            let class: Bound<'_, PyType> = schema.get_as_req(intern!(schema.py(), "cls"))?;
+            let Some(validator) = find_class_validator(schema_validator.get().validator.clone(), &class) else {
                 return Ok(None);
-            }
-            Ok(Some(Self { schema_validator }.into()))
+            };
+
+            Ok(Some(
+                Self {
+                    schema_validator,
+                    validator,
+                }
+                .into(),
+            ))
         })
     }
+}
+
+/// Walk a class's prebuilt validator tree from the root to the class's own `model`/`dataclass`
+/// validator, which is the only part of the tree that a schema *referencing* the class compiles
+/// by reference rather than inline:
+///
+/// - a recursive class stores its schema in a definition, making the root of its own tree a
+///   reference to that definition — resolve it (the class is complete, so the definition is
+///   filled);
+/// - `@model_validator(mode='after')`/`(mode='wrap')` validators are applied *outside* of the
+///   `model` (or `dataclass`) schema, and are therefore compiled inline by the referencing schema
+///   before the inner `model`/`dataclass` schema is reached. Delegating to them would run the
+///   function validators a second time, so strip them.
+///
+/// If the walk moves past any of those but does not end at the `model`/`dataclass` validator of
+/// the referenced class itself, the schema was built in some non-standard way (e.g. a custom
+/// `__get_pydantic_core_schema__` wrapping the model schema), and `None` is returned so that the
+/// referencing schema conservatively compiles the class's schema inline instead.
+///
+/// A root that is none of the above (e.g. a hand-built schema whose validator is a plain function
+/// validator) is delegated to wholesale, preserving the longstanding behavior that
+/// `__pydantic_validator__` stands in for the class wherever it is referenced.
+fn find_class_validator(
+    mut target: Arc<CombinedValidator>,
+    class: &Bound<'_, PyType>,
+) -> Option<Arc<CombinedValidator>> {
+    let mut walked = false;
+    // Bounded to guard against reference cycles, which a hand-built schema can produce.
+    for _ in 0..64 {
+        target = match target.as_ref() {
+            CombinedValidator::DefinitionRef(definition_ref_validator) => {
+                definition_ref_validator.resolved_validator()?
+            }
+            CombinedValidator::FunctionAfter(function_validator) => function_validator.inner_validator().clone(),
+            CombinedValidator::FunctionWrap(function_validator) => function_validator.inner_validator().clone(),
+            CombinedValidator::Model(model_validator) => {
+                return model_validator.class().is(class).then_some(target.clone());
+            }
+            CombinedValidator::Dataclass(dataclass_validator) => {
+                return dataclass_validator.class().is(class).then_some(target.clone());
+            }
+            _ if walked => return None,
+            _ => return Some(target.clone()),
+        };
+        walked = true;
+    }
+    None
 }
 
 impl_py_gc_traverse!(PrebuiltValidator { schema_validator });
@@ -37,10 +125,10 @@ impl Validator for PrebuiltValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
-        self.schema_validator.get().validator.validate(py, input, state)
+        self.validator.validate(py, input, state)
     }
 
     fn get_name(&self) -> &str {
-        self.schema_validator.get().validator.get_name()
+        self.validator.get_name()
     }
 }

--- a/pydantic-core/tests/test_prebuilt.py
+++ b/pydantic-core/tests/test_prebuilt.py
@@ -48,7 +48,7 @@ def test_prebuilt_val_and_ser_used() -> None:
     assert outer_serializer.to_python(result) == {'inner': {'x': 1}}
 
 
-def test_prebuilt_not_used_for_wrap_serializer_functions() -> None:
+def test_prebuilt_reuse_strips_wrap_serializer_functions() -> None:
     class InnerModel:
         x: str
 
@@ -101,12 +101,15 @@ def test_prebuilt_not_used_for_wrap_serializer_functions() -> None:
     inner_instance = InnerModel(x='hello')
     assert inner_serializer.to_python(inner_instance) == {'x': 'hello modified'}
 
-    # but the outer model doesn't reuse the custom wrap serializer function, so we see simple str ser
+    # the outer model reuses the prebuilt serializer of the inner model, but with the wrap
+    # serializer function stripped off (the referencing schema is responsible for applying it,
+    # and this hand-crafted one does not), so we see simple str ser
     outer_instance = OuterModel(inner=InnerModel(x='hello'))
+    assert 'PrebuiltSerializer' in repr(outer_serializer)
     assert outer_serializer.to_python(outer_instance) == {'inner': {'x': 'hello'}}
 
 
-def test_prebuilt_not_used_for_wrap_validator_functions() -> None:
+def test_prebuilt_reuse_strips_wrap_validator_functions() -> None:
     class InnerModel:
         x: str
 
@@ -161,12 +164,15 @@ def test_prebuilt_not_used_for_wrap_validator_functions() -> None:
     result_inner = inner_validator.validate_python({'x': 'hello'})
     assert result_inner.x == 'hello modified'
 
-    # but the outer model doesn't reuse the custom wrap validator function, so we see simple str val
+    # the outer model reuses the prebuilt validator of the inner model, but with the wrap
+    # validator function stripped off (the referencing schema is responsible for applying it,
+    # and this hand-crafted one does not), so we see simple str val
+    assert 'PrebuiltValidator' in repr(outer_validator)
     result_outer = outer_validator.validate_python({'inner': {'x': 'hello'}})
     assert result_outer.inner.x == 'hello'
 
 
-def test_prebuilt_not_used_for_after_validator_functions() -> None:
+def test_prebuilt_reuse_strips_after_validator_functions() -> None:
     class InnerModel:
         x: str
 
@@ -221,7 +227,10 @@ def test_prebuilt_not_used_for_after_validator_functions() -> None:
     result_inner = inner_validator.validate_python({'x': 'hello'})
     assert result_inner.x == 'hello modified'
 
-    # but the outer model doesn't reuse the custom after validator function, so we see simple str val
+    # the outer model reuses the prebuilt validator of the inner model, but with the after
+    # validator function stripped off (the referencing schema is responsible for applying it,
+    # and this hand-crafted one does not), so we see simple str val
+    assert 'PrebuiltValidator' in repr(outer_validator)
     result_outer = outer_validator.validate_python({'inner': {'x': 'hello'}})
     assert result_outer.inner.x == 'hello'
 
@@ -401,3 +410,96 @@ def test_reuse_before_validator_ok() -> None:
     result_outer = outer_validator.validate_python({'inner': {'x': 'hello'}})
     assert result_outer.inner.x == 'hello modified'
     assert 'PrebuiltValidator' in repr(outer_validator)
+
+
+def test_prebuilt_validator_used_through_pluggable_schema_validator_wrapper() -> None:
+    """When Pydantic plugins are installed, `__pydantic_validator__` is a
+    `pydantic.plugin._schema_validator.PluggableSchemaValidator` exposing the actual
+    `SchemaValidator` via its `_schema_validator` attribute. Prebuilt reuse should still work.
+    """
+
+    class PluggableSchemaValidatorStandIn:
+        def __init__(self, schema_validator: SchemaValidator) -> None:
+            self._schema_validator = schema_validator
+
+        def __getattr__(self, name: str):
+            return getattr(self._schema_validator, name)
+
+    class InnerModel:
+        x: int
+
+    inner_schema = core_schema.model_schema(
+        InnerModel,
+        schema=core_schema.model_fields_schema(
+            {'x': core_schema.model_field(schema=core_schema.int_schema())},
+        ),
+    )
+
+    InnerModel.__pydantic_complete__ = True  # pyright: ignore[reportAttributeAccessIssue]
+    InnerModel.__pydantic_validator__ = PluggableSchemaValidatorStandIn(  # pyright: ignore[reportAttributeAccessIssue]
+        SchemaValidator(inner_schema)
+    )
+
+    class OuterModel:
+        inner: InnerModel
+
+    outer_schema = core_schema.model_schema(
+        OuterModel,
+        schema=core_schema.model_fields_schema(
+            {
+                'inner': core_schema.model_field(
+                    schema=core_schema.model_schema(
+                        InnerModel,
+                        schema=core_schema.model_fields_schema(
+                            # note, we use str schema here even though that's incorrect
+                            # in order to verify that the prebuilt validator is used
+                            # off of InnerModel with the correct int schema, not this str schema
+                            {'x': core_schema.model_field(schema=core_schema.str_schema())},
+                        ),
+                    )
+                )
+            }
+        ),
+    )
+
+    outer_validator = SchemaValidator(outer_schema)
+    assert 'PrebuiltValidator' in repr(outer_validator)
+
+    result = outer_validator.validate_python({'inner': {'x': 1}})
+    assert result.inner.x == 1
+
+
+def test_prebuilt_validator_ignores_unrecognized_wrapper() -> None:
+    """An unknown `__pydantic_validator__` object (no `_schema_validator` attribute) is ignored,
+    and the schema is compiled inline as before."""
+
+    class InnerModel:
+        x: int
+
+    InnerModel.__pydantic_complete__ = True  # pyright: ignore[reportAttributeAccessIssue]
+    InnerModel.__pydantic_validator__ = object()  # pyright: ignore[reportAttributeAccessIssue]
+
+    class OuterModel:
+        inner: InnerModel
+
+    outer_schema = core_schema.model_schema(
+        OuterModel,
+        schema=core_schema.model_fields_schema(
+            {
+                'inner': core_schema.model_field(
+                    schema=core_schema.model_schema(
+                        InnerModel,
+                        schema=core_schema.model_fields_schema(
+                            {'x': core_schema.model_field(schema=core_schema.int_schema())},
+                        ),
+                    )
+                )
+            }
+        ),
+    )
+
+    outer_validator = SchemaValidator(outer_schema)
+    assert 'PrebuiltValidator' not in repr(outer_validator)
+
+    result = outer_validator.validate_python({'inner': {'x': 1}})
+    assert result.inner.x == 1

--- a/pydantic/plugin/_schema_validator.py
+++ b/pydantic/plugin/_schema_validator.py
@@ -39,7 +39,7 @@ def create_schema_validator(
 
     plugins = get_plugins()
     if plugins:
-        return PluggableSchemaValidator(
+        pluggable_schema_validator = PluggableSchemaValidator(
             schema,
             schema_type,
             SchemaTypePath(schema_type_module, schema_type_name),
@@ -49,6 +49,15 @@ def create_schema_validator(
             plugin_settings or {},
             _use_prebuilt=_use_prebuilt,
         )
+        if pluggable_schema_validator._has_event_handlers:
+            return pluggable_schema_validator
+        else:
+            # No plugin provided any event handler for this schema, so the wrapper is functionally
+            # inert. Return the underlying `SchemaValidator` instead: an unnecessary wrapper isn't
+            # free — in particular, it prevents `pydantic-core` from reusing the already built
+            # validator when other models reference this schema's type (which can massively
+            # increase memory usage in applications with many interconnected models).
+            return pluggable_schema_validator._schema_validator
     else:
         return SchemaValidator(schema, config, _use_prebuilt=_use_prebuilt)
 
@@ -56,7 +65,7 @@ def create_schema_validator(
 class PluggableSchemaValidator:
     """Pluggable schema validator."""
 
-    __slots__ = '_schema_validator', 'validate_json', 'validate_python', 'validate_strings'
+    __slots__ = '_schema_validator', '_has_event_handlers', 'validate_json', 'validate_python', 'validate_strings'
 
     def __init__(
         self,
@@ -88,6 +97,7 @@ class PluggableSchemaValidator:
             if s is not None:
                 strings_event_handlers.append(s)
 
+        self._has_event_handlers = bool(python_event_handlers or json_event_handlers or strings_event_handlers)
         self.validate_python = build_wrapper(self._schema_validator.validate_python, python_event_handlers)
         self.validate_json = build_wrapper(self._schema_validator.validate_json, json_event_handlers)
         self.validate_strings = build_wrapper(self._schema_validator.validate_strings, strings_event_handlers)

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -193,3 +193,141 @@ def test_after_validator_wrong_signature() -> None:
     Model2()
     Model3()
     Model4()
+
+
+def test_after_and_wrap_model_validators_run_once_when_reused_as_prebuilt() -> None:
+    """`pydantic-core` reuses the already built ("prebuilt") validator of a completed model when other
+    models reference it. `'after'`/`'wrap'` model validators are applied outside of the `model` core
+    schema, and are compiled inline by the referencing model, so the prebuilt validator is stripped
+    down to the inner `model` validator to avoid running the function validators twice.
+    """
+    after_calls: list[Any] = []
+    wrap_calls: list[Any] = []
+
+    class InnerAfter(BaseModel):
+        x: int
+
+        @model_validator(mode='after')
+        def after_validator(self) -> InnerAfter:
+            after_calls.append(self.x)
+            return self
+
+    class InnerWrap(BaseModel):
+        x: int
+
+        @model_validator(mode='wrap')
+        @classmethod
+        def wrap_validator(cls, data: Any, handler: ValidatorFunctionWrapHandler) -> InnerWrap:
+            wrap_calls.append(data)
+            return cast(InnerWrap, handler(data))
+
+    class Outer(BaseModel):
+        after: InnerAfter
+        wrap: InnerWrap
+
+    # the inner models' validators are reused, stripped of the model validators:
+    assert repr(Outer.__pydantic_validator__).count('PrebuiltValidator') == 2
+
+    Outer.model_validate({'after': {'x': 1}, 'wrap': {'x': 2}})
+    assert after_calls == [1]
+    assert wrap_calls == [{'x': 2}]
+
+
+def test_model_config_isolated_when_validator_reused_as_prebuilt() -> None:
+    """Nested validation delegating to a referenced model's prebuilt validator must apply the
+    referenced model's own config, not the referencing model's (the `'model'` core schema carries
+    its own `'config'`, so this also holds for inline compilation)."""
+    from pydantic import ConfigDict, ValidationError
+
+    class StrictChild(BaseModel):
+        model_config = ConfigDict(strict=True)
+
+        x: int
+
+        @model_validator(mode='after')
+        def validate_model(self) -> StrictChild:
+            return self
+
+    class LaxParent(BaseModel):
+        model_config = ConfigDict(strict=False)
+
+        child: StrictChild
+        y: int
+
+    assert 'PrebuiltValidator' in repr(LaxParent.__pydantic_validator__)
+
+    # The parent's lax config still applies to its own fields:
+    validated = LaxParent.model_validate({'child': {'x': 1}, 'y': '2'})
+    assert validated.y == 2
+
+    # The child's strict config applies to the child, even when nested in a lax parent:
+    with pytest.raises(ValidationError, match='int_type'):
+        LaxParent.model_validate({'child': {'x': '1'}, 'y': 2})
+
+    class LaxChild(BaseModel):
+        model_config = ConfigDict(strict=False)
+
+        x: int
+
+        @model_validator(mode='after')
+        def validate_model(self) -> LaxChild:
+            return self
+
+    class StrictParent(BaseModel):
+        model_config = ConfigDict(strict=True)
+
+        child: LaxChild
+
+    assert 'PrebuiltValidator' in repr(StrictParent.__pydantic_validator__)
+
+    # The child's lax config applies to the child, even when nested in a strict parent:
+    assert StrictParent.model_validate({'child': {'x': '1'}}).child.x == 1
+
+
+def test_after_and_wrap_model_validators_run_once_when_recursive_model_reused_as_prebuilt() -> None:
+    """A recursive model stores its schema in a core schema definition, making the root of its own
+    validator a reference to that definition, with the `'after'`/`'wrap'` model validators inside
+    the definition. The validator reused by a referencing model must still be the inner `model`
+    validator, so that the model validators (compiled inline by the referencing model) run exactly
+    once.
+
+    This was broken before the reuse logic resolved definition references: the full prebuilt
+    validator, including the model validators, was reused, running them a second time.
+    """
+    after_calls: list[Any] = []
+    wrap_calls: list[Any] = []
+
+    class NodeAfter(BaseModel):
+        child: NodeAfter | None = None
+
+        @model_validator(mode='after')
+        def after_validator(self) -> NodeAfter:
+            after_calls.append(None)
+            return self
+
+    class NodeWrap(BaseModel):
+        child: NodeWrap | None = None
+
+        @model_validator(mode='wrap')
+        @classmethod
+        def wrap_validator(cls, data: Any, handler: ValidatorFunctionWrapHandler) -> NodeWrap:
+            wrap_calls.append(None)
+            return cast(NodeWrap, handler(data))
+
+    class Outer(BaseModel):
+        after: NodeAfter
+        wrap: NodeWrap
+
+    # the recursive models' validators are still reused, stripped of the model validators:
+    assert repr(Outer.__pydantic_validator__).count('PrebuiltValidator') == 2
+
+    Outer.model_validate({'after': {}, 'wrap': {}})
+    assert after_calls == [None]
+    assert wrap_calls == [None]
+
+    # the model validators also run exactly once per node of a nested input:
+    after_calls.clear()
+    wrap_calls.clear()
+    Outer.model_validate({'after': {'child': {'child': {}}}, 'wrap': {'child': {}}})
+    assert after_calls == [None] * 3
+    assert wrap_calls == [None] * 2

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 from pydantic_core import SchemaValidator, ValidationError
 
-from pydantic import BaseModel, TypeAdapter, create_model, dataclasses, field_validator, validate_call
+from pydantic import BaseModel, TypeAdapter, create_model, dataclasses, field_validator, model_validator, validate_call
 from pydantic.config import ExtraValues
 from pydantic.plugin import (
     PydanticPluginProtocol,
@@ -555,3 +555,37 @@ def test_plugin_with_event_handlers_still_reuses_prebuilt_validators() -> None:
         assert isinstance(Outer.__pydantic_validator__, PluggableSchemaValidator)
         assert 'PrebuiltValidator' in repr(Outer.__pydantic_validator__._schema_validator)
         assert Outer.model_validate({'inner': {'a': 1}}).inner.a == 1
+
+
+def test_plugin_prebuilt_recursive_model_validator_runs_once() -> None:
+    """https://github.com/pydantic/pydantic/pull/13535#issuecomment-5115875059
+
+    A recursive model with an `'after'` model validator, referenced by another model while a plugin
+    is installed, must run the model validator exactly once.
+    """
+    calls: list[None] = []
+
+    class CustomOnValidatePython(ValidatePythonHandlerProtocol):
+        def on_enter(self, input, **kwargs) -> None:
+            pass
+
+    class Plugin:
+        def new_schema_validator(self, schema, schema_type, schema_type_path, schema_kind, config, plugin_settings):
+            return CustomOnValidatePython(), None, None
+
+    with install_plugin(Plugin()):
+
+        class Node(BaseModel):
+            child: Node | None = None
+
+            @model_validator(mode='after')
+            def validate_model(self) -> Node:
+                calls.append(None)
+                return self
+
+        class Outer(BaseModel):
+            node: Node
+
+        Outer.model_validate({'node': {}})
+
+    assert calls == [None]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,7 +6,7 @@ from functools import partial
 from typing import Any
 
 import pytest
-from pydantic_core import ValidationError
+from pydantic_core import SchemaValidator, ValidationError
 
 from pydantic import BaseModel, TypeAdapter, create_model, dataclasses, field_validator, validate_call
 from pydantic.config import ExtraValues
@@ -18,6 +18,7 @@ from pydantic.plugin import (
     ValidateStringsHandlerProtocol,
 )
 from pydantic.plugin._loader import _plugins
+from pydantic.plugin._schema_validator import PluggableSchemaValidator
 
 pytestmark = pytest.mark.thread_unsafe(reason='`install_plugin()` is thread unsafe')
 
@@ -500,3 +501,57 @@ def test_plugin_path_complex() -> None:
             'BaseModel',
         ),
     ]
+
+
+def test_plugin_no_event_handlers_returns_plain_schema_validator() -> None:
+    """A plugin providing no event handlers for a schema doesn't result in a `PluggableSchemaValidator`.
+
+    The wrapper would be functionally inert, and would prevent `pydantic-core` from reusing the
+    built validator when other models reference this model (see `PrebuiltValidator`), which can
+    massively increase memory usage in applications with many interconnected models.
+    """
+
+    class Plugin:
+        def new_schema_validator(self, schema, schema_type, schema_type_path, schema_kind, config, plugin_settings):
+            return None, None, None
+
+    plugin = Plugin()
+    with install_plugin(plugin):
+
+        class Inner(BaseModel):
+            a: int
+
+        class Outer(BaseModel):
+            inner: Inner
+
+        assert isinstance(Inner.__pydantic_validator__, SchemaValidator)
+        assert isinstance(Outer.__pydantic_validator__, SchemaValidator)
+        assert 'PrebuiltValidator' in repr(Outer.__pydantic_validator__)
+        assert Outer.model_validate({'inner': {'a': 1}}).inner.a == 1
+
+
+def test_plugin_with_event_handlers_still_reuses_prebuilt_validators() -> None:
+    """Even when validators are wrapped in a `PluggableSchemaValidator`, referencing models reuse
+    the underlying prebuilt validator (plugin callbacks only fire on top-level validation calls)."""
+
+    class CustomOnValidatePython(ValidatePythonHandlerProtocol):
+        def on_enter(self, input, **kwargs) -> None:
+            pass
+
+    class Plugin:
+        def new_schema_validator(self, schema, schema_type, schema_type_path, schema_kind, config, plugin_settings):
+            return CustomOnValidatePython(), None, None
+
+    plugin = Plugin()
+    with install_plugin(plugin):
+
+        class Inner(BaseModel):
+            a: int
+
+        class Outer(BaseModel):
+            inner: Inner
+
+        assert isinstance(Inner.__pydantic_validator__, PluggableSchemaValidator)
+        assert isinstance(Outer.__pydantic_validator__, PluggableSchemaValidator)
+        assert 'PrebuiltValidator' in repr(Outer.__pydantic_validator__._schema_validator)
+        assert Outer.model_validate({'inner': {'a': 1}}).inner.a == 1

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1394,3 +1394,109 @@ def test_wrap_ser_called_once() -> None:
 
     my_model = MyParentModel.model_validate({'nested': {'inner_value': 'foo'}})
     assert my_model.model_dump() == {'nested': {'inner_value': 'my_prefix:foo'}}
+
+
+def test_wrap_model_serializer_runs_once_when_reused_as_prebuilt() -> None:
+    """`pydantic-core` reuses the already built ("prebuilt") serializer of a completed model when
+    other models reference it. A `'wrap'` model serializer is applied around the `model` core
+    schema serializer, and is compiled inline by the referencing model, so the prebuilt serializer
+    is stripped down to the wrapped serializer to avoid applying the function twice.
+    """
+    calls: list[int] = []
+
+    class Inner(BaseModel):
+        x: int
+
+        @model_serializer(mode='wrap')
+        def ser(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+            calls.append(self.x)
+            data = handler(self)
+            data['extra'] = True
+            return data
+
+    class Outer(BaseModel):
+        inner: Inner
+
+    assert 'PrebuiltSerializer' in repr(Outer.__pydantic_serializer__)
+
+    outer = Outer.model_validate({'inner': {'x': 1}})
+    assert outer.model_dump() == {'inner': {'x': 1, 'extra': True}}
+    assert calls == [1]
+
+    calls.clear()
+    assert outer.model_dump_json() == '{"inner":{"x":1,"extra":true}}'
+    assert calls == [1]
+
+
+def test_polymorphic_serialization_preserved_when_wrap_serializer_model_reused_as_prebuilt() -> None:
+    """The prebuilt serializer of a model with a `'wrap'` model serializer delegates to the
+    serializer that the wrap function wraps. That serializer must retain the polymorphism
+    trampoline, so that serializing a subclass instance still dispatches to the subclass's own
+    serializer."""
+
+    class Inner(BaseModel):
+        model_config = ConfigDict(polymorphic_serialization=True)
+
+        x: int
+
+        @model_serializer(mode='wrap')
+        def ser(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+            data = handler(self)
+            data['which'] = 'base'
+            return data
+
+    class Sub(Inner):
+        @model_serializer(mode='wrap')
+        def ser(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+            data = handler(self)
+            data['which'] = 'sub'
+            return data
+
+    class Outer(BaseModel):
+        inner: Inner
+
+    # the prebuilt serializer of `Inner` is reused (stripped of the wrap function):
+    assert 'PrebuiltSerializer' in repr(Outer.__pydantic_serializer__)
+
+    outer = Outer(inner=Sub(x=1))
+    assert outer.model_dump() == {'inner': {'x': 1, 'which': 'sub'}}
+    assert outer.model_dump(polymorphic_serialization=False) == {'inner': {'x': 1, 'which': 'base'}}
+
+
+def test_wrap_model_serializer_runs_once_when_recursive_model_reused_as_prebuilt() -> None:
+    """A recursive model stores its schema in a core schema definition, making the root of its own
+    serializer a reference to that definition, with the `'wrap'` model serializer inside the
+    definition. The serializer reused by a referencing model must still be the one that the wrap
+    function wraps, so that the wrap function (compiled inline by the referencing model) runs
+    exactly once.
+
+    This was broken before the reuse logic resolved definition references: the full prebuilt
+    serializer, including the wrap function, was reused, applying it a second time.
+    """
+    calls: list[Any] = []
+
+    class Node(BaseModel):
+        child: 'Node | None' = None
+
+        @model_serializer(mode='wrap')
+        def ser(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+            calls.append(None)
+            data = handler(self)
+            data['extra'] = True
+            return data
+
+    class Outer(BaseModel):
+        node: Node
+
+    # the recursive model's serializer is still reused, stripped of the wrap function:
+    assert 'PrebuiltSerializer' in repr(Outer.__pydantic_serializer__)
+
+    outer = Outer.model_validate({'node': {}})
+    assert outer.model_dump() == {'node': {'child': None, 'extra': True}}
+    assert calls == [None]
+
+    # the wrap serializer also runs exactly once per node of a nested value:
+    calls.clear()
+    nested = Outer.model_validate({'node': {'child': {}}})
+    assert nested.model_dump() == {'node': {'child': {'child': None, 'extra': True}, 'extra': True}}
+    assert calls == [None] * 2


### PR DESCRIPTION
When a completed model is referenced by another model, `pydantic-core` reuses its already built ("prebuilt") validator/serializer instead of compiling a full copy of its validator/serializer trees. Two common situations silently disabled this reuse, making memory usage grow with the total size of every model's transitive closure instead of with the number of models:

* **Any installed Pydantic plugin** (e.g. Logfire — even with Pydantic recording disabled, the default) wraps validators in a `PluggableSchemaValidator`, which failed the `SchemaValidator` extraction in `PrebuiltValidator`. Fixed on both sides: `create_schema_validator()` now returns a plain `SchemaValidator` when no plugin provides event handlers for the schema, and `pydantic-core` unwraps `_schema_validator` otherwise. Plugin event handlers only fire on top-level validation calls (never on nested validation of a sub-model), so behavior is unchanged.
* **`'after'`/`'wrap'` model validators and `'wrap'` model serializers** are applied outside of the `'model'` core schema and are compiled inline by the referencing schema, so reusing the full prebuilt validator/serializer would apply them a second time. Instead of refusing to reuse (the previous behavior), the reuse logic now walks the prebuilt tree — resolving definition references and stripping the function wrappers — and only delegates if the walk lands exactly on the referenced class's own `model`/`dataclass` validator (for serializers, the polymorphism trampoline around it), compiling inline otherwise.

Resolving definition references also **fixes a double-application bug present in released pydantic, with no plugins involved**: a recursive model's schema lives in a core schema definition, so the root of its prebuilt tree is a definition *reference*, which the previous root-shape check could not see through. As a result, `model_validator(mode='after')`, `model_validator(mode='wrap')` and `model_serializer(mode='wrap')` all run **twice** on pydantic 2.13.4 when a recursive model is validated/serialized through a referencing model:

```python
calls = []

class Node(BaseModel):
    child: Node | None = None

    @model_validator(mode='after')
    def check(self) -> Node:
        calls.append(1)
        return self

class Outer(BaseModel):
    node: Node

Outer.model_validate({'node': {}})
assert calls == [1, 1]  # on pydantic 2.13.4; [1] with this PR
```

The same hole is what https://github.com/pydantic/pydantic/pull/13535#issuecomment-5115875059 hits with a plugin installed (the plugin only matters on `main` because it blocks prebuilt extraction entirely); that test is included here, and #13539 adds it to `main` independently. Regression tests for the recursive after/wrap validator and wrap serializer cases are included in `tests/test_model_validator.py` and `tests/test_serialize.py`, and recursive models still get prebuilt reuse.

Measured on `import google.genai` (766 models, 2707 fields, Logfire installed): resident memory after import drops from 110.5MB to 80.7MB (−27%), and import time from 1.2s to 0.75s. In an environment closer to production (Python 3.14, more transitive dependencies), this duplication accounted for 57MB of a 160MB import.

`PrebuiltValidator`/`PrebuiltSerializer` also no longer expand the delegated tree in their `Debug` output, as the expansion can be exponentially large with highly interconnected models.

https://claude.ai/code/session_01S88sBbxZGM1RnWsuZQYKVE