### PR TITLE
Fix Flag enum dict-key round-trip through JSON

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -16,7 +16,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from copy import copy
 from decimal import Decimal
-from enum import Enum
+from enum import Enum, Flag
 from fractions import Fraction
 from functools import partial
 from inspect import Parameter, _ParameterKind
@@ -433,8 +433,35 @@ class GenerateSchema:
             # TODO this is an ugly hack, how do we trigger an Any schema for serialization?
             value_ser_type = core_schema.plain_serializer_function_ser_schema(lambda x: x)
 
-        if cases:
+        # Flag enums support arbitrary bitwise-OR combinations of their declared
+        # members, so the value space isn't limited to `cases`. Validate/serialize
+        # via the enum's own int reconstruction instead of the fixed-members schema.
+        if cases and issubclass(enum_type, Flag):
 
+            def validate_flag(value: Any) -> Any:
+                if isinstance(value, enum_type):
+                    return value
+                if isinstance(value, str) and value.lstrip('-').isdigit():
+                    value = int(value)
+                try:
+                    return enum_type(value)
+                except ValueError as e:
+                    raise PydanticCustomError(
+                        'enum',
+                        'Input should be a valid {enum_name} value',
+                        {'enum_name': enum_type.__name__},
+                    ) from e
+
+            def serialize_flag(value: Any) -> Any:
+                return value.value
+
+            return core_schema.no_info_plain_validator_function(
+                validate_flag,
+                serialization=core_schema.plain_serializer_function_ser_schema(serialize_flag),
+                ref=enum_ref,
+            )
+
+        if cases:
             def get_json_schema(schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
                 json_schema = handler(schema)
                 original_schema = handler.resolve_ref_schema(json_schema)

--- a/solution.patch
+++ b/solution.patch
@@ -1,0 +1,50 @@
+diff --git a/pydantic/_internal/_generate_schema.py b/pydantic/_internal/_generate_schema.py
+index 003920f8f..9f93668cf 100644
+--- a/pydantic/_internal/_generate_schema.py
++++ b/pydantic/_internal/_generate_schema.py
+@@ -16,7 +16,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
+ from contextlib import contextmanager
+ from copy import copy
+ from decimal import Decimal
+-from enum import Enum
++from enum import Enum, Flag
+ from fractions import Fraction
+ from functools import partial
+ from inspect import Parameter, _ParameterKind
+@@ -433,8 +433,35 @@ class GenerateSchema:
+             # TODO this is an ugly hack, how do we trigger an Any schema for serialization?
+             value_ser_type = core_schema.plain_serializer_function_ser_schema(lambda x: x)
+ 
+-        if cases:
++        # Flag enums support arbitrary bitwise-OR combinations of their declared
++        # members, so the value space isn't limited to `cases`. Validate/serialize
++        # via the enum's own int reconstruction instead of the fixed-members schema.
++        if cases and issubclass(enum_type, Flag):
++
++            def validate_flag(value: Any) -> Any:
++                if isinstance(value, enum_type):
++                    return value
++                if isinstance(value, str) and value.lstrip('-').isdigit():
++                    value = int(value)
++                try:
++                    return enum_type(value)
++                except ValueError as e:
++                    raise PydanticCustomError(
++                        'enum',
++                        'Input should be a valid {enum_name} value',
++                        {'enum_name': enum_type.__name__},
++                    ) from e
+ 
++            def serialize_flag(value: Any) -> Any:
++                return value.value
++
++            return core_schema.no_info_plain_validator_function(
++                validate_flag,
++                serialization=core_schema.plain_serializer_function_ser_schema(serialize_flag),
++                ref=enum_ref,
++            )
++
++        if cases:
+             def get_json_schema(schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+                 json_schema = handler(schema)
+                 original_schema = handler.resolve_ref_schema(json_schema)

--- a/test.patch
+++ b/test.patch
@@ -1,0 +1,81 @@
+diff --git a/test.sh b/test.sh
+new file mode 100644
+index 000000000..41bedc214
+--- /dev/null
++++ b/test.sh
+@@ -0,0 +1,30 @@
++#!/usr/bin/env bash
++set -uo pipefail
++cd /app
++
++OUTPUT_PATH=""
++if [ "${1:-}" = "--output_path" ]; then
++  OUTPUT_PATH="$2"
++  shift 2
++fi
++
++MODE="${1:-new}"
++
++case "$MODE" in
++  base)
++    ARGS="tests/test_types.py -k flag or Flag"
++    ;;
++  new)
++    ARGS="tests/test_flag_enum_roundtrip.py"
++    ;;
++  *)
++    echo "unknown mode: $MODE" >&2
++    exit 2
++    ;;
++esac
++
++if [ -n "$OUTPUT_PATH" ]; then
++  python -m pytest $ARGS --junitxml="$OUTPUT_PATH" -v
++else
++  python -m pytest $ARGS -v
++fi
+\ No newline at end of file
+diff --git a/tests/test_flag_enum_roundtrip.py b/tests/test_flag_enum_roundtrip.py
+new file mode 100644
+index 000000000..41c85c4c4
+--- /dev/null
++++ b/tests/test_flag_enum_roundtrip.py
+@@ -0,0 +1,37 @@
++from enum import Flag, auto
++
++import pytest
++
++from pydantic import BaseModel
++
++
++class Color(Flag):
++    RED = auto()
++    GREEN = auto()
++    BLUE = auto()
++
++
++class Palette(BaseModel):
++    counts: dict[Color, int]
++
++
++def test_single_member_key_roundtrips():
++    m = Palette(counts={Color.RED: 1})
++    reloaded = Palette.model_validate_json(m.model_dump_json())
++    assert reloaded == m
++
++
++def test_combined_member_key_roundtrips():
++    m = Palette(counts={Color.RED | Color.BLUE: 5})
++    reloaded = Palette.model_validate_json(m.model_dump_json())
++    assert reloaded == m
++
++
++def test_multiple_keys_including_combined_roundtrip():
++    m = Palette(counts={
++        Color.RED: 1,
++        Color.GREEN | Color.BLUE: 2,
++        Color.RED | Color.GREEN | Color.BLUE: 3,
++    })
++    reloaded = Palette.model_validate_json(m.model_dump_json())
++    assert reloaded == m
+\ No newline at end of file

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd /app
+
+OUTPUT_PATH=""
+if [ "${1:-}" = "--output_path" ]; then
+  OUTPUT_PATH="$2"
+  shift 2
+fi
+
+MODE="${1:-new}"
+
+case "$MODE" in
+  base)
+    ARGS="tests/test_types.py -k flag or Flag"
+    ;;
+  new)
+    ARGS="tests/test_flag_enum_roundtrip.py"
+    ;;
+  *)
+    echo "unknown mode: $MODE" >&2
+    exit 2
+    ;;
+esac
+
+if [ -n "$OUTPUT_PATH" ]; then
+  python -m pytest $ARGS --junitxml="$OUTPUT_PATH" -v
+else
+  python -m pytest $ARGS -v
+fi

--- a/tests/test_flag_enum_roundtrip.py
+++ b/tests/test_flag_enum_roundtrip.py
@@ -1,0 +1,37 @@
+from enum import Flag, auto
+
+import pytest
+
+from pydantic import BaseModel
+
+
+class Color(Flag):
+    RED = auto()
+    GREEN = auto()
+    BLUE = auto()
+
+
+class Palette(BaseModel):
+    counts: dict[Color, int]
+
+
+def test_single_member_key_roundtrips():
+    m = Palette(counts={Color.RED: 1})
+    reloaded = Palette.model_validate_json(m.model_dump_json())
+    assert reloaded == m
+
+
+def test_combined_member_key_roundtrips():
+    m = Palette(counts={Color.RED | Color.BLUE: 5})
+    reloaded = Palette.model_validate_json(m.model_dump_json())
+    assert reloaded == m
+
+
+def test_multiple_keys_including_combined_roundtrip():
+    m = Palette(counts={
+        Color.RED: 1,
+        Color.GREEN | Color.BLUE: 2,
+        Color.RED | Color.GREEN | Color.BLUE: 3,
+    })
+    reloaded = Palette.model_validate_json(m.model_dump_json())
+    assert reloaded == m


### PR DESCRIPTION
## Change Summary

When a model field is typed as a dict with a `Flag` enum as the key type, dumping the model to JSON and then validating that JSON back currently raises a `ValidationError`, even though the data hasn't changed. `Flag` values round-trip through JSON as their underlying integer values, including combined values produced by OR-ing multiple members together, but the existing enum validation logic only accepts individually declared members and rejects those integer-derived keys.

This PR adds a dedicated code path in `_enum_schema` for `Flag` subclasses: instead of routing through the standard fixed-members enum schema, `Flag` types are validated and serialized using the enum's own int-based reconstruction (`enum_type(value)`), which natively supports arbitrary bitwise-OR combinations of declared members.

This is an initial fix focused on the dict-key round-trip case described in the linked issue. I haven't yet tested interactions with `IntFlag`/`StrFlag` (3.11+), `use_enum_values` config, or JSON Schema generation for `Flag` types specifically — happy to extend this based on maintainer feedback if a broader fix is wanted.

## Related issue number

Fixes #12448

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**