### PR TITLE
fix(types): end-anchor byte_string_pattern in ByteSize to reject trailing data

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2100,7 +2100,7 @@ class ByteSize(int):
     }
     byte_sizes.update({k.lower()[0]: v for k, v in byte_sizes.items() if 'i' not in k})
 
-    byte_string_pattern = r'^\s*(\d*\.?\d+)\s*(\w+)?'
+    byte_string_pattern = r'^\s*(\d*\.?\d+)\s*(\w+)?\s*$'
     byte_string_re = re.compile(byte_string_pattern, re.IGNORECASE)
 
     @classmethod


### PR DESCRIPTION
## Description
This PR resolves issue #13519 by end-anchoring (`\s*$`) the regex pattern `byte_string_pattern` in `ByteSize` in `pydantic/types.py`.

## Details
- Prevents `ByteSize` from silently parsing and ignoring unparsed trailing data (e.g. `1KB junk`).