### PR TITLE
fix(functional_validators): add serialization return_schema for ValidateAs

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -895,7 +895,12 @@ class ValidateAs:
 
     def __get_pydantic_core_schema__(self, source: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
         schema = handler(self.from_type)
+        return_schema = handler(source)
         return core_schema.no_info_after_validator_function(
             self.instantiation_hook,
             schema=schema,
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                lambda v, h: h(v),
+                return_schema=return_schema,
+            ),
         )


### PR DESCRIPTION
## Description
This PR resolves issue #13460 by setting a wrap serializer schema with `return_schema=handler(source)` in `ValidateAs.__get_pydantic_core_schema__()` (`pydantic/functional_validators.py`).

## Details
- Prevents `PydanticSerializationUnexpectedValue` during serialization when validating from an intermediate type (e.g. `ValidateAs(list[int], ...)`).