### PR TITLE
Box rarely-used oversized `CombinedValidator` variants

### DIFF
--- a/pydantic-core/src/validators/int.rs
+++ b/pydantic-core/src/validators/int.rs
@@ -98,14 +98,14 @@ pub struct ConstrainedIntValidator {
 impl ConstrainedIntValidator {
     fn build(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
-        Ok(CombinedValidator::ConstrainedInt(Self {
+        Ok(CombinedValidator::ConstrainedInt(Box::new(Self {
             strict: is_strict(schema, config)?,
             multiple_of: validate_as_int(schema, intern!(py, "multiple_of"))?,
             le: validate_as_int(schema, intern!(py, "le"))?,
             lt: validate_as_int(schema, intern!(py, "lt"))?,
             ge: validate_as_int(schema, intern!(py, "ge"))?,
             gt: validate_as_int(schema, intern!(py, "gt"))?,
-        })
+        }))
         .into())
     }
 }

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -730,7 +730,7 @@ pub enum CombinedValidator {
     TypedDict(typed_dict::TypedDictValidator),
     // unions
     Union(union::UnionValidator),
-    TaggedUnion(union::TaggedUnionValidator),
+    TaggedUnion(Box<union::TaggedUnionValidator>),
     // nullables
     Nullable(nullable::NullableValidator),
     // create new model classes
@@ -744,7 +744,7 @@ pub enum CombinedValidator {
     StrConstrained(string::StrConstrainedValidator),
     // integers
     Int(int::IntValidator),
-    ConstrainedInt(int::ConstrainedIntValidator),
+    ConstrainedInt(Box<int::ConstrainedIntValidator>),
     // booleans
     Bool(bool::BoolValidator),
     // floats
@@ -815,8 +815,8 @@ pub enum CombinedValidator {
     // json data
     Json(json::JsonValidator),
     // url types
-    Url(url::UrlValidator),
-    MultiHostUrl(url::MultiHostUrlValidator),
+    Url(Box<url::UrlValidator>),
+    MultiHostUrl(Box<url::MultiHostUrlValidator>),
     // uuid types
     Uuid(uuid::UuidValidator),
     // reference to definition, useful for recursive (self-referencing) models
@@ -867,4 +867,60 @@ pub trait Validator: Send + Sync + Debug {
     /// `get_name` generally returns `Self::EXPECTED_TYPE` or some other clear identifier of the validator
     /// this is used in the error location in unions, and in the top level message in `ValidationError`
     fn get_name(&self) -> &str;
+}
+
+/// Rarely-used validators which are much larger than the rest are stored boxed in `CombinedValidator`,
+/// so that they don't inflate the size of *every* validator node. Delegate straight through to the inner
+/// validator so that `enum_dispatch` can treat `Box<V>` as a variant type.
+impl<T: Validator> Validator for Box<T> {
+    fn validate<'py>(
+        &self,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Py<PyAny>> {
+        (**self).validate(py, input, state)
+    }
+
+    fn default_value<'py>(
+        &self,
+        py: Python<'py>,
+        outer_loc: Option<impl Into<LocItem>>,
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Option<Py<PyAny>>> {
+        (**self).default_value(py, outer_loc, state)
+    }
+
+    fn validate_assignment<'py>(
+        &self,
+        py: Python<'py>,
+        obj: &Bound<'py, PyAny>,
+        field_name: &PyBackedStr,
+        field_value: &Bound<'py, PyAny>,
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Py<PyAny>> {
+        (**self).validate_assignment(py, obj, field_name, field_value, state)
+    }
+
+    fn get_name(&self) -> &str {
+        (**self).get_name()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `CombinedValidator` is instantiated once per node of every schema, so its size is multiplied
+    /// across every model in an application. Rarely-used variants which are much larger than the rest
+    /// are boxed to keep this down — if this assertion fails, box the offending variant rather than
+    /// raising the limit.
+    #[test]
+    fn combined_validator_size() {
+        assert!(
+            std::mem::size_of::<CombinedValidator>() <= 144,
+            "CombinedValidator grew to {} bytes",
+            std::mem::size_of::<CombinedValidator>()
+        );
+    }
 }

--- a/pydantic-core/src/validators/union.rs
+++ b/pydantic-core/src/validators/union.rs
@@ -338,7 +338,7 @@ impl BuildValidator for TaggedUnionValidator {
         let key = intern!(py, "from_attributes");
         let from_attributes = schema_or_config(schema, config, key, key)?.unwrap_or(true);
 
-        Ok(CombinedValidator::TaggedUnion(Self {
+        Ok(CombinedValidator::TaggedUnion(Box::new(Self {
             discriminator: Box::new(discriminator),
             lookup,
             from_attributes,
@@ -346,7 +346,7 @@ impl BuildValidator for TaggedUnionValidator {
             tags_repr,
             discriminator_repr,
             name: format!("{}[{descr}]", Self::EXPECTED_TYPE),
-        })
+        }))
         .into())
     }
 }

--- a/pydantic-core/src/validators/url.rs
+++ b/pydantic-core/src/validators/url.rs
@@ -41,7 +41,7 @@ pub struct UrlValidator {
 }
 
 static SIMPLE_URL_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| {
-    Arc::new(CombinedValidator::Url(UrlValidator {
+    Arc::new(CombinedValidator::Url(Box::new(UrlValidator {
         strict: false,
         max_length: None,
         allowed_schemes: None,
@@ -51,11 +51,11 @@ static SIMPLE_URL_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(||
         default_path: None,
         name: "url".to_string(),
         preserve_empty_path: false,
-    }))
+    })))
 });
 
 static SIMPLE_URL_VALIDATOR_STRICT: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| {
-    Arc::new(CombinedValidator::Url(UrlValidator {
+    Arc::new(CombinedValidator::Url(Box::new(UrlValidator {
         strict: true,
         max_length: None,
         allowed_schemes: None,
@@ -65,11 +65,11 @@ static SIMPLE_URL_VALIDATOR_STRICT: LazyLock<Arc<CombinedValidator>> = LazyLock:
         default_path: None,
         name: "url".to_string(),
         preserve_empty_path: false,
-    }))
+    })))
 });
 
 static SIMPLE_URL_VALIDATOR_PRESERVE_EMPTY_PATH: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| {
-    Arc::new(CombinedValidator::Url(UrlValidator {
+    Arc::new(CombinedValidator::Url(Box::new(UrlValidator {
         strict: false,
         max_length: None,
         allowed_schemes: None,
@@ -79,11 +79,11 @@ static SIMPLE_URL_VALIDATOR_PRESERVE_EMPTY_PATH: LazyLock<Arc<CombinedValidator>
         default_path: None,
         name: "url".to_string(),
         preserve_empty_path: true,
-    }))
+    })))
 });
 
 static SIMPLE_URL_VALIDATOR_STRICT_PRESERVE_EMPTY_PATH: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| {
-    Arc::new(CombinedValidator::Url(UrlValidator {
+    Arc::new(CombinedValidator::Url(Box::new(UrlValidator {
         strict: true,
         max_length: None,
         allowed_schemes: None,
@@ -93,7 +93,7 @@ static SIMPLE_URL_VALIDATOR_STRICT_PRESERVE_EMPTY_PATH: LazyLock<Arc<CombinedVal
         default_path: None,
         name: "url".to_string(),
         preserve_empty_path: true,
-    }))
+    })))
 });
 
 fn get_preserve_empty_path(schema: &Bound<'_, PyDict>, config: Option<&Bound<'_, PyDict>>) -> PyResult<bool> {
@@ -139,7 +139,7 @@ impl BuildValidator for UrlValidator {
             return Ok(UrlValidator::get_simple(validator.strict, validator.preserve_empty_path).clone());
         }
 
-        Ok(CombinedValidator::Url(validator).into())
+        Ok(CombinedValidator::Url(Box::new(validator)).into())
     }
 }
 
@@ -295,7 +295,7 @@ pub struct MultiHostUrlValidator {
 }
 
 static SIMPLE_MULTI_HOST_URL_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| {
-    Arc::new(CombinedValidator::MultiHostUrl(MultiHostUrlValidator {
+    Arc::new(CombinedValidator::MultiHostUrl(Box::new(MultiHostUrlValidator {
         strict: false,
         max_length: None,
         allowed_schemes: None,
@@ -305,11 +305,11 @@ static SIMPLE_MULTI_HOST_URL_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyL
         default_path: None,
         name: "multi-host-url".to_string(),
         preserve_empty_path: false,
-    }))
+    })))
 });
 
 static SIMPLE_MULTI_HOST_URL_VALIDATOR_STRICT: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| {
-    Arc::new(CombinedValidator::MultiHostUrl(MultiHostUrlValidator {
+    Arc::new(CombinedValidator::MultiHostUrl(Box::new(MultiHostUrlValidator {
         strict: true,
         max_length: None,
         allowed_schemes: None,
@@ -319,11 +319,11 @@ static SIMPLE_MULTI_HOST_URL_VALIDATOR_STRICT: LazyLock<Arc<CombinedValidator>> 
         default_path: None,
         name: "multi-host-url".to_string(),
         preserve_empty_path: false,
-    }))
+    })))
 });
 
 static SIMPLE_MULTI_HOST_URL_VALIDATOR_PRESERVE_EMPTY_PATH: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| {
-    Arc::new(CombinedValidator::MultiHostUrl(MultiHostUrlValidator {
+    Arc::new(CombinedValidator::MultiHostUrl(Box::new(MultiHostUrlValidator {
         strict: false,
         max_length: None,
         allowed_schemes: None,
@@ -333,12 +333,12 @@ static SIMPLE_MULTI_HOST_URL_VALIDATOR_PRESERVE_EMPTY_PATH: LazyLock<Arc<Combine
         default_path: None,
         name: "multi-host-url".to_string(),
         preserve_empty_path: true,
-    }))
+    })))
 });
 
 static SIMPLE_MULTI_HOST_URL_VALIDATOR_STRICT_PRESERVE_EMPTY_PATH: LazyLock<Arc<CombinedValidator>> =
     LazyLock::new(|| {
-        Arc::new(CombinedValidator::MultiHostUrl(MultiHostUrlValidator {
+        Arc::new(CombinedValidator::MultiHostUrl(Box::new(MultiHostUrlValidator {
             strict: true,
             max_length: None,
             allowed_schemes: None,
@@ -348,7 +348,7 @@ static SIMPLE_MULTI_HOST_URL_VALIDATOR_STRICT_PRESERVE_EMPTY_PATH: LazyLock<Arc<
             default_path: None,
             name: "multi-host-url".to_string(),
             preserve_empty_path: true,
-        }))
+        })))
     });
 
 impl BuildValidator for MultiHostUrlValidator {
@@ -390,7 +390,7 @@ impl BuildValidator for MultiHostUrlValidator {
             return Ok(MultiHostUrlValidator::get_simple(validator.strict, validator.preserve_empty_path).clone());
         }
 
-        Ok(CombinedValidator::MultiHostUrl(validator).into())
+        Ok(CombinedValidator::MultiHostUrl(Box::new(validator)).into())
     }
 }
 


### PR DESCRIPTION
`CombinedValidator` is instantiated once per node of every schema, so its size is multiplied across every field of every model in an application. Four variants were far larger than the rest and set the size of all of them:

| variant | size |
| --- | --- |
| `Url` | 184 |
| `MultiHostUrl` | 184 |
| `TaggedUnion` | 176 |
| `ConstrainedInt` | 168 |
| *next largest (`Union`, `ModelFields`)* | *136* |

Boxing those four takes `CombinedValidator` from **192 to 144 bytes**, saving 48 bytes for every allocated validator node.

All four are cold paths: URL validators are shared statics for the common unconstrained case, and tagged unions and constrained ints are rare relative to plain fields — so the extra indirection isn't on any hot path.

**Measured** on an application defining 2000 models with 20 optional fields each: **129.3MB → 125.4MB (−3.0%)**. On `google-genai` (766 models) it's ~0.4MB.

A unit test asserts the size stays at or below 144 bytes, so a future variant can't silently inflate every node again.

https://claude.ai/code/session_01X7dHs3MUC19dMtHEUNsG7V