### PR TITLE
fix: ByteSize validation should reject trailing data [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2100,7 +2100,7 @@ class ByteSize(int):
     }
     byte_sizes.update({k.lower()[0]: v for k, v in byte_sizes.items() if 'i' not in k})
 
-    byte_string_pattern = r'^\s*(\d*\.?\d+)\s*(\w+)?'
+    byte_string_pattern = r'^\s*(\d*\.?\d+)\s*(\w+)?$'
     byte_string_re = re.compile(byte_string_pattern, re.IGNORECASE)
 
     @classmethod


### PR DESCRIPTION
## Description
The `ByteSize.byte_string_pattern` regex only anchored at the start (`^`) but not at the end, so `re.match()` would silently ignore trailing characters after a valid byte string. For example, `'1KB junk'` was incorrectly accepted as 1024 bytes.

Adding `$` anchor ensures the entire string is consumed, raising a validation error for trailing data.

## Fix
Changed `byte_string_pattern` from `r'^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?'` to `r'^\\s*(\\d*\\.?\\d+)\\s*(\\w+)?$'`

## Tests
All 15 ByteSize tests pass.