### PR TITLE
Restrict `PaymentCardNumber.validate_digits` to ASCII digits

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1973,7 +1973,9 @@ class PaymentCardNumber(str):
     @classmethod
     def validate_digits(cls, card_number: str) -> None:
         """Validate that the card number is all digits."""
-        if not card_number.isdigit():
+        # `str.isdigit()` is true for non-ASCII digits, which `int()` reads numerically but the
+        # brand prefix comparisons read as literals, so restrict to ASCII.
+        if not (card_number.isascii() and card_number.isdigit()):
             raise PydanticCustomError('payment_card_number_digits', 'Card number is not all digits')
 
     @classmethod

--- a/tests/test_types_payment_card_number.py
+++ b/tests/test_types_payment_card_number.py
@@ -20,6 +20,9 @@ VALID_VISA_19 = '4050000000000000001'
 VALID_OTHER = '2000000000000000008'
 LUHN_INVALID = '4000000000000000'
 LEN_INVALID = '40000000000000006'
+# `LEN_INVALID` with its leading digit swapped for FULLWIDTH DIGIT FOUR: still luhn valid,
+# but the Visa prefix check no longer matches, so the length check for the brand is skipped.
+LEN_INVALID_NON_ASCII = '４' + LEN_INVALID[1:]
 
 
 # Mock PaymentCardNumber
@@ -40,6 +43,19 @@ def test_validate_digits():
     assert PaymentCardNumber.validate_digits(digits) is None
     with pytest.raises(PydanticCustomError, match='Card number is not all digits'):
         PaymentCardNumber.validate_digits('hello')
+
+
+@pytest.mark.parametrize(
+    'card_number',
+    [
+        '１２３４５',  # fullwidth
+        '٤٢٤٢٤',  # arabic-indic
+        LEN_INVALID_NON_ASCII,
+    ],
+)
+def test_validate_digits_non_ascii(card_number: str):
+    with pytest.raises(PydanticCustomError, match='Card number is not all digits'):
+        PaymentCardNumber.validate_digits(card_number)
 
 
 @pytest.mark.parametrize(
@@ -129,6 +145,7 @@ def test_valid(PaymentCard):
         ('1' * 11, 'type=string_too_short,'),
         ('1' * 20, 'type=string_too_long,'),
         ('h' * 16, 'type=payment_card_number_digits'),
+        (LEN_INVALID_NON_ASCII, 'type=payment_card_number_digits'),
         (LUHN_INVALID, 'type=payment_card_number_luhn,'),
         (LEN_INVALID, 'type=payment_card_number_brand,'),
     ],


### PR DESCRIPTION
## Change Summary

`PaymentCardNumber.validate_digits` gates input with `str.isdigit()`, which is Unicode-aware and returns `True` for characters like FULLWIDTH DIGIT FOUR (U+FF14) or ARABIC-INDIC DIGIT FOUR (U+0664). The two validators that run after it disagree about what those characters mean:

* `validate_luhn_check_digit` reads each character with `int()`, which is also Unicode-aware, so the checksum verifies normally.
* `validate_brand` compares the prefix against ASCII literals (`card_number[0] == '4'`, `card_number[:2] in {'34', '37'}`), so a non-ASCII leading digit matches no brand.

A number with a non-ASCII leading digit therefore falls through to `PaymentCardBrand.other`, which carries no length rule, and the per-brand length check is skipped:

```python
from pydantic import BaseModel
from pydantic.types import PaymentCardNumber

class Card(BaseModel):
    card_number: PaymentCardNumber

Card(card_number='41111111111114')
#> ValidationError: Length for a Visa card must be 13, 16 or 19

Card(card_number='４1111111111114')  # leading U+FF14
#> Card(card_number='４1111111111114')   brand is PaymentCardBrand.other
```

Both strings are the same digits to a reader, and `unicodedata.normalize('NFKC', '４1111111111114')` returns exactly the value pydantic just rejected. Anything that normalizes downstream (a database collation, a log pipeline, a gateway client) ends up holding a value that failed validation here. `bin`, `last4`, and `masked` slice the raw non-ASCII characters through as well.

Requiring `isascii()` alongside `isdigit()` keeps the digit check and the prefix comparisons working on the same alphabet. `pydantic-extra-types`, which this deprecated class points users to, already restricts to ASCII (`all('0' <= c <= '9' for c in card_number)`), so the two implementations agree again after this.

The stricter check only rejects input that was previously misclassified, so numbers that resolved to a real brand are unaffected.

## Related issue number

None filed. Happy to open one first if you would rather discuss it separately.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
