### PR TITLE
Revert "Make `FailFast` hashable"

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -3297,6 +3297,3 @@ class FailFast(_fields.PydanticMetadata, BaseMetadata):
     """
 
     fail_fast: bool = True
-
-    def __hash__(self) -> int:
-        return hash(self.fail_fast)


### PR DESCRIPTION
Reverts pydantic/pydantic#13503

See https://github.com/pydantic/pydantic/pull/13503#issuecomment-5115655524