### PR TITLE
Fix `SecretStr` equality comparison raising `TypeError` on non-ASCII values

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1888,7 +1888,8 @@ class SecretStr(_SecretField[str]):
         if not isinstance(other, self.__class__):
             return False
 
-        return secrets.compare_digest(self.get_secret_value(), other.get_secret_value())
+        # `secrets.compare_digest()` only supports ASCII strings, so encode to bytes first:
+        return secrets.compare_digest(self.get_secret_value().encode(), other.get_secret_value().encode())
 
     def _display(self) -> str:
         return _secret_display(self._secret_value)

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1889,7 +1889,10 @@ class SecretStr(_SecretField[str]):
             return False
 
         # `secrets.compare_digest()` only supports ASCII strings, so encode to bytes first:
-        return secrets.compare_digest(self.get_secret_value().encode(), other.get_secret_value().encode())
+        return secrets.compare_digest(
+            self.get_secret_value().encode('utf-8', errors='surrogatepass'),
+            other.get_secret_value().encode('utf-8', errors='surrogatepass'),
+        )
 
     def _display(self) -> str:
         return _secret_display(self._secret_value)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4465,6 +4465,7 @@ def test_secretstr_equality():
     assert SecretStr('123') is not SecretStr('123')
     assert SecretStr('café') == SecretStr('café')
     assert SecretStr('café') != SecretStr('cafe')
+    assert SecretStr('\ud800') == SecretStr('\ud800')  # lone surrogate, unencodable with strict utf-8
 
 
 def test_secretstr_idempotent():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4463,6 +4463,8 @@ def test_secretstr_equality():
     assert SecretStr('123') != SecretStr('321')
     assert SecretStr('123') != '123'
     assert SecretStr('123') is not SecretStr('123')
+    assert SecretStr('café') == SecretStr('café')
+    assert SecretStr('café') != SecretStr('cafe')
 
 
 def test_secretstr_idempotent():


### PR DESCRIPTION
## Change Summary

#13518 changed `SecretStr.__eq__()` to use `secrets.compare_digest()`, which only supports ASCII when given `str` arguments. Comparing two `SecretStr` instances holding non-ASCII values now raises a `TypeError`:

```python
from pydantic import SecretStr

SecretStr('café') == SecretStr('café')
#> TypeError: comparing strings with non-ASCII characters is not supported
```

Encoding the secret values to bytes before the comparison keeps the constant-time property and restores equality for any string value. `SecretBytes` is unaffected, as `secrets.compare_digest()` accepts arbitrary bytes.

## Related issue number

N/A, regression from #13518, found while reading that commit.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable <!-- not applicable -->
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
