### PR TITLE
Prevent a validator method from overriding an inherited validator of a different kind

### DIFF
--- a/docs/errors/usage_errors.md
+++ b/docs/errors/usage_errors.md
@@ -984,6 +984,73 @@ except PydanticUserError as exc_info:
     assert exc_info.code == 'multiple-field-serializers'
 ```
 
+## Overriding a validator method {#validator-method-override}
+
+This error is raised when a class reuses the name of an inherited validator or serializer method
+for a *different* kind of validator or serializer.
+
+Each validator is registered under its method name, and that name is resolved again on the class
+it is bound to. Reusing a name across two kinds of validator would therefore leave the inherited
+one pointing at the override, silently running a single method in two different roles.
+
+```python
+from typing import Any
+
+from pydantic import (
+    BaseModel,
+    PydanticUserError,
+    field_validator,
+    model_validator,
+)
+
+try:
+
+    class Parent(BaseModel):
+        x: int
+
+        @field_validator('x')
+        @classmethod
+        def transform(cls, value: Any) -> Any:
+            return value
+
+    class Child(Parent):
+        @model_validator(mode='before')
+        @classmethod
+        def transform(cls, data: Any) -> Any:
+            return data
+
+except PydanticUserError as exc_info:
+    assert exc_info.code == 'validator-method-override'
+```
+
+Overriding an inherited validator with a validator of the *same* kind is ordinary subclassing and
+remains allowed:
+
+```python
+from typing import Any
+
+from pydantic import BaseModel, field_validator
+
+
+class Parent(BaseModel):
+    x: int
+
+    @field_validator('x')
+    @classmethod
+    def transform(cls, value: Any) -> Any:
+        return value
+
+
+class Child(Parent):
+    @field_validator('x')
+    @classmethod
+    def transform(cls, value: Any) -> Any:
+        return value * 2
+
+
+assert Child(x=2).x == 4
+```
+
 ## Invalid annotated type {#invalid-annotated-type}
 
 This error is raised when an annotation cannot annotate a type.

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -3,7 +3,7 @@
 from __future__ import annotations as _annotations
 
 import types
-from collections import deque
+from collections import Counter, deque
 from collections.abc import Callable, Iterable
 from copy import copy
 from dataclasses import dataclass, field
@@ -476,6 +476,33 @@ class DecoratorInfos:
         res._validate()
         return res
 
+    def find_duplicates(self) -> list[str]:
+        """Return the names registered under more than one kind of decorator.
+
+        Every registry is keyed by the attribute name in the class namespace, and
+        [`Decorator.bind_to_cls()`][pydantic._internal._decorators.Decorator.bind_to_cls]
+        re-resolves that attribute on the target class. So when a subclass reuses the name of
+        an inherited validator for a *different* kind of validator, the inherited entry is
+        rebound to the override, and a single function silently ends up being invoked in two
+        different roles.
+
+        Overriding a validator with one of the same kind only replaces the existing entry,
+        which is ordinary subclassing, so those names are not reported.
+        """
+        counts = Counter(
+            name
+            for registry in (
+                self.validators,
+                self.field_validators,
+                self.root_validators,
+                self.field_serializers,
+                self.model_serializers,
+                self.model_validators,
+            )
+            for name in registry
+        )
+        return sorted(name for name, count in counts.items() if count > 1)
+
     def _validate(self) -> None:
         seen: set[str] = set()
         for field_ser in self.field_serializers.values():
@@ -486,6 +513,16 @@ class DecoratorInfos:
                         code='multiple-field-serializers',
                     )
                 seen.add(f_name)
+
+        if duplicates := self.find_duplicates():
+            if len(duplicates) == 1:
+                message = (
+                    f'Validator method {duplicates[0]!r} overrides an existing validator method, this is not allowed.'
+                )
+            else:
+                names = ', '.join(repr(name) for name in duplicates)
+                message = f'Validator methods {names} override existing validator methods, this is not allowed.'
+            raise PydanticUserError(message, code='validator-method-override')
 
     def update_from_config(self, config_wrapper: ConfigWrapper) -> None:
         """Update the decorator infos from the configuration of the class they are attached to."""

--- a/pydantic/errors.py
+++ b/pydantic/errors.py
@@ -61,6 +61,7 @@ PydanticErrorCodes = Literal[
     'field-serializer-signature',
     'model-serializer-signature',
     'multiple-field-serializers',
+    'validator-method-override',
     'invalid-annotated-type',
     'type-adapter-config-unused',
     'root-model-extra',

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -34,7 +34,9 @@ from pydantic import (
     ValidationInfo,
     ValidatorFunctionWrapHandler,
     errors,
+    field_serializer,
     field_validator,
+    model_serializer,
     model_validator,
     root_validator,
     validate_call,
@@ -3177,3 +3179,166 @@ def test_model_validate_json_default_value_validator_with_validation_info() -> N
     f2 = Foo.model_validate_json('{"field1": 1}', context='context')
 
     assert f1.field == f2.field == 2
+
+
+def test_validator_method_override_field_then_model() -> None:
+    """Reusing an inherited field validator's name for a model validator is an error.
+
+    The registries are keyed by method name and rebound to the owning class, so the
+    inherited entry would otherwise point at the override and a single method would run
+    in two different roles. See #11299.
+    """
+    with pytest.raises(
+        PydanticUserError,
+        match=re.escape("Validator method 'transform' overrides an existing validator method, this is not allowed."),
+    ) as exc_info:
+
+        class Parent(BaseModel):
+            x: int
+
+            @field_validator('x')
+            @classmethod
+            def transform(cls, value: Any) -> Any:
+                return value
+
+        class Child(Parent):
+            @model_validator(mode='before')
+            @classmethod
+            def transform(cls, data: Any) -> Any:
+                return data
+
+    assert exc_info.value.code == 'validator-method-override'
+
+
+def test_validator_method_override_model_then_field() -> None:
+    """The check is direction agnostic."""
+    with pytest.raises(PydanticUserError, check=lambda e: e.code == 'validator-method-override'):
+
+        class Parent(BaseModel):
+            x: int
+
+            @model_validator(mode='before')
+            @classmethod
+            def transform(cls, data: Any) -> Any:
+                return data
+
+        class Child(Parent):
+            @field_validator('x')
+            @classmethod
+            def transform(cls, value: Any) -> Any:
+                return value
+
+
+def test_validator_method_override_serializer() -> None:
+    """Serializers share the same namespace, so they clash the same way."""
+    with pytest.raises(PydanticUserError, check=lambda e: e.code == 'validator-method-override'):
+
+        class Parent(BaseModel):
+            x: int
+
+            @field_validator('x')
+            @classmethod
+            def transform(cls, value: Any) -> Any:
+                return value
+
+        class Child(Parent):
+            @field_serializer('x')
+            def transform(self, value: Any) -> Any:
+                return value
+
+
+def test_validator_method_override_field_serializer_then_model_serializer() -> None:
+    with pytest.raises(PydanticUserError, check=lambda e: e.code == 'validator-method-override'):
+
+        class Parent(BaseModel):
+            x: int
+
+            @field_serializer('x')
+            def transform(self, value: Any) -> Any:
+                return value
+
+        class Child(Parent):
+            @model_serializer
+            def transform(self) -> Any:
+                return {}
+
+
+def test_validator_method_override_multiple_names() -> None:
+    """Every clashing name is reported, sorted, in a single error."""
+    with pytest.raises(
+        PydanticUserError,
+        match=re.escape(
+            "Validator methods 'first', 'second' override existing validator methods, this is not allowed."
+        ),
+    ) as exc_info:
+
+        class Parent(BaseModel):
+            x: int
+            y: int
+
+            @field_validator('x')
+            @classmethod
+            def first(cls, value: Any) -> Any:
+                return value
+
+            @field_validator('y')
+            @classmethod
+            def second(cls, value: Any) -> Any:
+                return value
+
+        class Child(Parent):
+            @model_validator(mode='before')
+            @classmethod
+            def first(cls, data: Any) -> Any:
+                return data
+
+            @model_validator(mode='before')
+            @classmethod
+            def second(cls, data: Any) -> Any:
+                return data
+
+    assert exc_info.value.code == 'validator-method-override'
+
+
+def test_validator_method_same_kind_override_allowed() -> None:
+    """Overriding a validator with one of the same kind is ordinary subclassing."""
+
+    class Parent(BaseModel):
+        x: int
+
+        @field_validator('x')
+        @classmethod
+        def transform(cls, value: Any) -> Any:
+            return value
+
+    class Child(Parent):
+        @field_validator('x')
+        @classmethod
+        def transform(cls, value: Any) -> Any:
+            return value * 2
+
+    assert Parent(x=2).x == 2
+    # Only the override runs, so the value is doubled exactly once.
+    assert Child(x=2).x == 4
+
+
+def test_validator_method_name_reuse_in_unrelated_models_allowed() -> None:
+    """The same method name in unrelated classes is not a clash."""
+
+    class First(BaseModel):
+        x: int
+
+        @field_validator('x')
+        @classmethod
+        def transform(cls, value: Any) -> Any:
+            return value + 1
+
+    class Second(BaseModel):
+        y: int
+
+        @model_validator(mode='after')
+        def transform(self) -> 'Second':
+            return self
+
+    assert First(x=1).x == 2
+    assert Second(y=1).y == 1


### PR DESCRIPTION
## Change Summary

`DecoratorInfos` keys every decorator registry by the **method name** in the class
namespace, and `Decorator.bind_to_cls()` resolves that name again on the class the
decorators are bound to. So when a subclass reuses the name of an inherited validator for
a *different* kind of validator, the inherited entry is rebound to the override and one
method is silently invoked in two different roles.

Using the example from #11299, inspecting the collected decorators on `BrokenModel` shows
both registries pointing at the same function:

```
field_validators['map_foo'] -> func.__qualname__ = BrokenModel.map_foo
model_validators['map_foo'] -> func.__qualname__ = BrokenModel.map_foo
```

The parent's `@field_validator` never runs, and the child's `@model_validator` runs twice
with unrelated inputs (once the whole input dict, once just the field value):

```
('model_validator', {'foo': 'foo'})
('model_validator', 'foo')
```

This adds `DecoratorInfos.find_duplicates()`, which returns the names registered under
more than one kind of validator or serializer, and raises `PydanticUserError` from the
existing `DecoratorInfos._validate()` with a new `validator-method-override` error code:

```
Validator method 'map_foo' overrides an existing validator method, this is not allowed.
```

Overriding an inherited validator with one of the **same** kind only replaces the existing
registry entry, which is ordinary subclassing, so it stays allowed.

### Notes on the previous attempt

This picks up #11782, which was closed without merging. I followed the review feedback
left there by @DouweM:

- the check is a method on `DecoratorInfos` using `self`, named `find_duplicates`, and
  returns a plain list that is built once (no double set conversion),
- there is a comment explaining *why* the clash is a problem rather than just that it is,
- the message is `Validator method {name!r} overrides an existing validator method, this is
  not allowed.`, with a separate message listing all names when several clash,
- a new error code is introduced and documented in `docs/errors/usage_errors.md`,
- the tests assert the exact error message.

One open question from that review was *"Should we also consider that serializer methods
may conflict?"* — **yes**, and this PR covers them. `field_serializers` and
`model_serializers` live in the same name-keyed registries and clash identically. I
verified each combination:

| parent | child | result |
| --- | --- | --- |
| `field_validator` | `model_validator` | `validator-method-override` |
| `model_validator` | `field_validator` | `validator-method-override` |
| `field_validator` | `field_serializer` | `validator-method-override` |
| `field_serializer` | `model_serializer` | `validator-method-override` |
| `field_validator` | `field_validator` | allowed (same kind) |

`computed_fields` is deliberately left out of the check: it is keyed by the property name
rather than a validator method name, and including it is a separate question.

## Related issue number

fix #11299

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

### How this was verified

The five tests that expect the new error fail on `main` with
`Failed: DID NOT RAISE PydanticUserError`, and pass with the change. The two tests that
assert the *allowed* cases pass both before and after, so they act as regression guards
against the check being too broad.

`tests/test_docs.py::test_docs_examples` is skipped on Windows
(`find_examples(..., skip=sys.platform == 'win32')`), so I checked the two new
documentation examples separately against the same rules `run_example` applies — ruff
lint, ruff format at 80 columns with single quotes, and actual execution — and all pass.

Full suite: no new failures, `5614 passed` (up 7, the new tests). `ruff check` and
`ruff format --check` are clean over `pydantic tests docs/plugins release`.
