### PR TITLE
Fix `max_digits`/`decimal_places` for high-precision decimals

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -10,7 +10,7 @@ import math
 import re
 import typing
 from collections.abc import Callable, Sequence
-from decimal import Decimal
+from decimal import MAX_EMAX, MAX_PREC, MIN_EMIN, Context, Decimal
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import Any, TypeAlias, TypeVar, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -372,10 +372,17 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
         raise TypeError(f'Unable to extract decimal digits info from supplied value {decimal}')
 
 
+# The constraints below normalize a value only to drop trailing zeros before counting its digits.
+# `Decimal.normalize()` uses the active context, which rounds to `prec` significant digits (28 by
+# default) and signals `Overflow` outside `Emax`/`Emin`, so it is given a context wide enough to leave
+# every `Decimal` untouched.
+_NORMALIZE_CONTEXT = Context(prec=MAX_PREC, Emax=MAX_EMAX, Emin=MIN_EMIN)
+
+
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
     try:
         _, num_digits = _extract_decimal_digits_info(x)
-        _, normalized_num_digits = _extract_decimal_digits_info(x.normalize())
+        _, normalized_num_digits = _extract_decimal_digits_info(x.normalize(_NORMALIZE_CONTEXT))
         if (num_digits > max_digits) and (normalized_num_digits > max_digits):
             raise PydanticKnownError(
                 'decimal_max_digits',
@@ -390,7 +397,7 @@ def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
     try:
         decimal_places_, _ = _extract_decimal_digits_info(x)
         if decimal_places_ > decimal_places:
-            normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize())
+            normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize(_NORMALIZE_CONTEXT))
             if normalized_decimal_places > decimal_places:
                 raise PydanticKnownError(
                     'decimal_max_places',

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -10,7 +10,7 @@ import math
 import re
 import typing
 from collections.abc import Callable, Sequence
-from decimal import MAX_EMAX, MAX_PREC, MIN_EMIN, Context, Decimal
+from decimal import Decimal
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import Any, TypeAlias, TypeVar, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -372,17 +372,31 @@ def _extract_decimal_digits_info(decimal: Decimal) -> tuple[int, int]:
         raise TypeError(f'Unable to extract decimal digits info from supplied value {decimal}')
 
 
-# The constraints below normalize a value only to drop trailing zeros before counting its digits.
-# `Decimal.normalize()` uses the active context, which rounds to `prec` significant digits (28 by
-# default) and signals `Overflow` outside `Emax`/`Emin`, so it is given a context wide enough to leave
-# every `Decimal` untouched.
-_NORMALIZE_CONTEXT = Context(prec=MAX_PREC, Emax=MAX_EMAX, Emin=MIN_EMIN)
+def _drop_trailing_zeros(value: Decimal) -> Decimal:
+    """Return `value` with trailing zeros removed from its coefficient, without rounding.
+
+    The constraints below only discount trailing zeros before counting digits. `Decimal.normalize()`
+    is not suitable for this: it uses the active (thread-local) context, which rounds to `prec`
+    significant digits and signals `Overflow` outside `Emax`/`Emin`, and the pure Python `decimal`
+    can construct exponents beyond any context's bounds. Working on the `as_tuple()` representation
+    involves no context at all.
+    """
+    sign, digits, exponent = value.as_tuple()
+    if not isinstance(exponent, int):
+        # a special value (`NaN`/`sNaN`/`Infinity`) has no trailing zeros to drop
+        return value
+    if digits == (0,) * len(digits):
+        return Decimal((sign, (0,), 0))
+    n = 0
+    while n < len(digits) - 1 and digits[-1 - n] == 0:
+        n += 1
+    return Decimal((sign, digits[: len(digits) - n], exponent + n))
 
 
 def max_digits_validator(x: Any, max_digits: Any) -> Any:
     try:
         _, num_digits = _extract_decimal_digits_info(x)
-        _, normalized_num_digits = _extract_decimal_digits_info(x.normalize(_NORMALIZE_CONTEXT))
+        _, normalized_num_digits = _extract_decimal_digits_info(_drop_trailing_zeros(x))
         if (num_digits > max_digits) and (normalized_num_digits > max_digits):
             raise PydanticKnownError(
                 'decimal_max_digits',
@@ -397,7 +411,7 @@ def decimal_places_validator(x: Any, decimal_places: Any) -> Any:
     try:
         decimal_places_, _ = _extract_decimal_digits_info(x)
         if decimal_places_ > decimal_places:
-            normalized_decimal_places, _ = _extract_decimal_digits_info(x.normalize(_NORMALIZE_CONTEXT))
+            normalized_decimal_places, _ = _extract_decimal_digits_info(_drop_trailing_zeros(x))
             if normalized_decimal_places > decimal_places:
                 raise PydanticKnownError(
                     'decimal_max_places',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3545,6 +3545,23 @@ def test_decimal_invalid():
             v: condecimal(allow_inf_nan=True, max_digits=4)
 
 
+@pytest.mark.parametrize(
+    'type_args,value',
+    [
+        (dict(max_digits=30), Decimal('1.' + '1' * 40)),
+        (dict(decimal_places=30), Decimal('1.' + '1' * 40)),
+        (dict(max_digits=30), Decimal('1E+1000000')),
+    ],
+)
+def test_decimal_constraints_wrapped_schema(type_args, value):
+    class Model(BaseModel):
+        # wrapping the decimal schema means the constraints are applied by pydantic, not pydantic-core
+        foo: Annotated[Decimal, AfterValidator(lambda v: v), Field(**type_args)]
+
+    with pytest.raises(ValidationError):
+        Model(foo=value)
+
+
 @pytest.mark.parametrize('value,result', (('/test/path', Path('/test/path')), (Path('/test/path'), Path('/test/path'))))
 def test_path_validation_success(value, result):
     class Model(BaseModel):


### PR DESCRIPTION
## Change Summary

Both decimal constraint validators normalize the value before counting its digits, only to discount trailing zeros, but `Decimal.normalize()` runs in the active decimal context:

- with the default `prec=28` a longer value is rounded before it is counted, so `Decimal('1.' + '1' * 40)` (41 significant digits, 40 decimal places) satisfies `max_digits=30` and `decimal_places=30`
- the strictness of the check therefore tracks `decimal.getcontext().prec`, which is thread-local and can be changed by anything else in the process
- a value outside the context's `Emax`/`Emin` signals instead of returning, so `Decimal('1E+1000000')` raises `decimal.Overflow` out of the validator, which only catches `TypeError`

The fix drops trailing zeros directly on the `as_tuple()` representation, with no context involved and nothing to signal. An earlier revision normalized in a fixed `Context(prec=MAX_PREC, Emax=MAX_EMAX, Emin=MIN_EMIN)`, but the pure Python `decimal` (the only implementation on PyPy) can construct exponents beyond any context's bounds, so a wide context still signaled there; the `as_tuple()` form closes that as well. Values with trailing zeros, e.g. `Decimal('1.230')` against `max_digits=3, decimal_places=2`, are still discounted as before.

These validators are reached when the constraint can't be pushed into the core decimal schema, e.g. `Annotated[Decimal, AfterValidator(...), Field(max_digits=30)]`. Two things reviewers should weigh:

- this is a behavioral tightening: values that previously passed only because context rounding shrank them below the limit before counting are now rejected
- the plain-field path in `pydantic-core` (`src/validators/decimal.rs`) calls `normalize()` with no context argument, so it rounds to the active `prec` the same way this code did; after this change the two paths disagree on such values until core gets the same treatment. I'm happy to file the core counterpart if you'd rather they move together.

## Related issue number

None filed. Happy to open one first if you would rather discuss it separately.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
