### PR TITLE
Fix exclude_computed_fields in field serializer info

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -556,7 +556,7 @@ impl SerializationInfo {
                     exclude_unset: extra.exclude_unset,
                     exclude_defaults: extra.exclude_defaults,
                     exclude_none: extra.exclude_none,
-                    exclude_computed_fields: extra.exclude_none,
+                    exclude_computed_fields: extra.exclude_computed_fields,
                     round_trip: extra.round_trip,
                     field_name: Some(field_name.to_string()),
                     serialize_as_any: extra.serialize_as_any,

--- a/pydantic-core/tests/serializers/test_model.py
+++ b/pydantic-core/tests/serializers/test_model.py
@@ -506,6 +506,40 @@ def test_function_plain_field_serializer_to_python():
     assert s.to_python(Model(x=1000)) == {'x': '1_000'}
 
 
+def test_field_serializer_info_serialization_flags():
+    @dataclasses.dataclass
+    class Model:
+        x: int
+
+        def ser_x(self, v: Any, info: core_schema.FieldSerializationInfo) -> dict[str, bool]:
+            return {
+                'exclude_none': info.exclude_none,
+                'exclude_computed_fields': info.exclude_computed_fields,
+            }
+
+    s = SchemaSerializer(
+        core_schema.model_schema(
+            Model,
+            core_schema.model_fields_schema(
+                {
+                    'x': core_schema.model_field(
+                        core_schema.int_schema(
+                            serialization=core_schema.plain_serializer_function_ser_schema(
+                                Model.ser_x, is_field_serializer=True, info_arg=True
+                            )
+                        )
+                    )
+                }
+            ),
+        )
+    )
+
+    assert s.to_python(Model(x=1), exclude_computed_fields=True) == {
+        'x': {'exclude_none': False, 'exclude_computed_fields': True}
+    }
+    assert s.to_python(Model(x=1), exclude_none=True) == {'x': {'exclude_none': True, 'exclude_computed_fields': False}}
+
+
 def test_field_serializer_cached_property():
     @dataclasses.dataclass
     class Model:


### PR DESCRIPTION
## Change Summary

`FieldSerializationInfo.exclude_computed_fields` was populated from `exclude_none` for field serializers. As a result, field serializers saw `False` when `exclude_computed_fields=True`, and incorrectly saw `True` when only `exclude_none=True`.

Propagate the correct serialization option and add a regression test covering both asymmetric flag combinations.

## Related issue number

N/A — small, self-contained correctness fix.

## Tests

* `pytest pydantic-core/tests/serializers` — 802 passed, 5 skipped, 1 xfailed
* `pytest tests/test_serialize.py tests/test_computed_fields.py` — 120 passed, 4 skipped, 2 xfailed
* `cargo test --manifest-path pydantic-core/Cargo.toml`
* `cargo clippy --manifest-path pydantic-core/Cargo.toml --tests -- -D warnings`
* Ruff check/format and Cargo fmt checks

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
