### PR TITLE
Correct typo in test comments

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -588,7 +588,7 @@ def test_config_is_not_inherited_in_model_fields():
         a: str
 
     class Outer(BaseModel):
-        # this cause the inner model incorrectly dumpped:
+        # this cause the inner model incorrectly dumped:
         model_config = ConfigDict(str_to_lower=True)
 
         x: list[str]  # should be converted to lower

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -884,7 +884,7 @@ def test_serialize_with_extra():
         a: str = 'a'
 
     class Outer(BaseModel):
-        # this cause the inner model incorrectly dumpped:
+        # this cause the inner model incorrectly dumped:
         model_config = ConfigDict(extra='allow')
         inner: Inner = Field(default_factory=Inner)
 


### PR DESCRIPTION
Fixes: dumpped → dumped in test_config.py and test_serialize.py