### PR TITLE
Fix `KeyError` when a custom `__get_pydantic_json_schema__` returns embedded `$defs`

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2354,9 +2354,10 @@ class GenerateJsonSchema:
                 raise self._core_defs_invalid_for_json_schema[def_ref]
             return self.definitions.get(def_ref, None)
         except KeyError:
-            if json_ref.startswith(('http://', 'https://')):
-                return None
-            raise
+            # A ref that resolves in neither pydantic's registry nor as an external
+            # URL points into a user-embedded ``$defs`` (e.g. returned by a custom
+            # ``__get_pydantic_json_schema__``). Pydantic does not manage it. See #12145.
+            return None
 
     def encode_default(self, dft: Any) -> Any:
         """Encode a default value to a JSON-serializable value.
@@ -2466,8 +2467,10 @@ class GenerateJsonSchema:
                             raise self._core_defs_invalid_for_json_schema[defs_ref]
                         _add_json_refs(self.definitions[defs_ref])
                     except KeyError:
-                        if not json_ref.startswith(('http://', 'https://')):
-                            raise
+                        # Refs pydantic doesn't own (external URLs or user-embedded
+                        # ``$defs`` from a custom ``__get_pydantic_json_schema__``) are
+                        # not in the registry; they are walked inline instead. See #12145.
+                        pass
 
                 for k, v in schema.items():
                     if k == 'examples' and isinstance(v, list):
@@ -2535,8 +2538,8 @@ class GenerateJsonSchema:
                 visited_defs_refs.add(next_defs_ref)
                 unvisited_json_refs.update(_get_all_json_refs(self.definitions[next_defs_ref]))
             except KeyError:
-                if not next_json_ref.startswith(('http://', 'https://')):
-                    raise
+                # Refs pydantic doesn't own are not registry definitions to retain. See #12145.
+                pass
 
         self.definitions = {k: v for k, v in self.definitions.items() if k in visited_defs_refs}
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -328,6 +328,43 @@ def test_enum_modify_schema():
     }
 
 
+def test_custom_json_schema_with_embedded_defs():
+    """A custom ``__get_pydantic_json_schema__`` may return a schema that carries its
+    own ``$defs`` and internal ``$ref``s. Pydantic must not assume every ``$ref``
+    resolves in its own definitions registry. See #12145."""
+
+    schema = {
+        '$defs': {
+            'Tire': {
+                'properties': {'brand': {'title': 'Brand', 'type': 'string'}},
+                'required': ['brand'],
+                'title': 'Tire',
+                'type': 'object',
+            }
+        },
+        'properties': {'tires': {'items': {'$ref': '#/$defs/Tire'}, 'title': 'Tires', 'type': 'array'}},
+        'required': ['tires'],
+        'title': 'Car',
+        'type': 'object',
+    }
+
+    class CarDict:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+            return core_schema.dict_schema(
+                keys_schema=core_schema.str_schema(),
+                values_schema=core_schema.any_schema(),
+            )
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return schema
+
+    assert TypeAdapter(CarDict).json_schema() == schema
+
+
 def test_enum_schema_custom_field():
     class FooBarEnum(str, Enum):
         foo = 'foo'


### PR DESCRIPTION
## Change Summary

A custom `__get_pydantic_json_schema__` may return a JSON schema that carries its **own** `$defs` and internal `$ref`s. Pydantic's JSON-schema assembly assumed every `$ref` resolves in its own definitions registry, so `TypeAdapter(...).json_schema()` crashed with `KeyError: '#/$defs/...'`.

Minimal repro (from #12145):

```python
from typing import Any
from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
from pydantic.json_schema import JsonSchemaValue
from pydantic_core import core_schema

class CarDict:
    @classmethod
    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler):
        return core_schema.dict_schema(keys_schema=core_schema.str_schema(), values_schema=core_schema.any_schema())
    @classmethod
    def __get_pydantic_json_schema__(cls, cs, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
        return {
            '$defs': {'Tire': {'properties': {'brand': {'title': 'Brand', 'type': 'string'}}, 'required': ['brand'], 'title': 'Tire', 'type': 'object'}},
            'properties': {'tires': {'items': {'$ref': '#/$defs/Tire'}, 'title': 'Tires', 'type': 'array'}},
            'required': ['tires'], 'title': 'Car', 'type': 'object',
        }

TypeAdapter(CarDict).json_schema()  # KeyError: '#/$defs/Tire'
```

### Fix

Three read-only passes — `get_schema_from_definitions`, `get_json_ref_counts`, and `_garbage_collect_definitions` — look each `$ref` up in `self.json_to_defs_refs`. They already tolerate external `http(s)://` refs they don't own, but re-raised on **local** refs they don't own. A `$ref` that resolves in neither the registry nor as an external URL points into a user-embedded `$defs`; pydantic doesn't manage it, so these passes now skip it (it is walked inline and passes through to the output unchanged) rather than crash.

The change is symmetric across the three sites and leaves behavior for pydantic-owned and external refs untouched.

## Related issue number

fix #12145

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
