### PR TITLE
feat: add mode='outer' model validator to wrap full validation pipeline (#13472)

### DIFF
--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -141,7 +141,7 @@ class ModelValidatorDecoratorInfo:
     """
 
     decorator_repr: ClassVar[str] = '@model_validator'
-    mode: Literal['wrap', 'before', 'after']
+    mode: Literal['wrap', 'before', 'after', 'outer']
 
 
 DecoratorInfo: TypeAlias = 'ValidatorDecoratorInfo | FieldValidatorDecoratorInfo | RootValidatorDecoratorInfo | FieldSerializerDecoratorInfo | ModelSerializerDecoratorInfo | ModelValidatorDecoratorInfo | ComputedFieldInfo'
@@ -539,7 +539,7 @@ def _decorator_infos_for_class(
 
 
 def inspect_validator(
-    validator: Callable[..., Any], *, mode: FieldValidatorModes, type: Literal['field', 'model']
+    validator: Callable[..., Any], *, mode: FieldValidatorModes | Literal['outer'], type: Literal['field', 'model']
 ) -> bool:
     """Look at a field or model validator function and determine whether it takes an info argument.
 
@@ -560,7 +560,7 @@ def inspect_validator(
         # In this case, we assume no info argument is present:
         return False
     n_positional = count_positional_required_params(sig)
-    if mode == 'wrap':
+    if mode in ('wrap', 'outer'):
         if n_positional == 3:
             return True
         elif n_positional == 2:

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -872,6 +872,7 @@ class GenerateSchema:
 
                 schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
                 schema = apply_model_validators(schema, model_validators, 'outer')
+                schema = apply_model_validators(schema, model_validators, 'outermost')
                 return self.defs.create_definition_reference_schema(schema)
 
     def _resolve_self_type(self, obj: Any) -> Any:
@@ -2593,12 +2594,13 @@ def _convert_to_aliases(
 def apply_model_validators(
     schema: core_schema.CoreSchema,
     validators: Iterable[Decorator[ModelValidatorDecoratorInfo]],
-    mode: Literal['inner', 'outer', 'all'],
+    mode: Literal['inner', 'outer', 'outermost', 'all'],
 ) -> core_schema.CoreSchema:
     """Apply model validators to a schema.
 
     If mode == 'inner', only "before" validators are applied
-    If mode == 'outer', validators other than "before" are applied
+    If mode == 'outer', validators other than "before" and "outer" are applied
+    If mode == 'outermost', only "outer" validators are applied
     If mode == 'all', all validators are applied
 
     Args:
@@ -2613,10 +2615,12 @@ def apply_model_validators(
     for validator in validators:
         if mode == 'inner' and validator.info.mode != 'before':
             continue
-        if mode == 'outer' and validator.info.mode == 'before':
+        if mode == 'outer' and validator.info.mode not in ('wrap', 'after'):
+            continue
+        if mode == 'outermost' and validator.info.mode != 'outer':
             continue
         info_arg = inspect_validator(validator.func, mode=validator.info.mode, type='model')
-        if validator.info.mode == 'wrap':
+        if validator.info.mode in ('wrap', 'outer'):
             if info_arg:
                 schema = core_schema.with_info_wrap_validator_function(function=validator.func, schema=schema)
             else:

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -658,6 +658,15 @@ def model_validator(
 @overload
 def model_validator(
     *,
+    mode: Literal['outer'],
+) -> Callable[
+    [_AnyModelWrapValidator[_ModelType]], _decorators.PydanticDescriptorProxy[_decorators.ModelValidatorDecoratorInfo]
+]: ...
+
+
+@overload
+def model_validator(
+    *,
     mode: Literal['before'],
 ) -> Callable[
     [_AnyModelBeforeValidator], _decorators.PydanticDescriptorProxy[_decorators.ModelValidatorDecoratorInfo]
@@ -675,7 +684,7 @@ def model_validator(
 
 def model_validator(
     *,
-    mode: Literal['wrap', 'before', 'after'],
+    mode: Literal['wrap', 'outer', 'before', 'after'],
 ) -> Any:
     """!!! abstract "Usage Documentation"
         [Model Validators](../concepts/validators.md#model-validators)
@@ -720,7 +729,7 @@ def model_validator(
 
     Args:
         mode: A required string literal that specifies the validation mode.
-            It can be one of the following: 'wrap', 'before', or 'after'.
+            It can be one of the following: 'wrap', 'outer', 'before', or 'after'.
 
     Returns:
         A decorator that can be used to decorate a function to be used as a model validator.

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -193,3 +193,238 @@ def test_after_validator_wrong_signature() -> None:
     Model2()
     Model3()
     Model4()
+
+
+def test_model_validator_outer_ordering() -> None:
+    calls: list[str] = []
+
+    class Model(BaseModel):
+        x: int
+
+        @model_validator(mode='before')
+        @classmethod
+        def val_before(cls, values: Any) -> Any:
+            calls.append('before')
+            return values
+
+        @model_validator(mode='wrap')
+        @classmethod
+        def val_wrap(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('wrap_enter')
+            res = handler(values)
+            calls.append('wrap_exit')
+            return res
+
+        @model_validator(mode='after')
+        def val_after(self) -> Model:
+            calls.append('after')
+            return self
+
+        @model_validator(mode='outer')
+        @classmethod
+        def val_outer(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('outer_enter')
+            res = handler(values)
+            calls.append('outer_exit')
+            return res
+
+    Model(x=1)
+    assert calls == ['outer_enter', 'wrap_enter', 'before', 'wrap_exit', 'after', 'outer_exit']
+
+
+def test_model_validator_outer_catches_after_error() -> None:
+    from pydantic import ValidationError
+
+    caught_errors: list[str] = []
+
+    class Model(BaseModel):
+        x: int
+
+        @model_validator(mode='after')
+        def val_after(self) -> Model:
+            if self.x < 0:
+                raise ValueError('x must be non-negative')
+            return self
+
+        @model_validator(mode='outer')
+        @classmethod
+        def val_outer(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            try:
+                return handler(values)
+            except ValidationError as e:
+                caught_errors.append(e.errors()[0]['msg'])
+                raise
+
+    with pytest.raises(ValidationError):
+        Model(x=-1)
+
+    assert caught_errors == ['Value error, x must be non-negative']
+
+
+def test_model_validator_outer_inheritance() -> None:
+    calls: list[str] = []
+
+    class Base(BaseModel):
+        @model_validator(mode='outer')
+        @classmethod
+        def base_outer(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('base_outer_enter')
+            res = handler(values)
+            calls.append('base_outer_exit')
+            return res
+
+    class Child(Base):
+        x: int
+
+        @model_validator(mode='after')
+        def child_after(self) -> Child:
+            calls.append('child_after')
+            return self
+
+    Child(x=1)
+    assert calls == ['base_outer_enter', 'child_after', 'base_outer_exit']
+
+
+def test_model_validator_outer_nested() -> None:
+    from pydantic import ValidationError
+
+    error_locs: list[tuple[str | int, ...]] = []
+
+    class Inner(BaseModel):
+        val: int
+
+    class Outer(BaseModel):
+        inner: Inner
+
+        @model_validator(mode='outer')
+        @classmethod
+        def outer_val(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            try:
+                return handler(values)
+            except ValidationError as e:
+                error_locs.extend(err['loc'] for err in e.errors())
+                raise
+
+    with pytest.raises(ValidationError):
+        Outer(inner={'val': 'invalid'})
+
+    assert error_locs == [('inner', 'val')]
+
+
+def test_model_validator_outer_root_model() -> None:
+    from pydantic import RootModel
+
+    calls: list[str] = []
+
+    class MyRoot(RootModel[int]):
+        @model_validator(mode='after')
+        def root_after(self) -> MyRoot:
+            calls.append('root_after')
+            return self
+
+        @model_validator(mode='outer')
+        @classmethod
+        def root_outer(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('root_outer_enter')
+            res = handler(values)
+            calls.append('root_outer_exit')
+            return res
+
+    r = MyRoot(42)
+    assert r.root == 42
+    assert calls == ['root_outer_enter', 'root_after', 'root_outer_exit']
+
+
+def test_model_validator_outer_generic_model() -> None:
+    from typing import Generic, TypeVar
+
+    T = TypeVar('T')
+    calls: list[str] = []
+
+    class GenericModel(BaseModel, Generic[T]):
+        value: T
+
+        @model_validator(mode='after')
+        def generic_after(self) -> GenericModel[T]:
+            calls.append('generic_after')
+            return self
+
+        @model_validator(mode='outer')
+        @classmethod
+        def generic_outer(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('generic_outer_enter')
+            res = handler(values)
+            calls.append('generic_outer_exit')
+            return res
+
+    m = GenericModel[int](value=10)
+    assert m.value == 10
+    assert calls == ['generic_outer_enter', 'generic_after', 'generic_outer_exit']
+
+
+def test_model_validator_outer_multiple() -> None:
+    calls: list[str] = []
+
+    class Model(BaseModel):
+        x: int
+
+        @model_validator(mode='outer')
+        @classmethod
+        def outer1(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('outer1_enter')
+            res = handler(values)
+            calls.append('outer1_exit')
+            return res
+
+        @model_validator(mode='outer')
+        @classmethod
+        def outer2(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('outer2_enter')
+            res = handler(values)
+            calls.append('outer2_exit')
+            return res
+
+    Model(x=1)
+    assert calls == ['outer2_enter', 'outer1_enter', 'outer1_exit', 'outer2_exit']
+
+
+def test_model_validator_outer_validation_info() -> None:
+    info_received: list[dict[str, Any]] = []
+
+    class Model(BaseModel):
+        x: int
+
+        @model_validator(mode='outer')
+        @classmethod
+        def val_outer(cls, values: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo) -> Any:
+            info_received.append({'mode': info.mode, 'context': info.context})
+            return handler(values)
+
+    Model.model_validate({'x': 1}, context={'foo': 'bar'})
+    assert info_received == [{'mode': 'python', 'context': {'foo': 'bar'}}]
+
+
+def test_model_validator_outer_serializer_interaction() -> None:
+    from pydantic import model_serializer
+
+    calls: list[str] = []
+
+    class Model(BaseModel):
+        x: int
+
+        @model_validator(mode='outer')
+        @classmethod
+        def val_outer(cls, values: Any, handler: ValidatorFunctionWrapHandler) -> Any:
+            calls.append('outer')
+            return handler(values)
+
+        @model_serializer
+        def ser(self) -> dict[str, int]:
+            calls.append('serializer')
+            return {'x': self.x * 2}
+
+    m = Model(x=5)
+    assert calls == ['outer']
+    dumped = m.model_dump()
+    assert dumped == {'x': 10}
+    assert calls == ['outer', 'serializer']


### PR DESCRIPTION
Closes #13472.

### Description
Adds support for `@model_validator(mode='outer')` which wraps the entire model validation pipeline, including `after` validators.

### Validation Pipeline Order
```text
[outer] → [after] → [wrap] → [model_schema] → [before] → [fields]
```

### Key Architecture & Implementation Details
- **Zero pydantic-core changes required**: Reuses existing `with_info_wrap_validator_function` core schema primitives inserted right before definition reference creation.
- **100% Backward Compatible**: Purely additive pass in `_model_schema()`.
- **Comprehensive Test Suite**: Adds 9 unit tests covering `RootModel`, `GenericModel`, inheritance ordering, nested models (`loc` preservation), `ValidationInfo` propagation, and serializer independence.