### PR TITLE
Fix documented signature of `field_title_generator`

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -127,7 +127,7 @@ class FieldInfo(_repr.Representation):
         validation_alias: The validation alias of the field.
         serialization_alias: The serialization alias of the field.
         title: The title of the field.
-        field_title_generator: A callable that takes a field name and returns title for it.
+        field_title_generator: A callable that takes a field's name and info and returns title for it.
         description: The description of the field.
         examples: List of examples of the field.
         exclude: Whether to exclude the field from the model serialization.
@@ -1233,7 +1233,7 @@ def Field(  # noqa: C901
         validation_alias: Like `alias`, but only affects validation, not serialization.
         serialization_alias: Like `alias`, but only affects serialization, not validation.
         title: Human-readable title.
-        field_title_generator: A callable that takes a field name and returns title for it.
+        field_title_generator: A callable that takes a field's name and info and returns title for it.
         description: Human-readable description.
         examples: Example values for this field.
         exclude: Whether to exclude the field from the model serialization.
@@ -1581,7 +1581,7 @@ class ComputedFieldInfo:
         alias: The alias of the property to be used during serialization.
         alias_priority: The priority of the alias. This affects whether an alias generator is used.
         title: Title of the computed field to include in the serialization JSON schema.
-        field_title_generator: A callable that takes a field name and returns title for it.
+        field_title_generator: A callable that takes a field's name and info and returns title for it.
         description: Description of the computed field to include in the serialization JSON schema.
         deprecated: A deprecation message, an instance of `warnings.deprecated` or the `typing_extensions.deprecated` backport,
             or a boolean. If `True`, a default deprecation message will be emitted when accessing the field.
@@ -1853,7 +1853,7 @@ def computed_field(
         alias_priority: priority of the alias. This affects whether an alias generator is used
         exclude_if: A callable that determines whether to exclude this computed field during serialization based on its value.
         title: Title to use when including this computed field in JSON Schema
-        field_title_generator: A callable that takes a field name and returns title for it.
+        field_title_generator: A callable that takes a field's name and info and returns title for it.
         description: Description to use when including this computed field in JSON Schema, defaults to the function's
             docstring
         deprecated: A deprecation message (or an instance of `warnings.deprecated` or the `typing_extensions.deprecated` backport).


### PR DESCRIPTION
## Change Summary

`field_title_generator` is documented in `pydantic/fields.py` as "A callable that takes a field name and returns title for it", in the docstrings of `Field()`, `FieldInfo.from_field()`, `computed_field()` and `ComputedFieldInfo`. The callable is actually invoked with two arguments, the field's name and its info object, so following the documented signature raises a `TypeError`:

```python
from pydantic import BaseModel, Field

class Model(BaseModel):
    x: int = Field(field_title_generator=lambda field_name: field_name.upper())
#> TypeError: <lambda>() takes 1 positional argument but 2 were given
```

`ConfigDict.field_title_generator` already documents it correctly, so this aligns the four `fields.py` docstrings with that wording.

## Related issue number

N/A, documentation fix.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist  <!-- docstring wording only -->
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
