### PR TITLE
Fix documented default of `ConfigDict.str_min_length`

### DIFF
--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -53,7 +53,7 @@ class ConfigDict(TypedDict, total=False):
     """Whether to strip leading and trailing whitespace for str types."""
 
     str_min_length: int
-    """The minimum length for str types. Defaults to `None`."""
+    """The minimum length for str types. Defaults to `0`."""
 
     str_max_length: int | None
     """The maximum length for str types. Defaults to `None`."""


### PR DESCRIPTION
## Change Summary

`ConfigDict.str_min_length` is annotated `int` and its actual default is `0` (`config_defaults` in `pydantic/_internal/_config.py`), but the docstring says "Defaults to `None`" — `None` isn't even a legal value for the annotation. Looks copied from the `str_max_length: int | None` entry directly below, where `None` is correct.

Since this docstring is rendered as the `ConfigDict` API reference, the published docs currently state an impossible default. One-line docstring fix, no runtime change.

## Related issue number

N/A — trivial docs-only fix per the template note.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist (n/a — docstring text only)
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review