### PR TITLE
Try `Format.VALUE` before `FORWARDREF` when evaluating annotations in `ModelMetaclass`

### DIFF
--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -126,7 +126,11 @@ class ModelMetaclass(ABCMeta):
                     from annotationlib import Format, call_annotate_function, get_annotate_from_class_namespace
 
                     if annotate := get_annotate_from_class_namespace(namespace):
-                        raw_annotations = call_annotate_function(annotate, format=Format.FORWARDREF)
+                        try:
+                            # Try the VALUE format first, as it is way more expensive to use the FORWARDREF format:
+                            raw_annotations = call_annotate_function(annotate, format=Format.VALUE)
+                        except Exception:
+                            raw_annotations = call_annotate_function(annotate, format=Format.FORWARDREF)
                     else:
                         raw_annotations = {}
             else:


### PR DESCRIPTION
While benchmarks will probably not be altered, this improves the `k8s_v2.py` file (https://github.com/pydantic/pydantic/issues/10285) from ~2.2s to 1.7s locally (only improves code *not* using `from __future__ import annotations`).

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
