### PR TITLE
Add `AllowInfNan` type to the field metadata gathering

### DIFF
--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -218,7 +218,7 @@ class FieldInfo(_repr.Representation):
         'min_length': annotated_types.MinLen,
         'max_length': annotated_types.MaxLen,
         'pattern': None,
-        'allow_inf_nan': None,
+        'allow_inf_nan': types.AllowInfNan,
         'max_digits': None,
         'decimal_places': None,
         'union_mode': None,


### PR DESCRIPTION
## Change Summary
Adds existing metadata type for `allow_inf_nan` field property.
It is the same as it is done for `confloat`, `FiniteFloat` and `condecimal` in `types.py`.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
