### PR TITLE
fix: prevent duplicate model validator execution on recursive models (#13581)

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -931,7 +931,7 @@ class GenerateSchema:
                         model_name=cls.__name__,
                     )
                     inner_schema = apply_validators(fields_schema, decorators.root_validators.values())
-                    inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
+                    inner_schema = apply_model_validators(inner_schema, model_validators, 'all')
 
                     model_schema = core_schema.model_schema(
                         cls,
@@ -945,7 +945,6 @@ class GenerateSchema:
                     )
 
                 schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
-                schema = apply_model_validators(schema, model_validators, 'outer')
                 return self.defs.create_definition_reference_schema(schema)
 
     def _resolve_self_type(self, obj: Any) -> Any:

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -193,3 +193,21 @@ def test_after_validator_wrong_signature() -> None:
     Model2()
     Model3()
     Model4()
+
+
+def test_recursive_model_validator_single_execution() -> None:
+    calls = []
+
+    class NodeVal(BaseModel):
+        child: 'NodeVal | None' = None
+
+        @model_validator(mode='after')
+        def validate_model(self) -> 'NodeVal':
+            calls.append(self)
+            return self
+
+    class OuterVal(BaseModel):
+        node: NodeVal
+
+    OuterVal.model_validate({'node': {}})
+    assert len(calls) == 1


### PR DESCRIPTION
### Selected PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

### Summary of Changes
Fixes #13581: Validators called twice with recursive models.

#### Root Cause
Previously, `apply_model_validators(..., 'outer')` in `pydantic/_internal/_generate_schema.py` wrapped `model_schema` in a `function-after` schema, placing `ref` on `function-after` instead of the underlying `model_schema`. When `pydantic-core` validated a `definition-ref` pointing to `function-after`, it executed `function-after` and then re-validated the returned model instance because the root definition schema was `function-after` rather than `type: 'model'`.

#### Fix
- Applied model validators to `inner_schema` prior to constructing `core_schema.model_schema` in `_generate_schema.py`.
- Preserves `model_schema` at the root of definition references, eliminating duplicate validator executions during model validation.
- Added unit test `test_recursive_model_validator_single_execution` in `tests/test_model_validator.py`.

### Verification
- Verified that validating recursive models (e.g. `OuterVal.model_validate({'node': {}})` where `NodeVal` references itself) executes `@model_validator(mode='after')` exactly once.