### PR TITLE
fix: prevent duplicate model validator execution on recursive models

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -907,7 +907,7 @@ class GenerateSchema:
                             metadata, pydantic_js_updates={'description': inspect.cleandoc(cls.__doc__)}
                         )
 
-                    inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
+                    inner_schema = apply_model_validators(inner_schema, model_validators, 'all')
                     model_schema = core_schema.model_schema(
                         cls,
                         inner_schema,

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -931,7 +931,7 @@ class GenerateSchema:
                         model_name=cls.__name__,
                     )
                     inner_schema = apply_validators(fields_schema, decorators.root_validators.values())
-                    inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
+                    inner_schema = apply_model_validators(inner_schema, model_validators, 'all')
 
                     model_schema = core_schema.model_schema(
                         cls,
@@ -945,7 +945,6 @@ class GenerateSchema:
                     )
 
                 schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
-                schema = apply_model_validators(schema, model_validators, 'outer')
                 return self.defs.create_definition_reference_schema(schema)
 
     def _resolve_self_type(self, obj: Any) -> Any:

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -193,3 +193,21 @@ def test_after_validator_wrong_signature() -> None:
     Model2()
     Model3()
     Model4()
+
+
+def test_recursive_model_validator_single_execution() -> None:
+    calls = []
+
+    class NodeVal(BaseModel):
+        child: 'NodeVal | None' = None
+
+        @model_validator(mode='after')
+        def validate_model(self) -> 'NodeVal':
+            calls.append(self)
+            return self
+
+    class OuterVal(BaseModel):
+        node: NodeVal
+
+    OuterVal.model_validate({'node': {}})
+    assert len(calls) == 1

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -211,3 +211,17 @@ def test_recursive_model_validator_single_execution() -> None:
 
     OuterVal.model_validate({'node': {}})
     assert len(calls) == 1
+
+
+def test_root_model_validator_execution() -> None:
+    calls = []
+
+    class MyRoot(RootModel[int]):
+        @model_validator(mode='after')
+        def validate_root(self) -> 'MyRoot':
+            calls.append(self)
+            return self
+
+    r = MyRoot.model_validate(42)
+    assert len(calls) == 1
+    assert r.root == 42


### PR DESCRIPTION
Fixes #13581: Prevent duplicate model validator execution on recursive models