### PR TITLE
Expose `strict` in `ValidationInfo`

### DIFF
--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -603,6 +603,7 @@ Both the field and model validators callables (in all modes) can optionally take
 * [already validated data](#validation-data)
 * [user defined context](#validation-context)
 * the current [validation mode](./models.md#validating-data): either `'python'`, `'json'` or `'strings'` (see the [`mode`][pydantic.ValidationInfo.mode] property)
+* the value of the `strict` argument provided at validation time (e.g. to [`model_validate()`][pydantic.BaseModel.model_validate]), if any (see the [`strict`][pydantic.ValidationInfo.strict] property)
 * the current field name, if using a [field validator](#field-validators) (see the [`field_name`][pydantic.ValidationInfo.field_name] property).
 
 ### Validation data

--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -231,6 +231,11 @@ class ValidationInfo(Protocol[ContextT]):
         ...
 
     @property
+    def strict(self) -> bool | None:
+        """The value of the `strict` argument provided at validation time, if any."""
+        ...
+
+    @property
     def data(self) -> dict[str, Any]:
         """The data being validated for this model."""
         ...

--- a/pydantic-core/src/validators/function.rs
+++ b/pydantic-core/src/validators/function.rs
@@ -530,6 +530,7 @@ pub struct ValidationInfo {
     data: Option<Py<PyDict>>,
     field_name: Option<Py<PyString>>,
     mode: InputType,
+    strict: Option<bool>,
 }
 
 impl_py_gc_traverse!(ValidationInfo {
@@ -548,6 +549,7 @@ impl ValidationInfo {
             field_name,
             data: state.data.as_ref().map(|data| data.clone().into()),
             mode: extra.input_type,
+            strict: extra.strict,
         }
     }
 

--- a/pydantic-core/tests/validators/test_function.py
+++ b/pydantic-core/tests/validators/test_function.py
@@ -20,6 +20,7 @@ def deepcopy_info(info: core_schema.ValidationInfo) -> dict[str, Any]:
         'data': deepcopy(info.data),
         'field_name': deepcopy(info.field_name),
         'config': deepcopy(info.config),
+        'strict': info.strict,
     }
 
 
@@ -381,7 +382,13 @@ def test_function_after_config():
     )
 
     assert v.validate_python({'test_field': b'321'}) == {'test_field': '321 Changed'}
-    assert f_kwargs == {'data': {}, 'config': {'allow_inf_nan': True}, 'context': None, 'field_name': 'test_field'}
+    assert f_kwargs == {
+        'data': {},
+        'config': {'allow_inf_nan': True},
+        'context': None,
+        'field_name': 'test_field',
+        'strict': None,
+    }
 
 
 def test_config_no_model():
@@ -395,7 +402,7 @@ def test_config_no_model():
     v = SchemaValidator(core_schema.with_info_after_validator_function(f, core_schema.str_schema()))
 
     assert v.validate_python(b'abc') == 'abc Changed'
-    assert f_kwargs == {'data': None, 'config': None, 'context': None, 'field_name': None}
+    assert f_kwargs == {'data': None, 'config': None, 'context': None, 'field_name': None, 'strict': None}
 
 
 def test_function_plain():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3177,3 +3177,24 @@ def test_model_validate_json_default_value_validator_with_validation_info() -> N
     f2 = Foo.model_validate_json('{"field1": 1}', context='context')
 
     assert f1.field == f2.field == 2
+
+
+def test_validation_info_properties() -> None:
+    class Model(BaseModel):
+        f: int
+
+        @field_validator('f', mode='after')
+        @classmethod
+        def ser_number(cls, value: int, info: ValidationInfo) -> Any:
+            return info
+
+    for property, value in (
+        ('context', 'context_value'),
+        ('strict', True),
+    ):
+        assert getattr(Model.model_validate({'f': 1}, **{property: value}).f, property) == value, (
+            f'{property!r} check failed'
+        )
+        assert getattr(Model.model_validate_json('{"f": 1}', **{property: value}).f, property) == value, (
+            f'{property!r} check failed'
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Closes https://github.com/pydantic/pydantic/issues/6802.

I'm not sure we want this as is. As per https://github.com/pydantic/pydantic/issues/13592, users seem to want to know if strict mode is active, but currently this only exposes the `strict` runtime validation flag.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
