### PR TITLE
Fix model validators called twice with recursive models

### DIFF
--- a/pydantic-core/src/validators/definitions.rs
+++ b/pydantic-core/src/validators/definitions.rs
@@ -52,6 +52,11 @@ impl DefinitionRefValidator {
     pub fn new(definition: DefinitionRef<Arc<CombinedValidator>>) -> Self {
         Self { definition }
     }
+
+    /// Read the validator this definition reference points to, if it was already built.
+    pub fn read_definition<R>(&self, f: impl FnOnce(Option<&CombinedValidator>) -> R) -> R {
+        self.definition.read(|validator| f(validator.map(Arc::as_ref)))
+    }
 }
 
 impl BuildValidator for DefinitionRefValidator {

--- a/pydantic-core/src/validators/prebuilt.rs
+++ b/pydantic-core/src/validators/prebuilt.rs
@@ -29,10 +29,26 @@ impl PrebuiltValidator {
                     Err(_) => return Ok(None),
                 },
             };
-            if matches!(
-                schema_validator.get().validator.as_ref(),
-                CombinedValidator::FunctionWrap(_) | CombinedValidator::FunctionAfter(_)
-            ) {
+            // Don't reuse the prebuilt validator if the model has `wrap` or `after` model validators:
+            // these wrap the class's root `model` validator, and the schema referencing the class
+            // applies the same wrappers around the reused `model` schema, so the model validators
+            // would run twice. For recursive models, the wrappers are behind a definition reference,
+            // so peek through it before checking.
+            // See https://github.com/pydantic/pydantic/issues/11505 and
+            // https://github.com/pydantic/pydantic/issues/13581.
+            let has_model_function_validator = match schema_validator.get().validator.as_ref() {
+                CombinedValidator::FunctionWrap(_) | CombinedValidator::FunctionAfter(_) => true,
+                CombinedValidator::DefinitionRef(definition_ref) => definition_ref.read_definition(|validator| {
+                    validator.is_some_and(|validator| {
+                        matches!(
+                            validator,
+                            CombinedValidator::FunctionWrap(_) | CombinedValidator::FunctionAfter(_)
+                        )
+                    })
+                }),
+                _ => false,
+            };
+            if has_model_function_validator {
                 return Ok(None);
             }
             Ok(Some(Self { schema_validator }.into()))

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3112,6 +3112,55 @@ def test_after_and_wrap_combo_called_once() -> None:
     assert my_model.nested.inner_value == 'after_prefix:wrap_prefix:foo'
 
 
+def test_recursive_model_after_val_called_once() -> None:
+    """See https://github.com/pydantic/pydantic/issues/13581 for context.
+
+    This is effectively confirming that prebuilt validators aren't used for after validators
+    on recursive models, where the model validator is behind a definition reference.
+    """
+    validator_calls = 0
+
+    class NodeVal(BaseModel):
+        child: 'NodeVal | None' = None
+
+        @model_validator(mode='after')
+        def validate_model(self) -> 'NodeVal':
+            nonlocal validator_calls
+            validator_calls += 1
+            return self
+
+    class OuterVal(BaseModel):
+        node: NodeVal
+
+    OuterVal.model_validate({'node': {}})
+    assert validator_calls == 1
+
+
+def test_recursive_model_wrap_val_called_once() -> None:
+    """See https://github.com/pydantic/pydantic/issues/13581 for context.
+
+    This is effectively confirming that prebuilt validators aren't used for wrap validators
+    on recursive models, where the model validator is behind a definition reference.
+    """
+    validator_calls = 0
+
+    class NodeVal(BaseModel):
+        child: 'NodeVal | None' = None
+
+        @model_validator(mode='wrap')
+        @classmethod
+        def validate_model(cls, data, handler) -> 'NodeVal':
+            nonlocal validator_calls
+            validator_calls += 1
+            return handler(data)
+
+    class OuterVal(BaseModel):
+        node: NodeVal
+
+    OuterVal.model_validate({'node': {}})
+    assert validator_calls == 1
+
+
 @pytest.mark.xfail(
     reason="Bug: Nested 'after' model_validator is re-executed. See issue #8452.", raises=ValidationError
 )


### PR DESCRIPTION
Fixes #13581

## Root cause

When a model references an already-built recursive model, the schema inlines the recursive model's definition as `function-after(model(...))` (or `function-wrap`). The prebuilt-validator guard added for #11505 rejects reuse when the class's root validator is `FunctionWrap`/`FunctionAfter`, but for recursive models the root validator is a `DefinitionRef` pointing at those wrappers. The guard missed it: the inner `model` schema was replaced by the full prebuilt validator (wrappers included) and the referencing schema applied the wrappers a second time, running `wrap`/`after` model validators twice per instance.

## Fix

Peek through the `DefinitionRef` before the guard check via a new `read_definition` accessor on `DefinitionRefValidator` (`definitions.rs`). Prebuilt reuse is preserved for recursive models without `wrap`/`after` model validators.

```python
from pydantic import BaseModel, model_validator

class NodeVal(BaseModel):
    value: int
    child: 'NodeVal | None' = None

    @model_validator(mode='after')
    def validate_node(self) -> 'NodeVal':
        print(f'validator called (value={self.value})')
        return self

class OuterVal(BaseModel):
    root: NodeVal

# Before: prints "validator called" twice
# After:  prints "validator called" once
OuterVal(root={'value': 1})
```

## Notes

- `before` validators are unaffected (single call, unchanged behavior)
- The serializer side has an analogous issue (`wrap` model serializers on recursive models run twice via `CombinedSerializer::Recursive`) - left as a follow-up to keep this change focused
- 2 regression tests added next to the existing #11505 tests (`test_recursive_model_after_val_called_once`, `test_recursive_model_wrap_val_called_once`)

## Tests

434 `tests/test_validators.py` + `tests/test_main.py`, 158 pydantic-core prebuilt/validator tests, 410 across `test_edge_cases`, `test_serialize`, `test_forward_ref`, `test_construction` - all pass.