### PR TITLE
Fix callable discriminators on PEP 695 type aliases

### DIFF
--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -65,7 +65,7 @@ def apply_discriminator(
         if isinstance(discriminator.discriminator, str):
             discriminator = discriminator.discriminator
         else:
-            return discriminator._convert_schema(schema)
+            return discriminator._convert_schema(schema, definitions=definitions)
 
     return _ApplyInferredDiscriminator(discriminator, definitions or {}).apply(schema)
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -3112,12 +3112,19 @@ class Discriminator:
             return self._convert_schema(original_schema, handler)
 
     def _convert_schema(
-        self, original_schema: core_schema.CoreSchema, handler: GetCoreSchemaHandler | None = None
+        self,
+        original_schema: core_schema.CoreSchema,
+        handler: GetCoreSchemaHandler | None = None,
+        definitions: dict[str, core_schema.CoreSchema] | None = None,
     ) -> core_schema.TaggedUnionSchema:
-        if handler is not None and original_schema['type'] == 'definition-ref':
+        if original_schema['type'] == 'definition-ref' and (handler is not None or definitions is not None):
             # Same logic as `_ApplyInferredDiscriminator._apply_to_root()`
             try:
-                def_schema = handler.resolve_ref_schema(original_schema)
+                if handler is not None:
+                    def_schema = handler.resolve_ref_schema(original_schema)
+                else:
+                    assert definitions is not None
+                    def_schema = definitions[original_schema['schema_ref']]
             except LookupError:  # pragma: no cover
                 from pydantic._internal._discriminated_union import MissingDefinitionForUnionRef
 

--- a/tests/types/unions/test_discriminated_union.py
+++ b/tests/types/unions/test_discriminated_union.py
@@ -2338,6 +2338,37 @@ def test_discriminated_union_type_alias_type_separate_callable_discriminator() -
     assert m.g == Bar(type='bar')
 
 
+@pytest.mark.skipif(sys.version_info < (3, 12), reason='Requires PEP 695 syntax')
+def test_discriminated_union_pep695_type_alias_field_callable_discriminator(create_module) -> None:
+    """https://github.com/pydantic/pydantic/issues/13599"""
+    module = create_module(
+        """\
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Discriminator, Field, Tag
+
+class Foo(BaseModel):
+    type: Literal['foo']
+
+class Bar(BaseModel):
+    type: Literal['bar']
+
+def get_discriminator_value(value: Any) -> str:
+    if isinstance(value, dict):
+        return value['type']
+    return value.type
+
+type FooBar = Annotated[Foo, Tag('foo')] | Annotated[Bar, Tag('bar')]
+
+class Main(BaseModel):
+    f: FooBar = Field(discriminator=Discriminator(get_discriminator_value))
+"""
+    )
+
+    assert module.Main(f={'type': 'foo'}).f == module.Foo(type='foo')
+    assert module.Main(f={'type': 'bar'}).f == module.Bar(type='bar')
+
+
 @pytest.mark.xfail(
     reason="Nested references aren't flattened (see comment in `_ApplyInferredDiscriminator._handle_choice()`)",
 )


### PR DESCRIPTION
## Change Summary

Fix callable discriminators applied with `Field(discriminator=...)` to PEP 695 type aliases.

A tagged alias such as:

```python
type FooBar = Annotated[Foo, Tag('foo')] | Annotated[Bar, Tag('bar')]

class Model(BaseModel):
    value: FooBar = Field(discriminator=Discriminator(get_type))
```

raised `callable-discriminator-no-tag` even though both choices had tags. The field path supplied the alias definitions to `apply_discriminator()`, but the callable branch discarded them before `_convert_schema()`, so the alias `definition-ref` could not be resolved to its tagged union.

The fix threads the existing definitions mapping into `_convert_schema()` and resolves the root reference before building the tagged union. A focused regression test covers both choices using native PEP 695 syntax.

Implementation and PR text were produced autonomously by GitHub Copilot CLI; the commit includes `Co-authored-by` attribution.

## Related issue number

Fix #13599

## Validation

- `uv run pytest -q tests/types/unions/test_discriminated_union.py` — 79 passed, 4 expected xfailed
- `make lint-python` — passed
- `make test` — 12,321 passed, 464 skipped, 35 expected xfailed

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable (no documentation change needed)
