### PR TITLE
Fix `exclude`/`include` ignored with `model_serializer(when_used="json")` in python mode

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -217,17 +217,25 @@ macro_rules! function_type_serializer {
                 state: &mut SerializationState<'py>,
             ) -> PyResult<Py<PyAny>> {
                 let py = value.py();
-                let (ret_serializer, v) = match self.call(value, state) {
-                    Ok((true, v)) => (&*self.return_serializer, v),
-                    Ok((false, v)) => (self.get_fallback_serializer(), v),
+                match self.call(value, state) {
+                    Ok((true, v)) => {
+                        // the function was called, so it is responsible for filtering
+                        // (via the SerializationCallable which carries include/exclude);
+                        // reset include/exclude here so the return value is not re-filtered
+                        let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
+                        self.return_serializer.to_python(v.bind(py), state)
+                    }
+                    Ok((false, v)) => {
+                        // the function was not used (e.g. `when_used` did not match);
+                        // use the fallback serializer with the original include/exclude
+                        // so that filtering (exclude/include) is still applied
+                        self.get_fallback_serializer().to_python(v.bind(py), state)
+                    }
                     Err(err) => {
                         on_error(py, err, &self.function_name, state)?;
-                        return infer_to_python(value, state);
+                        infer_to_python(value, state)
                     }
-                };
-                // None for include/exclude here, as filtering should be done
-                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
-                ret_serializer.to_python(v.bind(py), state)
+                }
             }
 
             fn json_key<'a, 'py>(
@@ -236,19 +244,22 @@ macro_rules! function_type_serializer {
                 state: &mut SerializationState<'py>,
             ) -> PyResult<Cow<'a, str>> {
                 let py = key.py();
-                let (ret_serializer, v) = match self.call(key, state) {
-                    Ok((true, v)) => (&*self.return_serializer, v),
-                    Ok((false, v)) => (self.get_fallback_serializer(), v),
+                match self.call(key, state) {
+                    Ok((true, v)) => {
+                        let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
+                        self.return_serializer
+                            .json_key(v.bind(py), state)
+                            .map(|cow| Cow::Owned(cow.into_owned()))
+                    }
+                    Ok((false, v)) => self
+                        .get_fallback_serializer()
+                        .json_key(v.bind(py), state)
+                        .map(|cow| Cow::Owned(cow.into_owned())),
                     Err(err) => {
                         on_error(py, err, &self.function_name, state)?;
-                        return infer_json_key(key, state);
+                        infer_json_key(key, state)
                     }
-                };
-                // None for include/exclude here, as filtering should be done
-                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
-                ret_serializer
-                    .json_key(v.bind(py), state)
-                    .map(|cow| Cow::Owned(cow.into_owned()))
+                }
             }
 
             fn serde_serialize<'py, S: serde::ser::Serializer>(
@@ -258,17 +269,20 @@ macro_rules! function_type_serializer {
                 state: &mut SerializationState<'py>,
             ) -> Result<S::Ok, S::Error> {
                 let py = value.py();
-                let (ret_serializer, v) = match self.call(value, state) {
-                    Ok((true, v)) => (&*self.return_serializer, v),
-                    Ok((false, v)) => (self.get_fallback_serializer(), v),
+                match self.call(value, state) {
+                    Ok((true, v)) => {
+                        let mut state = state.scoped_include_exclude(IncludeExclude::empty());
+                        self.return_serializer
+                            .serde_serialize(v.bind(py), serializer, &mut state)
+                    }
+                    Ok((false, v)) => self
+                        .get_fallback_serializer()
+                        .serde_serialize(v.bind(py), serializer, state),
                     Err(err) => {
                         on_error(py, err, &self.function_name, state).map_err(py_err_se_err)?;
-                        return infer_serialize(value, serializer, state);
+                        infer_serialize(value, serializer, state)
                     }
-                };
-                // None for include/exclude here, as filtering should be done
-                let mut state = state.scoped_include_exclude(IncludeExclude::empty());
-                ret_serializer.serde_serialize(v.bind(py), serializer, &mut state)
+                }
             }
 
             fn get_name(&self) -> &str {

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -544,6 +544,51 @@ def test_model_serializer_plain_json_return_type():
         assert m.model_dump_json() == '666'
 
 
+def test_model_serializer_wrap_json_exclude_python():
+    """https://github.com/pydantic/pydantic/issues/13601 — when_used='json' model serializer
+    should not cause exclude/include to be ignored in python mode (fallback path)."""
+
+    class MyModel(BaseModel):
+        a: int
+        b: int
+
+        @model_serializer(mode='wrap', when_used='json')
+        def _serialize(self, handler, info):
+            return handler(self)
+
+    m = MyModel(a=1, b=2)
+    assert m.model_dump(exclude={'b'}) == {'a': 1}
+    assert m.model_dump(mode='json', exclude={'b'}) == {'a': 1}
+    assert m.model_dump_json(exclude={'b'}) == '{"a":1}'
+
+    assert m.model_dump(include={'a'}) == {'a': 1}
+    assert m.model_dump(mode='json', include={'a'}) == {'a': 1}
+
+    assert m.model_dump() == {'a': 1, 'b': 2}
+    assert m.model_dump(mode='json') == {'a': 1, 'b': 2}
+
+
+def test_model_serializer_plain_json_exclude_python():
+    """Same as above but for plain mode — the fallback (default model serializer)
+    must honour exclude/include in python mode."""
+
+    class MyModel(BaseModel):
+        a: int
+        b: int
+
+        @model_serializer(when_used='json')
+        def _serialize(self) -> dict:
+            return {'a': self.a, 'b': self.b}
+
+    m = MyModel(a=1, b=2)
+    # In python mode the serializer is skipped, fallback honours exclude
+    assert m.model_dump(exclude={'b'}) == {'a': 1}
+    assert m.model_dump(include={'a'}) == {'a': 1}
+    assert m.model_dump() == {'a': 1, 'b': 2}
+    # In json mode the serializer is used, returns a plain dict (exclude not applied to custom output)
+    assert m.model_dump(mode='json') == {'a': 1, 'b': 2}
+
+
 def test_model_serializer_wrong_args():
     m = (
         r'Unrecognized model_serializer function signature for '


### PR DESCRIPTION
## Change Summary

Fix `exclude`/`include` being silently ignored when a model uses `@model_serializer(when_used="json")` (or any non-`always` `when_used`) and `model_dump()` is called in **python** mode.

**Root cause** (in `pydantic-core`, Rust): the `function_type_serializer!` macro — shared by `FunctionPlainSerializer` and `FunctionWrapSerializer` — unconditionally called `state.scoped_include_exclude(IncludeExclude::empty())` after `self.call()`, regardless of whether the user's serializer function was actually invoked. When `when_used` does not match (e.g. `when_used="json"` but mode is `python`), the function is skipped and the fallback serializer is used. Because include/exclude was reset to empty on this fallback path, the model-level `exclude`/`include` was silently dropped.

**Fix**: the `scoped_include_exclude(IncludeExclude::empty())` call is now applied only on the `Ok((true, v))` branch (function was called — it owns filtering via the `SerializationCallable`). On the `Ok((false, v))` fallback branch the original `state` is passed through unchanged, so the fallback serializer correctly applies `exclude`/`include`.

This affects all three serialization entry points (`to_python`, `json_key`, `serde_serialize`) and both `mode="wrap"` and `mode="plain"` model serializers. Field serializers were already correct (the model-level filter is applied before the field serializer is reached, so resetting the field-level scope to empty was a no-op).

```python
from pydantic import BaseModel, model_serializer

class Gated(BaseModel):
    a: int
    b: int

    @model_serializer(mode="wrap", when_used="json")
    def ser(self, handler, info):
        return handler(self)

# Before (python mode): {'a': 1, 'b': 2}  — exclude ignored
# After:                 {'a': 1}
assert Gated(a=1, b=2).model_dump(exclude={"b"}) == {"a": 1}
```

## Related issue number

Fix #13601

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
