### PR TITLE
Revert some docs changes from #13457

### DIFF
--- a/docs/concepts/dataclasses.md
+++ b/docs/concepts/dataclasses.md
@@ -4,11 +4,6 @@
 If you don't want to use Pydantic's [`BaseModel`][pydantic.BaseModel] you can instead get the same data validation
 on standard [dataclasses][dataclasses].
 
-!!! tip "Logfire integration"
-    Because a Pydantic dataclass validates its inputs just like a model, the same observability applies: if
-    you use [Logfire](../integrations/logfire.md), validations of Pydantic dataclasses are
-    [recorded alongside model validations](../errors/troubleshooting.md), input included.
-
 ```python
 from datetime import datetime
 
@@ -222,6 +217,10 @@ except pydantic.ValidationError as e:
       Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='pika', input_type=str]
     """
 ```
+
+Because a Pydantic dataclass validates its inputs just like a model, the same observability applies: if
+you use [Logfire](../integrations/logfire.md), validations of Pydantic dataclasses are
+[recorded alongside model validations](../errors/troubleshooting.md), input included.
 
 The decorator can also be applied directly on a stdlib dataclass, in which case a new subclass will be created:
 

--- a/docs/concepts/experimental.md
+++ b/docs/concepts/experimental.md
@@ -145,13 +145,12 @@ Partial validation allows you to validate an incomplete JSON string, or a Python
 
 Partial validation is particularly helpful when processing the output of an LLM, where the model streams structured responses, and you may wish to begin validating the stream while you're still receiving data (e.g. to show partial data to users).
 
+Streaming pipelines like this can be fiddly to debug after the fact. If you run one in production,
+[Logfire](../integrations/logfire.md) can record each validation in the context of the surrounding
+request, which makes it easier to reconstruct how a given stream was handled.
+
 !!! warning
     Partial validation is an experimental feature and may change in future versions of Pydantic. The current implementation should be considered a proof of concept at this time and has a number of [limitations](#limitations-of-partial-validation).
-
-!!! tip "Logfire integration"
-    Streaming pipelines like this can be fiddly to debug after the fact. If you run one in production,
-    [Logfire](../integrations/logfire.md) can record each validation in the context of the surrounding
-    request, which makes it easier to reconstruct how a given stream was handled.
 
 Partial validation can be enabled when using the three validation methods on `TypeAdapter`: [`TypeAdapter.validate_json()`][pydantic.TypeAdapter.validate_json], [`TypeAdapter.validate_python()`][pydantic.TypeAdapter.validate_python], and [`TypeAdapter.validate_strings()`][pydantic.TypeAdapter.validate_strings]. This allows you to parse and validation incomplete JSON, but also to validate Python objects created by parsing incomplete data of any format.
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -557,12 +557,11 @@ except ValidationError as e:
     """
 ```
 
-!!! tip "Logfire integration"
-    In an example like this one, the offending `data` is right there in the code. In a running application
-    it usually isn't. The exception says which fields failed, but the input that produced it is whatever a
-    user, API, or job happened to send at the time. If you need to see that input as well,
-    [Logfire can record failed validations](../errors/troubleshooting.md) together with the data that
-    caused them.
+In an example like this one, the offending `data` is right there in the code. In a running application
+it usually isn't. The exception says which fields failed, but the input that produced it is whatever a
+user, API, or job happened to send at the time. If you need to see that input as well,
+[Logfire can record failed validations](../errors/troubleshooting.md) together with the data that
+caused them.
 
 ## Arbitrary class instances
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -557,11 +557,10 @@ except ValidationError as e:
     """
 ```
 
-In an example like this one, the offending `data` is right there in the code. In a running application
-it usually isn't. The exception says which fields failed, but the input that produced it is whatever a
-user, API, or job happened to send at the time. If you need to see that input as well,
-[Logfire can record failed validations](../errors/troubleshooting.md) together with the data that
-caused them.
+In an example like this one, the offending `data` is right there in the code. A
+[`ValidationError`][pydantic_core.ValidationError] includes the value rejected at each failing
+location, but in a running application you may also need the complete validation input and its request
+or job context. [Logfire records failed validations](../errors/troubleshooting.md) with both.
 
 ## Arbitrary class instances
 

--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -133,12 +133,11 @@ variety of types ([date and time types][datetime], [`UUID`][uuid.UUID] objects, 
 is used and can't be serialized to JSON, a [`PydanticSerializationError`][pydantic_core.PydanticSerializationError] exception
 is raised.
 
-!!! tip "Logfire integration"
-    A serialization error like this often only shows up when a particular object reaches the point of being
-    serialized (commonly when building a response), so it can be easy to miss until it happens in
-    production. Like any exception, it's captured by [Logfire](../integrations/logfire.md) if you've
-    instrumented your application, in the context of the request that triggered it, and grouped with other
-    occurrences so you can tell a one-off from a recurring problem.
+A serialization error like this often only shows up when a particular object reaches the point of being
+serialized (commonly when building a response), so it can be easy to miss until it happens in
+production. Like any exception, it's captured by [Logfire](../integrations/logfire.md) if you've
+instrumented your application, in the context of the request that triggered it, and grouped with other
+occurrences so you can tell a one-off from a recurring problem.
 
 !!! info "See also"
     The [`TypeAdapter.dump_json()`][pydantic.TypeAdapter.dump_json] method, useful when *not* dealing with Pydantic models.

--- a/docs/concepts/strict_mode.md
+++ b/docs/concepts/strict_mode.md
@@ -43,6 +43,11 @@ except ValidationError as exc:
     """
 ```
 
+One caveat when enabling strict mode on models an existing application relies on: inputs that were
+being quietly coerced will start failing. If you can't audit every caller, it helps to watch validation
+failures while you roll the change out. [Logfire](../integrations/logfire.md) counts successful and
+failed validations as metrics, and records the inputs that were rejected.
+
 Strict mode can be enabled in various ways:
 
 * [As a validation parameter](#as-a-validation-parameter), such as when using [`model_validate()`][pydantic.BaseModel.model_validate],

--- a/docs/concepts/type_adapter.md
+++ b/docs/concepts/type_adapter.md
@@ -86,14 +86,15 @@ print(items)
 [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] is capable of parsing data into any of the types Pydantic can
 handle as fields of a [`BaseModel`][pydantic.main.BaseModel].
 
+Data parsed this way often comes from a source you don't control, like the API call in the example
+above, so validation can fail long after the code has shipped. A `TypeAdapter` raises the same
+structured errors as a model, so tooling that records validation failures in production, such as
+[Logfire](../integrations/logfire.md), captures these too.
+
 !!! info "Performance considerations"
     When creating an instance of [`TypeAdapter`][pydantic.type_adapter.TypeAdapter], the provided type must be analyzed and converted into a pydantic-core
     schema. This comes with some non-trivial overhead, so it is recommended to create a `TypeAdapter` for a given type
     just once and reuse it in loops or other performance-critical code.
-
-!!! tip "Logfire integration"
-    As with Pydantic models, the [Logfire integration](../integrations/logfire.md) records
-    validation errors for type adapters.
 
 ## Rebuilding a `TypeAdapter`'s schema
 

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -474,6 +474,11 @@ recursion.
 Discriminated unions help to simplify error messages in this case, as validation errors are only produced for
 the case with a matching discriminator value.
 
+Making sense of a union failure means working out which member *should* have matched. A
+[`ValidationError`][pydantic_core.ValidationError] includes each member's errors and rejected values;
+when the failure happens in a deployed service, [Logfire retains those details with the complete
+validation input](../errors/troubleshooting.md), so you can make that comparison after the fact.
+
 You can also customize the error type, message, and context for a `Discriminator` by passing
 these specifications as parameters to the `Discriminator` constructor, as seen in the example below.
 

--- a/docs/concepts/validation_decorator.md
+++ b/docs/concepts/validation_decorator.md
@@ -403,9 +403,9 @@ Currently upon validation failure, a standard Pydantic [`ValidationError`][pydan
 (see [model error handling](models.md#error-handling) for details). This is also true for missing required arguments,
 where Python normally raises a [`TypeError`][].
 
-The error names the argument that was rejected, but the traceback won't show you what value the caller
-actually passed. If that matters for your debugging, [Logfire](../errors/troubleshooting.md) records
-decorated calls together with their arguments when validation fails.
+The error identifies the argument and value that were rejected. If you also need the complete call
+input and its surrounding trace context, [Logfire](../errors/troubleshooting.md) records both when a
+decorated call fails.
 
 ### Performance
 

--- a/docs/concepts/validation_decorator.md
+++ b/docs/concepts/validation_decorator.md
@@ -403,9 +403,9 @@ Currently upon validation failure, a standard Pydantic [`ValidationError`][pydan
 (see [model error handling](models.md#error-handling) for details). This is also true for missing required arguments,
 where Python normally raises a [`TypeError`][].
 
-!!! tip "Logfire integration"
-    As with Pydantic models, the [Logfire integration](../integrations/logfire.md) records
-    validation errors for [`@validate_call`][pydantic.validate_call].
+The error names the argument that was rejected, but the traceback won't show you what value the caller
+actually passed. If that matters for your debugging, [Logfire](../errors/troubleshooting.md) records
+decorated calls together with their arguments when validation fails.
 
 ### Performance
 

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -34,9 +34,9 @@ The [`ErrorDetails`][pydantic_core.ErrorDetails] object is a dictionary. It cont
 The first item in the [`loc`][pydantic_core.ErrorDetails.loc] list will be the field where the error occurred, and if the field is a
 [sub-model](../concepts/models.md#nested-models), subsequent items will be present to indicate the nested location of the error.
 
-Accessing errors this way requires a `try`/`except` around the validation call. For validations spread
-across a running service, [Logfire](troubleshooting.md) records the same structured error list on each
-failure, together with the input that produced it, without wrapping each call.
+For validations spread across a running service, [Logfire](troubleshooting.md) records this same
+structured error list together with the complete validation input and trace context, without wrapping
+each call in `try`/`except`.
 
 As a demonstration:
 

--- a/docs/errors/errors.md
+++ b/docs/errors/errors.md
@@ -34,8 +34,9 @@ The [`ErrorDetails`][pydantic_core.ErrorDetails] object is a dictionary. It cont
 The first item in the [`loc`][pydantic_core.ErrorDetails.loc] list will be the field where the error occurred, and if the field is a
 [sub-model](../concepts/models.md#nested-models), subsequent items will be present to indicate the nested location of the error.
 
-!!! tip "Logfire integration"
-    [Logfire](troubleshooting.md) can be used to record validation errors, with the input that produced it.
+Accessing errors this way requires a `try`/`except` around the validation call. For validations spread
+across a running service, [Logfire](troubleshooting.md) records the same structured error list on each
+failure, together with the input that produced it, without wrapping each call.
 
 As a demonstration:
 

--- a/docs/examples/custom_validators.md
+++ b/docs/examples/custom_validators.md
@@ -290,5 +290,7 @@ and the forbidden passwords list will not get added to the context in the above 
 
 More details about validation context can be found in the [validators documentation](../concepts/validators.md#validation-context).
 
-!!! tip "Logfire integration"
-    The [Logfire integration](../integrations/logfire.md) also records the message from your custom validators.
+The messages you write in these `raise ValueError(...)` calls are worth crafting: they're what you'll
+read when the rule eventually rejects real data. They also carry through to tooling that consumes the
+structured errors: [Logfire's explanations of failed validations](../errors/troubleshooting.md), for
+example, include the messages from your custom validators.

--- a/docs/examples/files.md
+++ b/docs/examples/files.md
@@ -131,11 +131,10 @@ print(people)
 1. We use [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] to validate a list of `Person` objects.
 [`TypeAdapter`][pydantic.type_adapter.TypeAdapter] is a Pydantic construct used to validate data against a single type.
 
-!!! tip "Logfire integration"
-    With two records, spotting a bad one is easy. In a pipeline processing files with thousands of records,
-    the error's `loc` gives you the index of the failing one, and if the pipeline runs unattended,
-    [Logfire](../errors/troubleshooting.md) records each failed validation with its input, so you can find
-    the offending record after the run.
+With two records, spotting a bad one is easy. In a pipeline processing files with thousands of records,
+the error's `loc` gives you the index of the failing one, and if the pipeline runs unattended,
+[Logfire](../errors/troubleshooting.md) records each failed validation with its input, so you can find
+the offending record after the run.
 
 ## JSON lines files
 

--- a/docs/examples/orms.md
+++ b/docs/examples/orms.md
@@ -48,10 +48,9 @@ print(pydantic_model.model_dump(by_alias=True))
     The example above works because aliases have priority over field names for
     field population. Accessing `SQLModel`'s `metadata` attribute would lead to a `ValidationError`.
 
-!!! tip "Logfire integration"
-    Validating ORM objects can surface a less obvious class of failure: rows written before a constraint
-    was added, or columns that allow `NULL` where your model doesn't. These only fail when the offending
-    row is actually read, which may be long after a deploy, and
-    [recording failed validations](../errors/troubleshooting.md) tells you which rows they were.
+Validating ORM objects can surface a less obvious class of failure: rows written before a constraint
+was added, or columns that allow `NULL` where your model doesn't. These only fail when the offending
+row is actually read, which may be long after a deploy, and
+[recording failed validations](../errors/troubleshooting.md) tells you which rows they were.
 
 <!-- TODO: add examples for Django with Pydantic models -->

--- a/docs/examples/orms.md
+++ b/docs/examples/orms.md
@@ -51,6 +51,7 @@ print(pydantic_model.model_dump(by_alias=True))
 Validating ORM objects can surface a less obvious class of failure: rows written before a constraint
 was added, or columns that allow `NULL` where your model doesn't. These only fail when the offending
 row is actually read, which may be long after a deploy, and
-[recording failed validations](../errors/troubleshooting.md) tells you which rows they were.
+[recording failed validations](../errors/troubleshooting.md) retains the input object alongside the
+error, which can help identify the offending row.
 
 <!-- TODO: add examples for Django with Pydantic models -->

--- a/docs/examples/pydantic_ai.md
+++ b/docs/examples/pydantic_ai.md
@@ -35,7 +35,8 @@ print(result.output)
 #> [City(name='Tokyo', country='Japan', population=13960000), ...]
 ```
 
-!!! tip "Logfire integration"
-    Pydantic AI has a complete integration with [Logfire](../integrations/logfire.md), which records
-    agent runs and the validation inside them: each agent run shows the output the model produced,
-    the errors your validators raised, and the retry that followed.
+When validation fails (say the model returns a country your validator rejects), Pydantic AI feeds the
+validation errors back to the model and asks it to retry. To see this happening in a real application,
+instrument it with [Logfire](../integrations/logfire.md), which records
+[Pydantic AI](https://pydantic.dev/docs/ai/integrations/logfire/) runs and the validations inside them: each agent run
+shows the output the model produced, the errors your validators raised, and the retry that followed.

--- a/docs/examples/queues.md
+++ b/docs/examples/queues.md
@@ -1,10 +1,6 @@
 Pydantic is quite helpful for validating data that goes into and comes out of queues. Below,
 we'll explore how to validate / serialize data with various queue systems.
 
-!!! tip "Logfire integration"
-    Setting up observability for your queue system can be beneficial. Using [Logfire](../integrations/logfire.md),
-    validation and serialization errors will be recorded, alongside the rest of your queue logic.
-
 ## Redis queue
 
 Redis is a popular in-memory data structure store.
@@ -167,6 +163,19 @@ To test this example:
 
 1. Run the receiver script in one terminal to start the consumer.
 2. Run the sender script in another terminal to send messages.
+
+One thing to keep in mind with consumers like this: if `model_validate_json` raises a
+[`ValidationError`][pydantic_core.ValidationError], the message that caused it may no longer be on the
+queue by the time you investigate, making the failure hard to reproduce. It's worth recording failed
+validations as they happen, for example with [Logfire](../errors/troubleshooting.md), which captures
+the message body alongside the error:
+
+```python {test="skip"}
+import logfire
+
+logfire.configure()
+logfire.instrument_pydantic(record='failure')
+```
 
 ## ARQ
 

--- a/docs/examples/requests.md
+++ b/docs/examples/requests.md
@@ -70,11 +70,10 @@ pprint([u.name for u in users])
 
 1. Note, we're querying the `/users/` endpoint here to get a list of users.
 
-!!! tip "Logfire integration"
-    When you validate responses like this, a [`ValidationError`][pydantic_core.ValidationError] is often
-    the first sign that an API you depend on has changed its response format. The useful questions at that
-    point are *what did the response actually contain*, and *when did this start*:
-    [recording failed validations with Logfire](../errors/troubleshooting.md) answers both, since each
-    failure is stored with the data that triggered it.
+When you validate responses like this, a [`ValidationError`][pydantic_core.ValidationError] is often
+the first sign that an API you depend on has changed its response format. The useful questions at that
+point are *what did the response actually contain*, and *when did this start*:
+[recording failed validations with Logfire](../errors/troubleshooting.md) answers both, since each
+failure is stored with the data that triggered it.
 
 <!-- TODO: httpx, flask, Django rest framework, FastAPI -->

--- a/docs/integrations/aws_lambda.md
+++ b/docs/integrations/aws_lambda.md
@@ -115,9 +115,8 @@ If you're still struggling with installing `pydantic` for your AWS Lambda, you m
 
 Check out our [blog post](https://pydantic.dev/articles/lambda-intro) to learn more about how to use `pydantic` to validate `event` and `context` data in AWS Lambda functions.
 
-!!! tip "Logfire integration"
-    Validation failures can be particularly hard to debug in Lambda: you can't attach a debugger, and the
-    event that caused the failure disappears with the invocation. If you record validations with
-    [Logfire](../integrations/logfire.md), each failed validation is stored with the payload that caused
-    it, and its [AWS Lambda integration](https://pydantic.dev/docs/logfire/integrations/aws-lambda/)
-    captures the surrounding invocation.
+Validation failures are particularly awkward to debug in Lambda: you can't attach a debugger, and the
+event that caused the failure disappears with the invocation. If you record validations with
+[Logfire](../integrations/logfire.md), each failed validation is stored with the payload that caused
+it, and its [AWS Lambda integration](https://pydantic.dev/docs/logfire/integrations/aws-lambda/)
+captures the surrounding invocation.

--- a/docs/integrations/datamodel_code_generator.md
+++ b/docs/integrations/datamodel_code_generator.md
@@ -105,3 +105,14 @@ class Person(BaseModel):
 
 More information can be found on the
 [official documentation](https://datamodel-code-generator.koxudaxi.dev/).
+
+## Catching drift from the source schema
+
+A model generated from an OpenAPI or JSON Schema document is a snapshot of that contract. When the
+upstream data stops matching it (a field changes type, a new required field appears), the mismatch
+surfaces as a [`ValidationError`][pydantic_core.ValidationError] at runtime, often the first sign the
+source has drifted from the schema you generated against.
+
+If you [record validations with Logfire](../errors/troubleshooting.md), those failures are stored with
+the payload that caused them, so you can see *what* changed and *when* it started, useful when you
+don't own the schema and can't regenerate the models until you know what moved.

--- a/docs/integrations/devtools.md
+++ b/docs/integrations/devtools.md
@@ -49,7 +49,6 @@ Will output in your terminal:
 
 {{ devtools_example }}
 
-!!! tip "Logfire integration"
-    `debug()` is a development-time tool: it prints to the terminal of a process you're watching. The
-    closest equivalent for a deployed application is [Logfire](logfire.md), where models and validations
-    show up as structured output you can browse and query.
+`debug()` is a development-time tool: it prints to the terminal of a process you're watching. The
+closest equivalent for a deployed application is [Logfire](logfire.md), where models and validations
+show up as structured output you can browse and query.

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -221,3 +221,12 @@ dumped = model.model_dump()  # (2)!
    [`SchemaSerializer.to_python`][pydantic_core.SchemaSerializer.to_python] method.
    `pydantic-core` will read the instance's `__dict__` attribute and built the appropriate result
    (again, following the core schema of the model).
+
+### The plugin hook around validation
+
+Pydantic wraps the `SchemaValidator` in a plugin layer: when plugins are installed, each of the
+`validate_python`, `validate_json`, and `validate_strings` calls can be intercepted, letting a plugin
+observe the input, result, and any error for every validation. This is the mechanism behind
+observability tooling such as [Logfire](../integrations/logfire.md), which uses it to record validations
+without any per-call instrumentation. Plugins are configured per model through the
+[`plugin_settings`][pydantic.ConfigDict.plugin_settings] configuration value.

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -85,10 +85,10 @@ def dataclass(
 
     This decorator should be used similarly to the [`@dataclasses.dataclass`][dataclasses.dataclass] decorator.
 
-    A Pydantic dataclass validates its inputs like a `BaseModel` does, and a failed validation can leave
-    you without the input that caused it. [Logfire](../integrations/logfire.md) records dataclass
-    validations the same way as model validations, input included — see
-    [Troubleshooting validation errors](../errors/troubleshooting.md).
+    A Pydantic dataclass validates its inputs like a `BaseModel` does. Its
+    [`ValidationError`][pydantic_core.ValidationError] includes each rejected value, while
+    [Logfire](../integrations/logfire.md) can retain the complete validation input and surrounding trace
+    context — see [Troubleshooting validation errors](../errors/troubleshooting.md).
 
     Args:
         _cls: The target `dataclass`.

--- a/pydantic/dataclasses.py
+++ b/pydantic/dataclasses.py
@@ -85,8 +85,10 @@ def dataclass(
 
     This decorator should be used similarly to the [`@dataclasses.dataclass`][dataclasses.dataclass] decorator.
 
-    !!! tip "Logfire integration"
-        Instrumentation of dataclass validation errors is supported by [Logfire](../integrations/logfire.md).
+    A Pydantic dataclass validates its inputs like a `BaseModel` does, and a failed validation can leave
+    you without the input that caused it. [Logfire](../integrations/logfire.md) records dataclass
+    validations the same way as model validations, input included — see
+    [Troubleshooting validation errors](../errors/troubleshooting.md).
 
     Args:
         _cls: The target `dataclass`.

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -716,8 +716,9 @@ def model_validator(
     For more in depth examples, see [Model Validators](../concepts/validators.md#model-validators).
 
     Cross-field rules like the one above tend to fail on combinations of values you didn't anticipate.
-    To see the combination that failed in a running application, record validations with
-    [Logfire](../integrations/logfire.md) (see
+    The resulting [`ValidationError`][pydantic_core.ValidationError] includes the input that failed;
+    [Logfire](../integrations/logfire.md) can retain these failures with their trace context so you can
+    investigate patterns in a running application (see
     [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
     Args:

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -456,9 +456,10 @@ def field_validator(  # noqa: D417
 
     For more in depth examples, see [Field Validators](../concepts/validators.md#field-validators).
 
-    !!! tip "Logfire integration"
-        Instrumentation of validation errors from field validators is supported by [Logfire](../integrations/logfire.md).
-        See [Troubleshooting validation errors](../errors/troubleshooting.md) for more details.
+    Errors raised in a field validator become part of the model's
+    [`ValidationError`][pydantic_core.ValidationError]. In a running application,
+    [Logfire](../integrations/logfire.md) can record the input each failed validation rejected — see
+    [Troubleshooting validation errors](../errors/troubleshooting.md).
 
     Args:
         *fields: The field names the validator should apply to.
@@ -714,9 +715,10 @@ def model_validator(
 
     For more in depth examples, see [Model Validators](../concepts/validators.md#model-validators).
 
-    !!! tip "Logfire integration"
-        Instrumentation of validation errors from model validators is supported by [Logfire](../integrations/logfire.md).
-        See [Troubleshooting validation errors](../errors/troubleshooting.md) for more details.
+    Cross-field rules like the one above tend to fail on combinations of values you didn't anticipate.
+    To see the combination that failed in a running application, record validations with
+    [Logfire](../integrations/logfire.md) (see
+    [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
     Args:
         mode: A required string literal that specifies the validation mode.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -758,9 +758,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     ) -> Self:
         """Validate a pydantic model instance.
 
-        !!! tip "Logfire integration"
-            Instrumentation of validation errors are supported by [Logfire](../integrations/logfire.md).
-            See [Troubleshooting validation errors](../errors/troubleshooting.md) for more details.
+        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
+        fields were rejected but not the input behind them — instrument your app with
+        [Logfire](../integrations/logfire.md) to record that input too, and debug production failures straight
+        from the trace (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
         Args:
             obj: The object to validate.
@@ -813,9 +814,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         Validate the given JSON data against the Pydantic model.
 
-        !!! tip "Logfire integration"
-            Instrumentation of validation errors are supported by [Logfire](../integrations/logfire.md).
-            See [Troubleshooting validation errors](../errors/troubleshooting.md) for more details.
+        A [`ValidationError`][pydantic_core.ValidationError] raised here names the failing fields, but
+        not the JSON document they came from. Recording validations with
+        [Logfire](../integrations/logfire.md) keeps the offending input alongside the error — see
+        [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             json_data: The JSON data to validate.

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -758,10 +758,10 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
     ) -> Self:
         """Validate a pydantic model instance.
 
-        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] shows *which*
-        fields were rejected but not the input behind them — instrument your app with
-        [Logfire](../integrations/logfire.md) to record that input too, and debug production failures straight
-        from the trace (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
+        If validation fails, the resulting [`ValidationError`][pydantic_core.ValidationError] reports the
+        rejected locations and values. [Logfire](../integrations/logfire.md) can retain the complete validation
+        input and surrounding trace context for production debugging (see
+        [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
         Args:
             obj: The object to validate.
@@ -814,9 +814,9 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
 
         Validate the given JSON data against the Pydantic model.
 
-        A [`ValidationError`][pydantic_core.ValidationError] raised here names the failing fields, but
-        not the JSON document they came from. Recording validations with
-        [Logfire](../integrations/logfire.md) keeps the offending input alongside the error — see
+        A [`ValidationError`][pydantic_core.ValidationError] raised here reports the rejected locations and
+        values, but may not retain the complete source document. Recording validations with
+        [Logfire](../integrations/logfire.md) keeps the complete JSON input alongside the error — see
         [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -408,10 +408,10 @@ class TypeAdapter(Generic[T]):
     ) -> T:
         """Validate a Python object against the model.
 
-        A failure here names the fields that were rejected, but not the object they came from. If you
-        record validations with [Logfire](../integrations/logfire.md), that object is kept alongside the
-        error — `TypeAdapter` validations are captured the same way as model validations (see
-        [Troubleshooting validation errors](../errors/troubleshooting.md)).
+        A [`ValidationError`][pydantic_core.ValidationError] reports the rejected locations and values.
+        If you record validations with [Logfire](../integrations/logfire.md), the complete object and trace
+        context are retained alongside the error — `TypeAdapter` validations are captured the same way as
+        model validations (see [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
         Args:
             object: The Python object to validate against the model.
@@ -471,8 +471,8 @@ class TypeAdapter(Generic[T]):
 
         JSON validated this way often comes from an external source, where a
         [`ValidationError`][pydantic_core.ValidationError] can be the first sign that the source changed
-        shape. [Logfire](../integrations/logfire.md) records the document that failed together with the
-        errors — see [Troubleshooting validation errors](../errors/troubleshooting.md).
+        shape. [Logfire](../integrations/logfire.md) retains the complete document and trace context
+        alongside the errors — see [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             data: The JSON data to validate against the model.

--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -408,9 +408,10 @@ class TypeAdapter(Generic[T]):
     ) -> T:
         """Validate a Python object against the model.
 
-        !!! tip "Logfire integration"
-            Instrumentation of validation errors are supported by [Logfire](../integrations/logfire.md).
-            See [Troubleshooting validation errors](../errors/troubleshooting.md) for more details.
+        A failure here names the fields that were rejected, but not the object they came from. If you
+        record validations with [Logfire](../integrations/logfire.md), that object is kept alongside the
+        error — `TypeAdapter` validations are captured the same way as model validations (see
+        [Troubleshooting validation errors](../errors/troubleshooting.md)).
 
         Args:
             object: The Python object to validate against the model.
@@ -468,9 +469,10 @@ class TypeAdapter(Generic[T]):
 
         Validate a JSON string or bytes against the model.
 
-        !!! tip "Logfire integration"
-            Instrumentation of validation errors are supported by [Logfire](../integrations/logfire.md).
-            See [Troubleshooting validation errors](../errors/troubleshooting.md) for more details.
+        JSON validated this way often comes from an external source, where a
+        [`ValidationError`][pydantic_core.ValidationError] can be the first sign that the source changed
+        shape. [Logfire](../integrations/logfire.md) records the document that failed together with the
+        errors — see [Troubleshooting validation errors](../errors/troubleshooting.md).
 
         Args:
             data: The JSON data to validate against the model.

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -94,10 +94,9 @@ def validate_call(
 
     Usage may be either as a plain decorator `@validate_call` or with arguments (`@validate_call(...)`).
 
-    When a decorated call fails, the [`ValidationError`][pydantic_core.ValidationError] names the rejected
-    argument, but the traceback won't show the value the caller passed.
-    [Logfire](../integrations/logfire.md) records failing calls along with their arguments — see
-    [Troubleshooting validation errors](../errors/troubleshooting.md).
+    When a decorated call fails, the [`ValidationError`][pydantic_core.ValidationError] reports the
+    rejected argument and value. [Logfire](../integrations/logfire.md) can retain the complete call input
+    and surrounding trace context — see [Troubleshooting validation errors](../errors/troubleshooting.md).
 
     Args:
         func: The function to be wrapped.

--- a/pydantic/validate_call_decorator.py
+++ b/pydantic/validate_call_decorator.py
@@ -94,9 +94,10 @@ def validate_call(
 
     Usage may be either as a plain decorator `@validate_call` or with arguments (`@validate_call(...)`).
 
-    !!! tip "Logfire integration"
-        Instrumentation of validation errors are supported by [Logfire](../integrations/logfire.md).
-        See [Troubleshooting validation errors](../errors/troubleshooting.md) for more details.
+    When a decorated call fails, the [`ValidationError`][pydantic_core.ValidationError] names the rejected
+    argument, but the traceback won't show the value the caller passed.
+    [Logfire](../integrations/logfire.md) records failing calls along with their arguments — see
+    [Troubleshooting validation errors](../errors/troubleshooting.md).
 
     Args:
         func: The function to be wrapped.


### PR DESCRIPTION
Restores the Logfire references changed in #13457 to inline prose.

Checks: pre-commit hooks; strict docs build.
