### PR TITLE
fix(config): apply subclass field_title_generator to inherited fields (#13486)

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -162,7 +162,7 @@ def _apply_field_title_generator_to_field_info(
     field_name: str,
     field_info: FieldInfo,
 ):
-    if field_info.title is None:
+    if field_info.title is None or 'title' not in field_info._attributes_set:
         title = title_generator(field_name, field_info)
         if not isinstance(title, str):
             raise TypeError(f'field_title_generator {title_generator} must return str, not {title.__class__}')

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1603,6 +1603,7 @@ class ComputedFieldInfo:
     examples: list[Any] | None
     json_schema_extra: JsonDict | Callable[[JsonDict], None] | None
     repr: bool
+    _title_from_generator: bool = False
     # NOTE: if you add a new field, add it to the `__copy__()` implementation.
 
     def __copy__(self) -> Self:
@@ -1621,6 +1622,7 @@ class ComputedFieldInfo:
             if isinstance(self.json_schema_extra, dict)
             else self.json_schema_extra,
             repr=self.repr,
+            _title_from_generator=self._title_from_generator,
         )
 
     @property
@@ -1635,8 +1637,9 @@ class ComputedFieldInfo:
     def _update_from_config(self, config_wrapper: ConfigWrapper, name: str) -> None:
         """Update the instance from the configuration set on the class this computed field belongs to."""
         title_generator = self.field_title_generator or config_wrapper.field_title_generator
-        if title_generator is not None and self.title is None:
+        if title_generator is not None and (self.title is None or self._title_from_generator):
             self.title = title_generator(name, self)
+            self._title_from_generator = True
         if config_wrapper.alias_generator is not None:
             self._apply_alias_generator(config_wrapper.alias_generator, name)
 

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -492,3 +492,37 @@ def test_field_title_generator_returns_invalid_type(invalid_return_value, TypedD
             field_a: Annotated[str, Field(field_title_generator=lambda f, _: invalid_return_value)]
 
         TypeAdapter(MyTypedDict)
+
+
+def test_submodel_field_title_generator_inheritance():
+    class Model(BaseModel, field_title_generator=lambda v, _: v + 'a'):
+        a: int
+        explicit: int = Field(title='ExplicitTitle')
+        field_gen: int = Field(field_title_generator=lambda v, _: 'field_' + v)
+
+        @computed_field
+        def c(self) -> int:
+            return 1
+
+        @computed_field(title='ExplicitComputedTitle')
+        def explicit_c(self) -> int:
+            return 2
+
+    class Sub(Model, field_title_generator=lambda v, _: v + 'b'):
+        b: int
+
+        @computed_field
+        def d(self) -> int:
+            return 3
+
+    assert Model.model_fields['a'].title == 'aa'
+    assert Sub.model_fields['a'].title == 'ab'
+    assert Sub.model_fields['b'].title == 'bb'
+    assert Sub.model_fields['explicit'].title == 'ExplicitTitle'
+    assert Sub.model_fields['field_gen'].title == 'field_field_gen'
+
+    assert Model.model_computed_fields['c'].title == 'ca'
+    assert Sub.model_computed_fields['c'].title == 'cb'
+    assert Sub.model_computed_fields['d'].title == 'db'
+    assert Sub.model_computed_fields['explicit_c'].title == 'ExplicitComputedTitle'
+


### PR DESCRIPTION
## Description
Fixes #13486 by re-evaluating config-generated field titles against subclass-level `field_title_generator` while preserving explicit title definitions.

- Update `_apply_field_title_generator_to_field_info` in `pydantic/_internal/_fields.py` to re-evaluate titles when `field_info.title is None` or `'title' not in field_info._attributes_set`.
- Update `ComputedFieldInfo` in `pydantic/fields.py` to track `_title_from_generator` so inherited computed fields also re-evaluate subclass title generators.
- Added comprehensive unit test `test_submodel_field_title_generator_inheritance` in `tests/test_titles.py`.