### PR TITLE
Preserve `re.Pattern` instance for compiled patterns in the experimental pipeline

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -651,7 +651,12 @@ def _apply_constraint(  # noqa: C901
         assert isinstance(constraint, Pattern)
         if s and s['type'] == 'str':
             s = s.copy()
-            s['pattern'] = constraint.pattern
+            # Keep the compiled pattern rather than reducing it to `constraint.pattern`: the source
+            # string alone drops the `re` flags, and pydantic-core's regex defaults differ from
+            # Python's (e.g. Unicode-mode `\w`), so a pattern compiled with re.ASCII would silently
+            # stop being ASCII-only. The string schema accepts a compiled pattern and honors its
+            # flags, same as `StringConstraints`.
+            s['pattern'] = constraint
         else:
 
             def check_pattern(v: object) -> bool:

--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -651,11 +651,6 @@ def _apply_constraint(  # noqa: C901
         assert isinstance(constraint, Pattern)
         if s and s['type'] == 'str':
             s = s.copy()
-            # Keep the compiled pattern rather than reducing it to `constraint.pattern`: the source
-            # string alone drops the `re` flags, and pydantic-core's regex defaults differ from
-            # Python's (e.g. Unicode-mode `\w`), so a pattern compiled with re.ASCII would silently
-            # stop being ASCII-only. The string schema accepts a compiled pattern and honors its
-            # flags, same as `StringConstraints`.
             s['pattern'] = constraint
         else:
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import re
 from collections.abc import Callable
 from decimal import Decimal
 from typing import Annotated, Any
@@ -26,6 +27,22 @@ def test_parse_str_with_pattern() -> None:
     assert ta_pattern.validate_python('potato') == 'potato'
     with pytest.raises(ValueError):
         ta_pattern.validate_python('POTATO')
+
+
+def test_constrain_compiled_pattern_keeps_flags() -> None:
+    # A compiled pattern passed to `constrain` carries its flags; only the source string is
+    # representable in the string core schema, so inlining it there drops them. re.ASCII must
+    # keep `\w` ASCII-only, otherwise a non-ASCII homoglyph slips past an ASCII-scoped constraint.
+    ta_ascii = TypeAdapter[str](Annotated[str, validate_as(str).constrain(re.compile(r'^\w+$', re.ASCII))])
+    assert ta_ascii.validate_python('admin') == 'admin'
+    with pytest.raises(ValidationError):
+        ta_ascii.validate_python('аdmin')  # Cyrillic 'а'
+    with pytest.raises(ValidationError):
+        ta_ascii.validate_python('adminµ')  # micro sign
+
+    # re.IGNORECASE is likewise honored rather than silently dropped.
+    ta_ci = TypeAdapter[str](Annotated[str, validate_as(str).constrain(re.compile(r'^admin$', re.IGNORECASE))])
+    assert ta_ci.validate_python('ADMIN') == 'ADMIN'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -30,20 +30,14 @@ def test_parse_str_with_pattern() -> None:
 
 
 def test_constrain_compiled_pattern_keeps_flags() -> None:
-    # A compiled pattern passed to `constrain` carries its flags; only the source string is
-    # representable in the string core schema, so inlining it there drops them. re.ASCII must
-    # keep `\w` ASCII-only, otherwise a non-ASCII homoglyph slips past an ASCII-scoped constraint.
     ta_ascii = TypeAdapter[str](Annotated[str, validate_as(str).constrain(re.compile(r'^\w+$', re.ASCII))])
     assert ta_ascii.validate_python('admin') == 'admin'
-    with pytest.raises(ValidationError):
-        ta_ascii.validate_python('аdmin')  # Cyrillic 'а'
     with pytest.raises(ValidationError):
         ta_ascii.validate_python('adminµ')  # micro sign
 
     # re.IGNORECASE is likewise honored rather than silently dropped.
     ta_ci = TypeAdapter[str](Annotated[str, validate_as(str).constrain(re.compile(r'^admin$', re.IGNORECASE))])
     assert ta_ci.validate_python('ADMIN') == 'ADMIN'
-
 
 @pytest.mark.parametrize(
     'type_, pipeline, valid_cases, invalid_cases',

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -39,6 +39,7 @@ def test_constrain_compiled_pattern_keeps_flags() -> None:
     ta_ci = TypeAdapter[str](Annotated[str, validate_as(str).constrain(re.compile(r'^admin$', re.IGNORECASE))])
     assert ta_ci.validate_python('ADMIN') == 'ADMIN'
 
+
 @pytest.mark.parametrize(
     'type_, pipeline, valid_cases, invalid_cases',
     [


### PR DESCRIPTION
in `_apply_constraint`, a compiled `Pattern` constraint on a string schema was folded in as `s['pattern'] = constraint.pattern`, which keeps only the source string and drops the `re` flags. pydantic-core's regex defaults are not python's (`\w`/`\d`/`\b` are unicode-mode), so a pattern built with `re.ASCII` stops being ascii-only: `validate_as(str).constrain(re.compile(r'^\w+$', re.ASCII))` lets a cyrillic `аdmin` through, and `re.IGNORECASE` gets dropped the other way and rejects valid input. the string schema already accepts a compiled pattern and honors its flags, which is how `StringConstraints` passes one through, so this hands `constraint` over instead of its source. flag-free patterns (including `str_pattern`) fold identically to before; the regression test pins the re.ASCII and re.IGNORECASE cases.