### PR TITLE
Reject trailing input and non-ASCII digits in `ByteSize`

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2135,7 +2135,7 @@ class ByteSize(int):
     byte_sizes.update({k.lower()[0]: v for k, v in byte_sizes.items() if 'i' not in k})
 
     byte_string_pattern = r'^\s*(\d*\.?\d+)\s*(\w+)?'
-    byte_string_re = re.compile(byte_string_pattern, re.IGNORECASE)
+    byte_string_re = re.compile(byte_string_pattern + r'\s*$', re.IGNORECASE | re.ASCII)
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1355,6 +1355,26 @@ def test_bytesize_raises():
         m.size.to('1ZiB')
 
 
+@pytest.mark.parametrize(
+    'input_value',
+    (
+        '1kb; rm -rf /',  # trailing content after a valid size
+        '1kb\nHost: evil',  # trailing content after a newline
+        '1kb    junk',
+        '٤kb',  # ARABIC-INDIC DIGIT FOUR as the scalar
+        '１kb',  # FULLWIDTH DIGIT ONE as the scalar
+        '1Kb',  # KELVIN SIGN case-folds to 'k' but is not ASCII
+    ),
+)
+def test_bytesize_rejects_non_ascii_and_trailing(input_value):
+    class Model(BaseModel):
+        size: ByteSize
+
+    with pytest.raises(ValidationError, match='parse value') as exc_info:
+        Model(size=input_value)
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'byte_size'
+
+
 def test_custom_generic_containers():
     T = TypeVar('T')
 


### PR DESCRIPTION
## Change Summary

`ByteSize` parses a size string in `ByteSize._validate` with `byte_string_re.match()` against `^\s*(\d*\.?\d+)\s*(\w+)?`. The pattern has no end anchor and `.match()` only pins the start, so any content after a valid `<number><unit>` prefix is silently dropped: `'1kb; rm -rf /'`, `'1kb\nHost: evil'`, and `'1kb"><img>'` all validate to `1000`. In a `str` pattern `\d`/`\w` are Unicode-aware and `str.lower()` is a full case fold, so the scalar and unit accept non-ASCII spellings too: `'٤kb'` (Arabic-Indic four) parses to `4000`, `'１kb'` (fullwidth one) to `1000`, and a KELVIN SIGN unit folds to `k`.

The fix compiles `byte_string_re` with a trailing `\s*$` anchor and the `re.ASCII` flag, so the value has to be a complete, ASCII-only size string. The check sits on the parser because `ByteSize` is the trust boundary and a field typed `ByteSize` can't sanitize the raw value first; the core `str_schema` pattern stays as the coarse pre-filter. It tightens validation, so a few previously accepted malformed inputs now raise `byte_size`, while every well-formed value including surrounding whitespace still parses to the same result.

## Related issue number

None; found while reading the `ByteSize` parser.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
