### PR TITLE
fix: allow field_title_generator to re-evaluate for inherited model fields

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -130,7 +130,7 @@ def _apply_field_title_generator_to_field_info(
     field_name: str,
     field_info: FieldInfo,
 ):
-    if field_info.title is None:
+    if 'title' not in field_info._attributes_set:
         title = title_generator(field_name, field_info)
         if not isinstance(title, str):
             raise TypeError(f'field_title_generator {title_generator} must return str, not {title.__class__}')

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -491,3 +491,15 @@ def test_field_title_generator_returns_invalid_type(invalid_return_value, TypedD
             field_a: Annotated[str, Field(field_title_generator=lambda f, _: invalid_return_value)]
 
         TypeAdapter(MyTypedDict)
+
+
+def test_subclass_field_title_generator_inheritance():
+    class Model(BaseModel, field_title_generator=lambda v, _: v + 'a'):
+        a: int
+
+    class Sub(Model, field_title_generator=lambda v, _: v + 'b'):
+        b: int
+
+    assert Sub.model_fields['a'].title == 'ab'
+    assert Sub.model_fields['b'].title == 'bb'
+


### PR DESCRIPTION
### Summary

Fixes #13486

When a model subclass defines a ield_title_generator (either in ConfigDict or class kwargs), fields inherited from a parent model did not re-evaluate the child's ield_title_generator because _apply_field_title_generator_to_field_info only checked if field_info.title is None. Since the parent model had already generated a 	itle string during parent class construction, ield_info.title was no longer None.

### Details
- Refactored _apply_field_title_generator_to_field_info in pydantic/_internal/_fields.py to check if 'title' not in field_info._attributes_set.
- This ensures fields with explicitly set titles (Field(title=...)) retain their custom titles, while automatically generated field titles are updated according to the subclass's configuration.
- Added unit test 	est_subclass_field_title_generator_inheritance in 	ests/test_titles.py.