### PR TITLE
Allow `dict`, `frozendict` and `frozenset` as `defaultdict` default factories

### DIFF
--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -416,7 +416,7 @@ def defaultdict_validator(
         return collections.defaultdict(default_default_factory, handler(input_value))
 
 
-_defaultdict_allowed_default_types = {
+_defaultdict_allowed_default_types: dict[type[Any], type[Any]] = {
     float: float,
     int: int,
     str: str,
@@ -435,6 +435,7 @@ _defaultdict_allowed_default_types = {
 }
 
 if sys.version_info >= (3, 15):
+    _defaultdict_allowed_default_types[collections.abc.Mapping] = frozendict  # noqa: F821
     _defaultdict_allowed_default_types[frozendict] = frozendict  # noqa: F821
 
 
@@ -457,7 +458,7 @@ def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable
             return type_var_default_factory
         elif values_type not in _defaultdict_allowed_default_types:
             # a somewhat subjective set of types that have reasonable default values
-            allowed_msg = ', '.join([t.__name__ for t in set(_defaultdict_allowed_default_types.keys())])
+            allowed_msg = ', '.join([t.__name__ for t in _defaultdict_allowed_default_types.keys()])
             raise PydanticSchemaGenerationError(
                 f'Unable to infer a default factory for values of type {values_source_type}.'
                 f' Only {allowed_msg} are supported, other types require an explicit default factory'

--- a/pydantic/_internal/_validators.py
+++ b/pydantic/_internal/_validators.py
@@ -8,6 +8,7 @@ from __future__ import annotations as _annotations
 import collections.abc
 import math
 import re
+import sys
 import typing
 from collections.abc import Callable, Sequence
 from decimal import Decimal
@@ -415,27 +416,34 @@ def defaultdict_validator(
         return collections.defaultdict(default_default_factory, handler(input_value))
 
 
+_defaultdict_allowed_default_types = {
+    float: float,
+    int: int,
+    str: str,
+    bool: bool,
+    tuple: tuple,
+    collections.abc.Sequence: tuple,
+    collections.abc.MutableSequence: list,
+    list: list,
+    set: set,
+    collections.abc.MutableSet: set,
+    frozenset: frozenset,
+    collections.abc.Set: frozenset,
+    dict: dict,
+    collections.abc.Mapping: dict,
+    collections.abc.MutableMapping: dict,
+}
+
+if sys.version_info >= (3, 15):
+    _defaultdict_allowed_default_types[frozendict] = frozendict  # noqa: F821
+
+
 def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable[[], Any]:
     FieldInfo = import_cached_field_info()
 
     values_type_origin = get_origin(values_source_type)
 
     def infer_default() -> Callable[[], Any]:
-        allowed_default_types: dict[Any, Any] = {
-            tuple: tuple,
-            collections.abc.Sequence: tuple,
-            collections.abc.MutableSequence: list,
-            list: list,
-            set: set,
-            collections.abc.MutableSet: set,
-            collections.abc.Set: frozenset,
-            collections.abc.Mapping: dict,
-            collections.abc.MutableMapping: dict,
-            float: float,
-            int: int,
-            str: str,
-            bool: bool,
-        }
         values_type = values_type_origin or values_source_type
         instructions = 'set using `DefaultDict[..., Annotated[..., Field(default_factory=...)]]`'
         if typing_objects.is_typevar(values_type):
@@ -447,15 +455,15 @@ def get_defaultdict_default_default_factory(values_source_type: Any) -> Callable
                 )
 
             return type_var_default_factory
-        elif values_type not in allowed_default_types:
+        elif values_type not in _defaultdict_allowed_default_types:
             # a somewhat subjective set of types that have reasonable default values
-            allowed_msg = ', '.join([t.__name__ for t in set(allowed_default_types.keys())])
+            allowed_msg = ', '.join([t.__name__ for t in set(_defaultdict_allowed_default_types.keys())])
             raise PydanticSchemaGenerationError(
-                f'Unable to infer a default factory for keys of type {values_source_type}.'
+                f'Unable to infer a default factory for values of type {values_source_type}.'
                 f' Only {allowed_msg} are supported, other types require an explicit default factory'
                 ' ' + instructions
             )
-        return allowed_default_types[values_type]
+        return _defaultdict_allowed_default_types[values_type]
 
     # Assume Annotated[..., Field(...)]
     if typing_objects.is_annotated(values_type_origin):

--- a/tests/types/test_defaultdict.py
+++ b/tests/types/test_defaultdict.py
@@ -1,3 +1,4 @@
+import sys
 from collections import defaultdict
 from typing import Annotated, Any, TypeVar
 
@@ -24,9 +25,7 @@ def test_typing_coercion_defaultdict():
 
 
 def test_defaultdict_unknown_default_factory() -> None:
-    """
-    https://github.com/pydantic/pydantic/issues/4687
-    """
+    """https://github.com/pydantic/pydantic/issues/4687"""
     with pytest.raises(
         PydanticSchemaGenerationError,
         match=r'Unable to infer a default factory for keys of type collections.defaultdict\[int, int\]',
@@ -34,21 +33,32 @@ def test_defaultdict_unknown_default_factory() -> None:
         TypeAdapter(defaultdict[int, defaultdict[int, int]])
 
 
-def test_defaultdict_infer_default_factory() -> None:
-    ta_list = TypeAdapter(defaultdict[int, list[int]])
+defaultdict_types_params = [
+    (int, 0),
+    (float, 0.0),
+    (str, ''),
+    (bool, False),
+    (tuple, ()),
+    (list[int], []),
+    (list, []),
+    (set, set()),
+    (frozenset, frozenset()),
+    (dict, {}),
+]
+
+if sys.version_info >= (3, 15):
+    defaultdict_types_params.append((frozendict, frozendict()))  # noqa: F821
+
+
+@pytest.mark.parametrize(
+    ['default_factory_type', 'value'],
+    defaultdict_types_params,
+)
+def test_defaultdict_infer_default_factory(default_factory_type: Any, value: Any) -> None:
+    ta_list = TypeAdapter(defaultdict[int, default_factory_type])
     v = ta_list.validate_python({})
     assert v.default_factory is not None
-    assert v.default_factory() == []
-
-    ta_int = TypeAdapter(defaultdict[int, int])
-    v = ta_int.validate_python({})
-    assert v.default_factory is not None
-    assert v.default_factory() == 0
-
-    ta_set = TypeAdapter(defaultdict[int, set])
-    v = ta_set.validate_python({})
-    assert v.default_factory is not None
-    assert v.default_factory() == set()
+    assert v.default_factory() == value
 
 
 def test_defaultdict_explicit_default_factory() -> None:

--- a/tests/types/test_defaultdict.py
+++ b/tests/types/test_defaultdict.py
@@ -28,7 +28,7 @@ def test_defaultdict_unknown_default_factory() -> None:
     """https://github.com/pydantic/pydantic/issues/4687"""
     with pytest.raises(
         PydanticSchemaGenerationError,
-        match=r'Unable to infer a default factory for keys of type collections.defaultdict\[int, int\]',
+        match=r'Unable to infer a default factory for values of type collections.defaultdict\[int, int\]',
     ):
         TypeAdapter(defaultdict[int, defaultdict[int, int]])
 


### PR DESCRIPTION


<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13617.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
