### PR TITLE
Check GC traversal completeness when constructing validators and serializers in tests

### DIFF
--- a/pydantic-core/pyproject.toml
+++ b/pydantic-core/pyproject.toml
@@ -118,6 +118,9 @@ log_format = '%(name)s %(levelname)s: %(message)s'
 filterwarnings = ['error']
 timeout = 30
 xfail_strict = true
+markers = [
+    'skip_gc_traverse_check: skip the automatic GC traversal completeness check (see tests/conftest.py)',
+]
 # min, max, mean, stddev, median, iqr, outliers, ops, rounds, iterations
 addopts = [
     '--benchmark-columns',

--- a/pydantic-core/pyproject.toml
+++ b/pydantic-core/pyproject.toml
@@ -119,7 +119,7 @@ filterwarnings = ['error']
 timeout = 30
 xfail_strict = true
 markers = [
-    'skip_gc_traverse_check: skip the automatic GC traversal completeness check (see tests/conftest.py)',
+    'skip_gc_traverse_check: skip the automatic GC traversal completeness check',
 ]
 # min, max, mean, stddev, median, iqr, outliers, ops, rounds, iterations
 addopts = [

--- a/pydantic-core/tests/conftest.py
+++ b/pydantic-core/tests/conftest.py
@@ -16,7 +16,7 @@ from typing import Any, Literal
 import hypothesis
 import pytest
 
-from pydantic_core import ArgsKwargs, CoreSchema, SchemaValidator, ValidationError
+from pydantic_core import ArgsKwargs, CoreSchema, SchemaSerializer, SchemaValidator, ValidationError
 from pydantic_core.core_schema import CoreConfig, ExtraBehavior
 
 __all__ = 'Err', 'PyAndJson', 'assert_gc', 'is_free_threaded', 'plain_repr', 'infinite_generator'
@@ -29,6 +29,137 @@ try:
     is_free_threaded = not sys._is_gil_enabled()
 except AttributeError:
     is_free_threaded = False
+
+
+# --- GC traversal completeness check -----------------------------------------------------------------------
+# Every `SchemaValidator`/`SchemaSerializer` construction during tests verifies that the Python objects
+# retained from the core schema are reported to the garbage collector by `__traverse__`. A missing field in
+# an `impl_py_gc_traverse!()` call in the Rust sources results in reference cycles through the validator or
+# serializer never being collected (see https://github.com/pydantic/pydantic/issues/13625).
+
+_gc_traverse_check_active = False
+
+
+def _collect_gc_check_candidates(obj: Any, candidates: dict[int, Any], seen: set[int]) -> None:
+    """Collect Python objects from a core schema that pydantic-core is likely to retain.
+
+    Restricted to classes, callables and enum members: plain values may be converted (and not
+    referenced) on the Rust side, in which case they don't need to be traversed.
+    """
+    if isinstance(obj, dict):
+        if id(obj) in seen:
+            return
+        seen.add(id(obj))
+        for key, value in obj.items():
+            # Core schema `metadata` is opaque to pydantic-core and never retained on its own:
+            if key != 'metadata':
+                _collect_gc_check_candidates(value, candidates, seen)
+    elif isinstance(obj, (list, tuple)):
+        if id(obj) in seen:
+            return
+        seen.add(id(obj))
+        for value in obj:
+            _collect_gc_check_candidates(value, candidates, seen)
+    elif callable(obj) or hasattr(obj, '__objclass__'):
+        candidates.setdefault(id(obj), obj)
+
+
+def _gc_traverse_reachable(obj: Any, exclude_id: int) -> dict[int, Any]:
+    """Objects reported to the garbage collector by ``obj``'s ``tp_traverse``.
+
+    ``gc.get_referents()`` returns exactly what ``tp_traverse`` reports. Plain Python containers are
+    recursed into, as the GC tracks their contents through the containers' own ``tp_traverse``. The
+    retained core schema (``exclude_id``) is deliberately ignored: reachability through ``py_schema``
+    isn't enough for cycles to be collectable -- CPython requires every strong reference held by the
+    Rust structures to be reported individually.
+    """
+    reachable: dict[int, Any] = {}
+    stack = [obj]
+    while stack:
+        current = stack.pop()
+        for referent in gc.get_referents(current):
+            if id(referent) != exclude_id and id(referent) not in reachable:
+                reachable[id(referent)] = referent
+                if isinstance(referent, (dict, list, tuple)):
+                    stack.append(referent)
+    return reachable
+
+
+class _GcTraverseChecked:
+    """Callable standing in for `SchemaValidator`/`SchemaSerializer` during tests.
+
+    On every construction, Python objects from the core schema retained by the instance (detected
+    with `sys.getrefcount()` deltas) are checked to be reported to the garbage collector.
+    """
+
+    def __init__(self, cls: type) -> None:
+        self._cls = cls
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cls, name)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        schema = args[0] if args else kwargs.get('schema')
+        if not _gc_traverse_check_active or not isinstance(schema, dict):
+            return self._cls(*args, **kwargs)
+
+        candidates: dict[int, Any] = {}
+        _collect_gc_check_candidates(schema, candidates, set())
+        refcounts = {obj_id: sys.getrefcount(obj) for obj_id, obj in candidates.items()}
+        instance = self._cls(*args, **kwargs)
+        retained = [obj for obj_id, obj in candidates.items() if sys.getrefcount(obj) > refcounts[obj_id]]
+        if retained:
+            reachable = _gc_traverse_reachable(instance, exclude_id=id(schema))
+            missing = [obj for obj in retained if id(obj) not in reachable]
+            if missing:
+                missing_reprs = ', '.join(repr(obj) for obj in missing[:5])
+                pytest.fail(
+                    f'{self._cls.__name__} retains the following Python object(s) without reporting them '
+                    f'to the garbage collector, which can result in memory leaks: {missing_reprs}. '
+                    'This most likely means a field is missing from an `impl_py_gc_traverse!()` call in '
+                    'the pydantic-core Rust sources. If this is a false positive, apply the '
+                    '`skip_gc_traverse_check` marker to the test.'
+                )
+        return instance
+
+
+_TESTS_DIR = str(Path(__file__).parent)
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    """Swap `SchemaValidator`/`SchemaSerializer` for their GC checked versions in every test module.
+
+    Only modules inside the tests directory are patched (and only names referring to the actual
+    classes), so that other consumers of pydantic-core importable in the test environment (e.g.
+    the `pydantic` package itself) are unaffected.
+    """
+    replacements = [
+        ('SchemaValidator', SchemaValidator, _GcTraverseChecked(SchemaValidator)),
+        ('SchemaSerializer', SchemaSerializer, _GcTraverseChecked(SchemaSerializer)),
+    ]
+    for module in list(sys.modules.values()):
+        module_file = getattr(module, '__file__', None)
+        if module_file is not None and module_file.startswith(_TESTS_DIR):
+            for name, real, checked in replacements:
+                if getattr(module, name, None) is real:
+                    setattr(module, name, checked)
+
+
+@pytest.fixture(autouse=True)
+def _gc_traverse_check(request: pytest.FixtureRequest):
+    global _gc_traverse_check_active
+
+    _gc_traverse_check_active = (
+        sys.implementation.name == 'cpython'
+        # `sys.getrefcount()` isn't reliable with deferred reference counting:
+        and not is_free_threaded
+        and 'benchmark' not in request.fixturenames
+        and request.node.get_closest_marker('skip_gc_traverse_check') is None
+    )
+    try:
+        yield
+    finally:
+        _gc_traverse_check_active = False
 
 
 def plain_repr(obj):

--- a/pydantic-core/tests/conftest.py
+++ b/pydantic-core/tests/conftest.py
@@ -31,11 +31,13 @@ except AttributeError:
     is_free_threaded = False
 
 
-# --- GC traversal completeness check -----------------------------------------------------------------------
-# Every `SchemaValidator`/`SchemaSerializer` construction during tests verifies that the Python objects
-# retained from the core schema are reported to the garbage collector by `__traverse__`. A missing field in
-# an `impl_py_gc_traverse!()` call in the Rust sources results in reference cycles through the validator or
-# serializer never being collected (see https://github.com/pydantic/pydantic/issues/13625).
+# -- GC traversal completeness check --
+# A field holding a Python object that is missing from an `impl_py_gc_traverse!()` call in the Rust
+# sources leaves reference cycles through the validator or serializer uncollectable by the garbage
+# collector.
+# Until we get a proper PyO3 API for this (https://github.com/PyO3/pyo3/issues/5663), a test fixture
+# checks, on every `SchemaValidator`/`SchemaSerializer` construction during tests, that the Python
+# objects retained from the core schema are reported to the garbage collector by `__traverse__()`.
 
 _gc_traverse_check_active = False
 
@@ -65,13 +67,13 @@ def _collect_gc_check_candidates(obj: Any, candidates: dict[int, Any], seen: set
 
 
 def _gc_traverse_reachable(obj: Any, exclude_id: int) -> dict[int, Any]:
-    """Objects reported to the garbage collector by ``obj``'s ``tp_traverse``.
+    """Objects reported to the garbage collector by `obj`'s `tp_traverse`.
 
-    ``gc.get_referents()`` returns exactly what ``tp_traverse`` reports. Plain Python containers are
-    recursed into, as the GC tracks their contents through the containers' own ``tp_traverse``. The
-    retained core schema (``exclude_id``) is deliberately ignored: reachability through ``py_schema``
-    isn't enough for cycles to be collectable -- CPython requires every strong reference held by the
-    Rust structures to be reported individually.
+    `gc.get_referents()` returns exactly what `tp_traverse` reports. Plain Python containers are
+    recursed into, as the GC tracks their contents through the containers' own `tp_traverse`. The
+    retained core schema (`exclude_id`) is deliberately ignored: reachability through `py_schema`
+    isn't enough for cycles to be collectable (CPython requires every strong reference held by the
+    Rust structures to be reported individually).
     """
     reachable: dict[int, Any] = {}
     stack = [obj]
@@ -86,7 +88,7 @@ def _gc_traverse_reachable(obj: Any, exclude_id: int) -> dict[int, Any]:
 
 
 class _GcTraverseChecked:
-    """Callable standing in for `SchemaValidator`/`SchemaSerializer` during tests.
+    """Wrapper around `SchemaValidator`/`SchemaSerializer` during tests.
 
     On every construction, Python objects from the core schema retained by the instance (detected
     with `sys.getrefcount()` deltas) are checked to be reported to the garbage collector.


### PR DESCRIPTION
First approach to address #13625.

Part of #13625, defense-in-depth against bugs like #13621.

Every `SchemaValidator`/`SchemaSerializer` construction during the pydantic-core test suite now verifies that the Python objects retained from the core schema are reported to the garbage collector, so a field missing from an `impl_py_gc_traverse!()` call fails whichever existing test exercises that schema feature.

## How it works

`gc.get_referents(obj)` returns exactly what `tp_traverse` reports, which allows checking traversal completeness directly, without having to construct an actual leak scenario:

1. Walk the core schema and collect candidate objects (classes, callables, enum members — plain values may be converted on the Rust side and don't necessarily need to be traversed).
2. Construct the validator/serializer; candidates whose `sys.getrefcount()` increased are retained by it.
3. Assert every retained candidate appears in `gc.get_referents()` of the instance (recursing only into plain Python containers).

The retained `py_schema` is deliberately excluded from the reachability walk: reachability through it is not enough for cycles to be collectable, as CPython requires every strong reference held by the Rust structures to be reported individually (this exclusion is what makes the check work at all).

The interception swaps the `SchemaValidator`/`SchemaSerializer` names inside test modules only (after collection, once all test modules are imported), leaving `pydantic_core` itself and other consumers (e.g. `pydantic`) untouched. The check is disabled on non-CPython implementations, on free-threaded builds (`sys.getrefcount()` isn't reliable with deferred reference counting), for benchmarks, and per-test via the new `skip_gc_traverse_check` marker.

## Limitations

- The check is per-object membership, not per-edge counting: an object held via two Rust fields of the same struct with only one traversed would not be flagged. The realistic bug pattern — a new field never traversed anywhere — is caught.
- Candidates are limited to classes, callables and enum members; a missing edge holding e.g. only a plain container would not be flagged.
- Validators/serializers constructed at module import time (before collection finishes) are not checked.

https://claude.ai/code/session_01RvP2P4L9VLBy6FMAiotbCP
