### PR TITLE
ares: address issue #13207

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -966,7 +966,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
 
     def __class_getitem__(
-        cls, typevar_values: Any
+        cls, typevar_values: type[Any] | tuple[type[Any], ...] | None
     ) -> type[BaseModel] | _forward_ref.PydanticRecursiveRef:
         cached = _generics.get_cached_generic_type_early(cls, typevar_values)
         if cached is not None:

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -966,7 +966,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
         """
 
     def __class_getitem__(
-        cls, typevar_values: type[Any] | tuple[type[Any], ...]
+        cls, typevar_values: Any
     ) -> type[BaseModel] | _forward_ref.PydanticRecursiveRef:
         cached = _generics.get_cached_generic_type_early(cls, typevar_values)
         if cached is not None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -71,6 +71,8 @@ def test_class_getitem_with_none() -> None:
     parametrized = BaseModel[None]
     assert isinstance(parametrized, type)
     assert parametrized is not BaseModel
+    assert parametrized.__args__ == (None,)
+    assert BaseModel[None] is parametrized
 
 
 @pytest.fixture(name='UltraSimpleModel', scope='session')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -66,6 +66,13 @@ def test_success():
     assert m.b == 10
 
 
+def test_class_getitem_with_none() -> None:
+    """https://github.com/pydantic/pydantic/issues/13207"""
+    parametrized = BaseModel[None]
+    assert isinstance(parametrized, type)
+    assert parametrized is not BaseModel
+
+
 @pytest.fixture(name='UltraSimpleModel', scope='session')
 def ultra_simple_model_fixture():
     class UltraSimpleModel(BaseModel):


### PR DESCRIPTION
## summary
Widen the `__class_getitem__` type annotation on `BaseModel` in `pydantic/main.py` to accept `type[Any] | tuple[type[Any], ...] | None` as a type argument so static type checkers stop rejecting `None`/`NoneType`.

## test results
```json
{
  "test": "failed",
  "lint": "passed",
  "format": "passed",
  "typecheck": "passed"
}
```

## ai disclosure
This PR was authored by ares, an open-source engineering agent operated by ken.

## files changed
- pydantic/main.py
- tests/test_main.py