### PR TITLE
Replace `impl_py_gc_traverse!` with a `#[derive(PyGcTraverse)]` macro traversing all fields

### DIFF
--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "percent-encoding",
+ "pydantic-core-derive",
  "pyo3",
  "pyo3-build-config",
  "regex",
@@ -473,6 +474,15 @@ dependencies = [
  "url",
  "uuid",
  "version_check",
+]
+
+[[package]]
+name = "pydantic-core-derive"
+version = "2.48.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -14,6 +14,7 @@ include = [
     "/build.rs",
     "/rust-toolchain",
     "/src",
+    "/derive",
     "/python/pydantic_core",
     "/tests",
     "/.cargo",
@@ -49,6 +50,10 @@ jiter = { version = "0.16.0", features = ["python"] }
 hex = "0.4.3"
 percent-encoding = "2.3.2"
 hashbrown = { version = "0.17", default-features = false, features = ["inline-more"] }
+pydantic-core-derive = { path = "derive" }
+
+[workspace]
+members = ["derive"]
 
 [lib]
 name = "_pydantic_core"

--- a/pydantic-core/derive/Cargo.toml
+++ b/pydantic-core/derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pydantic-core-derive"
+version = "2.48.0"
+edition = "2024"
+license = "MIT"
+homepage = "https://github.com/pydantic/pydantic"
+repository = "https://github.com/pydantic/pydantic.git"
+description = "Internal derive macros for pydantic-core"
+rust-version = "1.88"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = "2"

--- a/pydantic-core/derive/src/lib.rs
+++ b/pydantic-core/derive/src/lib.rs
@@ -1,0 +1,150 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Field, Fields, Index, parse_macro_input};
+
+/// Derives an implementation of the `PyGcTraverse` trait (only usable within the
+/// `pydantic-core` crate).
+///
+/// Every field of the struct or enum is traversed, meaning every field type is required
+/// to implement `PyGcTraverse` (plain data types have a no-op implementation, defined in
+/// the `py_gc` module). Fields that should deliberately *not* be traversed must be
+/// explicitly marked with the `#[py_gc(skip)]` attribute — which is only sound if the
+/// field can never hold a strong reference to a Python object.
+#[proc_macro_derive(PyGcTraverse, attributes(py_gc))]
+pub fn derive_py_gc_traverse(input: TokenStream) -> TokenStream {
+    expand(&parse_macro_input!(input as DeriveInput))
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+fn is_skipped(field: &Field) -> syn::Result<bool> {
+    let mut skip = false;
+    for attr in &field.attrs {
+        if attr.path().is_ident("py_gc") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("skip") {
+                    skip = true;
+                    Ok(())
+                } else {
+                    Err(meta.error("unsupported `py_gc` attribute; expected `skip`"))
+                }
+            })?;
+        }
+    }
+    Ok(skip)
+}
+
+fn expand(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let name = &input.ident;
+
+    // Types of the traversed fields, used to add `where` predicates when the type is generic:
+    let mut field_types = Vec::new();
+
+    let body = match &input.data {
+        Data::Struct(data) => {
+            let mut statements = Vec::new();
+            match &data.fields {
+                Fields::Named(fields) => {
+                    for field in &fields.named {
+                        if !is_skipped(field)? {
+                            let ident = &field.ident;
+                            statements.push(quote! {
+                                crate::py_gc::PyGcTraverse::py_gc_traverse(&self.#ident, visit)?;
+                            });
+                            field_types.push(&field.ty);
+                        }
+                    }
+                }
+                Fields::Unnamed(fields) => {
+                    for (i, field) in fields.unnamed.iter().enumerate() {
+                        if !is_skipped(field)? {
+                            let index = Index::from(i);
+                            statements.push(quote! {
+                                crate::py_gc::PyGcTraverse::py_gc_traverse(&self.#index, visit)?;
+                            });
+                            field_types.push(&field.ty);
+                        }
+                    }
+                }
+                Fields::Unit => {}
+            }
+            quote! { #(#statements)* }
+        }
+        Data::Enum(data) => {
+            let mut arms = Vec::new();
+            for variant in &data.variants {
+                let variant_ident = &variant.ident;
+                match &variant.fields {
+                    Fields::Named(fields) => {
+                        let mut bindings = Vec::new();
+                        let mut statements = Vec::new();
+                        for field in &fields.named {
+                            if !is_skipped(field)? {
+                                let ident = &field.ident;
+                                bindings.push(quote! { #ident });
+                                statements.push(quote! {
+                                    crate::py_gc::PyGcTraverse::py_gc_traverse(#ident, visit)?;
+                                });
+                                field_types.push(&field.ty);
+                            }
+                        }
+                        arms.push(quote! {
+                            Self::#variant_ident { #(#bindings,)* .. } => { #(#statements)* }
+                        });
+                    }
+                    Fields::Unnamed(fields) => {
+                        let mut bindings = Vec::new();
+                        let mut statements = Vec::new();
+                        for (i, field) in fields.unnamed.iter().enumerate() {
+                            if is_skipped(field)? {
+                                bindings.push(quote! { _ });
+                            } else {
+                                let binding = format_ident!("f{i}");
+                                bindings.push(quote! { #binding });
+                                statements.push(quote! {
+                                    crate::py_gc::PyGcTraverse::py_gc_traverse(#binding, visit)?;
+                                });
+                                field_types.push(&field.ty);
+                            }
+                        }
+                        arms.push(quote! {
+                            Self::#variant_ident(#(#bindings),*) => { #(#statements)* }
+                        });
+                    }
+                    Fields::Unit => arms.push(quote! { Self::#variant_ident => {} }),
+                }
+            }
+            quote! { match self { #(#arms)* } }
+        }
+        Data::Union(_) => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "`PyGcTraverse` cannot be derived for unions",
+            ));
+        }
+    };
+
+    let mut generics = input.generics.clone();
+    // If the type is generic, require `PyGcTraverse` on the traversed field types
+    // (e.g. `PhantomData<T>: PyGcTraverse` for `EnumValidator<T>`):
+    if generics.type_params().next().is_some() {
+        let where_clause = generics.make_where_clause();
+        for ty in &field_types {
+            where_clause
+                .predicates
+                .push(syn::parse_quote! { #ty: crate::py_gc::PyGcTraverse });
+        }
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics crate::py_gc::PyGcTraverse for #name #ty_generics #where_clause {
+            #[allow(unused_variables)]
+            fn py_gc_traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
+                #body
+                Ok(())
+            }
+        }
+    })
+}

--- a/pydantic-core/src/build_tools.rs
+++ b/pydantic-core/src/build_tools.rs
@@ -10,6 +10,7 @@ use pyo3::{PyErrArguments, intern};
 use crate::ValidationError;
 use crate::errors::{PyLineError, ValError};
 use crate::input::InputType;
+use crate::py_gc::PyGcTraverse;
 use crate::tools::SchemaDict;
 
 pub fn schema_or_config<'py, T>(
@@ -170,7 +171,7 @@ macro_rules! py_schema_err {
 }
 pub(crate) use py_schema_err;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PyGcTraverse)]
 pub enum ExtraBehavior {
     Allow,
     Forbid,

--- a/pydantic-core/src/common/union.rs
+++ b/pydantic-core/src/common/union.rs
@@ -1,11 +1,10 @@
 use pyo3::prelude::*;
-use pyo3::{PyTraverseError, PyVisit};
 use smallvec::SmallVec;
 
 use crate::lookup_key::{LookupPath, ValidationAlias};
 use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub enum Discriminator {
     /// use `LookupPaths` to find the tag, same as we do to find values in typed_dict aliases
     LookupPaths(SmallVec<[LookupPath; 1]>),
@@ -28,16 +27,6 @@ impl Discriminator {
             Self::Function(f) => Ok(format!("{}()", f.getattr(py, "__name__")?)),
             Self::LookupPaths(paths) => Ok(paths.iter().map(ToString::to_string).collect::<Vec<_>>().join(" | ")),
         }
-    }
-}
-
-impl PyGcTraverse for Discriminator {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        match self {
-            Self::Function(obj) => visit.call(obj)?,
-            Self::LookupPaths(_) => {}
-        }
-        Ok(())
     }
 }
 

--- a/pydantic-core/src/definitions.rs
+++ b/pydantic-core/src/definitions.rs
@@ -109,11 +109,13 @@ impl<T: Debug> Debug for Definition<T> {
     }
 }
 
-impl<T: PyGcTraverse> PyGcTraverse for DefinitionRef<T> {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        if let Some(value) = self.value.upgrade().as_ref().and_then(|v| v.get()) {
-            value.py_gc_traverse(visit)?;
-        }
+/// Deliberately a no-op: definition references can be cyclic (e.g. for recursive schemas),
+/// so recursing into the target would never terminate. This is sound because every
+/// definition's content is traversed through the [`Definitions`] container, held by the
+/// top-level `SchemaValidator`/`SchemaSerializer`.
+impl<T> PyGcTraverse for DefinitionRef<T> {
+    #[inline]
+    fn py_gc_traverse(&self, _visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
         Ok(())
     }
 }
@@ -205,6 +207,7 @@ impl<T: std::fmt::Debug> DefinitionsBuilder<T> {
 /// Because definitions can create recursive structures, we often need to be able to populate
 /// values lazily from these structures in a way that avoids infinite recursion. This structure
 /// avoids infinite recursion by returning a default value when a recursion loop is detected.
+#[derive(PyGcTraverse)]
 pub(crate) struct RecursionSafeCache<T> {
     cache: OnceLock<T>,
     in_recursion: AtomicBool,

--- a/pydantic-core/src/errors/types.rs
+++ b/pydantic-core/src/errors/types.rs
@@ -16,6 +16,7 @@ use crate::input::{InputType, Int};
 use crate::tools::{py_err, py_error_type};
 
 use super::PydanticCustomError;
+use crate::py_gc::PyGcTraverse;
 
 #[pyfunction]
 pub fn list_all_errors(py: Python<'_>) -> PyResult<Bound<'_, PyList>> {
@@ -89,7 +90,7 @@ macro_rules! error_types {
             },
         )+
     ) => {
-        #[derive(Clone, Debug, Display, EnumMessage, EnumIter)]
+        #[derive(Clone, Debug, Display, EnumMessage, EnumIter, PyGcTraverse)]
         #[strum(serialize_all = "snake_case")]
         pub enum ErrorType {
             $(
@@ -806,7 +807,7 @@ impl ErrorType {
     }
 }
 
-#[derive(Clone, Debug, IntoPyObject, IntoPyObjectRef)]
+#[derive(Clone, Debug, IntoPyObject, IntoPyObjectRef, PyGcTraverse)]
 pub enum Number {
     Int(i64),
     BigInt(BigInt),

--- a/pydantic-core/src/errors/value_exception.rs
+++ b/pydantic-core/src/errors/value_exception.rs
@@ -6,6 +6,7 @@ use crate::input::InputType;
 
 use super::line_error::ToErrorValue;
 use super::{ErrorType, ValError};
+use crate::py_gc::PyGcTraverse;
 
 #[pyclass(extends=PyException, module="pydantic_core._pydantic_core", skip_from_py_object)]
 #[derive(Debug, Clone)]
@@ -54,7 +55,7 @@ impl PydanticUseDefault {
 }
 
 #[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core", subclass, frozen, skip_from_py_object)]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PyGcTraverse)]
 pub struct PydanticCustomError {
     error_type: String,
     message_template: String,
@@ -135,7 +136,7 @@ impl PydanticCustomError {
 }
 
 #[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core", skip_from_py_object, frozen)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct PydanticKnownError {
     error_type: ErrorType,
 }

--- a/pydantic-core/src/input/input_abstract.rs
+++ b/pydantic-core/src/input/input_abstract.rs
@@ -14,8 +14,9 @@ use crate::validators::{TemporalUnitMode, ValBytesMode};
 use super::datetime::{EitherDate, EitherDateTime, EitherTime, EitherTimedelta};
 use super::return_enums::{EitherBytes, EitherComplex, EitherInt, EitherString};
 use super::{EitherFloat, GenericIterator, ValidationMatch};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PyGcTraverse)]
 pub enum InputType {
     Python,
     Json,

--- a/pydantic-core/src/input/return_enums.rs
+++ b/pydantic-core/src/input/return_enums.rs
@@ -353,19 +353,11 @@ pub(crate) fn iterate_attributes<'a, 'py>(
     }))
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub enum GenericIterator<'data> {
     PyIterator(GenericPyIterator),
-    JsonArray(GenericJsonIterator<'data>),
-}
-
-impl PyGcTraverse for GenericIterator<'_> {
-    fn py_gc_traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
-        if let Self::PyIterator(iter) = self {
-            iter.py_gc_traverse(visit)?;
-        }
-        Ok(())
-    }
+    // JSON data cannot hold references to Python objects:
+    JsonArray(#[py_gc(skip)] GenericJsonIterator<'data>),
 }
 
 impl GenericIterator<'_> {
@@ -395,7 +387,7 @@ impl From<&Bound<'_, PyAny>> for GenericIterator<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct GenericPyIterator {
     obj: Py<PyAny>,
     iter: Py<PyIterator>,
@@ -425,8 +417,6 @@ impl GenericPyIterator {
         self.index
     }
 }
-
-impl_py_gc_traverse!(GenericPyIterator { obj, iter });
 
 #[derive(Debug, Clone)]
 pub struct GenericJsonIterator<'data> {
@@ -653,7 +643,7 @@ impl EitherFloat<'_> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, IntoPyObject)]
+#[derive(Debug, Clone, Serialize, IntoPyObject, PyGcTraverse)]
 #[serde(untagged)]
 pub enum Int {
     I64(i64),

--- a/pydantic-core/src/lookup_key.rs
+++ b/pydantic-core/src/lookup_key.rs
@@ -14,6 +14,7 @@ use smallvec::SmallVec;
 use crate::build_tools::py_schema_err;
 use crate::errors::{ErrorType, LocItem, Location, ValError, ValLineError, ValResult, py_err_string};
 use crate::input::StringMapping;
+use crate::py_gc::PyGcTraverse;
 use crate::tools::{mapping_get, py_err};
 
 /// The possible choices for an alias value in Python
@@ -48,7 +49,7 @@ impl FromPyObject<'_, '_> for LookupPath {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub(crate) struct LookupPath {
     /// All paths must start with a string key
     first_item: PathItemString,
@@ -213,7 +214,7 @@ impl LookupPath {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub(crate) enum PathItem {
     S(PathItemString),
     /// integer key, used to get items from a list, tuple OR a dict with int keys `dict[int, ...]` (python only)
@@ -222,7 +223,7 @@ pub(crate) enum PathItem {
 }
 
 /// String type key, used to get or identify items from a dict or anything that implements `__getitem__`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PyGcTraverse)]
 pub(crate) struct PathItemString(
     // stores the original Python value, easily accessible as a Rust &str
     pub PyBackedStr,
@@ -371,7 +372,7 @@ impl PathItemString {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 #[allow(clippy::struct_field_names)]
 pub struct LookupPathCollection {
     pub by_name: LookupPath,
@@ -430,7 +431,7 @@ impl LookupPathCollection {
 }
 
 /// Whether this lookup represents a name or an alias
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PyGcTraverse)]
 #[repr(u8)]
 pub enum LookupType {
     Name = 1,

--- a/pydantic-core/src/py_gc.rs
+++ b/pydantic-core/src/py_gc.rs
@@ -1,14 +1,119 @@
-use std::sync::Arc;
+use std::borrow::Cow;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Arc, OnceLock};
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use enum_dispatch::enum_dispatch;
 use hashbrown::HashTable;
+use num_bigint::BigInt;
 use pyo3::{Py, PyTraverseError, PyVisit, pybacked::PyBackedStr};
+
+/// Derives [`PyGcTraverse`], traversing every field not marked with `#[py_gc(skip)]`.
+pub use pydantic_core_derive::PyGcTraverse;
 
 /// Trait implemented by types which can be traversed by the Python GC.
 #[enum_dispatch]
 pub trait PyGcTraverse {
     fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError>;
+}
+
+/// Implements a no-op [`PyGcTraverse`] for plain data types which can never hold
+/// a strong reference to a Python object.
+macro_rules! impl_py_gc_traverse_noop {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl PyGcTraverse for $ty {
+                #[inline]
+                fn py_gc_traverse(&self, _visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+                    Ok(())
+                }
+            }
+        )*
+    };
+}
+
+impl_py_gc_traverse_noop!(
+    bool,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64,
+    char,
+    String,
+    AtomicBool,
+    AtomicUsize,
+    BigInt,
+);
+
+// Plain data types from external crates:
+impl_py_gc_traverse_noop!(
+    jiter::StringCacheMode,
+    regex::Regex,
+    speedate::Date,
+    speedate::DateTime,
+    speedate::Duration,
+    speedate::MicrosecondsPrecisionOverflowBehavior,
+    speedate::Time,
+);
+
+impl<A: smallvec::Array<Item = T>, T: PyGcTraverse> PyGcTraverse for smallvec::SmallVec<A> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        for item in self {
+            item.py_gc_traverse(visit)?;
+        }
+        Ok(())
+    }
+}
+
+impl PyGcTraverse for Cow<'_, str> {
+    #[inline]
+    fn py_gc_traverse(&self, _visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        Ok(())
+    }
+}
+
+impl<T> PyGcTraverse for PhantomData<T> {
+    #[inline]
+    fn py_gc_traverse(&self, _visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        Ok(())
+    }
+}
+
+impl<A: PyGcTraverse, B: PyGcTraverse> PyGcTraverse for (A, B) {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        self.0.py_gc_traverse(visit)?;
+        self.1.py_gc_traverse(visit)?;
+        Ok(())
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for AHashSet<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        for item in self {
+            item.py_gc_traverse(visit)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: PyGcTraverse> PyGcTraverse for OnceLock<T> {
+    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
+        match self.get() {
+            Some(item) => item.py_gc_traverse(visit),
+            None => Ok(()),
+        }
+    }
 }
 
 impl<T> PyGcTraverse for Py<T> {
@@ -32,19 +137,11 @@ impl<T: PyGcTraverse> PyGcTraverse for Vec<T> {
     }
 }
 
-impl<T: PyGcTraverse> PyGcTraverse for AHashMap<String, T> {
+impl<K: PyGcTraverse, V: PyGcTraverse> PyGcTraverse for AHashMap<K, V> {
     fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        for item in self.values() {
-            item.py_gc_traverse(visit)?;
-        }
-        Ok(())
-    }
-}
-
-impl<K: PyGcTraverse, T: PyGcTraverse> PyGcTraverse for AHashMap<K, T> {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        for item in self.values() {
-            item.py_gc_traverse(visit)?;
+        for (key, value) in self {
+            key.py_gc_traverse(visit)?;
+            value.py_gc_traverse(visit)?;
         }
         Ok(())
     }
@@ -75,23 +172,4 @@ impl<T: PyGcTraverse> PyGcTraverse for HashTable<T> {
     fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
         self.iter().try_for_each(|item| item.py_gc_traverse(visit))
     }
-}
-
-/// A crude alternative to a "derive" macro to help with building PyGcTraverse implementations
-macro_rules! impl_py_gc_traverse {
-    ($name:ty { }) => {
-        impl crate::py_gc::PyGcTraverse for $name {
-            fn py_gc_traverse(&self, _visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
-                Ok(())
-            }
-        }
-    };
-    ($name:ty { $($fields:ident),* $(,)? }) => {
-        impl crate::py_gc::PyGcTraverse for $name {
-            fn py_gc_traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
-                $(self.$fields.py_gc_traverse(visit)?;)*
-                Ok(())
-            }
-        }
-    };
 }

--- a/pydantic-core/src/recursion_guard.rs
+++ b/pydantic-core/src/recursion_guard.rs
@@ -1,3 +1,4 @@
+use crate::py_gc::PyGcTraverse;
 use ahash::AHashSet;
 use std::mem::MaybeUninit;
 
@@ -63,7 +64,7 @@ pub(crate) trait ContainsRecursionState {
 }
 
 /// State for the RecursionGuard. Can also be used directly to increase / decrease depth.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PyGcTraverse)]
 pub struct RecursionState {
     ids: RecursionStack,
     // depth could be a hashmap {validator_id => depth} but for simplicity and performance it's easier to just
@@ -142,9 +143,11 @@ impl RecursionState {
 // trial and error suggests this is a good value, going higher causes array lookups to get significantly slower
 const ARRAY_SIZE: usize = 16;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 enum RecursionStack {
     Array {
+        // Not traversed as partially uninitialized (and `RecursionKey` is plain data):
+        #[py_gc(skip)]
         data: [MaybeUninit<RecursionKey>; ARRAY_SIZE],
         len: usize,
     },

--- a/pydantic-core/src/serializers/computed_fields.rs
+++ b/pydantic-core/src/serializers/computed_fields.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyList};
-use pyo3::{PyTraverseError, PyVisit, intern};
 
 use crate::build_tools::py_schema_error_type;
 use crate::definitions::DefinitionsBuilder;
@@ -14,7 +14,7 @@ use crate::serializers::filter::SchemaFilter;
 use crate::serializers::shared::{BuildSerializer, CombinedSerializer, SerializeMap};
 use crate::tools::SchemaDict;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub(super) struct ComputedFields(Vec<ComputedField>);
 
 impl ComputedFields {
@@ -76,7 +76,7 @@ impl ComputedFields {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct ComputedField {
     property_name: PyBackedStr,
     serializer: Arc<CombinedSerializer>,
@@ -107,13 +107,5 @@ impl ComputedField {
             serialize_by_alias: config.get_as(intern!(py, "serialize_by_alias"))?,
             serialization_exclude_if: schema.get_as(intern!(py, "serialization_exclude_if"))?,
         })
-    }
-}
-
-impl_py_gc_traverse!(ComputedField { serializer });
-
-impl PyGcTraverse for ComputedFields {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        self.0.py_gc_traverse(visit)
     }
 }

--- a/pydantic-core/src/serializers/config.rs
+++ b/pydantic-core/src/serializers/config.rs
@@ -17,8 +17,9 @@ use crate::serializers::type_serializers::datetime_etc::{
 use crate::tools::SchemaDict;
 
 use super::errors::py_err_se_err;
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PyGcTraverse)]
 #[allow(clippy::struct_field_names)]
 pub(crate) struct SerializationConfig {
     pub temporal_mode: TemporalMode,
@@ -82,7 +83,7 @@ pub trait FromConfig {
 
 macro_rules! serialization_mode {
     ($name:ident, $config_key:expr, $($variant:ident => $value:expr),* $(,)?) => {
-        #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+        #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, crate::py_gc::PyGcTraverse)]
         pub enum $name {
             #[default]
             $($variant,)*

--- a/pydantic-core/src/serializers/errors.rs
+++ b/pydantic-core/src/serializers/errors.rs
@@ -7,6 +7,7 @@ use pyo3::types::PyString;
 
 use crate::tools::truncate_safe_repr;
 
+use crate::py_gc::PyGcTraverse;
 use serde::ser;
 
 /// `UNEXPECTED_TYPE_SER` is a special prefix to denote a `PydanticSerializationUnexpectedValue` error.
@@ -109,7 +110,7 @@ impl PydanticSerializationError {
 }
 
 #[pyclass(extends=PyValueError, module="pydantic_core._pydantic_core", skip_from_py_object, frozen)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct PydanticSerializationUnexpectedValue {
     message: Option<String>,
     field_name: Option<Py<PyString>>,

--- a/pydantic-core/src/serializers/extra.rs
+++ b/pydantic-core/src/serializers/extra.rs
@@ -15,6 +15,7 @@ use super::config::SerializationConfig;
 use super::errors::{PydanticSerializationUnexpectedValue, UNEXPECTED_TYPE_SER_MARKER};
 use super::ob_type::ObTypeLookup;
 use crate::PydanticSerializationError;
+use crate::py_gc::PyGcTraverse;
 use crate::recursion_guard::ContainsRecursionState;
 use crate::recursion_guard::RecursionError;
 use crate::recursion_guard::RecursionGuard;
@@ -230,7 +231,7 @@ impl<'py> Extra<'py> {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PyGcTraverse)]
 pub(crate) enum SerCheck {
     // no checks, used everywhere except in union choices
     None,
@@ -246,7 +247,7 @@ impl SerCheck {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PyGcTraverse)]
 pub(crate) struct ExtraOwned {
     mode: SerMode,
     warnings: CollectWarnings,
@@ -269,14 +270,6 @@ pub(crate) struct ExtraOwned {
     include: Option<Py<PyAny>>,
     exclude: Option<Py<PyAny>>,
 }
-
-impl_py_gc_traverse!(ExtraOwned {
-    model,
-    fallback,
-    context,
-    include,
-    exclude,
-});
 
 impl ExtraOwned {
     pub fn new(state: &SerializationState<'_>) -> Self {
@@ -342,7 +335,7 @@ impl ExtraOwned {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PyGcTraverse)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub(crate) enum SerMode {
     Python,
@@ -390,7 +383,7 @@ impl<'py> IntoPyObject<'py> for &'_ SerMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PyGcTraverse)]
 pub enum WarningsMode {
     None,
     Warn,
@@ -426,7 +419,7 @@ impl From<bool> for WarningsMode {
 }
 
 #[cfg_attr(debug_assertions, derive(Debug))]
-#[derive(Clone)]
+#[derive(Clone, PyGcTraverse)]
 pub(crate) struct CollectWarnings {
     mode: WarningsMode,
     warnings: Vec<PydanticSerializationUnexpectedValue>,

--- a/pydantic-core/src/serializers/fields.rs
+++ b/pydantic-core/src/serializers/fields.rs
@@ -22,9 +22,10 @@ use super::computed_fields::ComputedFields;
 use super::extra::Extra;
 use super::filter::SchemaFilter;
 use super::shared::{CombinedSerializer, TypeSerializer};
+use crate::py_gc::PyGcTraverse;
 
 /// representation of a field for serialization
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub(super) struct SerField {
     pub key: PyBackedStr,
     pub alias: Option<PyBackedStr>,
@@ -34,11 +35,6 @@ pub(super) struct SerField {
     pub serialize_by_alias: Option<bool>,
     pub serialization_exclude_if: Option<Py<PyAny>>,
 }
-
-impl_py_gc_traverse!(SerField {
-    serializer,
-    serialization_exclude_if
-});
 
 impl SerField {
     pub fn new(
@@ -95,7 +91,7 @@ fn exclude_default<'py>(
     Ok(false)
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, PyGcTraverse)]
 pub(super) enum FieldsMode {
     // typeddict with no extra items
     SimpleDict,
@@ -106,7 +102,7 @@ pub(super) enum FieldsMode {
 }
 
 /// General purpose serializer for fields - used by dataclasses, models and typed_dicts
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct GeneralFieldsSerializer {
     fields: AHashMap<PyBackedStr, SerField>,
     computed_fields: Option<ComputedFields>,
@@ -337,11 +333,6 @@ pub fn exclude_field_by_value<'py>(
 
     Ok(false)
 }
-
-impl_py_gc_traverse!(GeneralFieldsSerializer {
-    fields,
-    computed_fields
-});
 
 impl TypeSerializer for GeneralFieldsSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/filter.rs
+++ b/pydantic-core/src/serializers/filter.rs
@@ -7,11 +7,12 @@ use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PySet};
 
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::extra::IncludeExclude;
 use crate::tools::SchemaDict;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PyGcTraverse)]
 pub(crate) struct SchemaFilter<T> {
     include: Option<Box<AHashSet<T>>>,
     exclude: Option<Box<AHashSet<T>>>,
@@ -256,7 +257,7 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub(super) struct AnyFilter;
 
 impl AnyFilter {

--- a/pydantic-core/src/serializers/mod.rs
+++ b/pydantic-core/src/serializers/mod.rs
@@ -37,7 +37,7 @@ pub enum WarningsArg {
 }
 
 #[pyclass(module = "pydantic_core._pydantic_core", frozen)]
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct SchemaSerializer {
     serializer: Arc<CombinedSerializer>,
     definitions: Definitions<Arc<CombinedSerializer>>,
@@ -48,13 +48,6 @@ pub struct SchemaSerializer {
     py_schema: Py<PyDict>,
     py_config: Option<Py<PyDict>>,
 }
-
-impl_py_gc_traverse!(SchemaSerializer {
-    serializer,
-    definitions,
-    py_schema,
-    py_config,
-});
 
 #[pymethods]
 impl SchemaSerializer {

--- a/pydantic-core/src/serializers/polymorphism_trampoline.rs
+++ b/pydantic-core/src/serializers/polymorphism_trampoline.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
+use crate::py_gc::PyGcTraverse;
 use pyo3::{prelude::*, types::PyType};
 
 use crate::serializers::{
@@ -15,7 +16,7 @@ use crate::serializers::{
 ///
 /// This exists as a separate structure to allow for cases such as model serializers where the
 /// inner serializer may just be a function serializer and so cannot handle polymorphism itself.
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct PolymorphismTrampoline {
     class: Py<PyType>,
     /// Inner serializer used when the type is not a subclass (responsible for any fallback etc)
@@ -23,8 +24,6 @@ pub struct PolymorphismTrampoline {
     /// Whether polymorphic serialization is enabled from config
     enabled_from_config: bool,
 }
-
-impl_py_gc_traverse!(PolymorphismTrampoline { class, serializer });
 
 impl PolymorphismTrampoline {
     pub fn new(class: Py<PyType>, serializer: Arc<CombinedSerializer>, enabled_from_config: bool) -> Self {

--- a/pydantic-core/src/serializers/prebuilt.rs
+++ b/pydantic-core/src/serializers/prebuilt.rs
@@ -8,8 +8,9 @@ use crate::serializers::SerializationState;
 use crate::{common::prebuilt::get_prebuilt, serializers::polymorphism_trampoline::PolymorphismTrampoline};
 
 use super::shared::{CombinedSerializer, TypeSerializer};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct PrebuiltSerializer {
     schema_serializer: Py<SchemaSerializer>,
 }
@@ -40,8 +41,6 @@ impl PrebuiltSerializer {
         })
     }
 }
-
-impl_py_gc_traverse!(PrebuiltSerializer { schema_serializer });
 
 impl TypeSerializer for PrebuiltSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -5,10 +5,10 @@ use std::io::{self, Write};
 use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
+use pyo3::intern;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyString};
 use pyo3::{IntoPyObjectExt, prelude::*};
-use pyo3::{PyTraverseError, PyVisit, intern};
 
 use enum_dispatch::enum_dispatch;
 use serde::ser::SerializeMap as _;
@@ -18,7 +18,6 @@ use serde_json::ser::{Formatter, PrettyFormatter};
 use crate::build_tools::py_schema_err;
 use crate::build_tools::py_schema_error_type;
 use crate::definitions::DefinitionsBuilder;
-use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerMode;
 use crate::serializers::errors::WrappedSerError;
 use crate::serializers::polymorphism_trampoline::PolymorphismTrampoline;
@@ -48,7 +47,7 @@ macro_rules! combined_serializer {
         find_only: {$($builder:path;)*}
         both: {$($b_key:ident: $b_serializer:path;)*}
     ) => {
-        #[derive(Debug)]
+        #[derive(Debug, crate::py_gc::PyGcTraverse)]
         #[enum_dispatch]
         pub enum CombinedSerializer {
             $($e_key($e_serializer),)*
@@ -344,59 +343,6 @@ impl BuildSerializer for CombinedSerializer {
         let use_prebuilt = definitions.use_prebuilt();
         let serializer = Self::_build(schema, config, definitions, use_prebuilt)?;
         Self::maybe_wrap_in_polymorphism_trampoline(serializer, schema)
-    }
-}
-
-// Implemented by hand because `enum_dispatch` fails with a proc macro compile error =/
-impl PyGcTraverse for CombinedSerializer {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        match self {
-            CombinedSerializer::Function(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::FunctionWrap(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Fields(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Prebuilt(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::None(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Nullable(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Int(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Bool(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Float(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Decimal(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Fraction(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Str(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Bytes(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Datetime(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::TimeDelta(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Date(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Time(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::List(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Set(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::FrozenSet(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Generator(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Dict(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Model(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Dataclass(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Url(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::MultiHostUrl(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Any(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Format(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::ToString(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::WithDefault(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Json(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::JsonOrPython(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Union(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::TaggedUnion(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Literal(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::MissingSentinel(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Ellipsis(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Enum(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Recursive(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Tuple(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Uuid(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::Complex(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::TypedDict(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::NamedTuple(inner) => inner.py_gc_traverse(visit),
-            CombinedSerializer::PolymorphismTrampoline(inner) => inner.py_gc_traverse(visit),
-        }
     }
 }
 

--- a/pydantic-core/src/serializers/type_serializers/any.rs
+++ b/pydantic-core/src/serializers/type_serializers/any.rs
@@ -11,8 +11,9 @@ use serde::ser::Serializer;
 use crate::{definitions::DefinitionsBuilder, serializers::SerializationState};
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, infer_serialize, infer_to_python};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PyGcTraverse)]
 pub struct AnySerializer;
 
 impl AnySerializer {
@@ -33,8 +34,6 @@ impl BuildSerializer for AnySerializer {
         Ok(Self::get().clone())
     }
 }
-
-impl_py_gc_traverse!(AnySerializer {});
 
 impl TypeSerializer for AnySerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/bytes.rs
+++ b/pydantic-core/src/serializers/type_serializers/bytes.rs
@@ -5,6 +5,7 @@ use pyo3::types::{PyBytes, PyDict};
 use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::config::{BytesMode, FromConfig};
 
@@ -12,7 +13,7 @@ use super::{
     BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct BytesSerializer {
     bytes_mode: BytesMode,
 }
@@ -60,8 +61,6 @@ impl BuildSerializer for BytesSerializer {
         }
     }
 }
-
-impl_py_gc_traverse!(BytesSerializer {});
 
 impl TypeSerializer for BytesSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/complex.rs
+++ b/pydantic-core/src/serializers/type_serializers/complex.rs
@@ -8,8 +8,9 @@ use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 
 use super::{BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_serialize, infer_to_python};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct ComplexSerializer {}
 
 static COMPLEX_SERIALIZER: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| Arc::new(ComplexSerializer {}.into()));
@@ -24,8 +25,6 @@ impl BuildSerializer for ComplexSerializer {
         Ok(COMPLEX_SERIALIZER.clone())
     }
 }
-
-impl_py_gc_traverse!(ComplexSerializer {});
 
 impl TypeSerializer for ComplexSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -9,6 +9,7 @@ use ahash::AHashMap;
 
 use crate::build_tools::{ExtraBehavior, py_schema_error_type};
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::errors::unwrap_ser_error;
 use crate::serializers::shared::DoSerialize;
@@ -81,7 +82,7 @@ impl BuildSerializer for DataclassArgsBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct DataclassSerializer {
     class: Py<PyType>,
     serializer: Arc<CombinedSerializer>,
@@ -168,8 +169,6 @@ impl DataclassSerializer {
         }
     }
 }
-
-impl_py_gc_traverse!(DataclassSerializer { class, serializer });
 
 impl TypeSerializer for DataclassSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
+++ b/pydantic-core/src/serializers/type_serializers/datetime_etc.rs
@@ -64,7 +64,7 @@ macro_rules! build_temporal_serializer {
         $json_key_fn:ident,
         $serialize_fn:ident
     ) => {
-        #[derive(Debug)]
+        #[derive(Debug, crate::py_gc::PyGcTraverse)]
         pub struct $Struct {
             temporal_mode: TemporalMode,
         }
@@ -81,8 +81,6 @@ macro_rules! build_temporal_serializer {
                 Ok(Arc::new(Self { temporal_mode }.into()))
             }
         }
-
-        impl_py_gc_traverse!($Struct {});
 
         impl TypeSerializer for $Struct {
             fn to_python<'py>(

--- a/pydantic-core/src/serializers/type_serializers/decimal.rs
+++ b/pydantic-core/src/serializers/type_serializers/decimal.rs
@@ -10,8 +10,9 @@ use crate::serializers::infer::{infer_json_key_known, infer_serialize_known, inf
 use crate::serializers::ob_type::{IsType, ObType};
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, infer_serialize, infer_to_python};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct DecimalSerializer {}
 
 static DECIMAL_SERIALIZER: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| Arc::new(DecimalSerializer {}.into()));
@@ -27,8 +28,6 @@ impl BuildSerializer for DecimalSerializer {
         Ok(DECIMAL_SERIALIZER.clone())
     }
 }
-
-impl_py_gc_traverse!(DecimalSerializer {});
 
 impl TypeSerializer for DecimalSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/definitions.rs
+++ b/pydantic-core/src/serializers/type_serializers/definitions.rs
@@ -13,6 +13,7 @@ use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer, py_err_se_err};
+use crate::py_gc::PyGcTraverse;
 
 #[derive(Debug)]
 pub struct DefinitionsSerializerBuilder;
@@ -41,6 +42,7 @@ impl BuildSerializer for DefinitionsSerializerBuilder {
     }
 }
 
+#[derive(PyGcTraverse)]
 pub struct DefinitionRefSerializer {
     definition: DefinitionRef<Arc<CombinedSerializer>>,
     retry_with_lax_check: RecursionSafeCache<bool>,
@@ -72,8 +74,6 @@ impl BuildSerializer for DefinitionRefSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(DefinitionRefSerializer {});
 
 impl TypeSerializer for DefinitionRefSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/dict.rs
@@ -18,8 +18,9 @@ use super::{
     BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerMode, TypeSerializer, infer_serialize,
     infer_to_python, py_err_se_err,
 };
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct DictSerializer {
     key_serializer: Arc<CombinedSerializer>,
     value_serializer: Arc<CombinedSerializer>,
@@ -68,11 +69,6 @@ impl BuildSerializer for DictSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(DictSerializer {
-    key_serializer,
-    value_serializer
-});
 
 impl TypeSerializer for DictSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/ellipsis.rs
+++ b/pydantic-core/src/serializers/type_serializers/ellipsis.rs
@@ -16,8 +16,9 @@ use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct EllipsisSerializer {}
 
 static ELLIPSIS_SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
@@ -34,8 +35,6 @@ impl BuildSerializer for EllipsisSerializer {
         Ok(ELLIPSIS_SERIALIZER.clone())
     }
 }
-
-impl_py_gc_traverse!(EllipsisSerializer {});
 
 impl TypeSerializer for EllipsisSerializer {
     fn to_python(&self, value: &Bound<'_, PyAny>, _state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/enum_.rs
+++ b/pydantic-core/src/serializers/type_serializers/enum_.rs
@@ -16,14 +16,13 @@ use super::float::FloatSerializer;
 use super::simple::IntSerializer;
 use super::string::StrSerializer;
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct EnumSerializer {
     class: Py<PyType>,
     serializer: Option<Arc<CombinedSerializer>>,
 }
-
-impl_py_gc_traverse!(EnumSerializer { class, serializer });
 
 impl BuildSerializer for EnumSerializer {
     const EXPECTED_TYPE: &'static str = "enum";

--- a/pydantic-core/src/serializers/type_serializers/float.rs
+++ b/pydantic-core/src/serializers/type_serializers/float.rs
@@ -16,9 +16,10 @@ use super::{
     BuildSerializer, CombinedSerializer, IsType, ObType, SerCheck, SerMode, TypeSerializer, infer_json_key,
     infer_serialize, infer_to_python,
 };
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::errors::PydanticSerializationUnexpectedValue;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FloatSerializer {
     inf_nan_mode: InfNanMode,
 }
@@ -85,8 +86,6 @@ impl BuildSerializer for FloatSerializer {
         Self::get(schema.py(), config).cloned()
     }
 }
-
-impl_py_gc_traverse!(FloatSerializer {});
 
 impl TypeSerializer for FloatSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/format.rs
+++ b/pydantic-core/src/serializers/type_serializers/format.rs
@@ -18,8 +18,9 @@ use crate::tools::SchemaDict;
 
 use super::simple::none_json_key;
 use super::{BuildSerializer, CombinedSerializer, Extra, PydanticSerializationError, TypeSerializer, py_err_se_err};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, PyGcTraverse)]
 pub(super) enum WhenUsed {
     Always,
     UnlessNone,
@@ -58,7 +59,7 @@ impl WhenUsed {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FormatSerializer {
     format_func: Py<PyAny>,
     formatting_string: Py<PyString>,
@@ -109,8 +110,6 @@ impl FormatSerializer {
     }
 }
 
-impl_py_gc_traverse!(FormatSerializer { format_func });
-
 impl TypeSerializer for FormatSerializer {
     fn to_python(&self, value: &Bound<'_, PyAny>, state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {
         if self.when_used.should_use(value, &state.extra) {
@@ -159,7 +158,7 @@ impl TypeSerializer for FormatSerializer {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ToStringSerializer {
     when_used: WhenUsed,
 }
@@ -178,8 +177,6 @@ impl BuildSerializer for ToStringSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(ToStringSerializer {});
 
 impl TypeSerializer for ToStringSerializer {
     fn to_python(&self, value: &Bound<'_, PyAny>, state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/fraction.rs
+++ b/pydantic-core/src/serializers/type_serializers/fraction.rs
@@ -11,8 +11,9 @@ use crate::serializers::ob_type::{IsType, ObType};
 use crate::serializers::SerializationState;
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, infer_serialize, infer_to_python};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FractionSerializer {}
 
 static FRACTION_SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
@@ -29,8 +30,6 @@ impl BuildSerializer for FractionSerializer {
         Ok(FRACTION_SERIALIZER.clone())
     }
 }
-
-impl_py_gc_traverse!(FractionSerializer {});
 
 impl TypeSerializer for FractionSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -75,7 +75,7 @@ impl BuildSerializer for FunctionPlainSerializerBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FunctionPlainSerializer {
     func: Py<PyAny>,
     name: String,
@@ -282,12 +282,6 @@ macro_rules! function_type_serializer {
     };
 }
 
-impl_py_gc_traverse!(FunctionPlainSerializer {
-    func,
-    return_serializer,
-    fallback_serializer
-});
-
 function_type_serializer!(FunctionPlainSerializer);
 
 fn copy_outer_schema<'py>(schema: &Bound<'py, PyDict>) -> PyResult<Bound<'py, PyDict>> {
@@ -322,7 +316,7 @@ impl BuildSerializer for FunctionWrapSerializerBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FunctionWrapSerializer {
     serializer: Arc<CombinedSerializer>,
     func: Py<PyAny>,
@@ -418,25 +412,15 @@ impl FunctionWrapSerializer {
     }
 }
 
-impl_py_gc_traverse!(FunctionWrapSerializer {
-    serializer,
-    func,
-    return_serializer
-});
-
 function_type_serializer!(FunctionWrapSerializer);
 
 #[pyclass(module = "pydantic_core._pydantic_core")]
+#[derive(PyGcTraverse)]
 pub(crate) struct SerializationCallable {
     serializer: Arc<CombinedSerializer>,
     extra_owned: ExtraOwned,
     filter: AnyFilter,
 }
-
-impl_py_gc_traverse!(SerializationCallable {
-    serializer,
-    extra_owned
-});
 
 impl SerializationCallable {
     pub fn new(serializer: &Arc<CombinedSerializer>, state: &SerializationState<'_>) -> Self {
@@ -513,6 +497,7 @@ impl SerializationCallable {
 
 #[pyclass(module = "pydantic_core._pydantic_core")]
 #[cfg_attr(debug_assertions, derive(Debug))]
+#[derive(PyGcTraverse)]
 struct SerializationInfo {
     #[pyo3(get)]
     include: Option<Py<PyAny>>,
@@ -540,12 +525,6 @@ struct SerializationInfo {
     #[pyo3(get)]
     polymorphic_serialization: Option<bool>,
 }
-
-impl_py_gc_traverse!(SerializationInfo {
-    include,
-    exclude,
-    context
-});
 
 impl SerializationInfo {
     fn new(state: &SerializationState<'_>, is_field_serializer: bool) -> PyResult<Self> {

--- a/pydantic-core/src/serializers/type_serializers/generator.rs
+++ b/pydantic-core/src/serializers/type_serializers/generator.rs
@@ -21,7 +21,7 @@ use super::{
     infer_serialize, infer_to_python, py_err_se_err,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct GeneratorSerializer {
     item_serializer: Arc<CombinedSerializer>,
     filter: SchemaFilter<usize>,
@@ -47,8 +47,6 @@ impl BuildSerializer for GeneratorSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(GeneratorSerializer { item_serializer });
 
 impl TypeSerializer for GeneratorSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
@@ -130,6 +128,7 @@ impl TypeSerializer for GeneratorSerializer {
 }
 
 #[pyclass(module = "pydantic_core._pydantic_core")]
+#[derive(PyGcTraverse)]
 pub(crate) struct SerializationIterator {
     iterator: Py<PyIterator>,
     #[pyo3(get)]
@@ -138,12 +137,6 @@ pub(crate) struct SerializationIterator {
     extra_owned: ExtraOwned,
     filter: SchemaFilter<usize>,
 }
-
-impl_py_gc_traverse!(SerializationIterator {
-    iterator,
-    item_serializer,
-    extra_owned,
-});
 
 impl SerializationIterator {
     pub fn new(

--- a/pydantic-core/src/serializers/type_serializers/json.rs
+++ b/pydantic-core/src/serializers/type_serializers/json.rs
@@ -17,8 +17,9 @@ use super::any::AnySerializer;
 use super::{
     BuildSerializer, CombinedSerializer, TypeSerializer, infer_json_key, py_err_se_err, to_json_bytes, utf8_py_error,
 };
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct JsonSerializer {
     serializer: Arc<CombinedSerializer>,
 }
@@ -40,8 +41,6 @@ impl BuildSerializer for JsonSerializer {
         Ok(Arc::new(Self { serializer }.into()))
     }
 }
-
-impl_py_gc_traverse!(JsonSerializer { serializer });
 
 impl TypeSerializer for JsonSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/json_or_python.rs
+++ b/pydantic-core/src/serializers/type_serializers/json_or_python.rs
@@ -7,10 +7,11 @@ use pyo3::types::PyDict;
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct JsonOrPythonSerializer {
     json: Arc<CombinedSerializer>,
     python: Arc<CombinedSerializer>,
@@ -41,8 +42,6 @@ impl BuildSerializer for JsonOrPythonSerializer {
         Ok(Arc::new(Self { json, python, name }.into()))
     }
 }
-
-impl_py_gc_traverse!(JsonOrPythonSerializer { json, python });
 
 impl TypeSerializer for JsonOrPythonSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/list.rs
+++ b/pydantic-core/src/serializers/type_serializers/list.rs
@@ -17,8 +17,9 @@ use super::{
     BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, TypeSerializer, infer_serialize,
     infer_to_python, py_err_se_err,
 };
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ListSerializer {
     item_serializer: Arc<CombinedSerializer>,
     filter: SchemaFilter<usize>,
@@ -49,8 +50,6 @@ impl BuildSerializer for ListSerializer {
         ))
     }
 }
-
-impl_py_gc_traverse!(ListSerializer { item_serializer });
 
 impl TypeSerializer for ListSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/literal.rs
+++ b/pydantic-core/src/serializers/type_serializers/literal.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 
 use crate::build_tools::py_schema_err;
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
@@ -19,7 +20,7 @@ use super::{
     py_err_se_err,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct LiteralSerializer {
     expected_int: Box<AHashSet<i64>>,
     expected_str: Box<AHashSet<String>>,
@@ -110,8 +111,6 @@ impl LiteralSerializer {
         }
     }
 }
-
-impl_py_gc_traverse!(LiteralSerializer { expected_py });
 
 impl TypeSerializer for LiteralSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
+++ b/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
@@ -19,8 +19,9 @@ use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct MissingSentinelSerializer {}
 
 static MISSING_SENTINEL_SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
@@ -37,8 +38,6 @@ impl BuildSerializer for MissingSentinelSerializer {
         Ok(MISSING_SENTINEL_SERIALIZER.clone())
     }
 }
-
-impl_py_gc_traverse!(MissingSentinelSerializer {});
 
 impl TypeSerializer for MissingSentinelSerializer {
     fn to_python(&self, value: &Bound<'_, PyAny>, _state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -17,6 +17,7 @@ use crate::build_tools::py_schema_err;
 use crate::build_tools::{ExtraBehavior, py_schema_error_type};
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::shared::DoSerialize;
 use crate::serializers::shared::serialize_to_json;
@@ -94,7 +95,7 @@ impl BuildSerializer for ModelFieldsBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ModelSerializer {
     class: Py<PyType>,
     serializer: Arc<CombinedSerializer>,
@@ -253,8 +254,6 @@ impl ModelSerializer {
         }
     }
 }
-
-impl_py_gc_traverse!(ModelSerializer { class, serializer });
 
 impl TypeSerializer for ModelSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/named_tuple.rs
+++ b/pydantic-core/src/serializers/type_serializers/named_tuple.rs
@@ -20,8 +20,9 @@ use super::{
     BuildSerializer, CombinedSerializer, PydanticSerializer, SchemaFilter, SerMode, TypeSerializer, infer_json_key,
     infer_serialize, infer_to_python, py_err_se_err,
 };
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct NamedTupleSerializer {
     class: Py<PyType>,
     serializers: Vec<Arc<CombinedSerializer>>,
@@ -66,8 +67,6 @@ impl BuildSerializer for NamedTupleSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(NamedTupleSerializer { class, serializers });
 
 impl TypeSerializer for NamedTupleSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/nullable.rs
+++ b/pydantic-core/src/serializers/type_serializers/nullable.rs
@@ -10,8 +10,9 @@ use crate::serializers::SerializationState;
 use crate::tools::SchemaDict;
 
 use super::{BuildSerializer, CombinedSerializer, IsType, ObType, TypeSerializer, infer_json_key_known};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct NullableSerializer {
     serializer: Arc<CombinedSerializer>,
 }
@@ -31,8 +32,6 @@ impl BuildSerializer for NullableSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(NullableSerializer { serializer });
 
 impl TypeSerializer for NullableSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
+++ b/pydantic-core/src/serializers/type_serializers/set_frozenset.rs
@@ -18,7 +18,7 @@ use super::{
 
 macro_rules! build_serializer {
     ($struct_name:ident, $expected_type:literal, $py_type:ty) => {
-        #[derive(Debug)]
+        #[derive(Debug, crate::py_gc::PyGcTraverse)]
         pub struct $struct_name {
             item_serializer: Arc<CombinedSerializer>,
             name: String,
@@ -47,8 +47,6 @@ macro_rules! build_serializer {
                 ))
             }
         }
-
-        impl_py_gc_traverse!($struct_name { item_serializer });
 
         impl TypeSerializer for $struct_name {
             fn to_python<'py>(

--- a/pydantic-core/src/serializers/type_serializers/simple.rs
+++ b/pydantic-core/src/serializers/type_serializers/simple.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use crate::PydanticSerializationUnexpectedValue;
 use crate::{definitions::DefinitionsBuilder, input::Int};
 
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 
 use super::{
@@ -17,7 +18,7 @@ use super::{
     infer_serialize, infer_to_python,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct NoneSerializer;
 
 static NONE_SERIALIZER: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| Arc::new(NoneSerializer.into()));
@@ -37,8 +38,6 @@ impl BuildSerializer for NoneSerializer {
 pub(crate) fn none_json_key() -> PyResult<Cow<'static, str>> {
     Ok(Cow::Borrowed("None"))
 }
-
-impl_py_gc_traverse!(NoneSerializer {});
 
 impl TypeSerializer for NoneSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
@@ -89,7 +88,7 @@ impl TypeSerializer for NoneSerializer {
 
 macro_rules! build_simple_serializer {
     ($struct_name:ident, $expected_type:literal, $rust_type:ty, $ob_type:expr, $key_method:ident, $subtypes_allowed:expr) => {
-        #[derive(Debug)]
+        #[derive(Debug, crate::py_gc::PyGcTraverse)]
         pub struct $struct_name;
 
         impl $struct_name {
@@ -111,8 +110,6 @@ macro_rules! build_simple_serializer {
                 Ok(Self::get().clone())
             }
         }
-
-        impl_py_gc_traverse!($struct_name {});
 
         impl TypeSerializer for $struct_name {
             fn to_python<'py>(

--- a/pydantic-core/src/serializers/type_serializers/string.rs
+++ b/pydantic-core/src/serializers/type_serializers/string.rs
@@ -5,6 +5,7 @@ use pyo3::types::{PyDict, PyString};
 use pyo3::{IntoPyObjectExt, prelude::*};
 
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::errors::unwrap_ser_error;
 use crate::serializers::shared::{DoSerialize, serialize_to_json};
@@ -14,7 +15,7 @@ use super::{
     infer_to_python,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct StrSerializer;
 
 static STR_SERIALIZER: LazyLock<Arc<CombinedSerializer>> = LazyLock::new(|| Arc::new(StrSerializer.into()));
@@ -36,8 +37,6 @@ impl BuildSerializer for StrSerializer {
         Ok(Self::get().clone())
     }
 }
-
-impl_py_gc_traverse!(StrSerializer {});
 
 impl TypeSerializer for StrSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/timedelta.rs
+++ b/pydantic-core/src/serializers/type_serializers/timedelta.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::definitions::DefinitionsBuilder;
 use crate::input::EitherTimedelta;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::config::{FromConfig, TemporalMode, TimedeltaMode};
 
@@ -13,7 +14,7 @@ use super::{
     BuildSerializer, CombinedSerializer, SerMode, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct TimeDeltaSerializer {
     temporal_mode: TemporalMode,
 }
@@ -39,8 +40,6 @@ impl BuildSerializer for TimeDeltaSerializer {
         Ok(Arc::new(Self { temporal_mode }.into()))
     }
 }
-
-impl_py_gc_traverse!(TimeDeltaSerializer {});
 
 impl TypeSerializer for TimeDeltaSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/tuple.rs
+++ b/pydantic-core/src/serializers/type_serializers/tuple.rs
@@ -9,6 +9,7 @@ use serde::ser::SerializeSeq;
 
 use crate::PydanticSerializationUnexpectedValue;
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 use crate::serializers::extra::IncludeExclude;
 use crate::serializers::extra::SerCheck;
@@ -20,7 +21,7 @@ use super::{
     infer_serialize, infer_to_python, py_err_se_err,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct TupleSerializer {
     serializers: Vec<Arc<CombinedSerializer>>,
     variadic_item_index: Option<usize>,
@@ -59,8 +60,6 @@ impl BuildSerializer for TupleSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(TupleSerializer { serializers });
 
 impl TypeSerializer for TupleSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/serializers/type_serializers/typed_dict.rs
+++ b/pydantic-core/src/serializers/type_serializers/typed_dict.rs
@@ -16,13 +16,12 @@ use crate::serializers::shared::TypeSerializer;
 use crate::tools::SchemaDict;
 
 use super::{BuildSerializer, CombinedSerializer, ComputedFields, FieldsMode, GeneralFieldsSerializer, SerField};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct TypedDictSerializer {
     serializer: GeneralFieldsSerializer,
 }
-
-impl_py_gc_traverse!(TypedDictSerializer { serializer });
 
 impl BuildSerializer for TypedDictSerializer {
     const EXPECTED_TYPE: &'static str = "typed-dict";

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -9,6 +9,7 @@ use std::sync::OnceLock;
 use crate::build_tools::py_schema_err;
 use crate::common::union::{Discriminator, SMALL_UNION_THRESHOLD};
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::PydanticSerializationUnexpectedValue;
 use crate::serializers::SerializationState;
 use crate::serializers::extra::IncludeExclude;
@@ -20,7 +21,7 @@ use super::{
     BuildSerializer, CombinedSerializer, SerCheck, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct UnionSerializer {
     choices: UnionChoices,
     name: String,
@@ -65,8 +66,6 @@ impl BuildSerializer for UnionSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(UnionSerializer { choices });
 
 impl TypeSerializer for UnionSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
@@ -113,7 +112,7 @@ impl TypeSerializer for UnionSerializer {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct TaggedUnionSerializer {
     discriminator: Box<Discriminator>,
     lookup: PyHashTable<usize>,
@@ -160,12 +159,6 @@ impl BuildSerializer for TaggedUnionSerializer {
         .into())
     }
 }
-
-impl_py_gc_traverse!(TaggedUnionSerializer {
-    discriminator,
-    lookup,
-    choices
-});
 
 impl TypeSerializer for TaggedUnionSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
@@ -329,12 +322,10 @@ fn initial_check_level(state: &SerializationState<'_>) -> SerCheck {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct UnionChoices {
     choices: Vec<Arc<CombinedSerializer>>,
 }
-
-impl_py_gc_traverse!(UnionChoices { choices });
 
 enum FromChoicesOutput {
     Single(Arc<CombinedSerializer>),

--- a/pydantic-core/src/serializers/type_serializers/url.rs
+++ b/pydantic-core/src/serializers/type_serializers/url.rs
@@ -15,7 +15,7 @@ use super::{
 
 macro_rules! build_serializer {
     ($struct_name:ident, $expected_type:literal, $extract:ty) => {
-        #[derive(Debug)]
+        #[derive(Debug, crate::py_gc::PyGcTraverse)]
         pub struct $struct_name;
 
         impl BuildSerializer for $struct_name {
@@ -31,8 +31,6 @@ macro_rules! build_serializer {
                 Ok(SERIALIZER.clone())
             }
         }
-
-        impl_py_gc_traverse!($struct_name {});
 
         impl TypeSerializer for $struct_name {
             fn to_python<'py>(

--- a/pydantic-core/src/serializers/type_serializers/uuid.rs
+++ b/pydantic-core/src/serializers/type_serializers/uuid.rs
@@ -6,6 +6,7 @@ use pyo3::{IntoPyObjectExt, intern, prelude::*};
 use uuid::Uuid;
 
 use crate::definitions::DefinitionsBuilder;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::SerializationState;
 
 use super::{
@@ -20,13 +21,11 @@ pub(crate) fn uuid_to_string(py_uuid: &Bound<'_, PyAny>) -> PyResult<String> {
     Ok(uuid.to_string())
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct UuidSerializer;
 
 static UUID_SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
     LazyLock::new(|| Arc::new(CombinedSerializer::from(UuidSerializer {})));
-
-impl_py_gc_traverse!(UuidSerializer {});
 
 impl BuildSerializer for UuidSerializer {
     const EXPECTED_TYPE: &'static str = "uuid";

--- a/pydantic-core/src/serializers/type_serializers/with_default.rs
+++ b/pydantic-core/src/serializers/type_serializers/with_default.rs
@@ -11,8 +11,9 @@ use crate::tools::SchemaDict;
 use crate::validators::DefaultType;
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct WithDefaultSerializer {
     default: DefaultType,
     serializer: Arc<CombinedSerializer>,
@@ -35,8 +36,6 @@ impl BuildSerializer for WithDefaultSerializer {
         Ok(Arc::new(Self { default, serializer }.into()))
     }
 }
-
-impl_py_gc_traverse!(WithDefaultSerializer { default, serializer });
 
 impl TypeSerializer for WithDefaultSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {

--- a/pydantic-core/src/tools.rs
+++ b/pydantic-core/src/tools.rs
@@ -1,8 +1,6 @@
 use core::fmt;
 
 use hashbrown::HashTable;
-use pyo3::PyTraverseError;
-use pyo3::PyVisit;
 use pyo3::exceptions::PyKeyError;
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -203,23 +201,16 @@ pub fn mapping_get<'py>(
 }
 
 /// A hash table which uses (hashable) Python objects as keys
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct PyHashTable<T>(HashTable<PyHashTableEntry<T>>);
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct PyHashTableEntry<T> {
     key: Py<PyAny>,
     /// Precomputed hash value (from Python hash) - this avoids possibility of Python
     /// dynamic nature causing rehashing to fail
     hash: u64,
     value: T,
-}
-
-impl PyGcTraverse for PyHashTable<usize> {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        // traverse only the keys, as the values are just usize indices
-        self.0.iter().try_for_each(|entry| entry.key.py_gc_traverse(visit))
-    }
 }
 
 impl<T> PyHashTable<T> {
@@ -296,21 +287,6 @@ fn hash_object(value: &Bound<'_, PyAny>) -> PyResult<u64> {
 // TODO: replace with isize::cast_unsigned on MSRV 1.87
 fn cast_unsigned(x: isize) -> usize {
     x as usize
-}
-
-impl<T: PyGcTraverse> PyGcTraverse for PyHashTableEntry<T> {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        self.key.py_gc_traverse(visit)?;
-        self.value.py_gc_traverse(visit)?;
-        Ok(())
-    }
-}
-
-impl PyGcTraverse for usize {
-    #[inline]
-    fn py_gc_traverse(&self, _visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        Ok(())
-    }
 }
 
 pub const ROOT_FIELD: &str = "root";

--- a/pydantic-core/src/validators/any.rs
+++ b/pydantic-core/src/validators/any.rs
@@ -5,13 +5,14 @@ use pyo3::types::PyDict;
 
 use crate::errors::ValResult;
 use crate::input::Input;
+use crate::py_gc::PyGcTraverse;
 
 use super::{
     BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, validation_state::Exactness,
 };
 
 /// This might seem useless, but it's useful in DictValidator to avoid Option<Validator> a lot
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct AnyValidator;
 
 static ANY_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| Arc::new(AnyValidator.into()));
@@ -27,8 +28,6 @@ impl BuildValidator for AnyValidator {
         Ok(ANY_VALIDATOR.clone())
     }
 }
-
-impl_py_gc_traverse!(AnyValidator {});
 
 impl Validator for AnyValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/arguments.rs
+++ b/pydantic-core/src/validators/arguments.rs
@@ -19,8 +19,9 @@ use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, PyGcTraverse)]
 enum VarKwargsMode {
     Uniform,
     UnpackedTypedDict,
@@ -41,7 +42,7 @@ impl FromStr for VarKwargsMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct Parameter {
     positional: bool,
     name: PyBackedStr,
@@ -51,7 +52,7 @@ struct Parameter {
     lookup_path_collection: Option<LookupPathCollection>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ArgumentsValidator {
     parameters: Vec<Parameter>,
     positional_params_count: usize,
@@ -176,14 +177,6 @@ impl BuildValidator for ArgumentsValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(Parameter { validator });
-
-impl_py_gc_traverse!(ArgumentsValidator {
-    parameters,
-    var_args_validator,
-    var_kwargs_validator
-});
 
 impl Validator for ArgumentsValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/arguments_v3.rs
+++ b/pydantic-core/src/validators/arguments_v3.rs
@@ -23,8 +23,9 @@ use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, PyGcTraverse)]
 enum ParameterMode {
     PositionalOnly,
     PositionalOrKeyword,
@@ -50,7 +51,7 @@ impl FromStr for ParameterMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct Parameter {
     name: PyBackedStr,
     mode: ParameterMode,
@@ -67,7 +68,7 @@ impl Parameter {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ArgumentsV3Validator {
     parameters: Vec<Parameter>,
     positional_params_count: usize,
@@ -214,10 +215,6 @@ impl BuildValidator for ArgumentsV3Validator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(Parameter { validator });
-
-impl_py_gc_traverse!(ArgumentsV3Validator { parameters });
 
 impl ArgumentsV3Validator {
     /// Validate the arguments from a mapping:

--- a/pydantic-core/src/validators/bool.rs
+++ b/pydantic-core/src/validators/bool.rs
@@ -8,8 +8,9 @@ use crate::errors::ValResult;
 use crate::input::Input;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct BoolValidator {
     strict: bool,
 }
@@ -35,8 +36,6 @@ impl BuildValidator for BoolValidator {
         }
     }
 }
-
-impl_py_gc_traverse!(BoolValidator {});
 
 impl Validator for BoolValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/bytes.rs
+++ b/pydantic-core/src/validators/bytes.rs
@@ -13,8 +13,9 @@ use crate::tools::SchemaDict;
 
 use super::config::ValBytesMode;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct BytesValidator {
     strict: bool,
     bytes_mode: ValBytesMode,
@@ -43,8 +44,6 @@ impl BuildValidator for BytesValidator {
     }
 }
 
-impl_py_gc_traverse!(BytesValidator {});
-
 impl Validator for BytesValidator {
     fn validate<'py>(
         &self,
@@ -62,15 +61,13 @@ impl Validator for BytesValidator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct BytesConstrainedValidator {
     strict: bool,
     bytes_mode: ValBytesMode,
     max_length: Option<usize>,
     min_length: Option<usize>,
 }
-
-impl_py_gc_traverse!(BytesConstrainedValidator {});
 
 impl Validator for BytesConstrainedValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/call.rs
+++ b/pydantic-core/src/validators/call.rs
@@ -13,8 +13,9 @@ use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct CallValidator {
     function: Py<PyAny>,
     arguments_validator: Arc<CombinedValidator>,
@@ -69,12 +70,6 @@ impl BuildValidator for CallValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(CallValidator {
-    function,
-    arguments_validator,
-    return_validator
-});
 
 impl Validator for CallValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/callable.rs
+++ b/pydantic-core/src/validators/callable.rs
@@ -8,8 +8,9 @@ use crate::input::Input;
 
 use super::validation_state::Exactness;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct CallableValidator;
 
 static CALLABLE_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| Arc::new(CallableValidator.into()));
@@ -25,8 +26,6 @@ impl BuildValidator for CallableValidator {
         Ok(CALLABLE_VALIDATOR.clone())
     }
 }
-
-impl_py_gc_traverse!(CallableValidator {});
 
 impl Validator for CallableValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/chain.rs
+++ b/pydantic-core/src/validators/chain.rs
@@ -11,8 +11,9 @@ use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ChainValidator {
     steps: Vec<Arc<CombinedValidator>>,
     name: String,
@@ -68,8 +69,6 @@ fn build_validator_steps(
         Ok(vec![validator])
     }
 }
-
-impl_py_gc_traverse!(ChainValidator { steps });
 
 impl Validator for ChainValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/complex.rs
+++ b/pydantic-core/src/validators/complex.rs
@@ -10,6 +10,7 @@ use crate::errors::{ErrorTypeDefaults, ToErrorValue, ValError, ValResult};
 use crate::input::Input;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 static COMPLEX_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
 
@@ -19,7 +20,7 @@ pub fn get_complex_type(py: Python<'_>) -> &Bound<'_, PyType> {
         .bind(py)
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ComplexValidator {
     strict: bool,
 }
@@ -44,8 +45,6 @@ impl BuildValidator for ComplexValidator {
         }
     }
 }
-
-impl_py_gc_traverse!(ComplexValidator {});
 
 impl Validator for ComplexValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/config.rs
+++ b/pydantic-core/src/validators/config.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use crate::build_tools::py_schema_err;
 use crate::errors::ErrorType;
 use crate::input::EitherBytes;
+use crate::py_gc::PyGcTraverse;
 use crate::serializers::BytesMode;
 use crate::tools::SchemaDict;
 use base64::engine::general_purpose::GeneralPurpose;
@@ -22,7 +23,7 @@ const STANDARD_OPTIONAL_PADDING: GeneralPurpose = GeneralPurpose::new(
     GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent),
 );
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PyGcTraverse)]
 pub enum TemporalUnitMode {
     Seconds,
     Milliseconds,
@@ -70,7 +71,7 @@ impl From<TemporalUnitMode> for TimestampUnit {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PyGcTraverse)]
 pub struct ValBytesMode {
     pub ser: BytesMode,
 }

--- a/pydantic-core/src/validators/custom_error.rs
+++ b/pydantic-core/src/validators/custom_error.rs
@@ -12,8 +12,9 @@ use crate::tools::SchemaDict;
 
 use super::validation_state::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub enum CustomError {
     Custom(PydanticCustomError),
     KnownError(PydanticKnownError),
@@ -59,7 +60,7 @@ impl CustomError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct CustomErrorValidator {
     validator: Arc<CombinedValidator>,
     custom_error: CustomError,
@@ -86,8 +87,6 @@ impl BuildValidator for CustomErrorValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(CustomErrorValidator { validator });
 
 impl Validator for CustomErrorValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/dataclass.rs
+++ b/pydantic-core/src/validators/dataclass.rs
@@ -23,8 +23,9 @@ use crate::validators::function::convert_err;
 use super::model::{Revalidate, create_class, force_setattr};
 use super::validation_state::Exactness;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct Field {
     kw_only: bool,
     name: PyBackedStr,
@@ -35,7 +36,7 @@ struct Field {
     frozen: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct DataclassArgsValidator {
     fields: Vec<Field>,
     positional_count: usize,
@@ -133,10 +134,6 @@ impl BuildValidator for DataclassArgsValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(Field { validator });
-
-impl_py_gc_traverse!(DataclassArgsValidator { fields });
 
 impl Validator for DataclassArgsValidator {
     fn validate<'py>(
@@ -447,7 +444,7 @@ impl Validator for DataclassArgsValidator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct DataclassValidator {
     strict: bool,
     validator: Arc<CombinedValidator>,
@@ -512,12 +509,6 @@ impl BuildValidator for DataclassValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(DataclassValidator {
-    class,
-    generic_origin,
-    validator
-});
 
 impl Validator for DataclassValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/date.rs
+++ b/pydantic-core/src/validators/date.rs
@@ -15,8 +15,9 @@ use crate::validators::datetime::{NowConstraint, NowOp};
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 use super::{Exactness, TemporalUnitMode};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct DateValidator {
     strict: bool,
     constraints: Option<DateConstraints>,
@@ -39,8 +40,6 @@ impl BuildValidator for DateValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(DateValidator {});
 
 impl Validator for DateValidator {
     fn validate<'py>(
@@ -156,7 +155,7 @@ fn date_from_datetime<'py>(
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 struct DateConstraints {
     le: Option<Date>,
     lt: Option<Date>,

--- a/pydantic-core/src/validators/datetime.rs
+++ b/pydantic-core/src/validators/datetime.rs
@@ -16,10 +16,11 @@ use crate::input::{EitherDateTime, Input};
 
 use super::Exactness;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 use crate::tools::SchemaDict;
 use crate::validators::config::TemporalUnitMode;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct DateTimeValidator {
     strict: bool,
     constraints: Option<DateTimeConstraints>,
@@ -58,8 +59,6 @@ impl BuildValidator for DateTimeValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(DateTimeValidator {});
 
 impl Validator for DateTimeValidator {
     fn validate<'py>(
@@ -183,7 +182,7 @@ fn datetime_from_date<'py>(input: &(impl Input<'py> + ?Sized)) -> Result<Option<
     Ok(Some(EitherDateTime::Raw(datetime)))
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 struct DateTimeConstraints {
     le: Option<DateTime>,
     lt: Option<DateTime>,
@@ -228,7 +227,7 @@ fn py_datetime_as_datetime(schema: &Bound<'_, PyDict>, key: &Bound<'_, PyString>
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub enum NowOp {
     Past,
     Future,
@@ -252,7 +251,7 @@ impl NowOp {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct NowConstraint {
     pub op: NowOp,
     utc_offset: Option<i32>,
@@ -285,7 +284,7 @@ impl NowConstraint {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub(super) enum TZConstraint {
     Naive,
     Aware(Option<i32>),

--- a/pydantic-core/src/validators/decimal.rs
+++ b/pydantic-core/src/validators/decimal.rs
@@ -15,6 +15,7 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 static DECIMAL_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
 
@@ -46,7 +47,7 @@ fn validate_as_decimal(
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct DecimalValidator {
     strict: bool,
     allow_inf_nan: bool,
@@ -93,14 +94,6 @@ impl BuildValidator for DecimalValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(DecimalValidator {
-    multiple_of,
-    le,
-    lt,
-    ge,
-    gt
-});
 
 fn extract_decimal_digits_info(decimal: &Bound<'_, PyAny>, normalized: bool) -> ValResult<(u64, u64)> {
     let py = decimal.py();

--- a/pydantic-core/src/validators/definitions.rs
+++ b/pydantic-core/src/validators/definitions.rs
@@ -14,6 +14,7 @@ use crate::recursion_guard::RecursionGuard;
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
 #[derive(Debug, Clone)]
 pub struct DefinitionsValidatorBuilder;
@@ -43,7 +44,7 @@ impl BuildValidator for DefinitionsValidatorBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct DefinitionRefValidator {
     definition: DefinitionRef<Arc<CombinedValidator>>,
 }
@@ -68,8 +69,6 @@ impl BuildValidator for DefinitionRefValidator {
         Ok(CombinedValidator::DefinitionRef(Self::new(definition)).into())
     }
 }
-
-impl_py_gc_traverse!(DefinitionRefValidator {});
 
 impl Validator for DefinitionRefValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/dict.rs
+++ b/pydantic-core/src/validators/dict.rs
@@ -15,8 +15,9 @@ use crate::tools::SchemaDict;
 use super::any::AnyValidator;
 use super::list::length_check;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct DictValidator {
     strict: bool,
     key_validator: Arc<CombinedValidator>,
@@ -62,11 +63,6 @@ impl BuildValidator for DictValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(DictValidator {
-    key_validator,
-    value_validator
-});
 
 impl Validator for DictValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/ellipsis.rs
+++ b/pydantic-core/src/validators/ellipsis.rs
@@ -8,8 +8,9 @@ use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct EllipsisValidator {}
 
 static ELLIPSIS_VALIDATOR: LazyLock<Arc<CombinedValidator>> =
@@ -26,8 +27,6 @@ impl BuildValidator for EllipsisValidator {
         Ok(ELLIPSIS_VALIDATOR.clone())
     }
 }
-
-impl_py_gc_traverse!(EllipsisValidator {});
 
 impl Validator for EllipsisValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/enum_.rs
+++ b/pydantic-core/src/validators/enum_.rs
@@ -16,6 +16,7 @@ use crate::validators::literal::expected_repr;
 use super::is_instance::class_repr;
 use super::literal::LiteralLookup;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 #[derive(Debug, Clone)]
 pub struct BuildEnumValidator;
@@ -83,7 +84,7 @@ pub trait EnumValidateValue: std::fmt::Debug + Clone + Send + Sync {
     ) -> ValResult<Option<Py<PyAny>>>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct EnumValidator<T: EnumValidateValue> {
     phantom: PhantomData<T>,
     class: Py<PyType>,
@@ -168,8 +169,6 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
 #[derive(Debug, Clone)]
 pub struct PlainEnumValidator;
 
-impl_py_gc_traverse!(EnumValidator<PlainEnumValidator> { class, lookup, missing });
-
 impl EnumValidateValue for PlainEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(
         py: Python<'py>,
@@ -200,8 +199,6 @@ impl EnumValidateValue for PlainEnumValidator {
 #[derive(Debug, Clone)]
 pub struct IntEnumValidator;
 
-impl_py_gc_traverse!(EnumValidator<IntEnumValidator> { class, lookup, missing });
-
 impl EnumValidateValue for IntEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(
         py: Python<'py>,
@@ -216,8 +213,6 @@ impl EnumValidateValue for IntEnumValidator {
 #[derive(Debug, Clone)]
 pub struct StrEnumValidator;
 
-impl_py_gc_traverse!(EnumValidator<StrEnumValidator> { class, lookup, missing });
-
 impl EnumValidateValue for StrEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(
         py: Python,
@@ -231,8 +226,6 @@ impl EnumValidateValue for StrEnumValidator {
 
 #[derive(Debug, Clone)]
 pub struct FloatEnumValidator;
-
-impl_py_gc_traverse!(EnumValidator<FloatEnumValidator> { class, lookup, missing });
 
 impl EnumValidateValue for FloatEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(

--- a/pydantic-core/src/validators/float.rs
+++ b/pydantic-core/src/validators/float.rs
@@ -12,6 +12,7 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 pub struct FloatBuilder;
 
@@ -40,7 +41,7 @@ impl BuildValidator for FloatBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct FloatValidator {
     strict: bool,
     allow_inf_nan: bool,
@@ -63,8 +64,6 @@ impl BuildValidator for FloatValidator {
     }
 }
 
-impl_py_gc_traverse!(FloatValidator {});
-
 impl Validator for FloatValidator {
     fn validate<'py>(
         &self,
@@ -84,7 +83,7 @@ impl Validator for FloatValidator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct ConstrainedFloatValidator {
     strict: bool,
     allow_inf_nan: bool,
@@ -94,8 +93,6 @@ pub struct ConstrainedFloatValidator {
     ge: Option<f64>,
     gt: Option<f64>,
 }
-
-impl_py_gc_traverse!(ConstrainedFloatValidator {});
 
 impl Validator for ConstrainedFloatValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/fraction.rs
+++ b/pydantic-core/src/validators/fraction.rs
@@ -13,6 +13,7 @@ use crate::errors::{ErrorType, Number, ToErrorValue, ValError};
 use crate::input::Input;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 static FRACTION_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
 
@@ -44,7 +45,7 @@ fn validate_as_fraction(
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct FractionValidator {
     strict: bool,
     le: Option<Py<PyAny>>,
@@ -72,8 +73,6 @@ impl BuildValidator for FractionValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(FractionValidator { le, lt, ge, gt });
 
 impl Validator for FractionValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/frozenset.rs
+++ b/pydantic-core/src/validators/frozenset.rs
@@ -11,8 +11,9 @@ use super::list::min_length_check;
 use super::set::set_build;
 use super::validation_state::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FrozenSetValidator {
     strict: bool,
     item_validator: Arc<CombinedValidator>,
@@ -26,8 +27,6 @@ impl BuildValidator for FrozenSetValidator {
     const EXPECTED_TYPE: &'static str = "frozenset";
     set_build!();
 }
-
-impl_py_gc_traverse!(FrozenSetValidator { item_validator });
 
 impl Validator for FrozenSetValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/function.rs
+++ b/pydantic-core/src/validators/function.rs
@@ -81,7 +81,7 @@ macro_rules! impl_build {
     };
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FunctionBeforeValidator {
     validator: Arc<CombinedValidator>,
     func: Py<PyAny>,
@@ -117,12 +117,6 @@ impl FunctionBeforeValidator {
     }
 }
 
-impl_py_gc_traverse!(FunctionBeforeValidator {
-    validator,
-    func,
-    config
-});
-
 impl Validator for FunctionBeforeValidator {
     fn validate<'py>(
         &self,
@@ -154,7 +148,7 @@ impl Validator for FunctionBeforeValidator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FunctionAfterValidator {
     validator: Arc<CombinedValidator>,
     func: Py<PyAny>,
@@ -190,12 +184,6 @@ impl FunctionAfterValidator {
     }
 }
 
-impl_py_gc_traverse!(FunctionAfterValidator {
-    validator,
-    func,
-    config
-});
-
 impl Validator for FunctionAfterValidator {
     fn validate<'py>(
         &self,
@@ -227,7 +215,7 @@ impl Validator for FunctionAfterValidator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct FunctionPlainValidator {
     func: Py<PyAny>,
     config: Py<PyAny>,
@@ -260,8 +248,6 @@ impl BuildValidator for FunctionPlainValidator {
     }
 }
 
-impl_py_gc_traverse!(FunctionPlainValidator { func, config });
-
 impl Validator for FunctionPlainValidator {
     fn validate<'py>(
         &self,
@@ -288,7 +274,7 @@ impl Validator for FunctionPlainValidator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct FunctionWrapValidator {
     validator: Arc<CombinedValidator>,
     func: Py<PyAny>,
@@ -352,12 +338,6 @@ impl FunctionWrapValidator {
         r.map_err(|e| convert_err(py, e, input))
     }
 }
-
-impl_py_gc_traverse!(FunctionWrapValidator {
-    validator,
-    func,
-    config
-});
 
 impl Validator for FunctionWrapValidator {
     fn validate<'py>(
@@ -524,6 +504,7 @@ pub fn convert_err(py: Python<'_>, err: PyErr, input: impl ToErrorValue) -> ValE
 }
 
 #[pyclass(module = "pydantic_core._pydantic_core", get_all)]
+#[derive(PyGcTraverse)]
 pub struct ValidationInfo {
     config: Py<PyAny>,
     context: Option<Py<PyAny>>,
@@ -531,13 +512,6 @@ pub struct ValidationInfo {
     field_name: Option<Py<PyString>>,
     mode: InputType,
 }
-
-impl_py_gc_traverse!(ValidationInfo {
-    config,
-    context,
-    data,
-    field_name
-});
 
 impl ValidationInfo {
     fn new(py: Python, state: &ValidationState<'_, '_>, config: &Py<PyAny>, field_name: Option<Py<PyString>>) -> Self {

--- a/pydantic-core/src/validators/generator.rs
+++ b/pydantic-core/src/validators/generator.rs
@@ -18,7 +18,7 @@ use super::{
     BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, Extra, InputType, ValidationState, Validator,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct GeneratorValidator {
     item_validator: Option<Arc<CombinedValidator>>,
     min_length: Option<usize>,
@@ -58,8 +58,6 @@ impl BuildValidator for GeneratorValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(GeneratorValidator { item_validator });
 
 impl Validator for GeneratorValidator {
     fn validate<'py>(
@@ -216,6 +214,7 @@ impl ValidatorIterator {
 
 /// Owned validator wrapper for use in generators in functions, this can be passed back to python
 /// mid-validation
+#[derive(PyGcTraverse)]
 pub struct InternalValidator {
     name: String,
     validator: Arc<CombinedValidator>,
@@ -358,10 +357,3 @@ impl InternalValidator {
         result
     }
 }
-
-impl_py_gc_traverse!(InternalValidator {
-    validator,
-    data,
-    context,
-    self_instance
-});

--- a/pydantic-core/src/validators/int.rs
+++ b/pydantic-core/src/validators/int.rs
@@ -12,6 +12,7 @@ use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{Input, Int};
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 fn validate_as_int(schema: &Bound<'_, PyDict>, key: &Bound<'_, PyString>) -> PyResult<Option<Int>> {
     match schema.get_item(key)? {
@@ -30,7 +31,7 @@ fn validate_as_int(schema: &Bound<'_, PyDict>, key: &Bound<'_, PyString>) -> PyR
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct IntValidator {
     strict: bool,
 }
@@ -66,8 +67,6 @@ impl BuildValidator for IntValidator {
     }
 }
 
-impl_py_gc_traverse!(IntValidator {});
-
 impl Validator for IntValidator {
     fn validate<'py>(
         &self,
@@ -85,7 +84,7 @@ impl Validator for IntValidator {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct ConstrainedIntValidator {
     strict: bool,
     multiple_of: Option<Int>,
@@ -109,8 +108,6 @@ impl ConstrainedIntValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(ConstrainedIntValidator {});
 
 impl Validator for ConstrainedIntValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/is_instance.rs
+++ b/pydantic-core/src/validators/is_instance.rs
@@ -10,8 +10,9 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct IsInstanceValidator {
     class: Py<PyAny>,
     class_repr: String,
@@ -46,8 +47,6 @@ impl BuildValidator for IsInstanceValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(IsInstanceValidator { class });
 
 impl Validator for IsInstanceValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/is_subclass.rs
+++ b/pydantic-core/src/validators/is_subclass.rs
@@ -9,8 +9,9 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct IsSubclassValidator {
     class: Py<PyType>,
     class_repr: String,
@@ -41,8 +42,6 @@ impl BuildValidator for IsSubclassValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(IsSubclassValidator { class });
 
 impl Validator for IsSubclassValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/json.rs
+++ b/pydantic-core/src/validators/json.rs
@@ -13,8 +13,9 @@ use crate::tools::SchemaDict;
 
 use super::config::ValBytesMode;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct JsonValidator {
     validator: Option<Arc<CombinedValidator>>,
     name: String,
@@ -46,8 +47,6 @@ impl BuildValidator for JsonValidator {
         Ok(CombinedValidator::Json(Self { validator, name }).into())
     }
 }
-
-impl_py_gc_traverse!(JsonValidator { validator });
 
 impl Validator for JsonValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/json_or_python.rs
+++ b/pydantic-core/src/validators/json_or_python.rs
@@ -10,8 +10,9 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, InputType, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct JsonOrPython {
     json: Arc<CombinedValidator>,
     python: Arc<CombinedValidator>,
@@ -42,8 +43,6 @@ impl BuildValidator for JsonOrPython {
         Ok(CombinedValidator::JsonOrPython(Self { json, python, name }).into())
     }
 }
-
-impl_py_gc_traverse!(JsonOrPython { json, python });
 
 impl Validator for JsonOrPython {
     fn validate<'py>(

--- a/pydantic-core/src/validators/lax_or_strict.rs
+++ b/pydantic-core/src/validators/lax_or_strict.rs
@@ -12,8 +12,9 @@ use crate::tools::SchemaDict;
 use super::Exactness;
 use super::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct LaxOrStrictValidator {
     strict: bool,
     lax_validator: Arc<CombinedValidator>,
@@ -51,11 +52,6 @@ impl BuildValidator for LaxOrStrictValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(LaxOrStrictValidator {
-    lax_validator,
-    strict_validator
-});
 
 impl Validator for LaxOrStrictValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/list.rs
+++ b/pydantic-core/src/validators/list.rs
@@ -10,8 +10,9 @@ use crate::input::{
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ListValidator {
     strict: bool,
     item_validator: Option<Arc<CombinedValidator>>,
@@ -115,8 +116,6 @@ impl BuildValidator for ListValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(ListValidator { item_validator });
 
 impl Validator for ListValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/literal.rs
+++ b/pydantic-core/src/validators/literal.rs
@@ -4,9 +4,9 @@ use core::fmt::Debug;
 use std::cell::OnceCell;
 use std::sync::Arc;
 
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyInt, PyList, PyString};
-use pyo3::{PyTraverseError, PyVisit, intern};
 
 use ahash::AHashMap;
 
@@ -18,13 +18,13 @@ use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PyGcTraverse)]
 struct BoolLiteral {
     pub true_id: Option<usize>,
     pub false_id: Option<usize>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct LiteralLookup<T: Debug> {
     // Specialized lookups for ints, bools and strings because they
     // (1) are easy to convert between Rust and Python
@@ -227,15 +227,7 @@ impl<T: Debug> LiteralLookup<T> {
     }
 }
 
-impl<T: PyGcTraverse + Debug> PyGcTraverse for LiteralLookup<T> {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        self.expected_py_dict.py_gc_traverse(visit)?;
-        self.values.py_gc_traverse(visit)?;
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct LiteralValidator {
     lookup: Box<LiteralLookup<Py<PyAny>>>,
     expected_repr: String,
@@ -270,8 +262,6 @@ impl BuildValidator for LiteralValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(LiteralValidator { lookup });
 
 impl Validator for LiteralValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/missing_sentinel.rs
+++ b/pydantic-core/src/validators/missing_sentinel.rs
@@ -9,8 +9,9 @@ use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct MissingSentinelValidator {}
 
 static MISSING_SENTINEL_VALIDATOR: LazyLock<Arc<CombinedValidator>> =
@@ -27,8 +28,6 @@ impl BuildValidator for MissingSentinelValidator {
         Ok(MISSING_SENTINEL_VALIDATOR.clone())
     }
 }
-
-impl_py_gc_traverse!(MissingSentinelValidator {});
 
 impl Validator for MissingSentinelValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -111,7 +111,7 @@ impl PySome {
 }
 
 #[pyclass(module = "pydantic_core._pydantic_core", frozen)]
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct SchemaValidator {
     validator: Arc<CombinedValidator>,
     definitions: Definitions<Arc<CombinedValidator>>,
@@ -125,13 +125,6 @@ pub struct SchemaValidator {
     validation_error_cause: bool,
     cache_str: StringCacheMode,
 }
-
-impl_py_gc_traverse!(SchemaValidator {
-    validator,
-    definitions,
-    py_schema,
-    py_config,
-});
 
 #[pymethods]
 impl SchemaValidator {

--- a/pydantic-core/src/validators/model.rs
+++ b/pydantic-core/src/validators/model.rs
@@ -17,6 +17,7 @@ use crate::build_tools::py_schema_err;
 use crate::build_tools::schema_or_config_same;
 use crate::errors::{ErrorType, ErrorTypeDefaults, ValError, ValResult};
 use crate::input::{Input, input_as_python_instance, py_error_on_minusone};
+use crate::py_gc::PyGcTraverse;
 use crate::tools::{ROOT_FIELD, SchemaDict, py_err, root_field_py_str};
 
 const DUNDER_DICT: &str = "__dict__";
@@ -24,7 +25,7 @@ const DUNDER_FIELDS_SET_KEY: &str = "__pydantic_fields_set__";
 const DUNDER_MODEL_EXTRA_KEY: &str = "__pydantic_extra__";
 const DUNDER_MODEL_PRIVATE_KEY: &str = "__pydantic_private__";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub(super) enum Revalidate {
     Always,
     Never,
@@ -50,7 +51,7 @@ impl Revalidate {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ModelValidator {
     revalidate: Revalidate,
     validator: Arc<CombinedValidator>,
@@ -107,12 +108,6 @@ impl BuildValidator for ModelValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(ModelValidator {
-    class,
-    generic_origin,
-    validator
-});
 
 impl Validator for ModelValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -24,8 +24,9 @@ use crate::validators::shared::lookup_tree::LookupFieldInfo;
 use crate::validators::shared::lookup_tree::LookupTree;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct Field {
     name: PyBackedStr,
     lookup_path_collection: LookupPathCollection,
@@ -33,9 +34,7 @@ struct Field {
     frozen: bool,
 }
 
-impl_py_gc_traverse!(Field { validator });
-
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct ModelFieldsValidator {
     fields: Vec<Field>,
     model_name: String,
@@ -123,11 +122,6 @@ impl BuildValidator for ModelFieldsValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(ModelFieldsValidator {
-    fields,
-    extras_validator
-});
 
 impl Validator for ModelFieldsValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/named_tuple.rs
+++ b/pydantic-core/src/validators/named_tuple.rs
@@ -18,17 +18,16 @@ use crate::validators::function::convert_err;
 
 use super::validation_state::Exactness;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct NamedTupleField {
     name: PyBackedStr,
     lookup_path_collection: LookupPathCollection,
     validator: Arc<CombinedValidator>,
 }
 
-impl_py_gc_traverse!(NamedTupleField { validator });
-
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct NamedTupleValidator {
     class: Py<PyType>,
     fields: Vec<NamedTupleField>,
@@ -95,8 +94,6 @@ impl BuildValidator for NamedTupleValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(NamedTupleValidator { class, fields });
 
 impl Validator for NamedTupleValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/none.rs
+++ b/pydantic-core/src/validators/none.rs
@@ -7,8 +7,9 @@ use crate::errors::{ErrorTypeDefaults, ValError, ValResult};
 use crate::input::Input;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct NoneValidator;
 
 static NONE_VALIDATOR: LazyLock<Arc<CombinedValidator>> = LazyLock::new(|| Arc::new(NoneValidator.into()));
@@ -24,8 +25,6 @@ impl BuildValidator for NoneValidator {
         Ok(NONE_VALIDATOR.clone())
     }
 }
-
-impl_py_gc_traverse!(NoneValidator {});
 
 impl Validator for NoneValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/nullable.rs
+++ b/pydantic-core/src/validators/nullable.rs
@@ -10,8 +10,9 @@ use crate::tools::SchemaDict;
 
 use super::ValidationState;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct NullableValidator {
     validator: Arc<CombinedValidator>,
     name: String,
@@ -31,8 +32,6 @@ impl BuildValidator for NullableValidator {
         Ok(CombinedValidator::Nullable(Self { validator, name }).into())
     }
 }
-
-impl_py_gc_traverse!(NullableValidator { validator });
 
 impl Validator for NullableValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/prebuilt.rs
+++ b/pydantic-core/src/validators/prebuilt.rs
@@ -8,8 +8,9 @@ use crate::input::Input;
 
 use super::ValidationState;
 use super::{CombinedValidator, SchemaValidator, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct PrebuiltValidator {
     schema_validator: Py<SchemaValidator>,
 }
@@ -39,8 +40,6 @@ impl PrebuiltValidator {
         })
     }
 }
-
-impl_py_gc_traverse!(PrebuiltValidator { schema_validator });
 
 impl Validator for PrebuiltValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/set.rs
+++ b/pydantic-core/src/validators/set.rs
@@ -9,8 +9,9 @@ use crate::tools::SchemaDict;
 
 use super::list::min_length_check;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct SetValidator {
     strict: bool,
     item_validator: Arc<CombinedValidator>,
@@ -55,8 +56,6 @@ impl BuildValidator for SetValidator {
     const EXPECTED_TYPE: &'static str = "set";
     set_build!();
 }
-
-impl_py_gc_traverse!(SetValidator { item_validator });
 
 impl Validator for SetValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/shared/lookup_tree.rs
+++ b/pydantic-core/src/validators/shared/lookup_tree.rs
@@ -6,12 +6,13 @@ use jiter::{JsonArray, JsonValue};
 use smallvec::SmallVec;
 
 use crate::lookup_key::{LookupPath, LookupPathCollection, LookupType, PathItem, PathItemString};
+use crate::py_gc::PyGcTraverse;
 
 /// A tree of paths for lookups when trying to find fields from input.
 ///
 /// The structure is nested maps, typically there is only one level unless there are `AliasPath` aliases
 /// which require deeper lookups.
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct LookupTree {
     inner: AHashMap<PathItemString, LookupTreeNode>,
 }
@@ -72,7 +73,7 @@ impl LookupTree {
 }
 
 /// When resolving data for a field, aliases are preferred over names, and earlier aliases are preferred over later ones.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PyGcTraverse)]
 pub struct LookupFieldPriority {
     /// The type of lookups that will match this lookup
     lookup_type: LookupType,
@@ -97,7 +98,7 @@ impl LookupFieldPriority {
 }
 
 /// Represents a location in the lookup tree which corresponds to data for a specific field.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PyGcTraverse)]
 pub struct LookupFieldInfo {
     /// The field which this lookup will populate.
     pub field_index: usize,
@@ -122,7 +123,7 @@ impl LookupFieldInfo {
 }
 
 /// Represents a point in the lookup tree, containing exact matches plus possible nested lookups.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PyGcTraverse)]
 pub struct LookupTreeNode {
     /// All fields which wanted _exactly_ this key, typically this is just a single entry
     fields: SmallVec<[LookupFieldInfo; 1]>,

--- a/pydantic-core/src/validators/string.rs
+++ b/pydantic-core/src/validators/string.rs
@@ -16,8 +16,9 @@ use crate::input::Input;
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct StrValidator {
     strict: bool,
     coerce_numbers_to_str: bool,
@@ -67,8 +68,6 @@ impl BuildValidator for StrValidator {
     }
 }
 
-impl_py_gc_traverse!(StrValidator {});
-
 impl Validator for StrValidator {
     fn validate<'py>(
         &self,
@@ -92,7 +91,7 @@ impl Validator for StrValidator {
 }
 
 /// Any new properties set here must be reflected in `has_constraints_set`
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PyGcTraverse)]
 pub struct StrConstrainedValidator {
     strict: bool,
     pattern: Option<Pattern>,
@@ -104,8 +103,6 @@ pub struct StrConstrainedValidator {
     coerce_numbers_to_str: bool,
     ascii_only: bool,
 }
-
-impl_py_gc_traverse!(StrConstrainedValidator {});
 
 impl Validator for StrConstrainedValidator {
     fn validate<'py>(
@@ -258,13 +255,13 @@ impl StrConstrainedValidator {
 static REGEX_CACHE: LazyLock<Mutex<LruCache<String, Regex>>> =
     LazyLock::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(50).unwrap())));
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 struct Pattern {
     pattern: String,
     engine: RegexEngine,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 enum RegexEngine {
     RustRegex(Regex),
     PythonRe(Py<PyAny>),

--- a/pydantic-core/src/validators/time.rs
+++ b/pydantic-core/src/validators/time.rs
@@ -15,8 +15,9 @@ use crate::input::Input;
 use super::datetime::TZConstraint;
 use super::datetime::extract_microseconds_precision;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct TimeValidator {
     strict: bool,
     constraints: Option<TimeConstraints>,
@@ -39,8 +40,6 @@ impl BuildValidator for TimeValidator {
         Ok(Arc::new(s.into()))
     }
 }
-
-impl_py_gc_traverse!(TimeValidator {});
 
 impl Validator for TimeValidator {
     fn validate<'py>(
@@ -100,7 +99,7 @@ fn convert_pytime(schema: &Bound<'_, PyDict>, key: &Bound<'_, PyString>) -> PyRe
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 struct TimeConstraints {
     le: Option<Time>,
     lt: Option<Time>,

--- a/pydantic-core/src/validators/timedelta.rs
+++ b/pydantic-core/src/validators/timedelta.rs
@@ -12,15 +12,16 @@ use crate::input::{Input, duration_as_pytimedelta};
 
 use super::datetime::extract_microseconds_precision;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct TimeDeltaValidator {
     strict: bool,
     constraints: Option<TimedeltaConstraints>,
     microseconds_precision: speedate::MicrosecondsPrecisionOverflowBehavior,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 struct TimedeltaConstraints {
     le: Option<Duration>,
     lt: Option<Duration>,
@@ -68,8 +69,6 @@ impl BuildValidator for TimeDeltaValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(TimeDeltaValidator {});
 
 impl Validator for TimeDeltaValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/tuple.rs
+++ b/pydantic-core/src/validators/tuple.rs
@@ -12,8 +12,9 @@ use crate::input::{BorrowInput, Input, ValidatedTuple};
 use crate::tools::SchemaDict;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct TupleValidator {
     strict: bool,
     validators: Vec<Arc<CombinedValidator>>,
@@ -58,8 +59,6 @@ impl BuildValidator for TupleValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(TupleValidator { validators });
 
 impl TupleValidator {
     #[allow(clippy::too_many_arguments)]

--- a/pydantic-core/src/validators/typed_dict.rs
+++ b/pydantic-core/src/validators/typed_dict.rs
@@ -20,8 +20,9 @@ use ahash::AHashSet;
 use jiter::PartialMode;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 struct TypedDictField {
     name: PyBackedStr,
     lookup_path_collection: LookupPathCollection,
@@ -29,9 +30,7 @@ struct TypedDictField {
     validator: Arc<CombinedValidator>,
 }
 
-impl_py_gc_traverse!(TypedDictField { validator });
-
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct TypedDictValidator {
     fields: Vec<TypedDictField>,
     extra_behavior: ExtraBehavior,
@@ -135,11 +134,6 @@ impl BuildValidator for TypedDictValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(TypedDictValidator {
-    fields,
-    extras_validator
-});
 
 impl Validator for TypedDictValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/union.rs
+++ b/pydantic-core/src/validators/union.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::py_gc::PyGcTraverse;
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString, PyTuple};
-use pyo3::{PyTraverseError, PyVisit, intern};
 use smallvec::SmallVec;
 
 use crate::build_tools::py_schema_err;
@@ -21,7 +21,7 @@ use super::{
     BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator, build_validator,
 };
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 enum UnionMode {
     Smart,
     LeftToRight,
@@ -39,7 +39,7 @@ impl FromStr for UnionMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct UnionValidator {
     mode: UnionMode,
     choices: Vec<(Arc<CombinedValidator>, Option<String>)>,
@@ -210,13 +210,6 @@ impl UnionValidator {
     }
 }
 
-impl PyGcTraverse for UnionValidator {
-    fn py_gc_traverse(&self, visit: &PyVisit<'_>) -> Result<(), PyTraverseError> {
-        self.choices.iter().try_for_each(|(v, _)| v.py_gc_traverse(visit))?;
-        Ok(())
-    }
-}
-
 impl Validator for UnionValidator {
     fn validate<'py>(
         &self,
@@ -289,7 +282,7 @@ impl<'a> MaybeErrors<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct TaggedUnionValidator {
     discriminator: Box<Discriminator>,
     lookup: Box<LiteralLookup<Arc<CombinedValidator>>>,
@@ -350,8 +343,6 @@ impl BuildValidator for TaggedUnionValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(TaggedUnionValidator { discriminator, lookup });
 
 impl Validator for TaggedUnionValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/url.rs
+++ b/pydantic-core/src/validators/url.rs
@@ -24,10 +24,11 @@ use crate::validators::literal::expected_repr;
 
 use super::Exactness;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 type AllowedSchemes = Option<(AHashSet<String>, String)>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct UrlValidator {
     strict: bool,
     max_length: Option<usize>,
@@ -142,8 +143,6 @@ impl BuildValidator for UrlValidator {
         Ok(CombinedValidator::Url(Box::new(validator)).into())
     }
 }
-
-impl_py_gc_traverse!(UrlValidator {});
 
 impl Validator for UrlValidator {
     fn validate<'py>(
@@ -281,7 +280,7 @@ impl CopyFromPyUrl for EitherUrl<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct MultiHostUrlValidator {
     strict: bool,
     max_length: Option<usize>,
@@ -393,8 +392,6 @@ impl BuildValidator for MultiHostUrlValidator {
         Ok(CombinedValidator::MultiHostUrl(Box::new(validator)).into())
     }
 }
-
-impl_py_gc_traverse!(MultiHostUrlValidator {});
 
 impl Validator for MultiHostUrlValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/uuid.rs
+++ b/pydantic-core/src/validators/uuid.rs
@@ -21,6 +21,7 @@ use super::config::ValBytesMode;
 use super::model::create_class;
 use super::model::force_setattr;
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, Exactness, ValidationState, Validator};
+use crate::py_gc::PyGcTraverse;
 
 const UUID_INT: &str = "int";
 const UUID_IS_SAFE: &str = "is_safe";
@@ -63,7 +64,7 @@ impl From<u8> for Version {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 pub struct UuidValidator {
     strict: bool,
     version: Option<usize>,
@@ -87,8 +88,6 @@ impl BuildValidator for UuidValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(UuidValidator {});
 
 impl Validator for UuidValidator {
     fn validate<'py>(

--- a/pydantic-core/src/validators/validation_state.rs
+++ b/pydantic-core/src/validators/validation_state.rs
@@ -10,8 +10,9 @@ use crate::recursion_guard::{ContainsRecursionState, RecursionState};
 use crate::tools::new_py_string;
 
 use super::Extra;
+use crate::py_gc::PyGcTraverse;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, PyGcTraverse)]
 pub enum Exactness {
     Lax,
     Strict,

--- a/pydantic-core/src/validators/with_default.rs
+++ b/pydantic-core/src/validators/with_default.rs
@@ -79,14 +79,14 @@ impl PyGcTraverse for DefaultType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyGcTraverse)]
 enum OnError {
     Raise,
     Omit,
     Default,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PyGcTraverse)]
 pub struct WithDefaultValidator {
     default: DefaultType,
     on_error: OnError,
@@ -148,8 +148,6 @@ impl BuildValidator for WithDefaultValidator {
         .into())
     }
 }
-
-impl_py_gc_traverse!(WithDefaultValidator { default, validator });
 
 impl Validator for WithDefaultValidator {
     fn validate<'py>(


### PR DESCRIPTION
Second approach to address #13625.

## What this does

Replaces the `impl_py_gc_traverse!` macro (and most hand-written `PyGcTraverse` impls) with a `#[derive(PyGcTraverse)]` proc macro, implemented in a new `pydantic-core-derive` workspace crate. The derive traverses **every** field by default:

- A field whose type doesn't implement `PyGcTraverse` is a **compile error**, forcing an explicit decision: derive on that type, add a no-op impl for plain data, or mark the field `#[py_gc(skip)]`.
- Skips are explicit, greppable, and reviewable. The entire codebase ends up with exactly **two**, both commented: the partially-uninitialized `RecursionStack::Array` buffer and `GenericIterator::JsonArray` (JSON data can't hold Python references).
- `py_gc.rs` gains no-op impls for primitives and plain external types (jiter/speedate/regex), plus container impls (`AHashSet`, `OnceLock`, `SmallVec`, 2-tuples).

Nice consequences of the migration:

- The hand-written 50-variant `CombinedSerializer` match ("implemented by hand because `enum_dispatch` fails") is now a derive.
- `EnumValidator<T>`'s four per-instantiation macro calls collapse into one generic derive.
- ~270 lines net deleted.

## Bugs this found and fixed

Migrating exposed real, previously-unknown leaks — every field the derive newly traverses was reviewed:

1. **`GeneralFieldsSerializer.extra_serializer`** was not traversed: serializer functions in `extras_schema` leaked (also caught by #13626's check; not covered by #13624). Fixed automatically by the derive.
2. **`StrConstrainedValidator`'s compiled pattern**: with `regex_engine='python-re'`, the validator holds a `Py<PyAny>` compiled pattern (`RegexEngine::PythonRe`) that was never reported to the GC. Fixed automatically by the derive.

## One trap worth reviewing closely

`DefinitionRefValidator`/`DefinitionRefSerializer` previously had deliberately *empty* traverse lists — they are the cycle-breakers for recursive schemas. Deriving all fields made them traverse `DefinitionRef<T>`, whose (previously unreachable) manual impl recursed into the definition target → infinite recursion → segfault on recursive schemas.

The fix makes `DefinitionRef<T>`'s traversal an explicit documented no-op: it is sound because every definition's content is already traversed through the `Definitions` container held by the top-level `SchemaValidator`/`SchemaSerializer`, and it removes the landmine for any future struct holding a `DefinitionRef`.

## Validation

- pydantic-core suite: 5616 passed (including `test_garbage_collection.py`), pydantic suite: 7930 passed.
- The `gc.get_referents()` completeness check (from #13626) passes for all five known leak scenarios: the three #13621 edges, `extra_serializer`, and the `python-re` pattern.
- `cargo clippy` clean (lib, tests, and the derive crate).

## Notes

- The derive crate is a path dependency; if pydantic-core is still published to crates.io, the crate needs publishing too (version is kept in lockstep) — happy to adjust.
- `/derive` is added to the sdist `include` list.
- Once PyO3/pyo3#5663 lands upstream, this crate can likely be deleted in favor of the official mechanism.

https://claude.ai/code/session_01RvP2P4L9VLBy6FMAiotbCP
