### PR TITLE
Fix JSON schema discriminator mapping keys for `bool` discriminators

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1380,6 +1380,10 @@ class GenerateJsonSchema:
         for k, v in schema['choices'].items():
             if isinstance(k, Enum):
                 k = k.value
+            elif isinstance(k, bool):
+                # Use the JSON representation so that the discriminator mapping
+                # can be matched against the serialized payload value
+                k = 'true' if k else 'false'
             try:
                 # Use str(k) since keys must be strings for json; while not technically correct,
                 # it's the closest that can be represented in valid JSON

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -3973,6 +3973,52 @@ def test_discriminated_annotated_union():
     }
 
 
+def test_bool_discriminated_union():
+    class Enabled(BaseModel):
+        enabled: Literal[True]
+        config: str
+
+    class Disabled(BaseModel):
+        enabled: Literal[False]
+
+    class Model(BaseModel):
+        setting: Enabled | Disabled = Field(discriminator='enabled')
+
+    # insert_assert(Model.model_json_schema())
+    assert Model.model_json_schema() == {
+        '$defs': {
+            'Disabled': {
+                'properties': {'enabled': {'const': False, 'title': 'Enabled', 'type': 'boolean'}},
+                'required': ['enabled'],
+                'title': 'Disabled',
+                'type': 'object',
+            },
+            'Enabled': {
+                'properties': {
+                    'config': {'title': 'Config', 'type': 'string'},
+                    'enabled': {'const': True, 'title': 'Enabled', 'type': 'boolean'},
+                },
+                'required': ['enabled', 'config'],
+                'title': 'Enabled',
+                'type': 'object',
+            },
+        },
+        'properties': {
+            'setting': {
+                'discriminator': {
+                    'mapping': {'false': '#/$defs/Disabled', 'true': '#/$defs/Enabled'},
+                    'propertyName': 'enabled',
+                },
+                'oneOf': [{'$ref': '#/$defs/Enabled'}, {'$ref': '#/$defs/Disabled'}],
+                'title': 'Setting',
+            }
+        },
+        'required': ['setting'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
 def test_nested_discriminated_union():
     class BlackCatWithHeight(BaseModel):
         color: Literal['black']

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -3975,6 +3975,7 @@ def test_discriminated_annotated_union():
 
 def test_bool_discriminated_union() -> None:
     """https://github.com/pydantic/pydantic/issues/13631"""
+
     class Enabled(BaseModel):
         enabled: Literal[True]
         config: str

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -3973,7 +3973,8 @@ def test_discriminated_annotated_union():
     }
 
 
-def test_bool_discriminated_union():
+def test_bool_discriminated_union() -> None:
+    """https://github.com/pydantic/pydantic/issues/13631"""
     class Enabled(BaseModel):
         enabled: Literal[True]
         config: str
@@ -3984,7 +3985,6 @@ def test_bool_discriminated_union():
     class Model(BaseModel):
         setting: Enabled | Disabled = Field(discriminator='enabled')
 
-    # insert_assert(Model.model_json_schema())
     assert Model.model_json_schema() == {
         '$defs': {
             'Disabled': {


### PR DESCRIPTION
## Change Summary

For discriminated unions with a `bool` discriminator, the JSON schema `discriminator.mapping` keys were generated with `str(k)`, yielding Python-style `"True"`/`"False"`. The OpenAPI spec requires mapping keys to match the serialized payload value, i.e. JSON `"true"`/`"false"`.

This normalizes `bool` keys to their JSON representation in `GenerateJsonSchema.tagged_union_schema`, mirroring the existing `Enum` key normalization. Added `test_bool_discriminated_union` covering the generated schema.

## Related issue number

fix #13631

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
