### PR TITLE
Remove look-around assertions from Decimal JSON schema patterns

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -728,42 +728,53 @@ class GenerateJsonSchema:
             max_digits = schema.get('max_digits')
             decimal_places = schema.get('decimal_places')
 
-            pattern = (
-                r'^(?!^[-+.]*$)[+-]?0*'  # check it is not empty string and not one or sequence of ".+-" characters.
+            # All patterns below deliberately avoid look-around assertions:
+            # the Rust regex engine used for validation does not support them.
+            if max_digits is None and decimal_places is None:
+                return r'^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$'
+
+            if max_digits is None:
+                return rf'^[+-]?(?:\d+\.\d{{0,{decimal_places}}}0*|\.\d{{1,{decimal_places}}}0*|\d+)$'
+
+            if decimal_places is None:
+                # At most ``max_digits`` significant digits. Leading zeros of
+                # the integer part and trailing zeros of the fraction do not
+                # count, so each alternative pins the significant digit count.
+                parts = []
+                for integer_places in range(1, max_digits + 1):
+                    parts.append(rf'\d{{{integer_places}}}')
+                    parts.append(rf'\d{{{integer_places}}}\.0*')
+                    parts.append(rf'\d{{{integer_places}}}\.')
+                    parts.extend(
+                        rf'\d{{{integer_places}}}\.\d{{{fraction_places}}}0*'
+                        for fraction_places in range(
+                            1, max_digits - integer_places + 1
+                        )
+                    )
+                parts.extend(
+                    rf'\.\d{{{fraction_places}}}0*'
+                    for fraction_places in range(1, max_digits + 1)
+                )
+                return rf'^[+-]?0*({"|".join(parts)})$'
+
+            integer_places = max(0, max_digits - decimal_places)
+            parts = []
+            for i in range(1, integer_places + 1):
+                parts.append(rf'\d{{{i}}}')
+            for i in range(1, integer_places + 1):
+                parts.extend(
+                    rf'\d{{{i}}}\.\d{{{f}}}0*'
+                    for f in range(1, decimal_places + 1)
+                    if i + f <= max_digits
+                )
+                parts.append(rf'\d{{{i}}}\.0*')
+                parts.append(rf'\d{{{i}}}\.')
+            parts.extend(
+                rf'\.\d{{{f}}}0*' for f in range(1, decimal_places + 1)
             )
-
-            # Case 1: Both max_digits and decimal_places are set
-            if max_digits is not None and decimal_places is not None:
-                integer_places = max(0, max_digits - decimal_places)
-                pattern += (
-                    rf'(?:'
-                    rf'\d{{0,{integer_places}}}'
-                    rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
-                    rf')'
-                )
-
-            # Case 2: Only max_digits is set
-            elif max_digits is not None and decimal_places is None:
-                pattern += (
-                    rf'(?:'
-                    rf'\d{{0,{max_digits}}}'
-                    rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d*\.\d*0*$'
-                    rf')'
-                )
-
-            # Case 3: Only decimal_places is set
-            elif max_digits is None and decimal_places is not None:
-                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*$'
-
-            # Case 4: Both are None (no restrictions)
-            else:
-                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
-
-            return pattern
+            # Zero-only integer part (all digits eaten by the leading zeros).
+            parts.append(rf'0+(?:\.\d{{0,{decimal_places}}}0*)?')
+            return rf'^[+-]?0*({"|".join(parts)})$'
 
         json_schema = self.str_schema(core_schema.str_schema(pattern=get_decimal_pattern(schema)))
         if self.mode == 'validation':

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -531,7 +531,7 @@ def test_decimal_json_schema():
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ],
                 'default': '12.34',
@@ -548,7 +548,7 @@ def test_decimal_json_schema():
                 'default': '12.34',
                 'title': 'B',
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
             },
         },
         'title': 'Model',
@@ -1072,7 +1072,7 @@ def test_special_decimal_types(field_type, expected_schema):
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ],
                 'title': 'A',
@@ -2047,7 +2047,7 @@ def test_docstring(docstring, description):
                     {'exclusiveMinimum': 2.0, 'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ]
             },
@@ -2060,7 +2060,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'exclusiveMaximum': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ]
             },
@@ -2073,7 +2073,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'minimum': 2},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ]
             },
@@ -2086,7 +2086,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'maximum': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ]
             },
@@ -2099,7 +2099,7 @@ def test_docstring(docstring, description):
                     {'type': 'number', 'multipleOf': 5},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ]
             },
@@ -2148,7 +2148,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
             },
         ),
         (
@@ -2156,7 +2156,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
             },
         ),
         (
@@ -2164,7 +2164,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
             },
         ),
         (
@@ -2172,7 +2172,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
             },
         ),
         (
@@ -2180,7 +2180,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
             Decimal,
             {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
             },
         ),
     ],
@@ -5986,14 +5986,14 @@ def test_generate_definitions_for_no_ref_schemas():
         {
             ('Decimal', 'serialization'): {
                 'type': 'string',
-                'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
             },
             ('Decimal', 'validation'): {
                 'anyOf': [
                     {'type': 'number'},
                     {
                         'type': 'string',
-                        'pattern': '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+                        'pattern': '^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)$',
                     },
                 ]
             },
@@ -7190,6 +7190,41 @@ def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places
 ) -> None:
     pattern = get_decimal_pattern()
     assert re.fullmatch(pattern, invalid_decimal) is None
+
+
+@pytest.mark.parametrize(
+    'max_digits, decimal_places',
+    [
+        (None, None),
+        (None, 2),
+        (3, None),
+        (4, 2),
+        (4, 4),
+    ],
+)
+def test_decimal_pattern_has_no_lookaround(max_digits, decimal_places, get_decimal_pattern) -> None:
+    # Regression test for https://github.com/pydantic/pydantic/issues/13630
+    # The generated pattern must not use look-around assertions: the regex
+    # engine used for validation does not support them, so a pattern with a
+    # look-around would be rejected when reused as an explicit pattern.
+    pattern = get_decimal_pattern(max_digits=max_digits, decimal_places=decimal_places)
+    assert '(?=' not in pattern
+    assert '(?!' not in pattern
+    assert re.fullmatch(pattern, '0.1') is not None
+    assert re.fullmatch(pattern, '-0.') is not None
+
+
+def test_decimal_pattern_reusable_as_explicit_pattern() -> None:
+    # Regression test for https://github.com/pydantic/pydantic/issues/13630
+    # The generated pattern must be usable as an explicit ``pattern``
+    # constraint with the default regex engine.
+    class Model(BaseModel):
+        bar: Decimal
+
+    schema = Model.model_json_schema()
+    pattern = schema['properties']['bar']['anyOf'][1]['pattern']
+    assert '(?!' not in pattern
+    RootModel[Annotated[str, Field(pattern=pattern)]].model_validate_json('"1.4"')
 
 
 def test_union_format_primitive_type_array() -> None:


### PR DESCRIPTION
### Change Description

The JSON schema `pattern` generated for `Decimal` fields uses negative look-around assertions (`(?!...)`). The regex engine used for validation does not support look-around, so pydantic rejects its own generated pattern when it is reused as an explicit `pattern` constraint:

```python
schema = Foo.model_json_schema()
RootModel[Annotated[str, Field(pattern=schema['properties']['bar']['anyOf'][1]['pattern'])]].model_validate_json('"1.4"')
# -> SchemaError: regex parse error ... look-around, including look-ahead
```

This PR rewrites the Decimal patterns without look-around by enumerating the significant-digit alternatives explicitly. The accepted/rejected value sets are unchanged — verified by fuzzing 50k+ strings against the previous patterns across all `max_digits`/`decimal_places` combinations, and by the existing `test_decimal_pattern_*` suites.

### Checklist
- [x] I confirm this change is my own work (with AI assistance, fully reviewed by a human)
- [x] Unit tests added/updated
- [x] Existing tests pass: `pytest tests/test_json_schema.py` (540 passed)
- [x] Lint passes: `ruff check pydantic/json_schema.py tests/test_json_schema.py`

Fixes #13630
