### PR TITLE
fix(docs_extraction): preserve docstrings from parent classes across hierarchy including TypedDict

### DIFF
--- a/pydantic/_internal/_docs_extraction.py
+++ b/pydantic/_internal/_docs_extraction.py
@@ -79,8 +79,26 @@ def _extract_source_from_frame(cls: type[Any]) -> list[str] | None:
         frame = frame.f_back
 
 
+def _get_class_hierarchy(cls: type[Any]) -> list[type[Any]]:
+    hierarchy: list[type[Any]] = []
+    seen: set[type[Any]] = set()
+
+    def _traverse(c: type[Any]) -> None:
+        if c in seen or c is object or c is dict or getattr(c, '__module__', None) in ('typing', 'typing_extensions', 'builtins'):
+            return
+        seen.add(c)
+        bases = getattr(c, '__orig_bases__', None) or c.__bases__
+        for base in bases:
+            if isinstance(base, type):
+                _traverse(base)
+        hierarchy.append(c)
+
+    _traverse(cls)
+    return hierarchy
+
+
 def extract_docstrings_from_cls(cls: type[Any], use_inspect: bool = False) -> dict[str, str]:
-    """Map model attributes and their corresponding docstring.
+    """Map model attributes and their corresponding docstring across class hierarchy.
 
     Args:
         cls: The class of the Pydantic model to inspect.
@@ -90,24 +108,42 @@ def extract_docstrings_from_cls(cls: type[Any], use_inspect: bool = False) -> di
     Returns:
         A mapping containing attribute names and their corresponding docstring.
     """
-    if use_inspect or sys.version_info >= (3, 13):
-        # On Python < 3.13, `inspect.getsourcelines()` might not work as expected
-        # if two classes have the same name in the same source file.
-        # On Python 3.13+, it will use the new `__firstlineno__` class attribute,
-        # making it way more robust.
+    fields_docs: dict[str, str] = {}
+    for base in _get_class_hierarchy(cls):
+        if use_inspect or sys.version_info >= (3, 13):
+            # On Python < 3.13, `inspect.getsourcelines()` might not work as expected
+            # if two classes have the same name in the same source file.
+            # On Python 3.13+, it will use the new `__firstlineno__` class attribute,
+            # making it way more robust.
+            try:
+                source, _ = inspect.getsourcelines(base)
+            except (OSError, TypeError):  # pragma: no cover
+                continue
+        else:
+            # TODO remove this implementation when we drop support for Python 3.12:
+            source = _extract_source_from_frame(base)
+
+        if not source:
+            continue
+
+        dedent_source = _dedent_source_lines(source)
+
         try:
-            source, _ = inspect.getsourcelines(cls)
-        except OSError:  # pragma: no cover
-            return {}
-    else:
-        # TODO remove this implementation when we drop support for Python 3.12:
-        source = _extract_source_from_frame(cls)
+            tree = ast.parse(dedent_source)
+        except SyntaxError:
+            continue
 
-    if not source:
-        return {}
+        target_node: ast.ClassDef | None = None
+        for stmt in ast.walk(tree):
+            if isinstance(stmt, ast.ClassDef) and stmt.name == base.__name__:
+                target_node = stmt
+                break
 
-    dedent_source = _dedent_source_lines(source)
+        if target_node is None:
+            continue
 
-    visitor = DocstringVisitor()
-    visitor.visit(ast.parse(dedent_source))
-    return visitor.attrs
+        visitor = DocstringVisitor()
+        visitor.visit(target_node)
+        fields_docs.update(visitor.attrs)
+
+    return fields_docs

--- a/tests/test_docs_extraction.py
+++ b/tests/test_docs_extraction.py
@@ -323,7 +323,6 @@ def test_stdlib_docs_extraction_duplicate_class():
     assert ta.json_schema()['properties']['a']['description'] == 'A docs'
 
 
-@pytest.mark.xfail(reason='Current implementation does not take inheritance into account.')
 def test_stdlib_docs_extraction_inheritance():
     @dataclass
     @with_config({'use_attribute_docstrings': True})
@@ -347,6 +346,26 @@ def test_stdlib_docs_extraction_inheritance():
         'required': ['a', 'b'],
         'title': 'MyStdlibDataclass',
         'type': 'object',
+    }
+
+
+def test_typeddict_docs_extraction_inheritance():
+    @with_config(ConfigDict(use_attribute_docstrings=True))
+    class Parent(TypedDict):
+        a: int
+        """Doc for a."""
+
+    @with_config(ConfigDict(use_attribute_docstrings=True))
+    class Child(Parent):
+        b: int
+        """Doc for b."""
+
+    assert TypeAdapter(Parent).json_schema()['properties'] == {
+        'a': {'description': 'Doc for a.', 'title': 'A', 'type': 'integer'}
+    }
+    assert TypeAdapter(Child).json_schema()['properties'] == {
+        'a': {'description': 'Doc for a.', 'title': 'A', 'type': 'integer'},
+        'b': {'description': 'Doc for b.', 'title': 'B', 'type': 'integer'},
     }
 
 


### PR DESCRIPTION
## Summary

Addresses issue 13468.

When \use_attribute_docstrings=True\ is set, fields inherited from a parent \TypedDict\ (or stdlib dataclass hierarchy) previously lost their docstring descriptions in the subclass JSON schema. This occurred because \extract_docstrings_from_cls\ only inspected the immediate subclass's AST rather than traversing parent bases in the class hierarchy (and \TypedDict\ classes store parent bases in \__orig_bases__\).

This PR:
1. Adds a \_get_class_hierarchy\ helper to traverse parent class bases (handling \__orig_bases__\ for \TypedDict\).
2. Targets specific \st.ClassDef\ nodes per base class to extract docstrings in reverse inheritance order (allowing subclasses to override parent field docstrings).
3. Resolves existing \xfail\ test \	est_stdlib_docs_extraction_inheritance\ and adds \	est_typeddict_docs_extraction_inheritance\.

## Test Plan
- Ran \pytest tests/test_docs_extraction.py\ (17 test cases passed cleanly).