### PR TITLE
Workaround circular import error in Mypy

### DIFF
--- a/pydantic/mypy.py
+++ b/pydantic/mypy.py
@@ -7,6 +7,8 @@ from collections.abc import Callable, Iterator
 from configparser import ConfigParser
 from typing import Any
 
+# To avoid import error (https://github.com/python/mypy/issues/17726):
+import mypy.types  # noqa: F401
 from mypy.errorcodes import ErrorCode
 from mypy.expandtype import expand_type, expand_type_by_instance
 from mypy.nodes import (


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Locally, I somehow started getting a test failure (see https://github.com/python/mypy/issues/17726):

```
platform darwin -- Python 3.14.5, pytest-9.1.1, pluggy-1.5.0
codspeed: 4.5.0 (disabled, mode: walltime, callgraph: not supported, timer_resolution: 41.7ns)
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=True warmup_iterations=100000)
rootdir: /Users/victorien/ws/pydantic
configfile: pyproject.toml
testpaths: tests
plugins: Faker-35.0.0, inline-snapshot-0.32.2, hypothesis-6.147.0, memray-1.7.0, devtools-0.12.2, timeout-2.4.0, codspeed-4.5.0, examples-0.0.15, benchmark-5.1.0, run-parallel-0.7.1, time-machine-3.3.0, mock-3.14.0, pretty-1.2.0
collected 12826 items / 12825 deselected / 1 selected                                                                                                                                                             
Collected 0 items to run in parallel

tests/test_exports.py F                                                                                                                                                                                     [100%]
tests/test_exports.py:30 test_public_internal - AttributeError: module 'mypy.expandtype' has no attribute 'ExpandTypeVisitor'…                                                                              [100%]
==================================================================================================== FAILURES =====================================================================================================
______________________________________________________________________________________________ test_public_internal _______________________________________________________________________________________________

    @pytest.mark.thread_unsafe
    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
    def test_public_internal():
        """
        check we don't make anything from _internal public
        """
        public_internal_attributes = []
    
        def _test_file(file: Path, module_name: str):
            if file.name != '__init__.py' and not file.name.startswith('_'):
                module = sys.modules.get(module_name)
                if module is None:
                    spec = importlib.util.spec_from_file_location(module_name, str(file))
                    module = importlib.util.module_from_spec(spec)
                    sys.modules[module_name] = module
                    try:
                        spec.loader.exec_module(module)
                    except ImportError:
                        return
    
                for name, attr in vars(module).items():
                    if not name.startswith('_'):
                        attr_module = getattr(attr, '__module__', '')
                        if attr_module.startswith('pydantic._internal'):
                            public_internal_attributes.append(f'{module.__name__}:{name} from {attr_module}')
    
        pydantic_files = (Path(__file__).parent.parent / 'pydantic').glob('*.py')
        experimental_files = (Path(__file__).parent.parent / 'pydantic' / 'experimental').glob('*.py')
    
        for file in pydantic_files:
>           _test_file(file, f'pydantic.{file.stem}')

tests/test_exports.py:61: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_exports.py:47: in _test_file
    spec.loader.exec_module(module)
<frozen importlib._bootstrap_external>:759: in exec_module
    ???
<frozen importlib._bootstrap>:491: in _call_with_frames_removed
    ???
pydantic/mypy.py:11: in <module>
    from mypy.expandtype import expand_type, expand_type_by_instance
mypy/expandtype.py:8: in <module>
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   AttributeError: module 'mypy.expandtype' has no attribute 'ExpandTypeVisitor'

mypy/types.py:4573: AttributeError
                                          Summary of Failures                                           
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃  File                   ┃  Function              ┃  Function Line  ┃  Error Line  ┃  Error           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│  tests/test_exports.py  │  test_public_internal  │  31             │  61          │  AttributeError  │
└─────────────────────────┴────────────────────────┴─────────────────┴──────────────┴──────────────────┘
```

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
