### PR TITLE
apply UrlConstraints to already-parsed url instances

### DIFF
--- a/pydantic/networks.py
+++ b/pydantic/networks.py
@@ -322,11 +322,14 @@ class _BaseUrl:
         cls, source: type[_BaseUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         def wrap_val(v, h):
-            if isinstance(v, source):
-                return v
             if isinstance(v, _BaseUrl):
-                v = str(v)
-            core_url = h(v)
+                # Run the (possibly constrained) inner schema against the already parsed
+                # core url so annotated `UrlConstraints` still apply to url instances.
+                core_url = h(v._url)
+                if isinstance(v, source):
+                    return v
+            else:
+                core_url = h(v)
             instance = source.__new__(source)
             instance._url = core_url
             return instance
@@ -538,11 +541,14 @@ class _BaseMultiHostUrl:
         cls, source: type[_BaseMultiHostUrl], handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         def wrap_val(v, h):
-            if isinstance(v, source):
-                return v
             if isinstance(v, _BaseMultiHostUrl):
-                v = str(v)
-            core_url = h(v)
+                # Run the (possibly constrained) inner schema against the already parsed
+                # core url so annotated `UrlConstraints` still apply to url instances.
+                core_url = h(v._url)
+                if isinstance(v, source):
+                    return v
+            else:
+                core_url = h(v)
             instance = source.__new__(source)
             instance._url = core_url
             return instance

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1115,6 +1115,32 @@ def test_custom_constraints() -> None:
         ta.validate_python('ftp://example.com')
 
 
+def test_custom_constraints_applied_to_url_instances() -> None:
+    Https = Annotated[AnyUrl, UrlConstraints(allowed_schemes=['https'], max_length=25)]
+    ta = TypeAdapter(Https)
+
+    # a url instance must be held to the same constraints as its string form
+    with pytest.raises(ValidationError, match='url_scheme'):
+        ta.validate_python(AnyUrl('http://example.com'))
+    with pytest.raises(ValidationError, match='url_too_long'):
+        ta.validate_python(AnyUrl('https://example.com/some/long/path'))
+
+    # revalidating an already validated (looser) model must not bypass the constraints
+    class Loose(BaseModel):
+        url: AnyUrl
+
+    loose = Loose(url='ftp://internal/etc/passwd')
+    with pytest.raises(ValidationError, match='url_scheme'):
+        ta.validate_python(loose.model_dump()['url'])
+
+    valid = ta.validate_python(AnyUrl('https://example.com'))
+    assert str(valid) == 'https://example.com/'
+
+    Postgres = Annotated[PostgresDsn, UrlConstraints(allowed_schemes=['postgresql'])]
+    with pytest.raises(ValidationError, match='url_scheme'):
+        TypeAdapter(Postgres).validate_python(PostgresDsn('postgres://user:pass@host/db'))
+
+
 def test_url_constraints_invalid_annotated_type() -> None:
     with pytest.raises(PydanticUserError):
         TypeAdapter(Annotated[str, UrlConstraints(max_length=1)])


### PR DESCRIPTION
## Change Summary

`UrlConstraints` writes `allowed_schemes` / `max_length` / `host_required` onto the inner url core schema that `_BaseUrl` and `_BaseMultiHostUrl` wrap. The wrap validator short-circuited with `if isinstance(v, source): return v`, so when the input was already a url object (not a string) the inner schema never ran and none of those constraints applied. `AnyUrl('http://evil.com')` passes an `Annotated[AnyUrl, UrlConstraints(allowed_schemes=['https'])]` field even though the string `'http://evil.com'` is correctly rejected. It is reachable without constructing urls by hand: `Tight.model_validate(loose.model_dump())` hits it because python-mode `model_dump()` keeps the live url instance, and `revalidate_instances='always'` does not help.

The fix runs the instance's already-parsed core url (`v._url`) through the inner schema so the constraints are enforced, then keeps the existing behavior of returning the same object when it already matches the target type, which preserves the documented subclass/identity pass-through (`TypeAdapter(AnyUrl).validate_python(any_http_url) is any_http_url`). Passing `v._url` rather than re-parsing `str(v)` avoids an extra parse on that hot path. Same change in both `_BaseUrl` and `_BaseMultiHostUrl`.

## Related issue number

None

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**