### PR TITLE
Refactor type references logic

### DIFF
--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -5,11 +5,6 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeGuard
 
 from pydantic_core import CoreSchema, core_schema
-from typing_extensions import get_args, get_origin  # noqa: UP035
-from typing_inspection import typing_objects
-
-from . import _repr
-from ._typing_extra import is_generic_alias
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -62,44 +57,6 @@ def is_list_like_schema_with_items_schema(
     schema: CoreSchema,
 ) -> TypeGuard[core_schema.ListSchema | core_schema.SetSchema | core_schema.FrozenSetSchema]:
     return schema['type'] in _LIST_LIKE_SCHEMA_WITH_ITEMS_TYPES
-
-
-def get_type_ref(type_: Any, args_override: tuple[type[Any], ...] | None = None) -> str:
-    """Produces the ref to be used for this type by pydantic_core's core schemas.
-
-    This `args_override` argument was added for the purpose of creating valid recursive references
-    when creating generic models without needing to create a concrete class.
-    """
-    origin = get_origin(type_) or type_
-
-    args = get_args(type_) if is_generic_alias(type_) else (args_override or ())
-    generic_metadata = getattr(type_, '__pydantic_generic_metadata__', None)
-    if generic_metadata:
-        origin = generic_metadata['origin'] or origin
-        args = generic_metadata['args'] or args
-
-    module_name = getattr(origin, '__module__', '<No __module__>')
-    if typing_objects.is_typealiastype(origin):
-        type_ref = f'{module_name}.{origin.__name__}:{id(origin)}'
-    else:
-        try:
-            qualname = getattr(origin, '__qualname__', f'<No __qualname__: {origin}>')
-        except Exception:
-            qualname = getattr(origin, '__qualname__', '<No __qualname__>')
-        type_ref = f'{module_name}.{qualname}:{id(origin)}'
-
-    arg_refs: list[str] = []
-    for arg in args:
-        if isinstance(arg, str):
-            # Handle string literals as a special case; we may be able to remove this special handling if we
-            # wrap them in a ForwardRef at some point.
-            arg_ref = f'{arg}:str-{id(arg)}'
-        else:
-            arg_ref = f'{_repr.display_as_type(arg)}:{id(arg)}'
-        arg_refs.append(arg_ref)
-    if arg_refs:
-        type_ref = f'{type_ref}[{",".join(arg_refs)}]'
-    return type_ref
 
 
 def get_ref(s: core_schema.CoreSchema) -> None | str:

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -231,8 +231,8 @@ class Decorator(Generic[DecoratorInfoType]):
     def build(
         cls_: Any,
         *,
-        cls_ref: str,
         cls_var_name: str,
+        cls_ref: str | None = None,
         shim: Callable[[Any], Any] | None,
         info: DecoratorInfoType,
     ) -> Decorator[DecoratorInfoType]:
@@ -248,6 +248,9 @@ class Decorator(Generic[DecoratorInfoType]):
         Returns:
             The new decorator instance.
         """
+        # For backwards compatibility for users using this (private!) method. TODO v3: make `cls_ref` required:
+        cls_ref = cls_ref if cls_ref is not None else _type_refs.any_class_type_ref(cls_)
+
         func = get_attribute_from_bases(cls_, cls_var_name)
         if shim is not None:
             func = shim(func)

--- a/pydantic/_internal/_decorators.py
+++ b/pydantic/_internal/_decorators.py
@@ -16,7 +16,7 @@ from pydantic_core import PydanticUndefined, PydanticUndefinedType, core_schema
 from typing_extensions import Self, is_typeddict
 
 from ..errors import PydanticUserError
-from ._core_utils import get_type_ref
+from . import _type_refs
 from ._namespace_utils import GlobalsNamespace, MappingNamespace
 from ._typing_extra import get_function_type_hints, signature_no_eval
 from ._utils import can_be_positional
@@ -231,6 +231,7 @@ class Decorator(Generic[DecoratorInfoType]):
     def build(
         cls_: Any,
         *,
+        cls_ref: str,
         cls_var_name: str,
         shim: Callable[[Any], Any] | None,
         info: DecoratorInfoType,
@@ -239,6 +240,7 @@ class Decorator(Generic[DecoratorInfoType]):
 
         Args:
             cls_: The class.
+            cls_ref: The type ref of the class.
             cls_var_name: The decorated function name.
             shim: A wrapper function to wrap V1 style function.
             info: The decorator info.
@@ -257,24 +259,26 @@ class Decorator(Generic[DecoratorInfoType]):
             if isinstance(attribute, PydanticDescriptorProxy):
                 func = unwrap_wrapped_function(attribute.wrapped)
         return Decorator(
-            cls_ref=get_type_ref(cls_),
+            cls_ref=cls_ref,
             cls_var_name=cls_var_name,
             func=func,
             shim=shim,
             info=info,
         )
 
-    def bind_to_cls(self, cls: Any) -> Decorator[DecoratorInfoType]:
+    def bind_to_cls(self, cls: Any, cls_ref: str) -> Decorator[DecoratorInfoType]:
         """Bind the decorator to a class.
 
         Args:
             cls: the class.
+            cls_ref: The type ref of the class.
 
         Returns:
             The new decorator instance.
         """
         return self.build(
             cls,
+            cls_ref=cls_ref,
             cls_var_name=self.cls_var_name,
             shim=self.shim,
             info=copy(self.info),
@@ -445,21 +449,46 @@ class DecoratorInfos:
         """
         # reminder: dicts are ordered and replacement does not alter the order
         res = cls()
+
+        type_ref: str | None = None
+
+        def cls_ref() -> str:
+            # The type ref is only required if at least one decorator is collected,
+            # so only compute it lazily (and only once):
+            nonlocal type_ref
+            if type_ref is None:
+                type_ref = _type_refs.any_class_type_ref(typ)
+            return type_ref
+
         # Iterate over the bases, without the actual `typ`.
         # `1:-1` because we don't need to include `object`/`TypedDict`:
         for base in reversed(mro(typ)[1:-1]):
             existing: DecoratorInfos | None = base.__dict__.get('__pydantic_decorators__')
             if existing is None:
-                existing, _ = _decorator_infos_for_class(base, collect_to_replace=False)
-            res.validators.update({k: v.bind_to_cls(typ) for k, v in existing.validators.items()})
-            res.field_validators.update({k: v.bind_to_cls(typ) for k, v in existing.field_validators.items()})
-            res.root_validators.update({k: v.bind_to_cls(typ) for k, v in existing.root_validators.items()})
-            res.field_serializers.update({k: v.bind_to_cls(typ) for k, v in existing.field_serializers.items()})
-            res.model_serializers.update({k: v.bind_to_cls(typ) for k, v in existing.model_serializers.items()})
-            res.model_validators.update({k: v.bind_to_cls(typ) for k, v in existing.model_validators.items()})
-            res.computed_fields.update({k: v.bind_to_cls(typ) for k, v in existing.computed_fields.items()})
+                existing, _ = _decorator_infos_for_class(
+                    base,
+                    # The class refs of the built decorators are irrelevant here, as `bind_to_cls()`
+                    # below rebinds every decorator to `typ` with the correct ref:
+                    cls_ref=lambda: '',
+                    collect_to_replace=False,
+                )
+            res.validators.update({k: v.bind_to_cls(typ, cls_ref()) for k, v in existing.validators.items()})
+            res.field_validators.update(
+                {k: v.bind_to_cls(typ, cls_ref()) for k, v in existing.field_validators.items()}
+            )
+            res.root_validators.update({k: v.bind_to_cls(typ, cls_ref()) for k, v in existing.root_validators.items()})
+            res.field_serializers.update(
+                {k: v.bind_to_cls(typ, cls_ref()) for k, v in existing.field_serializers.items()}
+            )
+            res.model_serializers.update(
+                {k: v.bind_to_cls(typ, cls_ref()) for k, v in existing.model_serializers.items()}
+            )
+            res.model_validators.update(
+                {k: v.bind_to_cls(typ, cls_ref()) for k, v in existing.model_validators.items()}
+            )
+            res.computed_fields.update({k: v.bind_to_cls(typ, cls_ref()) for k, v in existing.computed_fields.items()})
 
-        decorator_infos, to_replace = _decorator_infos_for_class(typ, collect_to_replace=True)
+        decorator_infos, to_replace = _decorator_infos_for_class(typ, cls_ref=cls_ref, collect_to_replace=True)
 
         res.validators.update(decorator_infos.validators)
         res.field_validators.update(decorator_infos.field_validators)
@@ -496,6 +525,7 @@ class DecoratorInfos:
 def _decorator_infos_for_class(
     typ: type[Any],
     *,
+    cls_ref: Callable[[], str],
     collect_to_replace: bool,
 ) -> tuple[DecoratorInfos, list[tuple[str, Any]]]:
     """Collect a `DecoratorInfos` for class, without looking into bases."""
@@ -506,32 +536,36 @@ def _decorator_infos_for_class(
         if isinstance(var_value, PydanticDescriptorProxy):
             info = var_value.decorator_info
             if isinstance(info, ValidatorDecoratorInfo):
-                res.validators[var_name] = Decorator.build(typ, cls_var_name=var_name, shim=var_value.shim, info=info)
+                res.validators[var_name] = Decorator.build(
+                    typ, cls_ref=cls_ref(), cls_var_name=var_name, shim=var_value.shim, info=info
+                )
             elif isinstance(info, FieldValidatorDecoratorInfo):
                 res.field_validators[var_name] = Decorator.build(
-                    typ, cls_var_name=var_name, shim=var_value.shim, info=info
+                    typ, cls_ref=cls_ref(), cls_var_name=var_name, shim=var_value.shim, info=info
                 )
             elif isinstance(info, RootValidatorDecoratorInfo):
                 res.root_validators[var_name] = Decorator.build(
-                    typ, cls_var_name=var_name, shim=var_value.shim, info=info
+                    typ, cls_ref=cls_ref(), cls_var_name=var_name, shim=var_value.shim, info=info
                 )
             elif isinstance(info, FieldSerializerDecoratorInfo):
                 res.field_serializers[var_name] = Decorator.build(
-                    typ, cls_var_name=var_name, shim=var_value.shim, info=info
+                    typ, cls_ref=cls_ref(), cls_var_name=var_name, shim=var_value.shim, info=info
                 )
             elif isinstance(info, ModelValidatorDecoratorInfo):
                 res.model_validators[var_name] = Decorator.build(
-                    typ, cls_var_name=var_name, shim=var_value.shim, info=info
+                    typ, cls_ref=cls_ref(), cls_var_name=var_name, shim=var_value.shim, info=info
                 )
             elif isinstance(info, ModelSerializerDecoratorInfo):
                 res.model_serializers[var_name] = Decorator.build(
-                    typ, cls_var_name=var_name, shim=var_value.shim, info=info
+                    typ, cls_ref=cls_ref(), cls_var_name=var_name, shim=var_value.shim, info=info
                 )
             else:
                 from ..fields import ComputedFieldInfo
 
                 isinstance(var_value, ComputedFieldInfo)
-                res.computed_fields[var_name] = Decorator.build(typ, cls_var_name=var_name, shim=None, info=info)
+                res.computed_fields[var_name] = Decorator.build(
+                    typ, cls_ref=cls_ref(), cls_var_name=var_name, shim=None, info=info
+                )
             if collect_to_replace:
                 to_replace.append((var_name, var_value.wrapped))
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -78,12 +78,11 @@ from ..warnings import (
     TypedDictExtraConfigWarning,
     UnsupportedFieldAttributeWarning,
 )
-from . import _decorators, _discriminated_union, _known_annotated_metadata, _repr, _typing_extra
+from . import _decorators, _discriminated_union, _known_annotated_metadata, _repr, _type_refs, _typing_extra
 from ._config import ConfigWrapper, ConfigWrapperStack
 from ._core_metadata import CoreMetadata, update_core_metadata
 from ._core_utils import (
     get_ref,
-    get_type_ref,
     is_list_like_schema_with_items_schema,
 )
 from ._decorators import (
@@ -483,7 +482,7 @@ class GenerateSchema:
     def _enum_schema(self, enum_type: type[Enum]) -> CoreSchema:
         cases: list[Any] = list(enum_type.__members__.values())
 
-        enum_ref = get_type_ref(enum_type)
+        enum_ref = _type_refs.enum_type_ref(enum_type)
         description = None if not enum_type.__doc__ else inspect.cleandoc(enum_type.__doc__)
         if (
             description == 'An enumeration.'
@@ -813,7 +812,8 @@ class GenerateSchema:
         """Generate schema for a Pydantic model."""
         BaseModel_ = import_cached_base_model()
 
-        with self.defs.get_schema_or_ref(cls) as (model_ref, maybe_schema):
+        model_ref = _type_refs.model_type_ref(cls)
+        with self.defs.get_definition_ref_schema(ref=model_ref) as maybe_schema:
             if maybe_schema is not None:
                 return maybe_schema
 
@@ -974,9 +974,11 @@ class GenerateSchema:
             # Some referenceable types might have a `__get_pydantic_core_schema__` method
             # defined on it by users (e.g. on a dataclass). This generally doesn't play well
             # as these types are already recognized by the `GenerateSchema` class and isn't ideal
-            # as we might end up calling `get_schema_or_ref` (expensive) on types that are actually
+            # as we might end up calling `any_class_type_ref()` (relatively expensive) on types that are actually
             # not referenceable:
-            with self.defs.get_schema_or_ref(obj) as (_, maybe_schema):
+            with self.defs.get_definition_ref_schema(
+                ref=_type_refs.any_class_type_ref(obj, get_origin(obj))
+            ) as maybe_schema:
                 if maybe_schema is not None:
                     return maybe_schema
 
@@ -1354,7 +1356,8 @@ class GenerateSchema:
         return s
 
     def _type_alias_type_schema(self, obj: TypeAliasType) -> CoreSchema:
-        with self.defs.get_schema_or_ref(obj) as (ref, maybe_schema):
+        ref = _type_refs.type_alias_type_ref(obj)
+        with self.defs.get_definition_ref_schema(ref=ref) as maybe_schema:
             if maybe_schema is not None:
                 return maybe_schema
 
@@ -1397,12 +1400,10 @@ class GenerateSchema:
         """
         FieldInfo = import_cached_field_info()
 
+        typed_dict_ref = _type_refs.class_type_ref(typed_dict_cls, origin)
         with (
             self.model_type_stack.push(typed_dict_cls),
-            self.defs.get_schema_or_ref(typed_dict_cls) as (
-                typed_dict_ref,
-                maybe_schema,
-            ),
+            self.defs.get_definition_ref_schema(ref=typed_dict_ref) as maybe_schema,
         ):
             if maybe_schema is not None:
                 return maybe_schema
@@ -1526,12 +1527,10 @@ class GenerateSchema:
 
     def _namedtuple_schema(self, namedtuple_cls: Any, origin: Any) -> core_schema.CoreSchema:
         """Generate schema for a NamedTuple."""
+        namedtuple_ref = _type_refs.class_type_ref(namedtuple_cls, origin)
         with (
             self.model_type_stack.push(namedtuple_cls),
-            self.defs.get_schema_or_ref(namedtuple_cls) as (
-                namedtuple_ref,
-                maybe_schema,
-            ),
+            self.defs.get_definition_ref_schema(ref=namedtuple_ref) as maybe_schema,
         ):
             if maybe_schema is not None:
                 return maybe_schema
@@ -1865,12 +1864,10 @@ class GenerateSchema:
         self, dataclass: type[StandardDataclass], origin: type[StandardDataclass] | None
     ) -> core_schema.CoreSchema:
         """Generate schema for a dataclass."""
+        dataclass_ref = _type_refs.class_type_ref(dataclass, origin)
         with (
             self.model_type_stack.push(dataclass),
-            self.defs.get_schema_or_ref(dataclass) as (
-                dataclass_ref,
-                maybe_schema,
-            ),
+            self.defs.get_definition_ref_schema(ref=dataclass_ref) as maybe_schema,
         ):
             if maybe_schema is not None:
                 return maybe_schema
@@ -2796,14 +2793,9 @@ class _Definitions:
         self._definitions = {}
 
     @contextmanager
-    def get_schema_or_ref(self, tp: Any, /) -> Generator[tuple[str, core_schema.DefinitionReferenceSchema | None]]:
-        """Get a definition for `tp` if one exists.
-
-        If a definition exists, a tuple of `(ref_string, CoreSchema)` is returned.
-        If no definition exists yet, a tuple of `(ref_string, None)` is returned.
-
-        Note that the returned `CoreSchema` will always be a `DefinitionReferenceSchema`,
-        not the actual definition itself.
+    def get_definition_ref_schema(self, *, ref: str) -> Generator[core_schema.DefinitionReferenceSchema | None]:
+        """Get a `'definition-ref'` schema for `ref`, if the reference was already encountered (or if we are in a cycle).
+        Get a definition for `tp` if one exists.
 
         This should be called for any type that can be identified by reference.
         This includes any recursive types.
@@ -2817,14 +2809,13 @@ class _Definitions:
         - `TypeAliasType` instances
         - Enums
         """
-        ref = get_type_ref(tp)
         # return the reference if we're either (1) in a cycle or (2) it the reference was already encountered:
         if ref in self._recursively_seen or ref in self._definitions:
-            yield (ref, core_schema.definition_reference_schema(ref))
+            yield core_schema.definition_reference_schema(ref)
         else:
             self._recursively_seen.add(ref)
             try:
-                yield (ref, None)
+                yield None
             finally:
                 self._recursively_seen.discard(ref)
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -974,11 +974,9 @@ class GenerateSchema:
             # Some referenceable types might have a `__get_pydantic_core_schema__` method
             # defined on it by users (e.g. on a dataclass). This generally doesn't play well
             # as these types are already recognized by the `GenerateSchema` class and isn't ideal
-            # as we might end up calling `any_class_type_ref()` (relatively expensive) on types that are actually
+            # as we might end up calling `any_type_ref()` (relatively expensive) on types that are actually
             # not referenceable:
-            with self.defs.get_definition_ref_schema(
-                ref=_type_refs.any_class_type_ref(obj, get_origin(obj))
-            ) as maybe_schema:
+            with self.defs.get_definition_ref_schema(ref=_type_refs.any_type_ref(obj, get_origin(obj))) as maybe_schema:
                 if maybe_schema is not None:
                     return maybe_schema
 

--- a/pydantic/_internal/_generics.py
+++ b/pydantic/_internal/_generics.py
@@ -18,8 +18,7 @@ import typing_extensions
 from typing_inspection import typing_objects
 from typing_inspection.introspection import is_union_origin
 
-from . import _typing_extra
-from ._core_utils import get_type_ref
+from . import _type_refs, _typing_extra
 from ._forward_ref import PydanticRecursiveRef
 from ._utils import all_identical, is_model_class
 
@@ -427,7 +426,7 @@ def generic_recursion_self_type(
         token = None
 
     try:
-        type_ref = get_type_ref(origin, args_override=args)
+        type_ref = _type_refs.model_type_ref(origin, args_override=args)
         if type_ref in previously_seen_type_refs:
             self_type = PydanticRecursiveRef(type_ref=type_ref)
             yield self_type

--- a/pydantic/_internal/_type_refs.py
+++ b/pydantic/_internal/_type_refs.py
@@ -1,0 +1,106 @@
+"""Logic related to reference computation for types."""
+
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import TYPE_CHECKING, Any, cast, get_args, get_origin
+
+from typing_extensions import Sentinel, TypeAliasType
+
+from . import _repr
+from ._import_utils import import_cached_base_model
+from ._utils import lenient_issubclass
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+
+def _args_ref(args: tuple[Any, ...]) -> str:
+    arg_refs: list[str] = []
+    for arg in args:
+        if isinstance(arg, str):
+            # Handle string args as a special case; we may be able to remove this special handling if we
+            # wrap them in a ForwardRef at some point.
+            arg_ref = f'{arg}:str-{id(arg)}'
+        else:
+            arg_ref = f'{_repr.display_as_type(arg)}:{id(arg)}'
+        arg_refs.append(arg_ref)
+
+    if arg_refs:
+        return f'[{",".join(arg_refs)}]'
+    else:
+        return ''
+
+
+def model_type_ref(type_: type[BaseModel], args_override: tuple[Any, ...] | None = None) -> str:
+    """Produce a reference for Pydantic base models."""
+    try:
+        generic_metadata = type_.__pydantic_generic_metadata__
+    except AttributeError:
+        # `type_` is `BaseModel`:
+        return f'{type_.__module__}.{type_.__qualname__}:{id(type_)}'
+
+    origin = generic_metadata['origin'] or type_
+    args = generic_metadata['args']
+    if not args and args_override is not None:
+        args = args_override
+
+    # While it is typed as `str`, `__module__` could in theory be `None`:
+    module_name = cast(str | None, origin.__module__)
+    if module_name is None:
+        module_name = '<No __module__>'
+
+    return f'{module_name}.{origin.__qualname__}:{id(origin)}{_args_ref(args)}'
+
+
+def class_type_ref(type_: Any, origin: type[Any] | None) -> str:
+    """Produce a reference for an arbitrary class (dataclasses, typed dictionaries, named tuples)."""
+    tp: type[Any] = origin if origin is not None else type_
+
+    # While it is typed as `str`, `__module__` could in theory be `None`:
+    module_name = cast(str | None, tp.__module__)
+    if module_name is None:
+        module_name = '<No __module__>'
+
+    return f'{module_name}.{tp.__qualname__}:{id(tp)}{_args_ref(get_args(type_))}'
+
+
+_NOT_PROVIDED = Sentinel('_NOT_PROVIDED')
+
+
+def any_class_type_ref(type_: Any, origin: type[Any] | None | _NOT_PROVIDED = _NOT_PROVIDED) -> str:
+    """Produce a reference for any class kind, including Pydantic models."""
+    BaseModel_ = import_cached_base_model()
+
+    if lenient_issubclass(type_, BaseModel_):
+        return model_type_ref(type_)  # pyright: ignore[reportArgumentType]
+
+    origin = get_origin(type_) if origin is _NOT_PROVIDED else origin
+    return class_type_ref(type_, origin)  # pyright: ignore[reportArgumentType] (https://github.com/microsoft/pyright/issues/11115)
+
+
+def enum_type_ref(type_: type[Enum]) -> str:
+    """Produce a reference for an enum class."""
+    # While it is typed as `str`, `__module__` could in theory be `None`:
+    module_name = cast(str | None, type_.__module__)
+    if module_name is None:
+        module_name = '<No __module__>'
+
+    return f'{module_name}.{type_.__qualname__}:{id(type_)}'
+
+
+def type_alias_type_ref(type_: TypeAliasType) -> str:
+    """Produce a reference for a type alias."""
+    origin: TypeAliasType = get_origin(type_) or type_
+
+    module_name = type_.__module__
+    if module_name is None:
+        module_name = '<No __module__>'
+
+    if sys.version_info >= (3, 15):
+        type_ref = f'{module_name}.{origin.__qualname__}:{id(origin)}'
+    else:
+        type_ref = f'{module_name}.{origin.__name__}:{id(origin)}'
+
+    return f'{type_ref}{_args_ref(get_args(type_))}'

--- a/pydantic/_internal/_type_refs.py
+++ b/pydantic/_internal/_type_refs.py
@@ -80,6 +80,28 @@ def any_class_type_ref(type_: Any, origin: type[Any] | None | _NOT_PROVIDED = _N
     return class_type_ref(type_, origin)  # pyright: ignore[reportArgumentType] (https://github.com/microsoft/pyright/issues/11115)
 
 
+def any_type_ref(type_: Any, origin: Any | _NOT_PROVIDED = _NOT_PROVIDED) -> str:
+    """Produce a reference for any object, including non-class objects."""
+    BaseModel_ = import_cached_base_model()
+
+    if lenient_issubclass(type_, BaseModel_):
+        return model_type_ref(type_)  # pyright: ignore[reportArgumentType]
+
+    origin = get_origin(type_) if origin is _NOT_PROVIDED else origin
+    tp: Any = origin if origin is not None else type_
+
+    module_name = getattr(tp, '__module__', None)
+    if module_name is None:
+        module_name = '<No __module__>'
+
+    try:
+        qualname = getattr(tp, '__qualname__', f'<No __qualname__: {tp}>')
+    except Exception:
+        qualname = getattr(tp, '__qualname__', '<No __qualname__>')
+
+    return f'{module_name}.{qualname}:{id(tp)}{_args_ref(get_args(type_))}'
+
+
 def enum_type_ref(type_: type[Enum]) -> str:
     """Produce a reference for an enum class."""
     # While it is typed as `str`, `__module__` could in theory be `None`:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -3198,3 +3198,12 @@ def test_interconnected_models_build_in_linear_time() -> None:
     instance = last.model_validate({'value': 1, 'ref2': {'value': 2, 'ref2': {'value': 3}}})
     assert instance.ref2.ref2.value == 3
     assert instance.model_dump(exclude_none=True) == {'value': 1, 'ref2': {'value': 2, 'ref2': {'value': 3}}}
+
+
+def test_get_pydantic_core_schema_instance() -> None:
+    class SchemaProvider:
+        def __get_pydantic_core_schema__(self, source: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+            return core_schema.int_schema()
+
+    ta = TypeAdapter(SchemaProvider())
+    assert ta.validate_python('1') == 1


### PR DESCRIPTION
The existing `get_type_ref()` was agnostic of any type being passed, and so would result in useless checks. As we control when type references are computed, we can define specialized logic for each type (Pydantic models, other classes, type aliases, etc).

Also refactor how `DecoratorInfos` computes references, to avoid useless calls. The `_decorators.py` module is internal, but widely used unfortunately. Backwards compatibility is only preserved on `Decorator.build()`:
- Usage of `Decorator.build()`: https://github.com/search?q=lang%3Apython+%22Decorator.build%28%22+NOT+path%3A**%2F_decorators.py&type=code
- Usage of `Decorator.bind_to_cls()`: https://github.com/search?q=lang%3Apython+%22bind_to_cls%28%22+NOT+path%3A**%2F_decorators.py&type=code

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
