### PR TITLE
Fix TypeError on unhashable annotations in match_type deprecated-alias lookup

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1124,10 +1124,18 @@ class GenerateSchema:
             # early for model-like fields, which handles it already.
             return core_schema.any_schema()
 
-        if origin is not None and (aliased_obj := typing_objects.DEPRECATED_ALIASES.get(obj)):
-            # See https://typing-inspection.pydantic.dev/dev/usage/#inspecting-the-type-expression:
-            obj = aliased_obj
-            origin = None
+        if origin is not None:
+            try:
+                aliased_obj = typing_objects.DEPRECATED_ALIASES.get(obj)
+            except TypeError:
+                # `obj` may be unhashable (e.g. a `types.GenericAlias` with a list argument,
+                # such as a PEP 695 alias with a `ParamSpec` parameterized by `[]`), in which
+                # case it can't be a deprecated alias.
+                aliased_obj = None
+            if aliased_obj is not None:
+                # See https://typing-inspection.pydantic.dev/dev/usage/#inspecting-the-type-expression:
+                obj = aliased_obj
+                origin = None
 
         if origin is None:
             # Thanks to the checks before this point, no origin means `obj` is a

--- a/tests/test_type_alias_type.py
+++ b/tests/test_type_alias_type.py
@@ -1,11 +1,11 @@
 import datetime
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Annotated, Generic, Literal, TypeVar, Union
+from typing import Annotated, Any, Generic, Literal, TypeVar, Union
 
 import pytest
 from annotated_types import MaxLen
-from typing_extensions import TypeAliasType
+from typing_extensions import ParamSpec, TypeAliasType
 
 from pydantic import BaseModel, PlainSerializer, PydanticUserError, TypeAdapter, ValidationError, WithJsonSchema
 
@@ -488,3 +488,19 @@ def test_type_alias_type_with_metadata() -> None:
 
     ta = TypeAdapter(B)
     assert ta.json_schema() == {'type': 'int', 'extra': 1}
+
+
+def test_unhashable_type_alias_type() -> None:
+    """https://github.com/pydantic/pydantic/issues/13645
+
+    Subscripting a `TypeAliasType` with a `ParamSpec` using a list (e.g. `Alias[[], int]`)
+    produces an unhashable `types.GenericAlias` (its `__args__` contain a `list`).
+    Schema building should not assume annotations are hashable.
+    """
+    P = ParamSpec('P')
+    Alias = TypeAliasType('Alias', Any, type_params=(P, T))
+
+    class Model(BaseModel):
+        f: Alias[[], int] | None = None
+
+    assert Model(f=1).f == 1


### PR DESCRIPTION
## Change Summary

`match_type` added an unguarded `typing_objects.DEPRECATED_ALIASES.get(obj)` lookup in 2.14 that assumes the annotation object is hashable. A `TypeAliasType` subscripted with a `ParamSpec` list argument (e.g. `Alias[[], int]`, common with PEP 695 `type Alias[**P, R] = ...` syntax) is a `types.GenericAlias` whose `__args__` contain a `list`, making it unhashable — so building a schema for any model containing such an annotation crashed with `TypeError: unhashable type: 'list'`. Regression vs 2.13.4.

This guards the lookup with `try/except TypeError`, matching the existing guard around `self._handlers.get(obj)` a few lines below. An unhashable object cannot be a `DEPRECATED_ALIASES` key by construction, so skipping the lookup is always correct.

Adds a regression test using `typing_extensions.TypeAliasType` so it runs on all supported Python versions.

## Related issue number

Fixes #13645 (real-world impact: broke `import giskard.checks` under 2.14.0b1, see Giskard-AI/giskard#2719)

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)