### PR TITLE
Fix field_title_generator override in inheritance (#13486)

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -162,7 +162,7 @@ def _apply_field_title_generator_to_field_info(
     field_name: str,
     field_info: FieldInfo,
 ):
-    if field_info.title is None:
+    if field_info.title is None or 'title' not in field_info._attributes_set:
         title = title_generator(field_name, field_info)
         if not isinstance(title, str):
             raise TypeError(f'field_title_generator {title_generator} must return str, not {title.__class__}')

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -2196,7 +2196,9 @@ class GenerateSchema:
         return_type = replace_types(return_type, self._typevars_map)
         # Create a new ComputedFieldInfo so that different type parametrizations of the same
         # generic model's computed field can have different return types.
-        d.info = dataclasses.replace(d.info, return_type=return_type)
+        new_info = dataclasses.replace(d.info, return_type=return_type)
+        new_info._title_from_generator = getattr(d.info, '_title_from_generator', False)
+        d.info = new_info
         return_type_schema = self.generate_schema(return_type)
         # Apply serializers to computed field if there exist
         return_type_schema = self._apply_field_serializers(

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1603,10 +1603,11 @@ class ComputedFieldInfo:
     examples: list[Any] | None
     json_schema_extra: JsonDict | Callable[[JsonDict], None] | None
     repr: bool
+    _title_from_generator: bool = dataclasses.field(default=False, init=False, repr=False)
     # NOTE: if you add a new field, add it to the `__copy__()` implementation.
 
     def __copy__(self) -> Self:
-        return type(self)(
+        cp = type(self)(
             wrapped_property=self.wrapped_property,
             return_type=self.return_type,
             alias=self.alias,
@@ -1622,6 +1623,8 @@ class ComputedFieldInfo:
             else self.json_schema_extra,
             repr=self.repr,
         )
+        cp._title_from_generator = self._title_from_generator
+        return cp
 
     @property
     def deprecation_message(self) -> str | None:
@@ -1635,8 +1638,9 @@ class ComputedFieldInfo:
     def _update_from_config(self, config_wrapper: ConfigWrapper, name: str) -> None:
         """Update the instance from the configuration set on the class this computed field belongs to."""
         title_generator = self.field_title_generator or config_wrapper.field_title_generator
-        if title_generator is not None and self.title is None:
+        if title_generator is not None and (self.title is None or self._title_from_generator):
             self.title = title_generator(name, self)
+            self._title_from_generator = True
         if config_wrapper.alias_generator is not None:
             self._apply_alias_generator(config_wrapper.alias_generator, name)
 

--- a/tests/test_issue_13486.py
+++ b/tests/test_issue_13486.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, computed_field
+
+
+def test_field_title_generator_inheritance():
+    class Model(BaseModel, field_title_generator=lambda v, _: v + 'a'):
+        a: int
+
+        @computed_field
+        def c(self) -> int:
+            return 1
+
+    class Sub(Model, field_title_generator=lambda v, _: v + 'b'):
+        b: int
+
+        @computed_field
+        def d(self) -> int:
+            return 2
+
+    assert Sub.model_fields['a'].title == 'ab'
+    assert Sub.model_fields['b'].title == 'bb'
+    assert Sub.model_computed_fields['c'].title == 'cb'
+    assert Sub.model_computed_fields['d'].title == 'db'


### PR DESCRIPTION
Fixes #13486. This PR ensures that field_title_generator respects explicit titles and works correctly through subclass inheritance for both regular and computed fields.