### PR TITLE
fix(pipeline): avoid redundant length validation

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -547,13 +547,15 @@ def _apply_constraint(  # noqa: C901
                 s['min_length'] = min_len
             if max_len is not None:
                 s['max_length'] = max_len
+        else:
 
-        def check_len(v: Any) -> bool:
-            if max_len is not None:
-                return (min_len <= len(v)) and (len(v) <= max_len)
-            return min_len <= len(v)
+            def check_len(v: Any) -> bool:
+                if max_len is not None:
+                    return (min_len <= len(v)) and (len(v) <= max_len)
+                return min_len <= len(v)
 
-        s = _check_func(check_len, f'length >= {min_len} and length <= {max_len}', s)
+            s = _check_func(check_len, f'length >= {min_len} and length <= {max_len}', s)
+
     elif isinstance(constraint, annotated_types.MultipleOf):
         multiple_of = constraint.multiple_of
         if s and s['type'] in {'int', 'float', 'decimal'}:


### PR DESCRIPTION
Fix redundant Python-level length validation in the experimental pipeline API.

When `.len()` is applied to types that natively support `min_length` / `max_length`, the native constraints are now used without adding an additional Python-level `check_len` validator.

For types without native length constraint support, the existing Python-level fallback is preserved.

Regression tests have been added to verify that native length constraints do not result in an unnecessary validator wrapper.

## Related issue number

Fix #13653

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**