### PR TITLE
Fix init=False dataclass fields consuming a positional slot

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1255,7 +1255,11 @@ class GenerateSchema:
             schema,
             init=field_info.init,
             init_only=field_info.init_var or None,
-            kw_only=None if field_info.kw_only else False,
+            # An `init=False` field is never supplied by the caller, so it must not
+            # take a positional slot. Emitting `kw_only=False` for it keeps it in the
+            # positional ordering (see the sort in `_dataclass_schema`), which shifts
+            # every later positional argument by one.
+            kw_only=None if field_info.kw_only or field_info.init is False else False,
             serialization_exclude=field_info.exclude,
             validation_alias=_convert_to_aliases(field_info.validation_alias),
             serialization_alias=field_info.serialization_alias,

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2927,6 +2927,47 @@ def test_init_false_not_in_signature(extra, field_constructor):
     assert 'b' in signature.parameters.keys()
 
 
+@pytest.mark.parametrize('field_constructor', [dataclasses.field, pydantic.dataclasses.Field])
+def test_init_false_does_not_take_a_positional_slot(field_constructor):
+    # An `init=False` field is absent from the signature, so it must not occupy a
+    # positional slot either. It used to, which shifted every positional argument
+    # by one: the first was dropped and the rest landed on the wrong field.
+    @pydantic.dataclasses.dataclass
+    class MyDataclass:
+        a: int = field_constructor(init=False, default=-1)
+        b: str = 'b_default'
+        c: int = 0
+
+    assert list(inspect.signature(MyDataclass).parameters) == ['b', 'c']
+
+    obj = MyDataclass('given')
+    assert (obj.a, obj.b, obj.c) == (-1, 'given', 0)
+
+    obj = MyDataclass('given', 5)
+    assert (obj.a, obj.b, obj.c) == (-1, 'given', 5)
+
+
+@pytest.mark.parametrize('default_kind', ['default', 'default_factory'])
+def test_init_false_inherited_does_not_break_subclass_positional(default_kind):
+    # An `init=False` field on the parent shifted the subclass's positional
+    # arguments, so a required subclass field reported itself as missing.
+    kwargs = {'default': 2} if default_kind == 'default' else {'default_factory': lambda: 2}
+
+    @pydantic.dataclasses.dataclass
+    class Parent:
+        a: int = dataclasses.field(init=False, **kwargs)
+
+    @pydantic.dataclasses.dataclass
+    class Child(Parent):
+        b: str
+
+    assert list(inspect.signature(Child).parameters) == ['b']
+
+    obj = Child('given')
+    assert (obj.a, obj.b) == (2, 'given')
+    assert Child(b='given') == obj
+
+
 init_test_cases = [
     ({'a': 2, 'b': -1}, 'ignore', {'a': 2, 'b': 1}),
     ({'a': 2}, 'ignore', {'a': 2, 'b': 1}),


### PR DESCRIPTION
Fixes #7821.

`init=False` fields are excluded from a pydantic dataclass's `__init__`
signature, but they still occupy a positional slot in the validator. Every
positional argument after one is shifted by one place.

What that looks like depends on what it shifts onto:

```python
from dataclasses import field
from pydantic.dataclasses import dataclass

@dataclass
class P:
    hidden: int = field(init=False, default=99)
    name: str = 'default_name'
    age: int = 0

inspect.signature(P)   # (name: str = 'default_name', age: int = 0)

P('alice')             # name='default_name'   <- input silently dropped
P('alice', 30)         # ValidationError at index 1: 'Input should be a valid string', input_value=30
```

stdlib `dataclasses` returns `name='alice'` for the first and accepts the
second. The signature says the same thing for both libraries; only the binding
differs.

The issue reports the third symptom: when the shifted-onto field is required, it
comes back as `Field required`. Note the title says `default_factory` breaks
while `default` works. That was true on 2.4; on 2.9.0 and on current main both
fail, because the trigger is `init=False` rather than which default was used.

## Cause

`_generate_dc_field_schema()` emits `kw_only=False` for any field that is not
explicitly keyword-only, and `_dataclass_schema` sorts on that to decide
positional ordering:

```python
key=lambda a: a.get('kw_only') is not False
```

So an `init=False` field, which the caller can never supply, is still given a
positional slot.

## Change

```python
kw_only=None if field_info.kw_only or field_info.init is False else False
```

`is False` rather than a falsy test on purpose: `init` is `bool | None`, and the
falsy form would make every field with an unset `init` keyword-only.

## Tests

Four cases in `tests/test_dataclasses.py`, next to the existing
`test_init_false_not_in_signature`, which already asserts the signature is right
but not that the binding agrees with it:

- `test_init_false_does_not_take_a_positional_slot`, over both `dataclasses.field`
  and `pydantic.dataclasses.Field`
- `test_init_false_inherited_does_not_break_subclass_positional`, over `default`
  and `default_factory`

All four fail on main. `tests/test_dataclasses.py` goes 264 -> 268 passed.
Across `test_dataclasses`, `test_main`, `test_edge_cases`, `test_fields` and
`test_construction`: 843 -> 847, no regressions.
