### PR TITLE
fix: apply the `__pydantic_extra__` annotation when `extra` is overridden at runtime

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -274,7 +274,8 @@ The configuration can take three values:
   The `__pydantic_extra__` can explicitly be annotated to provide validation for extra fields.
 
 The validation methods (e.g. [`model_validate()`][pydantic.main.BaseModel.model_validate]) have an optional `extra` argument
-that will override the `extra` configuration value of the model for that validation call.
+that will override the `extra` configuration value of the model for that validation call. If extra data is allowed this way,
+the `__pydantic_extra__` annotation (if set) is still used to validate the extra fields.
 
 For more details, refer to the [`extra`][pydantic.ConfigDict.extra] API documentation.
 

--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -3250,8 +3250,10 @@ def model_fields_schema(
         model_name: The name of the model, used for error messages, defaults to "Model"
         computed_fields: Computed fields to use when serializing the model, only applies when directly inside a model
         strict: Whether the model is strict
-        extras_schema: The schema to use when validating extra input data
-        extras_keys_schema: The schema to use when validating the keys of extra input data
+        extras_schema: The schema to use when validating extra input data. Only used if extra data is
+            allowed, either from the extra behavior or as overridden when validating
+        extras_keys_schema: The schema to use when validating the keys of extra input data. Only used if
+            extra data is allowed, either from the extra behavior or as overridden when validating
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
         extra_behavior: The extra behavior to use for the model fields

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -13,7 +13,6 @@ use super::{
     BuildSerializer, CombinedSerializer, ComputedFields, Extra, FieldsMode, GeneralFieldsSerializer, ObType, SerCheck,
     SerField, TypeSerializer, infer_json_key, infer_json_key_known,
 };
-use crate::build_tools::py_schema_err;
 use crate::build_tools::{ExtraBehavior, py_schema_error_type};
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::definitions::DefinitionsBuilder;
@@ -47,10 +46,12 @@ impl BuildSerializer for ModelFieldsBuilder {
         let fields_dict: Bound<'_, PyDict> = schema.get_as_req(intern!(py, "fields"))?;
         let mut fields = AHashMap::with_capacity(fields_dict.len());
 
-        let extra_serializer = match (schema.get_item(intern!(py, "extras_schema"))?, &fields_mode) {
-            (Some(v), FieldsMode::ModelExtra) => Some(CombinedSerializer::build(&v.extract()?, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
-            (_, _) => None,
+        // As with the model fields validator, the extras serializer is built even if extra data
+        // isn't allowed on the model (the schema is shared between the validator and the serializer,
+        // and the extra behavior can be overridden when validating):
+        let extra_serializer = match schema.get_item(intern!(py, "extras_schema"))? {
+            Some(v) => Some(CombinedSerializer::build(&v.extract()?, config, definitions)?),
+            None => None,
         };
 
         let serialize_by_alias = config.get_as(intern!(py, "serialize_by_alias"))?;

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -66,15 +66,15 @@ impl BuildValidator for ModelFieldsValidator {
 
         let extra_behavior = ExtraBehavior::from_schema_or_config(py, schema, config, ExtraBehavior::Ignore)?;
 
-        let extras_validator = match (schema.get_item(intern!(py, "extras_schema"))?, &extra_behavior) {
-            (Some(v), ExtraBehavior::Allow) => Some(build_validator(&v, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_schema can only be used if extra_behavior=allow"),
-            (_, _) => None,
+        // The extras validators are built even if extra data isn't allowed, as the extra behavior
+        // can be overridden when validating (in which case they are used):
+        let extras_validator = match schema.get_item(intern!(py, "extras_schema"))? {
+            Some(v) => Some(build_validator(&v, config, definitions)?),
+            None => None,
         };
-        let extras_keys_validator = match (schema.get_item(intern!(py, "extras_keys_schema"))?, &extra_behavior) {
-            (Some(v), ExtraBehavior::Allow) => Some(build_validator(&v, config, definitions)?),
-            (Some(_), _) => return py_schema_err!("extras_keys_schema can only be used if extra_behavior=allow"),
-            (_, _) => None,
+        let extras_keys_validator = match schema.get_item(intern!(py, "extras_keys_schema"))? {
+            Some(v) => Some(build_validator(&v, config, definitions)?),
+            None => None,
         };
         let model_name: String = schema
             .get_as(intern!(py, "model_name"))?

--- a/pydantic-core/tests/validators/test_model_fields.py
+++ b/pydantic-core/tests/validators/test_model_fields.py
@@ -211,20 +211,18 @@ def test_forbid_extra():
     ]
 
 
-def test_allow_extra_invalid():
-    with pytest.raises(SchemaError, match='extras_schema can only be used if extra_behavior=allow'):
-        SchemaValidator(
-            schema=core_schema.model_fields_schema(
-                fields={}, extras_schema=core_schema.int_schema(), extra_behavior='ignore'
-            )
+def test_extras_schemas_unused_if_extra_not_allowed():
+    """The extras schemas are ignored if extra data isn't allowed, as the extra behavior can be overridden."""
+    v = SchemaValidator(
+        schema=core_schema.model_fields_schema(
+            fields={},
+            extras_schema=core_schema.int_schema(),
+            extras_keys_schema=core_schema.str_schema(),
+            extra_behavior='ignore',
         )
+    )
 
-    with pytest.raises(SchemaError, match='extras_keys_schema can only be used if extra_behavior=allow'):
-        SchemaValidator(
-            schema=core_schema.model_fields_schema(
-                fields={}, extras_keys_schema=core_schema.int_schema(), extra_behavior='ignore'
-            )
-        )
+    assert v.validate_python({'extra_field': 'not_an_int'}) == ({}, None, set())
 
 
 def test_allow_extra_wrong():
@@ -1678,9 +1676,8 @@ def test_extra_behavior_allow(
     assert new_fields_set == {'not_f'}
 
 
-# We can't test the extra parameter of the validate_* functions above, since the
-# extras_schema parameter isn't valid unless the models are configured with extra='allow'.
-# Test the validate_* extra parameter separately instead:
+# Test the validate_* extra parameter separately, as the extra behavior of the schema
+# (or the config) isn't the one being applied in this case:
 @pytest.mark.parametrize(
     'config,schema_extra_behavior_kw',
     [
@@ -1694,20 +1691,27 @@ def test_extra_behavior_allow(
         (None, {'extra_behavior': None}),
     ],
 )
+@pytest.mark.parametrize(
+    'extras_schema_kw, expected_extra_value',
+    [({}, '123'), ({'extras_schema': None}, '123'), ({'extras_schema': core_schema.int_schema()}, 123)],
+    ids=['extras_schema=unset', 'extras_schema=None', 'extras_schema=int'],
+)
 def test_extra_behavior_allow_with_validate_fn_override(
     config: core_schema.CoreConfig | None,
     schema_extra_behavior_kw: dict[str, Any],
+    extras_schema_kw: dict[str, Any],
+    expected_extra_value: Any,
 ):
     v = SchemaValidator(
         core_schema.model_fields_schema(
-            {'f': core_schema.model_field(core_schema.str_schema())}, **schema_extra_behavior_kw
+            {'f': core_schema.model_field(core_schema.str_schema())}, **schema_extra_behavior_kw, **extras_schema_kw
         ),
         config=config,
     )
 
     m, model_extra, fields_set = v.validate_python({'f': 'x', 'extra_field': '123'}, extra='allow')
     assert m == {'f': 'x'}
-    assert model_extra == {'extra_field': '123'}
+    assert model_extra == {'extra_field': expected_extra_value}
     assert fields_set == {'f', 'extra_field'}
 
     v.validate_assignment(m, 'f', 'y', extra='allow')
@@ -1715,7 +1719,7 @@ def test_extra_behavior_allow_with_validate_fn_override(
 
     new_m, new_model_extra, new_fields_set = v.validate_assignment({**m, **model_extra}, 'not_f', '123', extra='allow')
     assert new_m == {'f': 'y'}
-    assert new_model_extra == {'extra_field': '123', 'not_f': '123'}
+    assert new_model_extra == {'extra_field': expected_extra_value, 'not_f': expected_extra_value}
     assert new_fields_set == {'not_f'}
 
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -876,7 +876,9 @@ class GenerateSchema:
 
                 extras_schema = None
                 extras_keys_schema = None
-                if core_config.get('extra_fields_behavior') == 'allow' and extra_info is not None:
+                # Note that the schemas are built even if extra data isn't allowed on the model, as the
+                # `extra` configuration value can be overridden at runtime (e.g. in `model_validate()`):
+                if extra_info is not None:
                     tp = get_origin(extra_info.annotation)
                     if tp is not dict:
                         raise PydanticSchemaGenerationError(

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1787,7 +1787,11 @@ class GenerateJsonSchema:
             named_required_fields.extend(self._name_required_computed_fields(schema.get('computed_fields', [])))
         json_schema = self._named_required_fields_schema(named_required_fields)
         extras_schema = schema.get('extras_schema', None)
-        if extras_schema is not None:
+        # The extras schema is present even if extra data isn't allowed on the model (as the `extra`
+        # configuration value can be overridden at runtime), so the extra behavior is checked as well.
+        # As during validation, the schema's extra behavior takes priority over the configuration value:
+        extra_behavior = schema.get('extra_behavior') or self._config.extra
+        if extras_schema is not None and extra_behavior == 'allow':
             schema_to_update = self.resolve_ref_schema(json_schema)
             schema_to_update['additionalProperties'] = self.generate_inner(extras_schema)
         return json_schema

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3482,6 +3482,35 @@ def test_extra_validator_named() -> None:
     }
 
 
+def test_extra_validator_with_extra_overridden_at_runtime() -> None:
+    """https://github.com/pydantic/pydantic/issues/13024"""
+
+    class Model(BaseModel, extra='forbid'):
+        __pydantic_extra__: dict[str, int]
+
+        a: int
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model.model_validate({'a': 1, 'b': 'not_an_int'}, extra='allow')
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'input': 'not_an_int',
+            'loc': ('b',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'type': 'int_parsing',
+        }
+    ]
+
+    assert Model.model_validate({'a': 1, 'b': '2'}, extra='allow').model_extra == {'b': 2}
+
+    # Extra data is still forbidden by default, and the annotation doesn't affect the JSON Schema:
+    with pytest.raises(ValidationError) as exc_info:
+        Model.model_validate({'a': 1, 'b': 2})
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'extra_forbidden'
+
+    assert Model.model_json_schema()['additionalProperties'] is False
+
+
 def test_extra_behavior_not_a_dict() -> None:
     with pytest.raises(PydanticSchemaGenerationError):
 


### PR DESCRIPTION
The extras schemas were only added to the core schema when extra data was allowed by the model configuration, so a model configured with `extra='forbid'` (or `'ignore'`) and validated with the `extra='allow'` override stored the extra values unvalidated. The schemas are now always built (`pydantic-core` no longer rejects them when the extra behavior isn't `'allow'`, as the behavior can be overridden when validating), and are only used when extra data is effectively allowed -- including in the JSON Schema, where `additionalProperties` keeps following the model configuration.

## Testing

tests/test_main.py::test_extra_validator_with_extra_overridden_at_runtime (new); pydantic-core/tests/validators/test_model_fields.py::test_extras_schemas_unused_if_extra_not_allowed (replaces test_allow_extra_invalid) and test_extra_behavior_allow_with_validate_fn_override (extended with an extras_schema parametrization)

Added tests fail on the current code and pass with this change; the relevant suite was run locally.

Closes #13024