### PR TITLE
fix(validators): avoid serializing twice with a plain validator

### DIFF
--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -219,10 +219,11 @@ class PlainValidator:
             # schema validation will fail. That's why we use 'type ignore' comments below.
             serialization = schema.get(
                 'serialization',
+                # No `return_schema` is provided on purpose: the wrap function already serializes
+                # the value using `schema`, so applying it again on the result would serialize twice.
                 core_schema.wrap_serializer_function_ser_schema(
                     function=lambda v, h: h(v),
                     schema=schema,
-                    return_schema=handler.generate_schema(source_type),
                 ),
             )
         except PydanticSchemaGenerationError:

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2227,6 +2227,11 @@ class GenerateJsonSchema:
             return_schema = schema.get('return_schema')
             if return_schema is not None:
                 return self.generate_inner(return_schema)
+            if schema_type == 'function-wrap' and (inner_schema := schema.get('schema')) is not None:
+                # The wrap serializer function delegates serialization to `inner_schema` (this is used
+                # internally to serialize a value using a schema different from the one it was validated
+                # against, e.g. with `PlainValidator`).
+                return self.generate_inner(inner_schema)
         elif schema_type == 'format' or schema_type == 'to-string':
             # FormatSerSchema or ToStringSerSchema
             return self.str_schema(core_schema.str_schema())

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -35,6 +35,7 @@ from pydantic import (
     ValidatorFunctionWrapHandler,
     errors,
     field_validator,
+    model_serializer,
     model_validator,
     root_validator,
     validate_call,
@@ -2946,6 +2947,32 @@ def test_plain_validator_plain_serializer_single_ser_call() -> None:
 
     assert data == {'foo': True}
     assert ser_count == 1
+
+
+def test_plain_validator_model_serializer_single_ser_call() -> None:
+    """https://github.com/pydantic/pydantic/issues/11917"""
+
+    ser_count = 0
+
+    class Child(BaseModel):
+        foo: str
+
+        @model_serializer(mode='plain')
+        def ser(self) -> str:
+            nonlocal ser_count
+            ser_count += 1
+            return self.foo
+
+    class Model(BaseModel):
+        child: Annotated[Child, PlainValidator(lambda v: v)]
+
+    model = Model(child=Child(foo='bar'))
+
+    assert model.model_dump() == {'child': 'bar'}
+    assert ser_count == 1
+
+    assert model.model_dump_json() == '{"child":"bar"}'
+    assert ser_count == 2
 
 
 @pytest.mark.xfail(reason='https://github.com/pydantic/pydantic/issues/10428')


### PR DESCRIPTION
fix(validators): avoid serializing twice with a plain validator

## Testing

tests/test_validators.py::test_plain_validator_model_serializer_single_ser_call - nested model with a plain `model_serializer` returning a str, behind a field annotated with `PlainValidator` (equivalent to the issue's `field_validator(mode='plain')`). Asserts the serializer runs exactly once for `model_dump()` and once more for `model_dump_json()`. Verified it FAILS on the unpatched tree with the exact error from the issue (PydanticSerializationError: Error calling function `ser`: AttributeError: 'str' object has no attribute 'foo') and PASSES with the fix.

Added tests fail on the current code and pass with this change; the relevant suite was run locally.

Closes #11917