### PR TITLE
Take `ser_json_temporal` into account when generating JSON Schema

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -864,7 +864,7 @@ class GenerateJsonSchema:
             temporal_format = self._config.ser_json_temporal
         else:
             # `ser_json_temporal` supersedes `ser_json_timedelta`, which only applies when the former isn't
-            # explicitly set. This mirrors the resolution done in `pydantic-core`:
+            # explicitly set.
             temporal_format = 'seconds' if self._config.ser_json_timedelta == 'float' else 'iso8601'
         return self._common_temporal_schema('duration', temporal_format)
 

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -827,7 +827,7 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        return {'type': 'string', 'format': 'date'}
+        return self._common_temporal_schema('date', self._config.ser_json_temporal)
 
     def time_schema(self, schema: core_schema.TimeSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a time value.
@@ -838,7 +838,7 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        return {'type': 'string', 'format': 'time'}
+        return self._common_temporal_schema('time', self._config.ser_json_temporal)
 
     def datetime_schema(self, schema: core_schema.DatetimeSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a datetime value.
@@ -849,7 +849,7 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        return {'type': 'string', 'format': 'date-time'}
+        return self._common_temporal_schema('date-time', self._config.ser_json_temporal)
 
     def timedelta_schema(self, schema: core_schema.TimedeltaSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a timedelta value.
@@ -860,9 +860,21 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        if self._config.ser_json_timedelta == 'float':
+        if 'ser_json_temporal' in self._config.config_dict:
+            temporal_format = self._config.ser_json_temporal
+        else:
+            # `ser_json_temporal` supersedes `ser_json_timedelta`, which only applies when the former isn't
+            # explicitly set. This mirrors the resolution done in `pydantic-core`:
+            temporal_format = 'seconds' if self._config.ser_json_timedelta == 'float' else 'iso8601'
+        return self._common_temporal_schema('duration', temporal_format)
+
+    def _common_temporal_schema(
+        self, format: str, temporal_format: Literal['iso8601', 'seconds', 'milliseconds']
+    ) -> JsonSchemaValue:
+        if temporal_format != 'iso8601':
+            # Both `'seconds'` and `'milliseconds'` serialize to a number:
             return {'type': 'number'}
-        return {'type': 'string', 'format': 'duration'}
+        return {'type': 'string', 'format': format}
 
     def literal_schema(self, schema: core_schema.LiteralSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a literal value.

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -830,6 +830,73 @@ def test_date_types(field_type, expected_schema):
     assert Model.model_json_schema() == base_schema
 
 
+@pytest.mark.parametrize('ser_json_temporal', ['iso8601', 'seconds', 'milliseconds'])
+@pytest.mark.parametrize(
+    'field_type,iso8601_format',
+    [
+        (datetime, 'date-time'),
+        (date, 'date'),
+        (time, 'time'),
+        (timedelta, 'duration'),
+    ],
+)
+def test_date_types_ser_json_temporal(field_type, iso8601_format, ser_json_temporal):
+    """https://github.com/pydantic/pydantic/issues/13664"""
+
+    class Model(BaseModel):
+        model_config = ConfigDict(ser_json_temporal=ser_json_temporal)
+
+        a: field_type
+
+    if ser_json_temporal == 'iso8601':
+        expected_schema = {'title': 'A', 'type': 'string', 'format': iso8601_format}
+    else:
+        expected_schema = {'title': 'A', 'type': 'number'}
+
+    assert Model.model_json_schema(mode='serialization')['properties']['a'] == expected_schema
+
+
+@pytest.mark.parametrize('ser_json_temporal', ['iso8601', 'seconds', 'milliseconds'])
+def test_date_types_ser_json_temporal_matches_serialized_output(ser_json_temporal):
+    """The serialization schema must describe the values `model_dump_json()` actually emits."""
+
+    class Model(BaseModel):
+        model_config = ConfigDict(ser_json_temporal=ser_json_temporal)
+
+        dt: datetime
+        d: date
+        t: time
+        td: timedelta
+
+    model = Model(dt=datetime(2020, 1, 1), d=date(2020, 1, 1), t=time(12, 0), td=timedelta(days=1))
+    properties = Model.model_json_schema(mode='serialization')['properties']
+    expected_type = 'string' if ser_json_temporal == 'iso8601' else 'number'
+
+    for field_name, value in json.loads(model.model_dump_json()).items():
+        assert properties[field_name]['type'] == expected_type
+        assert isinstance(value, str if ser_json_temporal == 'iso8601' else float)
+
+
+@pytest.mark.parametrize(
+    'config,expected_schema',
+    [
+        ({'ser_json_timedelta': 'float'}, {'type': 'number'}),
+        ({'ser_json_timedelta': 'iso8601'}, {'type': 'string', 'format': 'duration'}),
+        ({'ser_json_temporal': 'seconds', 'ser_json_timedelta': 'iso8601'}, {'type': 'number'}),
+        ({'ser_json_temporal': 'iso8601', 'ser_json_timedelta': 'float'}, {'type': 'string', 'format': 'duration'}),
+    ],
+)
+def test_timedelta_ser_json_temporal_takes_precedence(config, expected_schema):
+    """`ser_json_temporal` supersedes `ser_json_timedelta`, but only when it is explicitly set."""
+
+    class Model(BaseModel):
+        model_config = ConfigDict(**config)
+
+        a: timedelta
+
+    assert Model.model_json_schema(mode='serialization')['properties']['a'] == {'title': 'A', **expected_schema}
+
+
 @pytest.mark.parametrize(
     'interval',
     [

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -858,8 +858,6 @@ def test_date_types_ser_json_temporal(field_type, iso8601_format, ser_json_tempo
 
 @pytest.mark.parametrize('ser_json_temporal', ['iso8601', 'seconds', 'milliseconds'])
 def test_date_types_ser_json_temporal_matches_serialized_output(ser_json_temporal):
-    """The serialization schema must describe the values `model_dump_json()` actually emits."""
-
     class Model(BaseModel):
         model_config = ConfigDict(ser_json_temporal=ser_json_temporal)
 
@@ -874,7 +872,10 @@ def test_date_types_ser_json_temporal_matches_serialized_output(ser_json_tempora
 
     for field_name, value in json.loads(model.model_dump_json()).items():
         assert properties[field_name]['type'] == expected_type
-        assert isinstance(value, str if ser_json_temporal == 'iso8601' else float)
+        if ser_json_temporal == 'iso8601':
+            assert isinstance(value, str)
+        else:
+            assert isinstance(value, float)
 
 
 @pytest.mark.parametrize(
@@ -887,10 +888,8 @@ def test_date_types_ser_json_temporal_matches_serialized_output(ser_json_tempora
     ],
 )
 def test_timedelta_ser_json_temporal_takes_precedence(config, expected_schema):
-    """`ser_json_temporal` supersedes `ser_json_timedelta`, but only when it is explicitly set."""
-
     class Model(BaseModel):
-        model_config = ConfigDict(**config)
+        model_config = config
 
         a: timedelta
 


### PR DESCRIPTION
## Change Summary

`ser_json_temporal` was added in v2.12 but `GenerateJsonSchema` was never taught about it, so a `mode='serialization'` schema describes `datetime`, `date`, `time` and `timedelta` as strings even when `model_dump_json()` writes numbers. The published schema then rejects the payload pydantic itself just produced.

`date_schema`, `time_schema` and `datetime_schema` read no config at all today, and `timedelta_schema` reads only the superseded `ser_json_timedelta`. That second one is wrong in both directions, because `ser_json_temporal` is documented to take precedence and pydantic-core implements that precedence by checking whether the key is present in the config before falling back:

```rust
// serializers/config.rs, and the same shape again in type_serializers/timedelta.rs
let temporal_set = config
    .and_then(|cfg| cfg.contains(intern!(cfg.py(), "ser_json_temporal")).ok())
    .unwrap_or(false);
let temporal_mode = if temporal_set {
    TemporalMode::from_config(config)?
} else {
    TimedeltaMode::from_config(config)?.into()
};
```

This mirrors that resolution in the four temporal schema methods and routes them through a small `_common_temporal_schema` helper, in the same way `set_schema`/`frozenset_schema` share `_common_set_schema`. `'seconds'` and `'milliseconds'` both serialize to a number, so both map to `{'type': 'number'}`.

Before and after, with `ser_json_temporal='seconds'`:

```python
class Model(BaseModel):
    model_config = ConfigDict(ser_json_temporal='seconds')

    dt: datetime
    td: timedelta

Model.model_json_schema(mode='serialization')['properties']
# before: {'dt': {'type': 'string', 'format': 'date-time'}, 'td': {'type': 'string', 'format': 'duration'}}
# after:  {'dt': {'type': 'number'}, 'td': {'type': 'number'}}

json.loads(Model(dt=datetime(2020, 1, 1), td=timedelta(days=1)).model_dump_json())
# {'dt': 1577836800.0, 'td': 86400.0}
```

And the reverse case on `timedelta`, where the schema previously said `number` while the dump was `"P1D"`:

```python
class Model(BaseModel):
    model_config = ConfigDict(ser_json_temporal='iso8601', ser_json_timedelta='float')

    td: timedelta

# before: {'td': {'type': 'number'}}
# after:  {'td': {'type': 'string', 'format': 'duration'}}
```

A couple of notes on scope:

- Existing `ser_json_timedelta` behaviour is unchanged. When `ser_json_temporal` is absent from the config the old branch is taken, so `ser_json_timedelta='float'` still gives `{'type': 'number'}` exactly as before.
- I kept the existing convention of these methods reading the serialization config without checking `self.mode`, which is what `timedelta_schema` and `bytes_schema` already do. Validation accepts both the numeric and the ISO form, so neither `type` alone is accurate in validation mode, but that is pre-existing and applies equally to `ser_json_timedelta` today. Happy to narrow this to `mode='serialization'` if you would rather fix that separately.
- There are two config plumbing gaps that this PR deliberately does not touch, because they are pre-existing and reproduce identically with `ser_json_timedelta` on 2.13.4. A config passed as `TypeAdapter(datetime, config=...)` reaches the serializer but not `GenerateJsonSchema`, and `__pydantic_config__` on a `TypedDict` reaches `GenerateJsonSchema` but not the serializer. `ser_json_temporal` now follows `ser_json_timedelta` exactly in both of those paths rather than inventing different behaviour. I can open a separate issue for them if that is useful.

## Related issue number

Closes #13664.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
