### PR TITLE
fix(json_schema): support scientific notation in Decimal pattern

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -727,41 +727,49 @@ class GenerateJsonSchema:
         def get_decimal_pattern(schema: core_schema.DecimalSchema) -> str:
             max_digits = schema.get('max_digits')
             decimal_places = schema.get('decimal_places')
-
+            # Allow optional scientific notation suffix
+            sci = r'(?:[eE][+-]?\d+)?'
+            # Ensure at least one digit or dot exists (not just sign/empty)
+            has_digit = r'(?=[\d.])'
             pattern = (
                 r'^(?!^[-+.]*$)[+-]?0*'  # check it is not empty string and not one or sequence of ".+-" characters.
             )
-
             # Case 1: Both max_digits and decimal_places are set
             if max_digits is not None and decimal_places is not None:
                 integer_places = max(0, max_digits - decimal_places)
                 pattern += (
-                    rf'(?:'
-                    rf'\d{{0,{integer_places}}}'
-                    rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*$'
-                    rf')'
+                    has_digit
+                    + rf'(?:'
+                    + rf'\d{{0,{integer_places}}}'
+                    + rf'|'
+                    + rf'(?=[\d.]{{1,{max_digits + 1}}}0*(?:[eE][+-]?\d+)?0*$)'
+                    + rf'\d{{0,{integer_places}}}\.\d{{0,{decimal_places}}}0*'
+                    + rf')'
+                    + sci
+                    + r'$'
                 )
 
             # Case 2: Only max_digits is set
             elif max_digits is not None and decimal_places is None:
                 pattern += (
-                    rf'(?:'
-                    rf'\d{{0,{max_digits}}}'
-                    rf'|'
-                    rf'(?=[\d.]{{1,{max_digits + 1}}}0*$)'
-                    rf'\d*\.\d*0*$'
-                    rf')'
+                    has_digit
+                    + rf'(?:'
+                    + rf'\d{{0,{max_digits}}}'
+                    + rf'|'
+                    + rf'(?=[\d.]{{1,{max_digits + 1}}}0*(?:[eE][+-]?\d+)?0*$)'
+                    + rf'\d*\.\d*0*'
+                    + rf')'
+                    + sci
+                    + r'$'
                 )
 
             # Case 3: Only decimal_places is set
             elif max_digits is None and decimal_places is not None:
-                pattern += rf'\d*\.?\d{{0,{decimal_places}}}0*$'
+                pattern += has_digit + rf'\d*\.?\d{{0,{decimal_places}}}0*' + sci + r'$'
 
             # Case 4: Both are None (no restrictions)
             else:
-                pattern += r'\d*\.?\d*$'  # look for arbitrary integer or decimal
+                pattern += has_digit + r'\d*\.?\d*' + sci + r'$'  # look for arbitrary integer or decimal
 
             return pattern
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7235,6 +7235,22 @@ def test_decimal_pattern_reject_invalid_not_numerical_values_with_decimal_places
     assert re.fullmatch(pattern, invalid_decimal) is None
 
 
+@pytest.mark.parametrize(
+    'valid_decimal', ['1e10', '1E10', '1e+10', '1E-3', '1.5e10', '1.5E-3', '-1e10', '-1.5e10', '+1e10', '0.1e10']
+)
+def test_decimal_pattern_scientific_notation_valid(valid_decimal, get_decimal_pattern) -> None:
+    """Test that scientific notation is accepted by the decimal pattern (issue #13089)."""
+    pattern = get_decimal_pattern()
+    assert re.fullmatch(pattern, valid_decimal) is not None
+
+
+@pytest.mark.parametrize('invalid_decimal', ['1e', '1E', '1e+', '1e-', '1ee10', '1e10e10', 'e10'])
+def test_decimal_pattern_scientific_notation_invalid(invalid_decimal, get_decimal_pattern) -> None:
+    """Test that malformed scientific notation is rejected by the decimal pattern."""
+    pattern = get_decimal_pattern()
+    assert re.fullmatch(pattern, invalid_decimal) is None
+
+
 def test_union_format_primitive_type_array() -> None:
     class Sub(BaseModel):
         pass


### PR DESCRIPTION
## Summary

The JSON schema pattern generated for `Decimal` fields did not support scientific notation (e.g., `1e10`, `1.5E-3`, `1E+10`), even though Python's `Decimal` type accepts such values. This caused valid Decimal values to be incorrectly rejected by JSON schema validators.

## Problem

When a pydantic model with a `Decimal` field generates a JSON schema, the `pattern` field uses a regex that only matches standard decimal notation:

```
^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
```

This pattern does not match scientific notation like `1e10` or `1.5E-3`, which are valid Python `Decimal` values.

## Solution

Added an optional scientific notation suffix `(?:[eE][+-]?\d+)?` to the end of all four pattern variants in `get_decimal_pattern()`. Also updated the lookaheads in cases 1 and 2 to account for the scientific notation suffix.

Additionally, added a `(?=[\d.])` lookahead after the prefix to prevent false positives like `e10` (which would match if the numeric part is empty followed by the sci suffix).

## Changes

- `pydantic/json_schema.py`: Updated `decimal_schema()` to include scientific notation in the pattern
- `tests/test_json_schema.py`: Added test cases for valid and invalid scientific notation

## Test Cases Added

Valid scientific notation: `1e10`, `1E10`, `1e+10`, `1E-3`, `1.5e10`, `1.5E-3`, `-1e10`, `-1.5e10`, `+1e10`, `0.1e10`

Invalid scientific notation: `1e`, `1E`, `1e+`, `1e-`, `1ee10`, `1e10e10`, `e10`

Fixes #13089