### PR TITLE
Fix V1.10 documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We've launched Pydantic Logfire to help you monitor your applications.
 Pydantic V2 is a ground-up rewrite that offers many new features, performance improvements, and some breaking changes compared to Pydantic V1.
 
 If you're using Pydantic V1 you may want to look at the
-[pydantic V1.10 Documentation](https://pydantic.dev/docs/validation/latest/get-started/) or,
+[pydantic V1.10 Documentation](https://pydantic.dev/docs/validation/1.10/overview/) or,
 [`1.10.X-fixes` git branch](https://github.com/pydantic/pydantic/tree/1.10.X-fixes). Pydantic V2 also ships with the latest version of Pydantic V1 built in so that you can incrementally upgrade your code base and projects: `from pydantic import v1 as pydantic_v1`.
 
 ## Help


### PR DESCRIPTION
## Change Summary

The `pydantic V1.10 Documentation` link in the README points to the V2 get-started page (`https://pydantic.dev/docs/validation/latest/get-started/`). This was introduced by #13229, which rewrote documentation URLs across the repository and applied the V2 URL to this V1-specific link too.

This PR points it back at the V1.10 documentation (`https://pydantic.dev/docs/validation/1.10/overview/`), the same target already used by `docs/migration.md` ("See the Pydantic V1 documentation").

Before: link text says "V1.10 Documentation" but opens the current V2 docs.
After: link opens the V1.10 documentation overview.

Related: #13226 reported the V1.10 link and was closed in favor of #13229, which introduced this regression.

## Related issue number

No open issue; regression from merged PR #13229.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist (docs-only change, no code touched)
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, please add a comment including the phrase "please review" to assign reviewers
