### PR TITLE
Use config of `TypeAdapter` in JSON Schema generation

### DIFF
--- a/pydantic/type_adapter.py
+++ b/pydantic/type_adapter.py
@@ -736,7 +736,10 @@ class TypeAdapter(Generic[T]):
         if isinstance(self.core_schema, _mock_val_ser.MockCoreSchema):
             self.core_schema.rebuild()
             assert not isinstance(self.core_schema, _mock_val_ser.MockCoreSchema), 'this is a bug! please report it'
-        return schema_generator_instance.generate(self.core_schema, mode=mode)
+        # The configuration provided to the type adapter (if any) is not part of the core schema,
+        # so we need to explicitly make it available to the JSON Schema generator:
+        with schema_generator_instance._config_wrapper_stack.push(self._config):
+            return schema_generator_instance.generate(self.core_schema, mode=mode)
 
     @staticmethod
     def json_schemas(

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -555,6 +555,12 @@ def test_ta_config_with_annotated_type() -> None:
     ]
 
 
+def test_ta_config_used_for_json_schema() -> None:
+    """https://github.com/pydantic/pydantic/issues/13675"""
+    ta = TypeAdapter(list[bytes], config=ConfigDict(ser_json_bytes='base64'))
+    assert ta.json_schema() == {'type': 'array', 'items': {'type': 'string', 'format': 'base64url'}}
+
+
 def defer_build_test_models(config: ConfigDict) -> list[Any]:
     class Model(BaseModel):
         model_config = config


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13675.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
