### PR TITLE
Allow any `CoreSchema` to be used as serialization

### DIFF
--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -12,7 +12,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from fractions import Fraction
 from re import Pattern
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 from typing_extensions import TypeVar, deprecated
 
@@ -1627,7 +1627,7 @@ def filter_seq_schema(*, include: set[int] | None = None, exclude: set[int] | No
     return _dict_not_none(type='include-exclude-sequence', include=include, exclude=exclude)
 
 
-IncExSeqOrElseSerSchema: TypeAlias = 'IncExSeqSerSchema | SerSchema'
+IncExSeqOrElseSerSchema: TypeAlias = Union[IncExSeqSerSchema, SerSchema]  # noqa: UP007 (TypeError when evaluating)
 
 
 class ListSchema(TypedDict, total=False):
@@ -2033,7 +2033,7 @@ def filter_dict_schema(*, include: IncExDict | None = None, exclude: IncExDict |
     return _dict_not_none(type='include-exclude-dict', include=include, exclude=exclude)
 
 
-IncExDictOrElseSerSchema: TypeAlias = 'IncExDictSerSchema | SerSchema'
+IncExDictOrElseSerSchema: TypeAlias = Union[IncExDictSerSchema, SerSchema]  # noqa: UP007 (TypeError when evaluating)
 
 
 class DictSchema(TypedDict, total=False):

--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -278,6 +278,9 @@ def simple_ser_schema(type: ExpectedSerializationTypes) -> SimpleSerSchema:
     """
     Returns a schema for serialization with a custom type.
 
+    Note that any core schema can be used as a serialization schema, e.g. `int_schema()`
+    is equivalent to `simple_ser_schema('int')`.
+
     Args:
         type: The type to use for serialization
     """
@@ -469,6 +472,9 @@ def model_ser_schema(cls: type[Any], schema: CoreSchema) -> ModelSerSchema:
     """
     Returns a schema for serialization using a model.
 
+    Note that any core schema can be used as a serialization schema, e.g. `model_schema()`
+    can be used instead.
+
     Args:
         cls: The expected class type, used to generate warnings if the wrong type is passed
         schema: Internal schema to use to serialize the model dict
@@ -476,14 +482,9 @@ def model_ser_schema(cls: type[Any], schema: CoreSchema) -> ModelSerSchema:
     return ModelSerSchema(type='model', cls=cls, schema=schema)
 
 
-SerSchema: TypeAlias = (
-    SimpleSerSchema
-    | PlainSerializerFunctionSerSchema
-    | WrapSerializerFunctionSerSchema
-    | FormatSerSchema
-    | ToStringSerSchema
-    | ModelSerSchema
-)
+SerSchema: TypeAlias = 'SimpleSerSchema | PlainSerializerFunctionSerSchema | WrapSerializerFunctionSerSchema | FormatSerSchema | ToStringSerSchema | ModelSerSchema | CoreSchema'
+
+"""The schemas that can be used as the `serialization` key of a core schema."""
 
 
 class InvalidSchema(TypedDict, total=False):
@@ -1626,7 +1627,7 @@ def filter_seq_schema(*, include: set[int] | None = None, exclude: set[int] | No
     return _dict_not_none(type='include-exclude-sequence', include=include, exclude=exclude)
 
 
-IncExSeqOrElseSerSchema: TypeAlias = IncExSeqSerSchema | SerSchema
+IncExSeqOrElseSerSchema: TypeAlias = 'IncExSeqSerSchema | SerSchema'
 
 
 class ListSchema(TypedDict, total=False):
@@ -2032,7 +2033,7 @@ def filter_dict_schema(*, include: IncExDict | None = None, exclude: IncExDict |
     return _dict_not_none(type='include-exclude-dict', include=include, exclude=exclude)
 
 
-IncExDictOrElseSerSchema: TypeAlias = IncExDictSerSchema | SerSchema
+IncExDictOrElseSerSchema: TypeAlias = 'IncExDictSerSchema | SerSchema'
 
 
 class DictSchema(TypedDict, total=False):

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -163,14 +163,6 @@ combined_serializer! {
     }
 }
 
-/// Whether the `'function-plain'`/`'function-wrap'` schema is a function *validator* schema
-/// (i.e. a core schema), as opposed to a function *ser* schema.
-fn is_function_validator_schema(schema: &Bound<'_, PyDict>) -> PyResult<bool> {
-    Ok(schema
-        .get_item(intern!(schema.py(), "function"))?
-        .is_some_and(|function| function.is_instance_of::<PyDict>()))
-}
-
 impl CombinedSerializer {
     fn _build(
         schema: &Bound<'_, PyDict>,
@@ -184,12 +176,9 @@ impl CombinedSerializer {
         if let Some(ser_schema) = schema.get_as::<Bound<'_, PyDict>>(intern!(py, "serialization"))? {
             let op_ser_type: Option<Bound<'_, PyString>> = ser_schema.get_as(type_key)?;
             match op_ser_type.as_ref().map(|py_str| py_str.to_str()).transpose()? {
-                // `'function-plain'` and `'function-wrap'` are special cases, not included in `find_serializer()`
-                // since they mean something different in `schema.type`. As core schemas of the same type
-                // are also accepted as `schema.serialization` (see the last match arm below), we need to
-                // distinguish between the two: function *ser* schemas have a callable as `function`, while
-                // function *validator* schemas have a validator function core schema as `function`.
-                Some("function-plain") if !is_function_validator_schema(&ser_schema)? => {
+                Some("function-plain") => {
+                    // `function-plain` is a special case, not included in `find_serializer` since it means
+                    // something different in `schema.type`
                     // NOTE! we use the `schema` here, not `ser_schema`
                     return super::type_serializers::function::FunctionPlainSerializer::build(
                         schema,
@@ -198,7 +187,9 @@ impl CombinedSerializer {
                     )
                     .map_err(|err| py_schema_error_type!("Error building `function-plain` serializer:\n  {err}"));
                 }
-                Some("function-wrap") if !is_function_validator_schema(&ser_schema)? => {
+                Some("function-wrap") => {
+                    // `function-wrap` is also a special case, not included in `find_serializer` since it mean
+                    // something different in `schema.type`
                     // NOTE! we use the `schema` here, not `ser_schema`
                     return super::type_serializers::function::FunctionWrapSerializer::build(
                         schema,
@@ -221,6 +212,8 @@ impl CombinedSerializer {
                     // the main schema (this ensures nested `serialization` schemas, prebuilt serializers
                     // and polymorphic serialization are handled). In this case, it's an error if a
                     // serializer isn't found.
+                    // Note that as a consequence, `function-plain`/`function-wrap` *validator* schemas can't
+                    // be used as `schema.serialization`, as they are interpreted as the function *ser* schemas.
                     return Self::build(&ser_schema, config, definitions);
                 }
             }

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -163,6 +163,14 @@ combined_serializer! {
     }
 }
 
+/// Whether the `'function-plain'`/`'function-wrap'` schema is a function *validator* schema
+/// (i.e. a core schema), as opposed to a function *ser* schema.
+fn is_function_validator_schema(schema: &Bound<'_, PyDict>) -> PyResult<bool> {
+    Ok(schema
+        .get_item(intern!(schema.py(), "function"))?
+        .is_some_and(|function| function.is_instance_of::<PyDict>()))
+}
+
 impl CombinedSerializer {
     fn _build(
         schema: &Bound<'_, PyDict>,
@@ -176,9 +184,12 @@ impl CombinedSerializer {
         if let Some(ser_schema) = schema.get_as::<Bound<'_, PyDict>>(intern!(py, "serialization"))? {
             let op_ser_type: Option<Bound<'_, PyString>> = ser_schema.get_as(type_key)?;
             match op_ser_type.as_ref().map(|py_str| py_str.to_str()).transpose()? {
-                Some("function-plain") => {
-                    // `function-plain` is a special case, not included in `find_serializer` since it means
-                    // something different in `schema.type`
+                // `'function-plain'` and `'function-wrap'` are special cases, not included in `find_serializer()`
+                // since they mean something different in `schema.type`. As core schemas of the same type
+                // are also accepted as `schema.serialization` (see the last match arm below), we need to
+                // distinguish between the two: function *ser* schemas have a callable as `function`, while
+                // function *validator* schemas have a validator function core schema as `function`.
+                Some("function-plain") if !is_function_validator_schema(&ser_schema)? => {
                     // NOTE! we use the `schema` here, not `ser_schema`
                     return super::type_serializers::function::FunctionPlainSerializer::build(
                         schema,
@@ -187,9 +198,7 @@ impl CombinedSerializer {
                     )
                     .map_err(|err| py_schema_error_type!("Error building `function-plain` serializer:\n  {err}"));
                 }
-                Some("function-wrap") => {
-                    // `function-wrap` is also a special case, not included in `find_serializer` since it mean
-                    // something different in `schema.type`
+                Some("function-wrap") if !is_function_validator_schema(&ser_schema)? => {
                     // NOTE! we use the `schema` here, not `ser_schema`
                     return super::type_serializers::function::FunctionWrapSerializer::build(
                         schema,
@@ -206,10 +215,13 @@ impl CombinedSerializer {
                 )
                 // if `schema.serialization.type` is None, fall back to `schema.type`
                 | None => (),
-                Some(ser_type) => {
-                    // otherwise if `schema.serialization.type` is defined, use that with `find_serializer`
-                    // instead of `schema.type`. In this case it's an error if a serializer isn't found.
-                    return Self::find_serializer(ser_type, &ser_schema, config, definitions);
+                Some(_) => {
+                    // otherwise, `schema.serialization` is an arbitrary core schema (which includes the
+                    // simple `{'type': ...}` ser schemas), so build a serializer from it as if it was
+                    // the main schema (this ensures nested `serialization` schemas, prebuilt serializers
+                    // and polymorphic serialization are handled). In this case, it's an error if a
+                    // serializer isn't found.
+                    return Self::build(&ser_schema, config, definitions);
                 }
             }
         }

--- a/pydantic-core/tests/serializers/test_core_schema_as_ser_schema.py
+++ b/pydantic-core/tests/serializers/test_core_schema_as_ser_schema.py
@@ -49,20 +49,6 @@ from ..conftest import plain_repr
             1,
             b'1',
         ),
-        # `'function-plain'`/`'function-wrap'` core validator schemas are distinguished from the
-        # function *ser* schemas (whose `function` value is a callable, not a dict):
-        (
-            core_schema.no_info_plain_validator_function(lambda v: v),
-            {'a': 1},
-            {'a': 1},
-            b'{"a":1}',
-        ),
-        (
-            core_schema.no_info_wrap_validator_function(lambda v, h: h(v), core_schema.str_schema()),
-            'a',
-            'a',
-            b'"a"',
-        ),
     ],
 )
 def test_core_schema_as_ser_schema(ser_schema: Any, value: Any, expected_python: Any, expected_json: bytes) -> None:
@@ -84,19 +70,6 @@ def test_core_schema_as_ser_schema_nested_serialization() -> None:
     s = SchemaSerializer(
         core_schema.any_schema(
             serialization=core_schema.int_schema(
-                serialization=core_schema.plain_serializer_function_ser_schema(lambda v: v * 2),
-            ),
-        )
-    )
-
-    assert s.to_python(3) == 6
-    assert s.to_json(3) == b'6'
-
-    # Also for function *validator* schemas, which have a special handling:
-    s = SchemaSerializer(
-        core_schema.any_schema(
-            serialization=core_schema.no_info_plain_validator_function(
-                lambda v: v,
                 serialization=core_schema.plain_serializer_function_ser_schema(lambda v: v * 2),
             ),
         )

--- a/pydantic-core/tests/serializers/test_core_schema_as_ser_schema.py
+++ b/pydantic-core/tests/serializers/test_core_schema_as_ser_schema.py
@@ -1,0 +1,151 @@
+"""Tests for arbitrary core schemas being used as the `serialization` schema."""
+
+from typing import Any
+
+import pytest
+
+from pydantic_core import SchemaError, SchemaSerializer, core_schema
+
+from ..conftest import plain_repr
+
+
+@pytest.mark.parametrize(
+    ['ser_schema', 'value', 'expected_python', 'expected_json'],
+    [
+        # equivalent to `simple_ser_schema('list')` (i.e. it must still work):
+        (core_schema.simple_ser_schema('list'), [1, 'a'], [1, 'a'], b'[1,"a"]'),
+        (core_schema.list_schema(core_schema.int_schema()), [1, 2], [1, 2], b'[1,2]'),
+        (
+            core_schema.tuple_schema([core_schema.int_schema(), core_schema.str_schema()]),
+            (1, 'a'),
+            (1, 'a'),
+            b'[1,"a"]',
+        ),
+        (
+            core_schema.dict_schema(core_schema.str_schema(), core_schema.int_schema()),
+            {'a': 1},
+            {'a': 1},
+            b'{"a":1}',
+        ),
+        (
+            core_schema.typed_dict_schema({'a': core_schema.typed_dict_field(core_schema.int_schema())}),
+            {'a': 1, 'b': 2},
+            {'a': 1},
+            b'{"a":1}',
+        ),
+        (
+            core_schema.definitions_schema(
+                core_schema.definition_reference_schema('list_of_int'),
+                [core_schema.list_schema(core_schema.int_schema(), ref='list_of_int')],
+            ),
+            [1, 2],
+            [1, 2],
+            b'[1,2]',
+        ),
+        # `'function-before'`/`'function-after'` core schemas serialize using the inner schema:
+        (
+            core_schema.no_info_after_validator_function(lambda v: v, core_schema.int_schema()),
+            1,
+            1,
+            b'1',
+        ),
+        # `'function-plain'`/`'function-wrap'` core validator schemas are distinguished from the
+        # function *ser* schemas (whose `function` value is a callable, not a dict):
+        (
+            core_schema.no_info_plain_validator_function(lambda v: v),
+            {'a': 1},
+            {'a': 1},
+            b'{"a":1}',
+        ),
+        (
+            core_schema.no_info_wrap_validator_function(lambda v, h: h(v), core_schema.str_schema()),
+            'a',
+            'a',
+            b'"a"',
+        ),
+    ],
+)
+def test_core_schema_as_ser_schema(ser_schema: Any, value: Any, expected_python: Any, expected_json: bytes) -> None:
+    s = SchemaSerializer(core_schema.any_schema(serialization=ser_schema))
+
+    assert s.to_python(value) == expected_python
+    assert s.to_json(value) == expected_json
+
+
+def test_core_schema_as_ser_schema_expected_type() -> None:
+    s = SchemaSerializer(core_schema.any_schema(serialization=core_schema.list_schema(core_schema.int_schema())))
+
+    with pytest.warns(UserWarning, match=r'Expected `int` - serialized value may not be as expected'):
+        assert s.to_python(['a']) == ['a']
+
+
+def test_core_schema_as_ser_schema_nested_serialization() -> None:
+    """The `serialization` schema of the core schema used as a `serialization` schema is taken into account."""
+    s = SchemaSerializer(
+        core_schema.any_schema(
+            serialization=core_schema.int_schema(
+                serialization=core_schema.plain_serializer_function_ser_schema(lambda v: v * 2),
+            ),
+        )
+    )
+
+    assert s.to_python(3) == 6
+    assert s.to_json(3) == b'6'
+
+    # Also for function *validator* schemas, which have a special handling:
+    s = SchemaSerializer(
+        core_schema.any_schema(
+            serialization=core_schema.no_info_plain_validator_function(
+                lambda v: v,
+                serialization=core_schema.plain_serializer_function_ser_schema(lambda v: v * 2),
+            ),
+        )
+    )
+
+    assert s.to_python(3) == 6
+    assert s.to_json(3) == b'6'
+
+
+def test_core_schema_as_ser_schema_unknown_type() -> None:
+    with pytest.raises(SchemaError, match=r'Unknown serialization schema type: `unknown`'):
+        SchemaSerializer(core_schema.any_schema(serialization={'type': 'unknown'}))  # pyright: ignore[reportArgumentType]
+
+
+def test_model_schema_as_ser_schema_polymorphic() -> None:
+    class Model:
+        __pydantic_complete__ = True
+
+    class SubModel(Model):
+        pass
+
+    model_schema = core_schema.model_schema(
+        Model,
+        schema=core_schema.model_fields_schema({'x': core_schema.model_field(core_schema.int_schema())}),
+        config=core_schema.CoreConfig(polymorphic_serialization=True),
+    )
+    Model.__pydantic_serializer__ = SchemaSerializer(model_schema)  # pyright: ignore[reportAttributeAccessIssue]
+
+    sub_model_schema = core_schema.model_schema(
+        SubModel,
+        schema=core_schema.model_fields_schema(
+            {
+                'x': core_schema.model_field(core_schema.int_schema()),
+                'y': core_schema.model_field(core_schema.int_schema()),
+            }
+        ),
+    )
+    SubModel.__pydantic_serializer__ = SchemaSerializer(sub_model_schema)  # pyright: ignore[reportAttributeAccessIssue]
+
+    s = SchemaSerializer(core_schema.any_schema(serialization=model_schema))
+    # Using the model schema as a serialization schema behaves the same as using it as the main schema
+    # (in this case, the prebuilt serializer of `Model` is used, wrapped in a polymorphism trampoline):
+    assert plain_repr(s) == plain_repr(SchemaSerializer(model_schema))
+    assert plain_repr(s).startswith(
+        'SchemaSerializer(serializer=PolymorphismTrampoline(PolymorphismTrampoline{class:Py(0x'
+    )
+    assert 'serializer:Prebuilt(PrebuiltSerializer{' in plain_repr(s)
+
+    sub_model = SubModel()
+    sub_model.__dict__ = {'x': 1, 'y': 2}
+    assert s.to_python(sub_model) == {'x': 1, 'y': 2}
+    assert s.to_json(sub_model) == b'{"x":1,"y":2}'

--- a/pydantic-core/tests/test_typing.py
+++ b/pydantic-core/tests/test_typing.py
@@ -247,6 +247,11 @@ def test_ser_function_wrap():
     )
 
 
+def test_ser_core_schema():
+    s = SchemaSerializer(core_schema.any_schema(serialization=core_schema.list_schema(core_schema.int_schema())))
+    assert s.to_python([1, 2]) == [1, 2]
+
+
 def test_error_details() -> None:
     # Test that the ErrorDetails type is correctly exported.
     def act_on_error_details(_: ErrorDetails) -> None:

--- a/pydantic/_internal/_core_utils.py
+++ b/pydantic/_internal/_core_utils.py
@@ -53,6 +53,29 @@ def is_function_with_inner_schema(
     return schema['type'] in _FUNCTION_WITH_INNER_SCHEMA_TYPES
 
 
+def as_ser_schema(schema: CoreSchema) -> core_schema.SerSchema:
+    """Return a schema suitable for the `'serialization'` key of a core schema, from an arbitrary core schema.
+
+    Any core schema can be used as a serialization schema, except `'function-plain'` and `'function-wrap'`
+    schemas, as these types are already used by the plain and wrap serializer *function* schemas.
+    For these, mimic what pydantic-core would do if they were used as the *main* schema:
+
+    - if the function schema has a `'serialization'` schema, use it.
+    - otherwise, a `'function-plain'` schema is serialized as `'any'`, and a `'function-wrap'` schema
+      is serialized using its inner schema.
+
+    Note that `schema` is expected to be a *core* schema (e.g. as returned by the schema generator),
+    not an existing `'serialization'` schema.
+    """
+    if schema['type'] == 'function-plain' or schema['type'] == 'function-wrap':
+        if (ser_schema := schema.get('serialization')) is not None:
+            return ser_schema
+        if schema['type'] == 'function-plain':
+            return core_schema.any_schema()
+        return as_ser_schema(schema['schema'])
+    return schema
+
+
 def is_list_like_schema_with_items_schema(
     schema: CoreSchema,
 ) -> TypeGuard[core_schema.ListSchema | core_schema.SetSchema | core_schema.FrozenSetSchema]:

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -912,7 +912,8 @@ class ValidateAs:
             ser_schema = core_schema.any_schema()
 
         # TODO: pydantic-core now accepts an arbitrary core schema for serialization, so the
-        # wrap serializer workaround below can be replaced with `schema['serialization'] = ser_schema`.
+        # wrap serializer workaround below can be replaced with
+        # `schema['serialization'] = _core_utils.as_ser_schema(ser_schema)`.
         # The same workaround is used in other parts of the code base, so grep for similar cases when fixing:
         schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
             function=lambda v, h: h(v), schema=ser_schema

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -911,10 +911,9 @@ class ValidateAs:
         except GENERATE_SCHEMA_ERRORS:
             ser_schema = core_schema.any_schema()
 
-        # TODO: pydantic-core currently doesn't accept it, but we should be able to provide an
-        # arbitrary core schema for serialization (currently `simple_ser_schema()` can be used,
-        # but only allow specifying a specific `'type`). Working around this with a wrap serializer
-        # is already done in other parts of the code base, so grep for similar cases when fixing:
+        # TODO: pydantic-core now accepts an arbitrary core schema for serialization, so the
+        # wrap serializer workaround below can be replaced with `schema['serialization'] = ser_schema`.
+        # The same workaround is used in other parts of the code base, so grep for similar cases when fixing:
         schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
             function=lambda v, h: h(v), schema=ser_schema
         )

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -3014,8 +3014,6 @@ def _get_ser_schema_for_default_value(schema: CoreSchema) -> core_schema.PlainSe
     if (
         (ser_schema := schema.get('serialization'))
         and ser_schema['type'] == 'function-plain'
-        # A `'function-plain'` *validator* schema can also be used as a serialization schema:
-        and callable(ser_schema.get('function'))
         and not ser_schema.get('info_arg')
     ):
         return cast('core_schema.PlainSerializerFunctionSerSchema', ser_schema)

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -2237,18 +2237,18 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        schema_type = schema['type']
-        if schema_type == 'function-plain' or schema_type == 'function-wrap':
-            # PlainSerializerFunctionSerSchema or WrapSerializerFunctionSerSchema
-            return_schema = schema.get('return_schema')
-            if return_schema is not None:
-                return self.generate_inner(return_schema)
-        elif schema_type == 'format' or schema_type == 'to-string':
-            # FormatSerSchema or ToStringSerSchema
-            return self.str_schema(core_schema.str_schema())
-        elif schema['type'] == 'model':
-            # ModelSerSchema
-            return self.generate_inner(schema['schema'])
+        match schema:
+            case {'type': 'function-plain' | 'function-wrap'}:
+                # PlainSerializerFunctionSerSchema or WrapSerializerFunctionSerSchema
+                return_schema = schema.get('return_schema')
+                if return_schema is not None:
+                    return self.generate_inner(return_schema)
+            case {'type': 'format' | 'to-string'}:
+                # FormatSerSchema or ToStringSerSchema
+                return self.str_schema(core_schema.str_schema())
+            case {'type': 'model'}:
+                # ModelSerSchema
+                return self.generate_inner(schema['schema'])
         return None
 
     def complex_schema(self, schema: core_schema.ComplexSchema) -> JsonSchemaValue:
@@ -3014,8 +3014,10 @@ def _get_ser_schema_for_default_value(schema: CoreSchema) -> core_schema.PlainSe
     if (
         (ser_schema := schema.get('serialization'))
         and ser_schema['type'] == 'function-plain'
+        # A `'function-plain'` *validator* schema can also be used as a serialization schema:
+        and callable(ser_schema.get('function'))
         and not ser_schema.get('info_arg')
     ):
-        return ser_schema
+        return cast('core_schema.PlainSerializerFunctionSerSchema', ser_schema)
     if _core_utils.is_function_with_inner_schema(schema):
         return _get_ser_schema_for_default_value(schema['schema'])

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -16,6 +16,7 @@ from pydantic_core import core_schema as cs
 from pydantic import BaseModel, TypeAdapter
 from pydantic._internal._config import ConfigWrapper
 from pydantic._internal._core_metadata import update_core_metadata
+from pydantic._internal._core_utils import as_ser_schema
 from pydantic._internal._fields import resolve_default_value
 from pydantic._internal._generate_schema import GenerateSchema
 from pydantic._internal._repr import Representation
@@ -288,3 +289,58 @@ def test_resolve_default_value_missing_validated_data():
             validated_data=None,
             call_default_factory=True,
         )
+
+
+def _identity(v: Any) -> Any:
+    return v
+
+
+def _wrap_identity(v: Any, handler: Any) -> Any:
+    return handler(v)
+
+
+@pytest.mark.parametrize(
+    ['schema', 'expected'],
+    [
+        # Any non-function schema is returned as is:
+        (cs.int_schema(), cs.int_schema()),
+        (
+            cs.no_info_after_validator_function(_identity, cs.int_schema()),
+            cs.no_info_after_validator_function(_identity, cs.int_schema()),
+        ),
+        # The `'serialization'` schema of a plain/wrap function schema takes precedence:
+        (
+            cs.no_info_plain_validator_function(_identity, serialization=cs.simple_ser_schema('str')),
+            cs.simple_ser_schema('str'),
+        ),
+        (
+            cs.no_info_wrap_validator_function(
+                _wrap_identity, cs.int_schema(), serialization=cs.simple_ser_schema('str')
+            ),
+            cs.simple_ser_schema('str'),
+        ),
+        # Otherwise, plain function schemas are serialized as `'any'`, wrap function schemas using the inner schema:
+        (cs.no_info_plain_validator_function(_identity), cs.any_schema()),
+        (cs.no_info_wrap_validator_function(_wrap_identity, cs.int_schema()), cs.int_schema()),
+        # Nested plain/wrap function schemas are unwrapped:
+        (
+            cs.no_info_wrap_validator_function(
+                _wrap_identity, cs.no_info_wrap_validator_function(_wrap_identity, cs.int_schema())
+            ),
+            cs.int_schema(),
+        ),
+        (
+            cs.no_info_wrap_validator_function(_wrap_identity, cs.no_info_plain_validator_function(_identity)),
+            cs.any_schema(),
+        ),
+        (
+            cs.no_info_wrap_validator_function(
+                _wrap_identity,
+                cs.no_info_plain_validator_function(_identity, serialization=cs.simple_ser_schema('str')),
+            ),
+            cs.simple_ser_schema('str'),
+        ),
+    ],
+)
+def test_as_ser_schema(schema: CoreSchema, expected: cs.SerSchema) -> None:
+    assert as_ser_schema(schema) == expected


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Closes https://github.com/pydantic/pydantic/issues/13579. There's a bit of friction between validators and serializer function schemas, because they share the same name, so the `as_ser_schema()` util assumes the passed schema can't be a serializer function schema.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
