### PR TITLE
Simplify serialization core schemas in some places

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -78,7 +78,15 @@ from ..warnings import (
     TypedDictExtraConfigWarning,
     UnsupportedFieldAttributeWarning,
 )
-from . import _decorators, _discriminated_union, _known_annotated_metadata, _repr, _type_refs, _typing_extra
+from . import (
+    _core_utils,
+    _decorators,
+    _discriminated_union,
+    _known_annotated_metadata,
+    _repr,
+    _type_refs,
+    _typing_extra,
+)
 from ._config import ConfigWrapper, ConfigWrapperStack
 from ._core_metadata import CoreMetadata, update_core_metadata
 from ._core_utils import (
@@ -706,9 +714,7 @@ class GenerateSchema:
             schema = core_schema.lax_or_strict_schema(
                 lax_schema=lax_schema,
                 strict_schema=strict_schema,
-                serialization=core_schema.wrap_serializer_function_ser_schema(
-                    lambda v, h: h(v), schema=dict_schema, info_arg=False
-                ),
+                serialization=_core_utils.as_ser_schema(dict_schema),
             )
 
         return schema

--- a/pydantic/functional_validators.py
+++ b/pydantic/functional_validators.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, TypeVar, c
 from pydantic_core import PydanticUndefined, core_schema
 from typing_extensions import Self
 
-from ._internal import _decorators, _generics
+from ._internal import _core_utils, _decorators, _generics
 from .annotated_handlers import GetCoreSchemaHandler
 from .errors import PydanticUserError
 from .version import version_short
@@ -92,7 +92,13 @@ class BeforeValidator:
     """!!! abstract "Usage Documentation"
         [field *before* validators](../concepts/validators.md#field-before-validator)
 
-    A metadata class that indicates that a validation should be applied **before** the inner validation logic.
+    A class used as [annotated metadata](../concepts/fields.md#the-annotated-pattern) that indicates
+    that a validation should be applied **before** the inner validation logic.
+
+    /// version-added | v2.9
+    The `json_schema_input_type` parameter can be used to specify the input type of the function to be used in the
+    JSON Schema (in `'validation'` mode, the default).
+    ///
 
     Attributes:
         func: The validator function.
@@ -159,12 +165,13 @@ class PlainValidator:
     """!!! abstract "Usage Documentation"
         [field *plain* validators](../concepts/validators.md#field-plain-validator)
 
-    A metadata class that indicates that a validation should be applied **instead** of the inner validation logic.
+    A class used as [annotated metadata](../concepts/fields.md#the-annotated-pattern) that indicates that
+    a validation should be applied **instead** of the inner validation logic.
 
-    !!! note
-        Before v2.9, `PlainValidator` wasn't always compatible with JSON Schema generation for `mode='validation'`.
-        You can now use the `json_schema_input_type` argument to specify the input type of the function
-        to be used in the JSON schema when `mode='validation'` (the default). See the example below for more details.
+    /// version-added | v2.9
+    The `json_schema_input_type` parameter can be used to specify the input type of the function to be used in the
+    JSON Schema (in `'validation'` mode, the default).
+    ///
 
     Attributes:
         func: The validator function.
@@ -206,26 +213,16 @@ class PlainValidator:
     json_schema_input_type: Any = Any
 
     def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
-        # Note that for some valid uses of PlainValidator, it is not possible to generate a core schema for the
-        # source_type, so calling `handler(source_type)` will error, which prevents us from generating a proper
-        # serialization schema. To work around this for use cases that will not involve serialization, we simply
-        # catch any PydanticSchemaGenerationError that may be raised while attempting to build the serialization schema
-        # and abort any attempts to handle special serialization.
-        from pydantic import PydanticSchemaGenerationError
+        # For some valid uses of PlainValidator, it is not possible to generate a core schema for the
+        # `source_type`, so calling `handler(source_type)` will error, so we handle errors gracefully
+        # by not including any serialization schema.
+        # Lazy import to avoid cycle:
+        from pydantic._internal._generate_schema import GENERATE_SCHEMA_ERRORS
 
         try:
             schema = handler(source_type)
-            # TODO if `schema['serialization']` is one of `'include-exclude-dict/sequence',
-            # schema validation will fail. That's why we use 'type ignore' comments below.
-            serialization = schema.get(
-                'serialization',
-                core_schema.wrap_serializer_function_ser_schema(
-                    function=lambda v, h: h(v),
-                    schema=schema,
-                    return_schema=handler.generate_schema(source_type),
-                ),
-            )
-        except PydanticSchemaGenerationError:
+            serialization = _core_utils.as_ser_schema(schema)
+        except GENERATE_SCHEMA_ERRORS:
             serialization = None
 
         input_schema = handler.generate_schema(self.json_schema_input_type)
@@ -235,14 +232,14 @@ class PlainValidator:
             func = cast(core_schema.WithInfoValidatorFunction, self.func)
             return core_schema.with_info_plain_validator_function(
                 func,
-                serialization=serialization,  # pyright: ignore[reportArgumentType]
+                serialization=serialization,
                 json_schema_input_schema=input_schema,
             )
         else:
             func = cast(core_schema.NoInfoValidatorFunction, self.func)
             return core_schema.no_info_plain_validator_function(
                 func,
-                serialization=serialization,  # pyright: ignore[reportArgumentType]
+                serialization=serialization,
                 json_schema_input_schema=input_schema,
             )
 
@@ -259,7 +256,13 @@ class WrapValidator:
     """!!! abstract "Usage Documentation"
         [field *wrap* validators](../concepts/validators.md#field-wrap-validator)
 
-    A metadata class that indicates that a validation should be applied **around** the inner validation logic.
+    A class used as [annotated metadata](../concepts/fields.md#the-annotated-pattern) that indicates that
+    a validation should be applied **around** the inner validation logic.
+
+    /// version-added | v2.9
+    The `json_schema_input_type` parameter can be used to specify the input type of the function to be used in the
+    JSON Schema (in `'validation'` mode, the default).
+    ///
 
     Attributes:
         func: The validator function.
@@ -825,15 +828,13 @@ else:
 
     @dataclasses.dataclass(slots=True)
     class SkipValidation:
-        """If this is applied as an annotation (e.g., via `x: Annotated[int, SkipValidation]`), validation will be
-            skipped. You can also use `SkipValidation[int]` as a shorthand for `Annotated[int, SkipValidation]`.
+        """A helper class to skip validation.
 
-        This can be useful if you want to use a type annotation for documentation/IDE/type-checking purposes,
-        and know that it is safe to skip validation for one or more of the fields.
+        This helper can be used as a parameterized annotation, e.g. `SkipValidation[int]`, which is a shorthand
+        for `Annotated[int, SkipValidation()]`.
 
-        Because this converts the validation schema to `any_schema`, subsequent annotation-applied transformations
-        may not have the expected effects. Therefore, when used, this annotation should generally be the final
-        annotation applied to a type.
+        Internally, this helper will treat the type as if it was [`Any`][typing.Any], while still advertizing the
+        original type to tools such as type checkers and IDEs.
         """
 
         def __class_getitem__(cls, item: Any) -> Any:
@@ -847,9 +848,7 @@ else:
             metadata = {'pydantic_js_annotation_functions': [lambda _c, h: h(original_schema)]}
             return core_schema.any_schema(
                 metadata=metadata,
-                serialization=core_schema.wrap_serializer_function_ser_schema(
-                    function=lambda v, h: h(v), schema=original_schema
-                ),
+                serialization=_core_utils.as_ser_schema(original_schema),
             )
 
         __hash__ = object.__hash__
@@ -911,11 +910,5 @@ class ValidateAs:
         except GENERATE_SCHEMA_ERRORS:
             ser_schema = core_schema.any_schema()
 
-        # TODO: pydantic-core now accepts an arbitrary core schema for serialization, so the
-        # wrap serializer workaround below can be replaced with
-        # `schema['serialization'] = _core_utils.as_ser_schema(ser_schema)`.
-        # The same workaround is used in other parts of the code base, so grep for similar cases when fixing:
-        schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
-            function=lambda v, h: h(v), schema=ser_schema
-        )
+        schema['serialization'] = _core_utils.as_ser_schema(ser_schema)
         return schema

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1675,7 +1675,8 @@ class GenerateJsonSchema:
         # We do not use schema['model'].model_json_schema() here
         # because it could lead to inconsistent refs handling, etc.
         cls = cast('type[BaseModel]', schema['cls'])
-        config = cls.model_config
+        # `cls` might not be a model in the case of a `ModelSerSchema`, hence the `getattr()`:
+        config = cast('ConfigDict', getattr(cls, 'model_config', {}))
 
         with self._config_wrapper_stack.push(config):
             json_schema = self.generate_inner(schema['schema'])
@@ -2243,13 +2244,21 @@ class GenerateJsonSchema:
                 return_schema = schema.get('return_schema')
                 if return_schema is not None:
                     return self.generate_inner(return_schema)
+                return None
             case {'type': 'format' | 'to-string'}:
                 # FormatSerSchema or ToStringSerSchema
                 return self.str_schema(core_schema.str_schema())
-            case {'type': 'model'}:
-                # ModelSerSchema
-                return self.generate_inner(schema['schema'])
-        return None
+            case {'type': 'include-exclude-sequence' | 'include-exclude-dict'}:
+                # IncExSeqSerSchema or IncExDictSerSchema, no impact on the JSON Schema
+                return None
+            case {'type': 'any'}:
+                # An `'any'` serialization schema doesn't provide any information about the serialized value,
+                # so use the main schema instead, which is a more precise description in practice.
+                return None
+            case _:
+                # An arbitrary core schema (this includes `SimpleSerSchema` and `ModelSerSchema`, which are
+                # subsets of the corresponding core schemas, hence the cast):
+                return self.generate_inner(cast('CoreSchema', schema))
 
     def complex_schema(self, schema: core_schema.ComplexSchema) -> JsonSchemaValue:
         """Generates a JSON schema that matches a complex number.

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -49,6 +49,7 @@ from pydantic import (
     PydanticDeprecatedSince29,
     PydanticUserError,
     RootModel,
+    SerializeAsAny,
     ValidationError,
     WithJsonSchema,
     WrapValidator,
@@ -6854,7 +6855,7 @@ def test_min_and_max_in_schema() -> None:
 
 
 def test_plain_field_validator_serialization() -> None:
-    """`PlainValidator` internally creates a wrap ser. schema. This tests that we can
+    """`PlainValidator` internally uses the source type's schema as the ser. schema. This tests that we can
     still generate a JSON Schema in `'serialization'` mode.
     """
 
@@ -6867,6 +6868,107 @@ def test_plain_field_validator_serialization() -> None:
         'title': 'Foo',
         'type': 'object',
     }
+
+
+def test_core_schema_as_ser_schema() -> None:
+    """In `'serialization'` mode, the JSON Schema is generated from the (arbitrary) core schema used as a serialization schema."""
+
+    class Model(BaseModel):
+        a: int
+
+    class ListOfInts:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+            return core_schema.str_schema(serialization=core_schema.list_schema(core_schema.int_schema()))
+
+    class AsModel:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+            return core_schema.str_schema(serialization=handler(Model))
+
+    class Foo(BaseModel):
+        a: ListOfInts
+        b: AsModel
+
+    assert Foo.model_json_schema(mode='validation') == {
+        'properties': {'a': {'title': 'A', 'type': 'string'}, 'b': {'title': 'B', 'type': 'string'}},
+        'required': ['a', 'b'],
+        'title': 'Foo',
+        'type': 'object',
+    }
+    assert Foo.model_json_schema(mode='serialization') == {
+        '$defs': {
+            'Model': {
+                'properties': {'a': {'title': 'A', 'type': 'integer'}},
+                'required': ['a'],
+                'title': 'Model',
+                'type': 'object',
+            }
+        },
+        'properties': {
+            'a': {'items': {'type': 'integer'}, 'title': 'A', 'type': 'array'},
+            'b': {'$ref': '#/$defs/Model', 'title': 'B'},
+        },
+        'required': ['a', 'b'],
+        'title': 'Foo',
+        'type': 'object',
+    }
+
+
+def test_model_ser_schema() -> None:
+    """A `ModelSerSchema` (a subset of the model schema) is handled by `model_schema()`, even with a non-model class."""
+
+    class NotAModel:
+        """A class."""
+
+    class WithModelSerSchema:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+            return core_schema.any_schema(
+                serialization=core_schema.model_ser_schema(
+                    NotAModel,
+                    core_schema.model_fields_schema({'a': core_schema.model_field(core_schema.int_schema())}),
+                )
+            )
+
+    assert TypeAdapter(WithModelSerSchema).json_schema(mode='serialization') == {
+        'description': 'A class.',
+        'properties': {'a': {'title': 'A', 'type': 'integer'}},
+        'required': ['a'],
+        'title': 'NotAModel',
+        'type': 'object',
+    }
+
+
+def test_any_ser_schema_uses_main_schema() -> None:
+    """An `'any'` serialization schema (as used by `SerializeAsAny` or TypeVars with a bound) doesn't
+    provide any information about the serialized value, so the main schema is used instead."""
+
+    class Model(BaseModel):
+        a: int
+
+    T = TypeVar('T', bound=int)
+
+    class Foo(BaseModel, Generic[T]):
+        a: SerializeAsAny[Model]
+        t: T
+
+    expected = {
+        '$defs': {
+            'Model': {
+                'properties': {'a': {'title': 'A', 'type': 'integer'}},
+                'required': ['a'],
+                'title': 'Model',
+                'type': 'object',
+            }
+        },
+        'properties': {'a': {'$ref': '#/$defs/Model'}, 't': {'title': 'T', 'type': 'integer'}},
+        'required': ['a', 't'],
+        'title': 'Foo',
+        'type': 'object',
+    }
+    assert Foo.model_json_schema(mode='validation') == expected
+    assert Foo.model_json_schema(mode='serialization') == expected
 
 
 def test_annotated_field_validator_input_type() -> None:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 from dirty_equals import HasRepr, IsInstance
 from pydantic_core import core_schema
-from typing_extensions import TypeAliasType, TypedDict
+from typing_extensions import NotRequired, TypeAliasType, TypedDict
 
 from pydantic import (
     BaseModel,
@@ -2948,7 +2948,6 @@ def test_plain_validator_plain_serializer_single_ser_call() -> None:
     assert ser_count == 1
 
 
-@pytest.mark.xfail(reason='https://github.com/pydantic/pydantic/issues/10428')
 def test_plain_validator_with_filter_dict_schema() -> None:
     class MyDict:
         @classmethod
@@ -2981,6 +2980,21 @@ def test_plain_validator_with_unsupported_type() -> None:
     model = type_adapter.validate_python('abcdefg')
     assert isinstance(model, UnsupportedClass)
     assert isinstance(type_adapter.dump_python(model), UnsupportedClass)
+
+
+def test_plain_validator_with_schema_generation_error() -> None:
+    @dataclass
+    class ClassWithInvalidAnnotations:
+        a: 'Unknown' = 1  # noqa: F821
+        b: NotRequired[int] = 1
+
+    class Model(BaseModel):
+        f: Annotated[ClassWithInvalidAnnotations, PlainValidator(lambda _: ClassWithInvalidAnnotations())]
+
+    m = Model(f='abcdefg')
+    assert isinstance(m.f, ClassWithInvalidAnnotations)
+    # No serialization schema is set, so serialization is inferred:
+    assert m.model_dump() == {'f': {'a': 1, 'b': 1}}
 
 
 def test_validator_with_default_values() -> None:


### PR DESCRIPTION
With https://github.com/pydantic/pydantic/pull/13680, we can now remove the ugly wrap serializer workaround.

Also rewrite some docstrings, and handle all schema generation errors in `PlainValidator`.

Also fixes https://github.com/pydantic/pydantic/issues/10428.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
