### PR TITLE
Fix MRO resolution for inherited fields (#13678)

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -313,8 +313,16 @@ def collect_model_fields(  # noqa: C901
 
     bases = cls.__bases__
     parent_fields_lookup: dict[str, FieldInfo] = {}
-    for base in reversed(bases):
+    def _is_field_defined(base, k):
+        if k in _typing_extra.safe_get_annotations(base):
+            return True
+        if getattr(base, '__pydantic_generic_metadata__', {}).get('origin') is not None:
+            return True
+        return False
+
+    for base in reversed(cls.__mro__[1:]):
         if model_fields := getattr(base, '__pydantic_fields__', None):
+            model_fields = {k: v for k, v in model_fields.items() if _is_field_defined(base, k)}
             parent_fields_lookup.update(model_fields)
 
     type_hints = _typing_extra.get_model_type_hints(cls, ns_resolver=ns_resolver)

--- a/tests/test_inheritance_mro.py
+++ b/tests/test_inheritance_mro.py
@@ -1,4 +1,6 @@
 from pydantic import BaseModel
+
+
 def test_multiple_inheritance_mro_fields():
     class Base(BaseModel):
         f: str = "base"

--- a/tests/test_inheritance_mro.py
+++ b/tests/test_inheritance_mro.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+def test_multiple_inheritance_mro_fields():
+    class Base(BaseModel):
+        f: str = "base"
+    class Override(Base):
+        f: str = "override"
+    class Plain(Base):
+        pass
+    class Swapped(Plain, Override):
+        pass
+    class Composed(Override, Plain):
+        pass
+
+    assert Swapped().f == "override"
+    assert Composed().f == "override"


### PR DESCRIPTION
# Fix MRO resolution for inherited fields (#13678)

Fixes #13678.

## Description
This pull request fixes a structural bug where fields in multiple inheritance would fail to respect Python's Method Resolution Order (MRO) when merging flattened fields from bases. 

Currently, `collect_model_fields` populates the `parent_fields_lookup` by iterating backward over the immediate `bases`. Because `__pydantic_fields__` contains all inherited fields from previous bases in flattened form, a base class that merely inherits a field will bring its parent's field to the merge, unintentionally overwriting a sibling class that legitimately overrode the field, if the former appears later in `reversed(bases)`.

This fix changes the collection logic to:
1. Traverse the full `cls.__mro__[1:]` in reverse order.
2. Filter the fields retrieved from `getattr(base, '__pydantic_fields__')` to only include those that were **actually defined** on that specific base. This is determined by verifying if the field exists in `_typing_extra.safe_get_annotations(base)` or if the base itself is a parametrized generic (where all substituted fields are effectively defined by the generic parametrization).

## Example
```python
from pydantic import BaseModel

class Base(BaseModel):
    f: str = "base"

class Override(Base):
    f: str = "override"

class Plain(Base):
    pass

class Swapped(Plain, Override):
    pass

class Composed(Override, Plain):
    pass

print(Swapped().f)    # Previously "base", now correctly "override"
print(Composed().f)  # "override"
```

## Testing
Added a regression test covering multiple inheritance MRO behavior in `tests/test_inheritance_mro.py`. All tests pass locally.

## Related
Also relates to #11700 (private attribute MRO) as described in the issue, though this PR explicitly targets field resolution which resolves the immediate regression.
