### PR TITLE
Add safe unified docs preview dispatch

### DIFF
--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -18,7 +18,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: docs-navigation-${{ github.event.pull_request.number }}
+  group: docs-navigation-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -33,6 +33,7 @@ jobs:
 
     steps:
       - name: Verify a maintainer triggered the check
+        id: verify
         env:
           ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ github.token }}
@@ -90,7 +91,7 @@ jobs:
           )
 
           existing=$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
-            --jq '[.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))][0].url // empty')
+            --jq '([.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))] | last).url // empty')
           if [ -n "$existing" ]; then
             gh api -X PATCH "$existing" -f body="$body"
           else
@@ -98,7 +99,7 @@ jobs:
           fi
 
       - name: Comment failure on PR
-        if: failure() && (steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
+        if: failure() && (steps.verify.outcome == 'failure' || steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -52,7 +52,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.DOCS_APP_ID }}
+          client-id: ${{ vars.DOCS_APP_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: unified-docs

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -58,6 +58,7 @@ jobs:
           permission-contents: write
 
       - name: Dispatch navigation check
+        id: dispatch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -73,6 +74,7 @@ jobs:
             -f "client_payload[source_sha]=${HEAD_SHA}"
 
       - name: Acknowledge on PR
+        id: acknowledge
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -96,7 +98,7 @@ jobs:
           fi
 
       - name: Comment failure on PR
-        if: failure()
+        if: failure() && (steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -109,6 +111,22 @@ jobs:
           The navigation check could not be queued. See [the workflow run](${RUN_URL}) for details.
 
           <sub>Re-add the \`trigger:docs\` label to retry.</sub>
+          EOF
+          )
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"
+
+      - name: Report acknowledgement failure on PR
+        if: failure() && steps.dispatch.outcome == 'success' && steps.acknowledge.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          body=$(cat <<EOF
+          ## Docs Navigation Check — queued
+
+          Navigation validation was queued, but this workflow could not post its normal acknowledgement. See [the workflow run](${RUN_URL}) for details.
           EOF
           )
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -11,10 +11,11 @@ name: Docs Navigation Check
 
 on:
   # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so fork PRs can
-  # access the DOCS_APP credentials. The labeled event verifies that the label actor
-  # has write access. While that trusted label remains present, synchronize events
-  # supersede an in-flight dispatch so the receiver never gets stranded on a stale
-  # SHA. This workflow never checks out or executes PR code.
+  # access the DOCS_APP credentials. Every run verifies that the actor who most
+  # recently applied the label has write access. While that trusted label remains
+  # present, synchronize events supersede an in-flight dispatch so the receiver
+  # never gets stranded on a stale SHA. This workflow never checks out or executes
+  # PR code.
   pull_request_target:
     types: [labeled, synchronize]
 
@@ -37,19 +38,26 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Verify a maintainer triggered the check
-        if: github.event.action == 'labeled'
+      - name: Verify a maintainer owns the trigger label
         id: verify
         env:
-          ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          permission=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq .permission)
+          label_actor=$(gh api --paginate --slurp \
+            "repos/${REPO}/issues/${PR_NUMBER}/timeline?per_page=100" \
+            --jq '([.[][] | select(.event == "labeled" and .label.name == "trigger:docs")] | last | .actor.login) // empty')
+          if [ -z "$label_actor" ]; then
+            echo "Could not identify who applied trigger:docs" >&2
+            exit 1
+          fi
+
+          permission=$(gh api "repos/${REPO}/collaborators/${label_actor}/permission" --jq .permission)
           case "$permission" in
             admin|maintain|write) ;;
             *)
-              echo "${ACTOR} does not have permission to dispatch a docs navigation check" >&2
+              echo "${label_actor} does not have permission to dispatch a docs navigation check" >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -5,34 +5,40 @@ name: Docs Navigation Check
 # Markdown files without executing pull-request content.
 #
 # This workflow is purely a dispatcher. The data-only validation and final
-# comment happen in unified-docs. The `trigger:docs` label is removed at the
-# end so re-adding it reruns the check.
+# comment happen in unified-docs. After a successful dispatch, the label stays
+# present until unified-docs reaches a terminal result so a pushed commit can
+# supersede an in-flight exact-SHA run.
 
 on:
   # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so fork PRs can
-  # access the DOCS_APP credentials. The dispatch explicitly verifies that the label
-  # actor has write access, and this workflow does not check out or execute PR code.
+  # access the DOCS_APP credentials. The labeled event verifies that the label actor
+  # has write access. While that trusted label remains present, synchronize events
+  # supersede an in-flight dispatch so the receiver never gets stranded on a stale
+  # SHA. This workflow never checks out or executes PR code.
   pull_request_target:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 permissions: {}
 
 concurrency:
-  group: docs-navigation-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  group: docs-navigation-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   dispatch:
     name: Dispatch Docs Navigation Check
-    if: github.event.label.name == 'trigger:docs'
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'trigger:docs') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'trigger:docs'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      # Needed to post the queued comment and remove the trigger label.
+      # Needed to post the queued comment and clean up a failed dispatch.
       pull-requests: write
 
     steps:
       - name: Verify a maintainer triggered the check
+        if: github.event.action == 'labeled'
         id: verify
         env:
           ACTOR: ${{ github.actor }}
@@ -132,8 +138,8 @@ jobs:
           )
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"
 
-      - name: Remove trigger:docs label
-        if: always()
+      - name: Remove trigger:docs label after dispatch failure
+        if: always() && steps.dispatch.outcome != 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -1,0 +1,122 @@
+name: Docs Navigation Check
+
+# Label-triggered navigation validation. Adding `trigger:docs` to a PR asks
+# pydantic/unified-docs to validate this PR's MkDocs navigation and referenced
+# Markdown files without executing pull-request content.
+#
+# This workflow is purely a dispatcher. The data-only validation and final
+# comment happen in unified-docs. The `trigger:docs` label is removed at the
+# end so re-adding it reruns the check.
+
+on:
+  # zizmor: ignore[dangerous-triggers] -- pull_request_target is required so fork PRs can
+  # access the DOCS_APP credentials. The dispatch explicitly verifies that the label
+  # actor has write access, and this workflow does not check out or execute PR code.
+  pull_request_target:
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  group: docs-navigation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch Docs Navigation Check
+    if: github.event.label.name == 'trigger:docs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # Needed to post the queued comment and remove the trigger label.
+      pull-requests: write
+
+    steps:
+      - name: Verify a maintainer triggered the check
+        env:
+          ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          permission=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq .permission)
+          case "$permission" in
+            admin|maintain|write) ;;
+            *)
+              echo "${ACTOR} does not have permission to dispatch a docs navigation check" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Generate app token for unified-docs
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: unified-docs
+          permission-contents: write
+
+      - name: Dispatch navigation check
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api repos/pydantic/unified-docs/dispatches \
+            --method POST \
+            -f event_type=docs-preview \
+            -f "client_payload[library]=validation" \
+            -f "client_payload[source_repo]=${REPO}" \
+            -f "client_payload[source_pr]=${PR_NUMBER}" \
+            -f "client_payload[source_sha]=${HEAD_SHA}"
+
+      - name: Acknowledge on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          sha7=${HEAD_SHA:0:7}
+          body=$(cat <<EOF
+          ## Docs Navigation Check — queued
+
+          Navigation validation for commit \`${sha7}\` has been queued. This comment will be updated when the check completes.
+          EOF
+          )
+
+          existing=$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '[.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))][0].url // empty')
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "$existing" -f body="$body"
+          else
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"
+          fi
+
+      - name: Comment failure on PR
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          body=$(cat <<EOF
+          ## Docs Navigation Check — dispatch failed
+
+          The navigation check could not be queued. See [the workflow run](${RUN_URL}) for details.
+
+          <sub>Re-add the \`trigger:docs\` label to retry.</sub>
+          EOF
+          )
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"
+
+      - name: Remove trigger:docs label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/trigger:docs" || true

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parents[1] / '.github' / 'workflows' / 'docs-navigation.yml'
+
+
+def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert 'pull_request_target:' in workflow
+    assert "github.event.label.name == 'trigger:docs'" in workflow
+    assert 'timeout-minutes: 5' in workflow
+    assert 'actions/checkout@' not in workflow
+    assert '/collaborators/${ACTOR}/permission' in workflow
+    assert 'admin|maintain|write)' in workflow
+    assert 'permission-contents: write' in workflow
+    assert workflow.index('Verify a maintainer triggered the check') < workflow.index('Generate app token')
+    assert '-f "client_payload[library]=validation"' in workflow
+    assert '-f "client_payload[source_repo]=${REPO}"' in workflow
+    assert '-f "client_payload[source_sha]=${HEAD_SHA}"' in workflow
+
+
+def test_public_comments_describe_data_only_navigation_validation() -> None:
+    workflow = WORKFLOW.read_text()
+
+    assert 'github.com/pydantic/unified-docs' not in workflow
+    assert 'Docs Navigation Check — queued' in workflow
+    assert 'Navigation validation for commit' in workflow
+    assert 'preview URL' not in workflow
+    assert '--paginate --slurp' in workflow

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -29,5 +29,7 @@ def test_public_comments_describe_data_only_navigation_validation() -> None:
     assert 'preview URL' not in workflow
     assert '--paginate --slurp' in workflow
     assert 'startswith("## Docs Preview")' in workflow
+    assert '| last).url // empty' in workflow
+    assert "steps.verify.outcome == 'failure'" in workflow
     assert "steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'" in workflow
     assert "steps.acknowledge.outcome == 'failure'" in workflow

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -4,7 +4,7 @@ WORKFLOW = Path(__file__).parents[1] / '.github' / 'workflows' / 'docs-navigatio
 
 
 def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
-    workflow = WORKFLOW.read_text()
+    workflow = WORKFLOW.read_text(encoding='utf-8')
 
     assert 'pull_request_target:' in workflow
     assert "github.event.label.name == 'trigger:docs'" in workflow
@@ -20,7 +20,7 @@ def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
 
 
 def test_public_comments_describe_data_only_navigation_validation() -> None:
-    workflow = WORKFLOW.read_text()
+    workflow = WORKFLOW.read_text(encoding='utf-8')
 
     assert 'github.com/pydantic/unified-docs' not in workflow
     assert 'Docs Navigation Check — queued' in workflow

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -28,3 +28,6 @@ def test_public_comments_describe_data_only_navigation_validation() -> None:
     assert 'Navigation validation for commit' in workflow
     assert 'preview URL' not in workflow
     assert '--paginate --slurp' in workflow
+    assert 'startswith("## Docs Preview")' in workflow
+    assert "steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'" in workflow
+    assert "steps.acknowledge.outcome == 'failure'" in workflow

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -13,6 +13,8 @@ def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
     assert 'actions/checkout@' not in workflow
     assert '/collaborators/${ACTOR}/permission' in workflow
     assert 'admin|maintain|write)' in workflow
+    assert 'client-id: ${{ vars.DOCS_APP_CLIENT_ID }}' in workflow
+    assert 'vars.DOCS_APP_ID' not in workflow
     assert 'permission-contents: write' in workflow
     assert workflow.index('Verify a maintainer triggered the check') < workflow.index('Generate app token')
     assert '-f "client_payload[library]=validation"' in workflow

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -15,13 +15,15 @@ def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
     assert 'docs-navigation-${{ github.event.pull_request.number }}-${{' not in workflow
     assert 'timeout-minutes: 5' in workflow
     assert 'actions/checkout@' not in workflow
-    assert '/collaborators/${ACTOR}/permission' in workflow
+    assert '/issues/${PR_NUMBER}/timeline?per_page=100' in workflow
+    assert '.event == "labeled" and .label.name == "trigger:docs"' in workflow
+    assert '| last | .actor.login' in workflow
+    assert '/collaborators/${label_actor}/permission' in workflow
     assert 'admin|maintain|write)' in workflow
-    assert "if: github.event.action == 'labeled'" in workflow
     assert 'client-id: ${{ vars.DOCS_APP_CLIENT_ID }}' in workflow
     assert 'vars.DOCS_APP_ID' not in workflow
     assert 'permission-contents: write' in workflow
-    assert workflow.index('Verify a maintainer triggered the check') < workflow.index('Generate app token')
+    assert workflow.index('Verify a maintainer owns the trigger label') < workflow.index('Generate app token')
     assert '-f "client_payload[library]=validation"' in workflow
     assert '-f "client_payload[source_repo]=${REPO}"' in workflow
     assert '-f "client_payload[source_sha]=${HEAD_SHA}"' in workflow

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -7,12 +7,17 @@ def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
     workflow = WORKFLOW.read_text(encoding='utf-8')
 
     assert 'pull_request_target:' in workflow
-    assert "github.event.label.name == 'trigger:docs'" in workflow
-    assert 'docs-navigation-${{ github.event.pull_request.number }}-${{ github.event.label.name }}' in workflow
+    assert 'types: [labeled, synchronize]' in workflow
+    assert "github.event.action == 'labeled' && github.event.label.name == 'trigger:docs'" in workflow
+    assert "github.event.action == 'synchronize'" in workflow
+    assert "contains(github.event.pull_request.labels.*.name, 'trigger:docs')" in workflow
+    assert 'docs-navigation-${{ github.event.pull_request.number }}' in workflow
+    assert 'docs-navigation-${{ github.event.pull_request.number }}-${{' not in workflow
     assert 'timeout-minutes: 5' in workflow
     assert 'actions/checkout@' not in workflow
     assert '/collaborators/${ACTOR}/permission' in workflow
     assert 'admin|maintain|write)' in workflow
+    assert "if: github.event.action == 'labeled'" in workflow
     assert 'client-id: ${{ vars.DOCS_APP_CLIENT_ID }}' in workflow
     assert 'vars.DOCS_APP_ID' not in workflow
     assert 'permission-contents: write' in workflow
@@ -35,3 +40,4 @@ def test_public_comments_describe_data_only_navigation_validation() -> None:
     assert "steps.verify.outcome == 'failure'" in workflow
     assert "steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'" in workflow
     assert "steps.acknowledge.outcome == 'failure'" in workflow
+    assert "if: always() && steps.dispatch.outcome != 'success'" in workflow

--- a/tests/test_docs_navigation_workflow.py
+++ b/tests/test_docs_navigation_workflow.py
@@ -8,6 +8,7 @@ def test_privileged_dispatcher_never_executes_pull_request_code() -> None:
 
     assert 'pull_request_target:' in workflow
     assert "github.event.label.name == 'trigger:docs'" in workflow
+    assert 'docs-navigation-${{ github.event.pull_request.number }}-${{ github.event.label.name }}' in workflow
     assert 'timeout-minutes: 5' in workflow
     assert 'actions/checkout@' not in workflow
     assert '/collaborators/${ACTOR}/permission' in workflow


### PR DESCRIPTION
## Change summary

Add a maintainer-triggered dispatcher for unified-docs checks and rendered Validation previews. The privileged workflow authenticates the label actor and sends the exact PR head SHA without checking out or executing pull-request content.

Public forks remain limited to data-only navigation validation. Same-repository branches become eligible for a rendered preview after pydantic/unified-docs#231 lands.

## Verification

- `uv run pytest -q tests/test_docs_navigation_workflow.py`
- `uv run ruff format --check tests/test_docs_navigation_workflow.py`
- `uv run ruff check tests/test_docs_navigation_workflow.py`
- `actionlint .github/workflows/docs-navigation.yml`
- `uvx zizmor .github/workflows/docs-navigation.yml`

## Rollout

Merge pydantic/unified-docs#231 first, then this PR. Add `trigger:docs` to a same-repository documentation PR to exercise the deployed preview path.

## Checklist

- [x] Unit tests cover the security and dispatch contract
- [x] Existing `DOCS_APP_CLIENT_ID` and `DOCS_APP_PRIVATE_KEY` configuration is reused
- [ ] CI passes
