### PR TITLE
Take `populate_by_name` and `validate_by_alias` into account when generating arguments schemas

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -185,6 +185,24 @@ class ConfigWrapper:
                 except KeyError:
                     raise AttributeError(f'Config has no attribute {name!r}') from None
 
+        @property
+        def validate_by_name(self) -> bool:
+            """The effective `validate_by_name` value, taking deprecated/related settings into account.
+
+            This mirrors the backwards compatibility patches applied in `core_config()`, so that direct
+            attribute accesses (e.g. when generating an arguments core schema, where the value is embedded
+            in the schema itself) stay consistent with the emitted pydantic-core configuration.
+            """
+            validate_by_name = self.config_dict.get('validate_by_name')
+            if validate_by_name is not None:
+                return validate_by_name
+            populate_by_name = self.config_dict.get('populate_by_name')
+            if populate_by_name is not None:
+                return populate_by_name
+            # `validate_by_name` defaults to `True` if `validate_by_alias` is explicitly set to `False`
+            # (otherwise no value could be provided for the field/argument):
+            return self.config_dict.get('validate_by_alias') is False
+
     def core_config(self, title: str | None) -> core_schema.CoreConfig:
         """Create a pydantic-core config.
 

--- a/tests/test_validate_call.py
+++ b/tests/test_validate_call.py
@@ -929,6 +929,29 @@ def test_validate_by_name():
     assert foo(a=10, c=1) == 11
 
 
+def test_populate_by_name_still_effective():
+    """The deprecated `populate_by_name` setting should behave as `validate_by_name=True`."""
+
+    @validate_call(config=dict(populate_by_name=True))
+    def foo(a: Annotated[int, Field(alias='b')]):
+        return a
+
+    assert foo(b=1) == 1
+    assert foo(a=2) == 2
+
+
+def test_validate_by_alias_disabled():
+    """Setting `validate_by_alias=False` should implicitly enable validation by name."""
+
+    @validate_call(config=dict(validate_by_alias=False))
+    def foo(a: Annotated[int, Field(alias='b')]):
+        return a
+
+    assert foo(a=1) == 1
+    with pytest.raises(ValidationError):
+        foo(b=1)
+
+
 def test_validate_return():
     @validate_call(config=dict(validate_return=True))
     def foo(a: int, b: int) -> int:


### PR DESCRIPTION
## Change Summary

`ConfigWrapper.core_config()` applies backwards-compatibility patches for the alias configuration settings (`populate_by_name` → `validate_by_name`, and implicit `validate_by_name=True` when `validate_by_alias=False`, per #11503). However, `_arguments_schema()` and `_arguments_v3_schema()` embed `validate_by_name` into the core schema via a direct `ConfigWrapper` attribute access, which bypasses those patches — and the schema-embedded value takes precedence over the core config in pydantic-core. As a result, `@validate_call(config=ConfigDict(populate_by_name=True))` rejects by-name arguments (regression: works on 2.10.6, broken since 2.11), and `validate_by_alias=False` makes aliased parameters impossible to provide at all.

This makes `validate_by_name` a runtime property on `ConfigWrapper` applying the same resolution as `core_config()`, so direct attribute accesses (arguments schema generation, `__signature__` generation) stay consistent with the emitted core config. The property lives in the existing `if not TYPE_CHECKING:` block, keeping the annotation contract with `ConfigDict` intact.

Tests: `test_populate_by_name_still_effective` and `test_validate_by_alias_disabled` in `tests/test_validate_call.py` — both fail without the fix and pass with it. Surrounding suites: `test_validate_call.py` 62 passed; `test_config.py`+`test_model_signature.py`+`test_internal.py`+`test_aliases.py` 255 passed; `test_main.py`+`test_dataclasses.py`+`test_experimental_arguments_schema.py`+`test_deprecated_validate_arguments.py` 549 passed. `ruff check`/`ruff format --check` clean.

## Related issue number

fix #13687

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes where applicable

Disclosure: this fix was developed with the assistance of Claude (Anthropic); I reviewed and tested all changes.