### PR TITLE
Use list schema for bare `collections.abc.MutableSequence`

### DIFF
--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -372,7 +372,7 @@ class GenerateSchema:
         collections.abc.MutableSet: lambda self, obj: self._set_schema(Any),
         frozenset: lambda self, obj: self._frozenset_schema(Any),
         collections.abc.Set: lambda self, obj: self._frozenset_schema(Any),
-        collections.abc.MutableSequence: lambda self, obj: self._sequence_schema(Any),
+        collections.abc.MutableSequence: lambda self, obj: self._list_schema(Any),
         collections.abc.Sequence: lambda self, obj: self._sequence_schema(Any),
         collections.deque: lambda self, obj: self._deque_schema(Any),
         collections.abc.Iterable: lambda self, obj: self._iterable_schema(obj),

--- a/tests/types/test_list.py
+++ b/tests/types/test_list.py
@@ -1,4 +1,5 @@
 from collections import deque
+from collections.abc import MutableSequence
 from typing import Annotated
 
 import annotated_types
@@ -287,4 +288,18 @@ def test_list_strict() -> None:
         ta.validate_python(['1', 2], strict=True)
     assert exc_info.value.errors(include_url=False) == [
         {'type': 'int_type', 'loc': (0,), 'msg': 'Input should be a valid integer', 'input': '1'}
+    ]
+
+
+def test_bare_mutable_sequence() -> None:
+    """A bare `MutableSequence` should behave as a bare `list`, as `MutableSequence[int]` does."""
+    ta = TypeAdapter(MutableSequence)
+
+    assert ta.validate_python([1, '2']) == [1, '2']
+    assert ta.validate_python((1, '2')) == [1, '2']
+
+    with pytest.raises(ValidationError) as exc_info:
+        ta.validate_python('abc')
+    assert exc_info.value.errors(include_url=False) == [
+        {'type': 'list_type', 'loc': (), 'msg': 'Input should be a valid list', 'input': 'abc'}
     ]

--- a/tests/types/test_list.py
+++ b/tests/types/test_list.py
@@ -292,7 +292,7 @@ def test_list_strict() -> None:
 
 
 def test_bare_mutable_sequence() -> None:
-    """A bare `MutableSequence` should behave as a bare `list`, as `MutableSequence[int]` does."""
+    """Regression test for https://github.com/pydantic/pydantic/pull/13573."""
     ta = TypeAdapter(MutableSequence)
 
     assert ta.validate_python([1, '2']) == [1, '2']


### PR DESCRIPTION
## Change Summary

Unreleased regression from #13573 ("Optimize type lookup logic in core schema generation", b75fadb, 2026-08-03). That refactor moved the bare/unsubscripted type dispatch into `_types_handlers`, and bare `collections.abc.MutableSequence` — previously part of `LIST_TYPES` — ended up mapped to `self._sequence_schema(Any)` instead of `self._list_schema(Any)`.

`_sequence_schema` builds an `is_instance_schema(typing.Sequence)`, so mutability is never checked and no coercion happens. On `main` today:

```python
from collections.abc import MutableSequence
from pydantic import TypeAdapter

ta = TypeAdapter(MutableSequence)
ta.validate_python('abc')    # -> 'abc'   (a str is not a MutableSequence)
ta.validate_python((1, 2))   # -> (1, 2)  (a tuple is not a MutableSequence)
```

Both should be a `list`: a `str` should be rejected with `list_type`, and a `tuple` should coerce to `[1, 2]`. `MutableSequence[int]` is unaffected — the generic handler at `_generic_handlers` already routes to `_list_schema`, so only the bare form regressed, which is why it slipped through.

The fix is the one-line dispatch entry, bringing the bare form back in line with:

* the subscripted handler `MutableSequence[T] -> _list_schema`,
* `_validators.py` `MAPPING_ORIGIN_MAP`/sequence handling, and
* `_serializers.py`, which both already map `MutableSequence -> list`.

This has only ever been tagged in `v2.14.0b1`, so no released version is affected and no deprecation or migration note is needed.

A regression test is added to `tests/types/test_list.py` covering the bare form: a `str` must be rejected and a `tuple` must coerce to a `list`.

## Related issue number

None — this is a one-line regression fix against an unreleased change (#13573), so no issue was filed first.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
