### PR TITLE
Fix `model_dump_json()` crashing on `SecretStr` with `None` default

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1574,7 +1574,11 @@ class _SecretBase(Generic[SecretType]):
         raise NotImplementedError
 
 
-def _serialize_secret(value: Secret[SecretType], info: core_schema.SerializationInfo) -> str | Secret[SecretType]:
+def _serialize_secret(
+    value: Secret[SecretType] | None, info: core_schema.SerializationInfo
+) -> str | Secret[SecretType] | None:
+    if value is None:
+        return None
     if info.mode == 'json':
         return str(value)
     else:
@@ -1751,8 +1755,10 @@ def _secret_display(value: SecretType) -> str:  # type: ignore
 
 
 def _serialize_secret_field(
-    value: _SecretField[SecretType], info: core_schema.SerializationInfo
-) -> str | _SecretField[SecretType]:
+    value: _SecretField[SecretType] | None, info: core_schema.SerializationInfo
+) -> str | _SecretField[SecretType] | None:
+    if value is None:
+        return None
     if info.mode == 'json':
         # we want the output to always be string without the `b'` prefix for bytes,
         # hence we just use `secret_display`

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2424,3 +2424,14 @@ def test_custom_serializer_override_secret_str() -> None:
 
     u = User(name='sam', password='hi')
     assert u.model_dump()['password'] == 'secret: **********'
+
+def test_secret_with_none_default() -> None:
+    # issue https://github.com/pydantic/pydantic/issues/13692
+    class M(BaseModel):
+        s1: SecretStr = None
+        s2: SecretBytes = None
+        s3: Secret[int] = None
+
+    m = M()
+    assert m.model_dump() == {'s1': None, 's2': None, 's3': None}
+    assert m.model_dump_json() == '{"s1":null,"s2":null,"s3":null}'


### PR DESCRIPTION
Fixes #13692.

This PR fixes an issue where `SecretStr`, `SecretBytes`, or `Secret[T]` fields with unvalidated `None` defaults would crash during JSON serialization.

By returning `None` early when the value is `None`, the unvalidated default is correctly serialized as `null` in JSON, consistent with other field types like `int = None`.