### PR TITLE
Fix duplicate model validator execution with custom init

### DIFF
--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -3275,6 +3275,21 @@ def model_fields_schema(
     )
 
 
+class ModelAfterValidatorFunctionSchema(TypedDict, total=False):
+    type: Required[Literal['after']]
+    function: Required[ValidationFunction]
+
+
+class ModelWrapValidatorFunctionSchema(TypedDict, total=False):
+    type: Required[Literal['wrap']]
+    function: Required[WrapValidatorFunction]
+
+
+# a `mode="after"` or `mode="wrap"` `@model_validator`, applied by `ModelValidator` itself rather
+# than as an external wrapping schema node - see `model_validators` on `model_schema` below.
+ModelValidatorFunctionSchema: TypeAlias = ModelAfterValidatorFunctionSchema | ModelWrapValidatorFunctionSchema
+
+
 class ModelSchema(TypedDict, total=False):
     type: Required[Literal['model']]
     cls: Required[type[Any]]
@@ -3291,6 +3306,7 @@ class ModelSchema(TypedDict, total=False):
     ref: str
     metadata: dict[str, Any]
     serialization: SerSchema
+    model_validators: list[ModelValidatorFunctionSchema]
 
 
 def model_schema(
@@ -3309,6 +3325,7 @@ def model_schema(
     ref: str | None = None,
     metadata: dict[str, Any] | None = None,
     serialization: SerSchema | None = None,
+    model_validators: list[ModelValidatorFunctionSchema] | None = None,
 ) -> ModelSchema:
     """
     A model schema generally contains a typed-dict schema.
@@ -3358,6 +3375,10 @@ def model_schema(
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
+        model_validators: `mode="after"`/`mode="wrap"` `@model_validator`s for this model, applied by
+            `ModelValidator` itself once the instance has actually been built - keeping their execution
+            gated on whether this pass is the one doing real construction, rather than a `custom_init`
+            bounce through `__init__`, so they run exactly once
     """
     return _dict_not_none(
         type='model',
@@ -3375,6 +3396,7 @@ def model_schema(
         ref=ref,
         metadata=metadata,
         serialization=serialization,
+        model_validators=model_validators,
     )
 
 

--- a/pydantic-core/src/validators/function.rs
+++ b/pydantic-core/src/validators/function.rs
@@ -20,14 +20,14 @@ use super::{
     BuildValidator, CombinedValidator, DefinitionsBuilder, InputType, ValidationState, Validator, build_validator,
 };
 
-struct FunctionInfo {
+pub(crate) struct FunctionInfo {
     /// The actual function object that will get called
     pub function: Py<PyAny>,
     pub field_name: Option<Py<PyString>>,
     pub info_arg: bool,
 }
 
-fn destructure_function_schema(schema: &Bound<'_, PyDict>) -> PyResult<FunctionInfo> {
+pub(crate) fn destructure_function_schema(schema: &Bound<'_, PyDict>) -> PyResult<FunctionInfo> {
     let func_dict: Bound<'_, PyDict> = schema.get_as_req(intern!(schema.py(), "function"))?;
     let function = func_dict.get_as_req(intern!(schema.py(), "function"))?;
     let func_type: Bound<'_, PyString> = func_dict.get_as_req(intern!(schema.py(), "type"))?;
@@ -167,6 +167,30 @@ pub struct FunctionAfterValidator {
 impl_build!(FunctionAfterValidator, "function-after");
 
 impl FunctionAfterValidator {
+    /// Build a `function-after` validator directly from Rust, without going through a schema dict.
+    /// Used by `ModelValidator` to apply `mode="after"` model validators as part of its own build,
+    /// so their execution can be gated on `self_instance` instead of being a generic wrapping node.
+    pub(crate) fn new_for_model(
+        py: Python<'_>,
+        validator: Arc<CombinedValidator>,
+        func_info: FunctionInfo,
+        config: Py<PyAny>,
+    ) -> PyResult<Self> {
+        let name = format!(
+            "function-after[{}(), {}]",
+            function_name(func_info.function.bind(py))?,
+            validator.get_name()
+        );
+        Ok(Self {
+            validator,
+            func: func_info.function,
+            config,
+            name,
+            field_name: func_info.field_name,
+            info_arg: func_info.info_arg,
+        })
+    }
+
     fn _validate<'py, I: Input<'py> + ?Sized>(
         &self,
         call: impl FnOnce(&I, &mut ValidationState<'_, 'py>) -> ValResult<Py<PyAny>>,
@@ -331,6 +355,30 @@ impl BuildValidator for FunctionWrapValidator {
 }
 
 impl FunctionWrapValidator {
+    /// Build a `function-wrap` validator directly from Rust, without going through a schema dict.
+    /// Used by `ModelValidator` to apply `mode="wrap"` model validators as part of its own build,
+    /// so their execution can be gated on `self_instance` instead of being a generic wrapping node.
+    pub(crate) fn new_for_model(
+        py: Python<'_>,
+        validator: Arc<CombinedValidator>,
+        func_info: FunctionInfo,
+        config: Py<PyAny>,
+        hide_input_in_errors: bool,
+        validation_error_cause: bool,
+    ) -> PyResult<Self> {
+        let name = format!("function-wrap[{}()]", function_name(func_info.function.bind(py))?);
+        Ok(Self {
+            validator,
+            func: func_info.function,
+            config,
+            name,
+            field_name: func_info.field_name,
+            info_arg: func_info.info_arg,
+            hide_input_in_errors,
+            validation_error_cause,
+        })
+    }
+
     fn _validate<'py>(
         &self,
         handler: &Bound<'_, PyAny>,

--- a/pydantic-core/src/validators/generator.rs
+++ b/pydantic-core/src/validators/generator.rs
@@ -229,6 +229,7 @@ pub struct InternalValidator {
     by_name: Option<bool>,
     field_name: Option<Py<PyString>>,
     self_instance: Option<Py<PyAny>>,
+    existing_fields_set: Option<Py<PyAny>>,
     recursion_guard: RecursionState,
     pub(crate) exactness: Option<Exactness>,
     pub(crate) fields_set_count: Option<usize>,
@@ -265,6 +266,7 @@ impl InternalValidator {
             by_name: extra.by_name,
             field_name: state.field_name().map(|d| d.clone().unbind()),
             self_instance: state.self_instance.map(|d| d.clone().unbind()),
+            existing_fields_set: state.existing_fields_set.as_ref().map(|d| d.clone().unbind()),
             recursion_guard: state.recursion_guard.clone(),
             exactness: state.exactness,
             fields_set_count: state.fields_set_count,
@@ -344,6 +346,7 @@ impl InternalValidator {
             self.self_instance.as_ref().map(|data| data.bind(py)),
         );
         state.data = self.data.as_ref().map(|data| data.bind(py).clone());
+        state.existing_fields_set = self.existing_fields_set.as_ref().map(|data| data.bind(py).clone());
         state.exactness = self.exactness;
         state.fields_set_count = self.fields_set_count;
         let result = self.validator.validate(py, input, &mut state).map_err(|e| {
@@ -367,5 +370,6 @@ impl_py_gc_traverse!(InternalValidator {
     validator,
     data,
     context,
-    self_instance
+    self_instance,
+    existing_fields_set
 });

--- a/pydantic-core/src/validators/mod.rs
+++ b/pydantic-core/src/validators/mod.rs
@@ -741,6 +741,9 @@ pub enum CombinedValidator {
     Nullable(nullable::NullableValidator),
     // create new model classes
     Model(model::ModelValidator),
+    // terminal instance-construction step for a model, wrapped by any outer (after/wrap) model
+    // validators; never built from a schema dict directly, only constructed by `ModelValidator::build`
+    ModelInstanceBuilder(model::ModelInstanceBuilder),
     ModelFields(model_fields::ModelFieldsValidator),
     // dataclasses
     DataclassArgs(dataclass::DataclassArgsValidator),

--- a/pydantic-core/src/validators/model.rs
+++ b/pydantic-core/src/validators/model.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::pybacked::PyBackedStr;
-use pyo3::types::{PyDict, PySet, PyString, PyTuple, PyType};
+use pyo3::types::{PyDict, PyList, PySet, PyString, PyTuple, PyType};
 use pyo3::{BoundObject, IntoPyObjectExt, ffi};
 use pyo3::{intern, prelude::*};
 
-use super::function::convert_err;
+use super::function::{self, convert_err};
 use super::validation_state::Exactness;
 use super::{
     BuildValidator, CombinedValidator, DefinitionsBuilder, Extra, ValidationState, Validator, build_validator,
@@ -50,18 +50,101 @@ impl Revalidate {
     }
 }
 
+/// The result of classifying `input` against a model's `class`/`generic_origin` and
+/// `revalidate_instances` config. This is the single source of truth for "existing instance ->
+/// already valid vs needs revalidation -> extract inner data", shared by `ModelValidator::validate`
+/// and both branches of `ModelInstanceBuilder::validate` - each of which used to (or, in the case of
+/// the `self_instance=None` branch, needed to but didn't) make this exact decision independently.
+/// Callers remain responsible for what they do with the result (e.g. `state.floor_exactness`,
+/// `existing_fields_set` scoping) - this only encapsulates the classification itself.
+enum InstanceInputClassification<'py> {
+    /// `input` is not an instance of `class` or `generic_origin` - treat it as raw data.
+    NotAnInstance,
+    /// `input` is already a valid instance that should not be revalidated - callers should return
+    /// it unchanged rather than feeding it to the fields validator.
+    AlreadyValid,
+    /// `input` is an existing instance that needs revalidating. `inner_input` is its extracted
+    /// `__dict__` (merged with `__pydantic_extra__`) or, for `RootModel`, its root field -
+    /// `fields_set` is its existing `__pydantic_fields_set__`. The fields validator must never be
+    /// given the raw instance directly; it only understands `inner_input`-shaped data.
+    NeedsRevalidation {
+        inner_input: Bound<'py, PyAny>,
+        fields_set: Bound<'py, PyAny>,
+    },
+}
+
+fn classify_instance_input<'py>(
+    py: Python<'py>,
+    input: &(impl Input<'py> + ?Sized),
+    class: &Bound<'py, PyType>,
+    generic_origin: Option<&Bound<'py, PyType>>,
+    revalidate: &Revalidate,
+    root_model: bool,
+) -> PyResult<InstanceInputClassification<'py>> {
+    // if the input is an instance of the class, we "revalidate" it - e.g. we extract and reuse
+    // `__pydantic_fields_set__` but use from attributes to create a new instance of the model
+    // field type. If the model has a generic origin, we allow input data to be instances of the
+    // generic origin rather than the class, as cases like isinstance(SomeModel[Int],
+    // SomeModel[Any]) fail the isinstance check, but are valid - we just have to enforce that the
+    // data is revalidated, hence `force_revalidate`.
+    let (py_instance_input, force_revalidate): (Option<&Bound<'py, PyAny>>, bool) =
+        match input_as_python_instance(input, class) {
+            Some(x) => (Some(x), false),
+            None => match generic_origin {
+                Some(generic_origin) => match input_as_python_instance(input, generic_origin) {
+                    Some(x) => (Some(x), true),
+                    None => (None, false),
+                },
+                None => (None, false),
+            },
+        };
+
+    let Some(py_input) = py_instance_input else {
+        return Ok(InstanceInputClassification::NotAnInstance);
+    };
+
+    if !(revalidate.should_revalidate(py_input, class) || force_revalidate) {
+        return Ok(InstanceInputClassification::AlreadyValid);
+    }
+
+    let fields_set = py_input.getattr(intern!(py, DUNDER_FIELDS_SET_KEY))?;
+    let inner_input = if root_model {
+        py_input.getattr(root_field_py_str(py))?
+    } else {
+        // get dict here so from_attributes logic doesn't apply
+        let dict = py_input.getattr(intern!(py, DUNDER_DICT))?;
+        let model_extra = py_input.getattr(intern!(py, DUNDER_MODEL_EXTRA_KEY))?;
+        if PyAnyMethods::is_none(&model_extra) {
+            dict
+        } else {
+            let full_model_dict = dict.cast::<PyDict>()?.copy()?;
+            full_model_dict.update(model_extra.cast()?)?;
+            full_model_dict.into_any()
+        }
+    };
+    Ok(InstanceInputClassification::NeedsRevalidation {
+        inner_input,
+        fields_set,
+    })
+}
+
 #[derive(Debug)]
 pub struct ModelValidator {
     revalidate: Revalidate,
-    validator: Arc<CombinedValidator>,
     class: Py<PyType>,
     generic_origin: Option<Py<PyType>>,
-    post_init: Option<Py<PyString>>,
     frozen: bool,
     custom_init: bool,
     root_model: bool,
-    undefined: Py<PyAny>,
     name: String,
+    /// The model's own inner validator (fields + `mode="before"` model validators), plus any
+    /// `mode="after"`/`mode="wrap"` model validators wrapped around it, built once here instead
+    /// of as external wrapping schema nodes (see `ModelValidator::build`). Keeping the outer
+    /// validators *inside* `ModelValidator` lets them be gated on `state.self_instance` the same
+    /// way `ModelValidator` itself already is, so they run exactly once even when `custom_init`
+    /// bounces validation through `BaseModel.__init__` (see `validate`/`validate_construct` below,
+    /// and GH-13471 for the bug this fixes).
+    outer_validator: Arc<CombinedValidator>,
 }
 
 impl BuildValidator for ModelValidator {
@@ -74,35 +157,92 @@ impl BuildValidator for ModelValidator {
     ) -> PyResult<Arc<CombinedValidator>> {
         let py = schema.py();
         // models ignore the parent config and always use the config from this model
-        let config = schema.get_as(intern!(py, "config"))?;
+        let config: Option<Bound<'_, PyDict>> = schema.get_as(intern!(py, "config"))?;
 
         let class: Bound<'_, PyType> = schema.get_as_req(intern!(py, "cls"))?;
         let generic_origin: Option<Bound<'_, PyType>> = schema.get_as(intern!(py, "generic_origin"))?;
         let sub_schema = schema.get_as_req(intern!(py, "schema"))?;
         let validator = build_validator(&sub_schema, config.as_ref(), definitions)?;
-        let name = class.getattr(intern!(py, "__name__"))?.extract()?;
-
-        Ok(CombinedValidator::Model(Self {
-            revalidate: Revalidate::from_str(
-                schema_or_config_same::<Bound<'_, PyString>>(
-                    schema,
-                    config.as_ref(),
-                    intern!(py, "revalidate_instances"),
-                )?
+        let name: String = class.getattr(intern!(py, "__name__"))?.extract()?;
+        let post_init: Option<Py<PyString>> = schema.get_as(intern!(py, "post_init"))?;
+        let root_model: bool = schema.get_as(intern!(py, "root_model"))?.unwrap_or(false);
+        let undefined = PydanticUndefinedType::get(py).clone_ref(py).into_any();
+        let revalidate = Revalidate::from_str(
+            schema_or_config_same::<Bound<'_, PyString>>(schema, config.as_ref(), intern!(py, "revalidate_instances"))?
                 .as_ref()
                 .map(|s| s.to_str())
                 .transpose()?,
-            )?,
-            validator,
+        )?;
+
+        let config_py: Py<PyAny> = match &config {
+            Some(c) => c.clone().into(),
+            None => py.None(),
+        };
+
+        let mut outer_validator: Arc<CombinedValidator> =
+            Arc::new(CombinedValidator::ModelInstanceBuilder(ModelInstanceBuilder {
+                validator,
+                class: class.clone().unbind(),
+                generic_origin: generic_origin.clone().map(std::convert::Into::into),
+                revalidate: revalidate.clone(),
+                post_init,
+                root_model,
+                undefined,
+                name: name.clone(),
+            }));
+
+        // `mode="after"`/`mode="wrap"` model validators, applied in declaration order - the first
+        // declared is the innermost (applied first), matching `apply_model_validators('outer', ...)`
+        // in `_generate_schema.py`.
+        if let Some(model_validators) = schema.get_as::<Bound<'_, PyList>>(intern!(py, "model_validators"))? {
+            for validator_schema in model_validators.iter() {
+                let validator_dict = validator_schema.cast::<PyDict>()?;
+                let type_: Bound<'_, PyString> = validator_dict.get_as_req(intern!(py, "type"))?;
+                let func_info = function::destructure_function_schema(validator_dict)?;
+                outer_validator = match type_.to_str()? {
+                    "after" => Arc::new(CombinedValidator::FunctionAfter(
+                        function::FunctionAfterValidator::new_for_model(
+                            py,
+                            outer_validator,
+                            func_info,
+                            config_py.clone_ref(py),
+                        )?,
+                    )),
+                    "wrap" => {
+                        let hide_input_in_errors: bool = config
+                            .as_ref()
+                            .get_as(intern!(py, "hide_input_in_errors"))?
+                            .unwrap_or(false);
+                        let validation_error_cause: bool = config
+                            .as_ref()
+                            .get_as(intern!(py, "validation_error_cause"))?
+                            .unwrap_or(false);
+                        Arc::new(CombinedValidator::FunctionWrap(
+                            function::FunctionWrapValidator::new_for_model(
+                                py,
+                                outer_validator,
+                                func_info,
+                                config_py.clone_ref(py),
+                                hide_input_in_errors,
+                                validation_error_cause,
+                            )?,
+                        ))
+                    }
+                    other => return py_schema_err!("Invalid model_validators entry type: {other}"),
+                };
+            }
+        }
+
+        Ok(CombinedValidator::Model(Self {
+            revalidate,
             class: class.into(),
             generic_origin: generic_origin.map(std::convert::Into::into),
-            post_init: schema.get_as(intern!(py, "post_init"))?,
             frozen: schema.get_as(intern!(py, "frozen"))?.unwrap_or(false),
             custom_init: schema.get_as(intern!(py, "custom_init"))?.unwrap_or(false),
-            root_model: schema.get_as(intern!(py, "root_model"))?.unwrap_or(false),
-            undefined: PydanticUndefinedType::get(py).clone_ref(schema.py()).into_any(),
+            root_model,
             // Get the class's `__name__`, not using `class.qualname()`
             name,
+            outer_validator,
         })
         .into())
     }
@@ -111,7 +251,7 @@ impl BuildValidator for ModelValidator {
 impl_py_gc_traverse!(ModelValidator {
     class,
     generic_origin,
-    validator
+    outer_validator
 });
 
 impl Validator for ModelValidator {
@@ -121,9 +261,13 @@ impl Validator for ModelValidator {
         input: &(impl Input<'py> + ?Sized),
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
-        if let Some(self_instance) = state.self_instance {
-            // in the case that self_instance is Some, we're calling validation from within `BaseModel.__init__`
-            return self.validate_init(py, self_instance, input, state);
+        if state.self_instance.is_some() {
+            // in the case that self_instance is Some, we're calling validation from within
+            // `BaseModel.__init__` - either directly, or as the resumed pass following a
+            // `custom_init` bounce through it (see `validate_construct` below). Either way, this
+            // is the single pass that actually builds the instance, so it's the only place outer
+            // (after/wrap) model validators should run - delegate straight to them.
+            return self.outer_validator.validate(py, input, state);
         }
 
         let class = self.class.bind(py);
@@ -131,53 +275,32 @@ impl Validator for ModelValidator {
 
         // if we're in strict mode, we require an exact instance of the class (from python, with JSON an object is ok)
         // if we're not in strict mode, instances subclasses are okay, as well as dicts, mappings, from attributes etc.
-        // if the input is an instance of the class, we "revalidate" it - e.g. we extract and reuse `__pydantic_fields_set__`
-        // but use from attributes to create a new instance of the model field type
-        let (py_instance_input, force_revalidate): (Option<&Bound<'_, PyAny>>, bool) =
-            match input_as_python_instance(input, class) {
-                Some(x) => (Some(x), false),
-                None => {
-                    // if the model has a generic origin, we allow input data to be instances of the generic origin rather than the class,
-                    // as cases like isinstance(SomeModel[Int], SomeModel[Any]) fail the isinstance check, but are valid, we just have to enforce
-                    // that the data is revalidated, hence we set force_revalidate to true
-                    if let Some(generic_origin) = generic_origin_class {
-                        match input_as_python_instance(input, generic_origin) {
-                            Some(x) => (Some(x), true),
-                            None => (None, false),
-                        }
-                    } else {
-                        (None, false)
-                    }
-                }
-            };
-
-        if let Some(py_input) = py_instance_input {
-            if self.revalidate.should_revalidate(py_input, class) || force_revalidate {
-                let fields_set = py_input.getattr(intern!(py, DUNDER_FIELDS_SET_KEY))?;
-                if self.root_model {
-                    let inner_input = py_input.getattr(root_field_py_str(py))?;
-                    self.validate_construct(py, &inner_input, Some(&fields_set), state)
-                } else {
-                    // get dict here so from_attributes logic doesn't apply
-                    let dict = py_input.getattr(intern!(py, DUNDER_DICT))?;
-                    let model_extra = py_input.getattr(intern!(py, DUNDER_MODEL_EXTRA_KEY))?;
-
-                    let inner_input = if PyAnyMethods::is_none(&model_extra) {
-                        dict
-                    } else {
-                        let full_model_dict = dict.cast::<PyDict>()?.copy()?;
-                        full_model_dict.update(model_extra.cast()?)?;
-                        full_model_dict.into_any()
-                    };
-                    self.validate_construct(py, &inner_input, Some(&fields_set), state)
-                }
-            } else {
-                Ok(input.to_object(py)?.unbind())
+        match classify_instance_input(
+            py,
+            input,
+            class,
+            generic_origin_class,
+            &self.revalidate,
+            self.root_model,
+        )? {
+            InstanceInputClassification::NeedsRevalidation {
+                inner_input,
+                fields_set,
+            } => self.validate_construct(py, &inner_input, Some(fields_set), state),
+            InstanceInputClassification::AlreadyValid => {
+                // Already a valid instance we don't need to revalidate - still give outer
+                // (after/wrap) model validators a chance to see/transform it, exactly like the old
+                // external wrapping nodes always did regardless of whether the inner schema itself
+                // does any work. `ModelInstanceBuilder` (the chain's terminal node) makes this same
+                // "already an instance, don't touch it" check itself, since a `mode="wrap"`
+                // validator may hand its `handler` a *different* value than `input` here.
+                self.outer_validator.validate(py, input, state)
             }
-        } else {
-            // Having to construct a new model is not an exact match
-            state.floor_exactness(Exactness::Strict);
-            self.validate_construct(py, input, None, state)
+            InstanceInputClassification::NotAnInstance => {
+                // Having to construct a new model is not an exact match
+                state.floor_exactness(Exactness::Strict);
+                self.validate_construct(py, input, None, state)
+            }
         }
     }
 
@@ -191,7 +314,153 @@ impl Validator for ModelValidator {
     ) -> ValResult<Py<PyAny>> {
         if self.frozen {
             return Err(ValError::new(ErrorTypeDefaults::FrozenInstance, field_value));
-        } else if self.root_model {
+        }
+        // outer (after/wrap) model validators, if any, apply on assignment too - delegate to them
+        // the same way the (now-removed) external wrapping nodes used to.
+        self.outer_validator
+            .validate_assignment(py, model, field_name, field_value, state)
+    }
+
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl ModelValidator {
+    fn validate_construct<'py>(
+        &self,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        existing_fields_set: Option<Bound<'py, PyAny>>,
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Py<PyAny>> {
+        if self.custom_init {
+            // If we wanted, we could introspect the __init__ signature, and store the
+            // keyword arguments and types, and create a validator for them.
+            // Perhaps something similar to `validate_call`? Could probably make
+            // this work with from_attributes, and would essentially allow you to
+            // handle init vars by adding them to the __init__ signature.
+            //
+            // We deliberately do NOT go through `self.outer_validator` here: the user's `__init__`
+            // is expected to call `super().__init__(**kwargs)`, which re-enters `validate` above
+            // with `state.self_instance` set - that resumed call is the one that applies the outer
+            // (after/wrap) model validators exactly once. Applying them here too (before we even
+            // know whether `__init__` will call `super().__init__()` at all) would run them twice.
+            if let Some(kwargs) = input.as_kwargs(py) {
+                return self
+                    .class
+                    .call(py, (), Some(&kwargs))
+                    .map_err(|e| convert_err(py, e, input));
+            }
+        }
+
+        let state = &mut state.scoped_set_existing_fields_set(existing_fields_set);
+        self.outer_validator.validate(py, input, state)
+    }
+}
+
+/// The terminal step of building a model instance: sets attributes on `state.self_instance` when
+/// one is active (the single resumed pass through `BaseModel.__init__`), or creates a fresh
+/// instance otherwise. Any outer (`mode="after"`/`mode="wrap"`) model validators are compiled as
+/// `FunctionAfter`/`FunctionWrap` nodes wrapping this validator (see `ModelValidator::build`), so
+/// from their point of view this is just "the rest of validation" - the same role a model's own
+/// `model_fields_schema` node plays for a field-level `after`/`wrap` validator.
+#[derive(Debug)]
+pub struct ModelInstanceBuilder {
+    validator: Arc<CombinedValidator>,
+    class: Py<PyType>,
+    generic_origin: Option<Py<PyType>>,
+    revalidate: Revalidate,
+    post_init: Option<Py<PyString>>,
+    root_model: bool,
+    undefined: Py<PyAny>,
+    name: String,
+}
+
+impl_py_gc_traverse!(ModelInstanceBuilder {
+    validator,
+    class,
+    generic_origin,
+    post_init,
+    undefined
+});
+
+impl Validator for ModelInstanceBuilder {
+    fn validate<'py>(
+        &self,
+        py: Python<'py>,
+        input: &(impl Input<'py> + ?Sized),
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Py<PyAny>> {
+        if let Some(self_instance) = state.self_instance {
+            // `input` here may itself be an existing instance requiring revalidation rather than
+            // raw field data - e.g. a `mode="wrap"` model validator's `handler` can be called with
+            // a different, already-existing instance (this is the only branch such a call can
+            // reach, since outer model validators only ever run during this resumed pass).
+            let class = self.class.bind(py);
+            let generic_origin_class = self.generic_origin.as_ref().map(|go| go.bind(py));
+
+            match classify_instance_input(
+                py,
+                input,
+                class,
+                generic_origin_class,
+                &self.revalidate,
+                self.root_model,
+            )? {
+                InstanceInputClassification::NeedsRevalidation {
+                    inner_input,
+                    fields_set: _,
+                } => {
+                    // Unlike `ModelValidator::validate_construct`, the freshly-extracted
+                    // `fields_set` is intentionally discarded here: when populating `self_instance`
+                    // directly, the fields validator's own output has always been the source of
+                    // truth for `__pydantic_fields_set__` in this code path (it never accepted an
+                    // `existing_fields_set` override, even before this struct existed).
+                    self.set_self_instance_attrs(py, &inner_input, self_instance, state)
+                }
+                InstanceInputClassification::AlreadyValid | InstanceInputClassification::NotAnInstance => {
+                    self.set_self_instance_attrs(py, input, self_instance, state)
+                }
+            }
+        } else {
+            // `input` here may not be the model's original top-level input at all - a
+            // `mode="wrap"` model validator can hand its `handler` any value it likes - so this
+            // check is independent of whatever `ModelValidator::validate` already decided about
+            // its own `input`.
+            let class = self.class.bind(py);
+            let generic_origin_class = self.generic_origin.as_ref().map(|go| go.bind(py));
+
+            match classify_instance_input(
+                py,
+                input,
+                class,
+                generic_origin_class,
+                &self.revalidate,
+                self.root_model,
+            )? {
+                InstanceInputClassification::AlreadyValid => Ok(input.to_object(py)?.unbind()),
+                InstanceInputClassification::NotAnInstance => {
+                    let existing_fields_set = state.existing_fields_set.clone();
+                    self.construct_fresh(py, input, existing_fields_set, state)
+                }
+                InstanceInputClassification::NeedsRevalidation {
+                    inner_input,
+                    fields_set,
+                } => self.construct_fresh(py, &inner_input, Some(fields_set), state),
+            }
+        }
+    }
+
+    fn validate_assignment<'py>(
+        &self,
+        py: Python<'py>,
+        model: &Bound<'py, PyAny>,
+        field_name: &PyBackedStr,
+        field_value: &Bound<'py, PyAny>,
+        state: &mut ValidationState<'_, 'py>,
+    ) -> ValResult<Py<PyAny>> {
+        if self.root_model {
             if field_name != ROOT_FIELD {
                 return Err(ValError::new_with_loc(
                     ErrorType::NoSuchAttribute {
@@ -244,18 +513,22 @@ impl Validator for ModelValidator {
     }
 }
 
-impl ModelValidator {
-    /// here we just call the inner validator, then set attributes on `self_instance`
-    fn validate_init<'py>(
+impl ModelInstanceBuilder {
+    /// Validates `input` (either the raw data passed to `__init__`, or - after extraction by the
+    /// caller - the `__dict__`/root-field of an existing instance being revalidated) and sets the
+    /// resulting attributes directly on `self_instance`.
+    fn set_self_instance_attrs<'py>(
         &self,
         py: Python<'py>,
-        self_instance: &Bound<'py, PyAny>,
         input: &(impl Input<'py> + ?Sized),
+        self_instance: &Bound<'py, PyAny>,
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
-        // we need to set `self_instance` to None for nested validators as we don't want to operate on self_instance
-        // anymore
+        // we need to set `self_instance` to None for nested validators as we don't want to
+        // operate on self_instance anymore, and clear `existing_fields_set` for the same
+        // reason - both are specific to *this* model's construction, not any nested one.
         let state = &mut state.scoped_clear_self_instance();
+        let state = &mut state.scoped_set_existing_fields_set(None);
 
         if self.root_model {
             let root_field = root_field_py_str(py);
@@ -279,26 +552,17 @@ impl ModelValidator {
         self.call_post_init(py, self_instance.clone(), input, state.extra())
     }
 
-    fn validate_construct<'py>(
+    /// Validates `input` (raw data, or - after extraction by the caller - the `__dict__`/root-field
+    /// of an existing instance being revalidated) and constructs a fresh instance from the result,
+    /// preferring `existing_fields_set` over the freshly-validated fields set when present.
+    fn construct_fresh<'py>(
         &self,
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
-        existing_fields_set: Option<&Bound<'_, PyAny>>,
+        existing_fields_set: Option<Bound<'py, PyAny>>,
         state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
-        if self.custom_init {
-            // If we wanted, we could introspect the __init__ signature, and store the
-            // keyword arguments and types, and create a validator for them.
-            // Perhaps something similar to `validate_call`? Could probably make
-            // this work with from_attributes, and would essentially allow you to
-            // handle init vars by adding them to the __init__ signature.
-            if let Some(kwargs) = input.as_kwargs(py) {
-                return self
-                    .class
-                    .call(py, (), Some(&kwargs))
-                    .map_err(|e| convert_err(py, e, input));
-            }
-        }
+        let state = &mut state.scoped_set_existing_fields_set(None);
 
         let instance;
 
@@ -321,7 +585,7 @@ impl ModelValidator {
 
             let (model_dict, model_extra, val_fields_set): (Bound<PyAny>, Bound<PyAny>, Bound<PyAny>) =
                 output.extract(py)?;
-            let fields_set = existing_fields_set.unwrap_or(&val_fields_set);
+            let fields_set = existing_fields_set.as_ref().unwrap_or(&val_fields_set);
             set_model_attrs(&instance, &model_dict, &model_extra, fields_set)?;
         }
         self.call_post_init(py, instance, input, state.extra())

--- a/pydantic-core/src/validators/validation_state.rs
+++ b/pydantic-core/src/validators/validation_state.rs
@@ -41,6 +41,10 @@ pub struct ValidationState<'a, 'py> {
     pub data: Option<Bound<'py, PyDict>>,
     /// This is an instance of the model or dataclass being validated, when validation is performed from `__init__`
     pub self_instance: Option<&'a Bound<'py, PyAny>>,
+    /// The `__pydantic_fields_set__` of an existing model instance being revalidated (e.g. via
+    /// `revalidate_instances`), threaded through to `ModelValidator`'s outer (`after`/`wrap`) model
+    /// validators the same way it used to be passed as a direct argument to `validate_construct`.
+    pub existing_fields_set: Option<Bound<'py, PyAny>>,
     // deliberately make Extra readonly
     extra: Extra<'a, 'py>,
 }
@@ -63,6 +67,7 @@ impl<'a, 'py> ValidationState<'a, 'py> {
             extra,
             data: None,
             self_instance,
+            existing_fields_set: None,
         }
     }
 
@@ -115,6 +120,14 @@ impl<'a, 'py> ValidationState<'a, 'py> {
     /// Set `self_instance` to `None`, reset on exit of the scope.
     pub fn scoped_clear_self_instance(&mut self) -> ScopedSelfInstanceState<'_, 'a, 'py> {
         self.scoped_set(Self::self_instance_mut, None)
+    }
+
+    /// Set `existing_fields_set` within state for the given scope.
+    pub fn scoped_set_existing_fields_set(
+        &mut self,
+        new_value: Option<Bound<'py, PyAny>>,
+    ) -> ScopedExistingFieldsSetState<'_, 'a, 'py> {
+        self.scoped_set(Self::existing_fields_set_mut, new_value)
     }
 
     pub fn field_name(&self) -> Option<&Bound<'py, PyString>> {
@@ -188,6 +201,10 @@ impl<'a, 'py> ValidationState<'a, 'py> {
 
     fn self_instance_mut(&mut self) -> &mut Option<&'a Bound<'py, PyAny>> {
         &mut self.self_instance
+    }
+
+    fn existing_fields_set_mut(&mut self) -> &mut Option<Bound<'py, PyAny>> {
+        &mut self.existing_fields_set
     }
 }
 
@@ -304,3 +321,4 @@ type ScopedFieldNameState<'scope, 'a, 'py> = ScopedSetStateT<'scope, 'a, 'py, Op
 type ScopedDataState<'scope, 'a, 'py> = ScopedSetStateT<'scope, 'a, 'py, Option<Bound<'py, PyDict>>>;
 type ScopedHasFieldErrorState<'scope, 'a, 'py> = ScopedSetStateT<'scope, 'a, 'py, bool>;
 type ScopedSelfInstanceState<'scope, 'a, 'py> = ScopedSetStateT<'scope, 'a, 'py, Option<&'a Bound<'py, PyAny>>>;
+type ScopedExistingFieldsSetState<'scope, 'a, 'py> = ScopedSetStateT<'scope, 'a, 'py, Option<Bound<'py, PyAny>>>;

--- a/pydantic-core/tests/validators/test_model_init.py
+++ b/pydantic-core/tests/validators/test_model_init.py
@@ -304,6 +304,233 @@ def test_model_custom_init_nested():
     assert calls == ["outer: {'a': 2, 'b': {'b': 3}}", "inner: {'b': 3}"]
 
 
+def test_model_custom_init_with_after_model_validator_runs_once():
+    """https://github.com/pydantic/pydantic/issues/13471
+
+    Outer (`model_validators`) validators used to run twice on a `custom_init` model: once before
+    `validate_construct` bounced validation through `__init__`, and once again on the resumed
+    `self_instance` pass. They should run exactly once, for both direct construction and
+    `validate_python`.
+    """
+    calls = []
+
+    class Model:
+        __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
+        a: int
+
+        def __init__(self, **kwargs):
+            self.__pydantic_validator__.validate_python(kwargs, self_instance=self)
+
+    def after_validator(m, info):
+        calls.append('after')
+        return m
+
+    Model.__pydantic_validator__ = SchemaValidator(
+        core_schema.model_schema(
+            Model,
+            core_schema.model_fields_schema({'a': core_schema.model_field(core_schema.int_schema())}),
+            custom_init=True,
+            model_validators=[{'type': 'after', 'function': {'type': 'with-info', 'function': after_validator}}],
+        )
+    )
+
+    m = Model(a=1)
+    assert calls == ['after']
+    assert m.a == 1
+
+    calls.clear()
+    Model.__pydantic_validator__.validate_python({'a': 2})
+    assert calls == ['after']
+
+
+def test_model_custom_init_with_wrap_model_validator_runs_once():
+    """https://github.com/pydantic/pydantic/issues/13471 - `mode="wrap"` variant."""
+    calls = []
+
+    class Model:
+        __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
+        a: int
+
+        def __init__(self, **kwargs):
+            self.__pydantic_validator__.validate_python(kwargs, self_instance=self)
+
+    def wrap_validator(value, handler, info):
+        calls.append('before')
+        result = handler(value)
+        calls.append('after')
+        return result
+
+    Model.__pydantic_validator__ = SchemaValidator(
+        core_schema.model_schema(
+            Model,
+            core_schema.model_fields_schema({'a': core_schema.model_field(core_schema.int_schema())}),
+            custom_init=True,
+            model_validators=[{'type': 'wrap', 'function': {'type': 'with-info', 'function': wrap_validator}}],
+        )
+    )
+
+    m = Model(a=1)
+    assert calls == ['before', 'after']
+    assert m.a == 1
+
+    calls.clear()
+    Model.__pydantic_validator__.validate_python({'a': 2})
+    assert calls == ['before', 'after']
+
+
+def test_model_custom_init_nested_with_after_model_validator_runs_once():
+    """Nested-field variant of the fix in https://github.com/pydantic/pydantic/issues/13471."""
+    calls = []
+
+    class ModelInner:
+        __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
+        a: int
+
+        def __init__(self, **data):
+            self.__pydantic_validator__.validate_python(data, self_instance=self)
+
+    def after_validator(m, info):
+        calls.append('inner')
+        return m
+
+    inner_schema = core_schema.model_schema(
+        ModelInner,
+        core_schema.model_fields_schema({'a': core_schema.model_field(core_schema.int_schema())}),
+        custom_init=True,
+        model_validators=[{'type': 'after', 'function': {'type': 'with-info', 'function': after_validator}}],
+    )
+    ModelInner.__pydantic_validator__ = SchemaValidator(inner_schema)
+
+    class ModelOuter:
+        __slots__ = '__dict__', '__pydantic_fields_set__'
+        b: ModelInner
+
+        def __init__(self, **data):
+            self.__pydantic_validator__.validate_python(data, self_instance=self)
+
+    ModelOuter.__pydantic_validator__ = SchemaValidator(
+        core_schema.model_schema(
+            ModelOuter,
+            core_schema.model_fields_schema({'b': core_schema.model_field(inner_schema)}),
+            custom_init=True,
+        )
+    )
+
+    m = ModelOuter(b={'a': 1})
+    assert calls == ['inner']
+    assert m.b.a == 1
+
+
+def test_model_custom_init_wrap_model_validator_revalidates_different_instance():
+    """Regression test for a follow-up bug introduced while fixing
+    https://github.com/pydantic/pydantic/issues/13471.
+
+    A `mode="wrap"` model validator's `handler` can be called with a value other than the model's
+    own input - including an *existing instance* of the model that needs revalidating. For a
+    `custom_init` model with `revalidate_instances='always'`, this used to work (pre-#13471-fix)
+    because `ModelValidator::validate` always extracted `__dict__` from an existing instance before
+    handing it to `validate_construct`, regardless of how it was reached. After the #13471 fix moved
+    that extraction into `ModelValidator`'s own (`self_instance=None`-only) code path, a `handler`
+    call landing in `ModelInstanceBuilder`'s `self_instance=Some` branch (the *only* branch a
+    `mode="wrap"` validator's `handler` can reach for a `custom_init` model, since outer model
+    validators now only run during that resumed pass) received the raw instance directly and failed
+    with a `model_type` error instead of revalidating it.
+    """
+    calls = []
+
+    class Model:
+        __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
+        a: int
+
+        def __init__(self, **kwargs):
+            calls.append(('init', dict(kwargs)))
+            self.__pydantic_validator__.validate_python(kwargs, self_instance=self)
+
+    built_once = {'v': False}
+
+    def wrap_validator(value, handler, info):
+        calls.append(('wrap-before', type(value).__name__))
+        if isinstance(value, dict) and not built_once['v']:
+            built_once['v'] = True
+            # a different, already-existing instance that needs revalidation (not the raw `value`
+            # this validator itself was called with)
+            other = Model.__new__(Model)
+            object.__setattr__(other, '__dict__', {'a': 999})
+            object.__setattr__(other, '__pydantic_fields_set__', {'a'})
+            object.__setattr__(other, '__pydantic_extra__', None)
+            object.__setattr__(other, '__pydantic_private__', None)
+            result = handler(other)
+        else:
+            result = handler(value)
+        calls.append(('wrap-after', result.a))
+        return result
+
+    Model.__pydantic_validator__ = SchemaValidator(
+        core_schema.model_schema(
+            Model,
+            core_schema.model_fields_schema({'a': core_schema.model_field(core_schema.int_schema())}),
+            custom_init=True,
+            config=CoreConfig(revalidate_instances='always'),
+            model_validators=[{'type': 'wrap', 'function': {'type': 'with-info', 'function': wrap_validator}}],
+        )
+    )
+
+    m = Model(a=1)
+    assert m.a == 999
+    # the wrap validator itself still runs exactly once (the #13471 fix stays intact)
+    assert calls == [('init', {'a': 1}), ('wrap-before', 'dict'), ('wrap-after', 999)]
+
+
+def test_model_wrap_model_validator_revalidates_different_instance_no_custom_init():
+    """Second confirmed regression from the same fix as
+    `test_model_custom_init_wrap_model_validator_revalidates_different_instance`, found during
+    final review: a *non*-`custom_init` model has the identical bug in the `self_instance=None`
+    branch of `ModelInstanceBuilder::validate` (specifically its `NotAnInstance`/`NeedsRevalidation`
+    fallthrough) - this is a genuinely different code path from the `custom_init` case (that one is
+    only ever reachable via the `self_instance=Some` branch, since outer model validators only run
+    during the resumed pass for `custom_init` models; a non-`custom_init` model's outer validators
+    run with `self_instance=None` throughout, so a `handler` call here never touches `self_instance`
+    at all), so it is intentionally kept as a separate test.
+    """
+    calls = []
+
+    class Model:
+        __slots__ = '__dict__', '__pydantic_fields_set__', '__pydantic_extra__', '__pydantic_private__'
+        a: int
+
+    built_once = {'v': False}
+
+    def wrap_validator(value, handler, info):
+        calls.append(('wrap-before', type(value).__name__))
+        if isinstance(value, dict) and not built_once['v']:
+            built_once['v'] = True
+            # a different, already-existing instance that needs revalidation (not the raw `value`
+            # this validator itself was called with)
+            other = Model.__new__(Model)
+            object.__setattr__(other, '__dict__', {'a': 999})
+            object.__setattr__(other, '__pydantic_fields_set__', {'a'})
+            object.__setattr__(other, '__pydantic_extra__', None)
+            object.__setattr__(other, '__pydantic_private__', None)
+            result = handler(other)
+        else:
+            result = handler(value)
+        calls.append(('wrap-after', result.a))
+        return result
+
+    Model.__pydantic_validator__ = SchemaValidator(
+        core_schema.model_schema(
+            Model,
+            core_schema.model_fields_schema({'a': core_schema.model_field(core_schema.int_schema())}),
+            config=CoreConfig(revalidate_instances='always'),
+            model_validators=[{'type': 'wrap', 'function': {'type': 'with-info', 'function': wrap_validator}}],
+        )
+    )
+
+    m = Model.__pydantic_validator__.validate_python({'a': 1})
+    assert m.a == 999
+    assert calls == [('wrap-before', 'dict'), ('wrap-after', 999)]
+
+
 def test_model_custom_init_extra():
     calls = []
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -924,6 +924,7 @@ class GenerateSchema:
                         config=core_config,
                         ref=model_ref,
                         metadata=metadata,
+                        model_validators=build_outer_model_validators(model_validators),
                     )
                 else:
                     fields_schema: core_schema.CoreSchema = core_schema.model_fields_schema(
@@ -948,10 +949,10 @@ class GenerateSchema:
                         post_init=getattr(cls, '__pydantic_post_init__', None),
                         config=core_config,
                         ref=model_ref,
+                        model_validators=build_outer_model_validators(model_validators),
                     )
 
                 schema = self._apply_model_serializers(model_schema, decorators.model_serializers.values())
-                schema = apply_model_validators(schema, model_validators, 'outer')
                 return self.defs.create_definition_reference_schema(schema)
 
     def _resolve_self_type(self, obj: Any) -> Any:
@@ -2686,6 +2687,42 @@ def apply_model_validators(
     if ref:
         schema['ref'] = ref  # type: ignore
     return schema
+
+
+def build_outer_model_validators(
+    validators: Iterable[Decorator[ModelValidatorDecoratorInfo]],
+) -> list[core_schema.ModelValidatorFunctionSchema] | None:
+    """Build the `model_validators` entries consumed by `core_schema.model_schema`'s own `model_validators` key.
+
+    This covers the same "outer" (`mode="after"`/`mode="wrap"`) validators as
+    `apply_model_validators(schema, validators, 'outer')`, but instead of compiling them as schema nodes
+    wrapping the `model` schema from the outside, they're passed to `ModelValidator` itself, which applies
+    them gated on whether the current validation pass is genuinely constructing the instance. This avoids
+    them running twice when the model has a custom `__init__`: previously, `custom_init` would bounce
+    validation through `BaseModel.__init__`, which re-entered the *entire* wrapped schema - including the
+    outer validators - a second time. See https://github.com/pydantic/pydantic/issues/13471.
+    """
+    result: list[core_schema.ModelValidatorFunctionSchema] = []
+    for validator in validators:
+        if validator.info.mode == 'before':
+            continue
+        info_arg = inspect_validator(validator.func, mode=validator.info.mode, type='model')
+        if validator.info.mode == 'wrap':
+            wrap_function: core_schema.WrapValidatorFunction = (
+                {'type': 'with-info', 'function': validator.func}
+                if info_arg
+                else {'type': 'no-info', 'function': validator.func}
+            )
+            result.append({'type': 'wrap', 'function': wrap_function})
+        else:
+            assert validator.info.mode == 'after'
+            after_function: core_schema.ValidationFunction = (
+                {'type': 'with-info', 'function': validator.func}
+                if info_arg
+                else {'type': 'no-info', 'function': validator.func}
+            )
+            result.append({'type': 'after', 'function': after_function})
+    return result or None
 
 
 def wrap_default(field_info: FieldInfo, schema: core_schema.CoreSchema) -> core_schema.CoreSchema:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1383,6 +1383,116 @@ def test_nested_custom_init():
     assert m.nest.modified_number == 1
 
 
+def test_custom_init_model_validator_runs_once():
+    """https://github.com/pydantic/pydantic/issues/13471
+
+    A custom `__init__` bounces validation through `BaseModel.__init__`, which used to cause any
+    `mode='after'`/`mode='wrap'` model validator to run twice: once before the bounce and once
+    after. This should happen exactly once, whether the model is validated directly, as a nested
+    field, via `model_validate`, or via `TypeAdapter`.
+    """
+    after_calls: list[str] = []
+    wrap_calls: list[str] = []
+
+    class Inner(BaseModel):
+        id: int
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+        @model_validator(mode='after')
+        def _after(self) -> 'Inner':
+            after_calls.append('inner')
+            return self
+
+    class Outer(BaseModel):
+        item: Inner
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+        @model_validator(mode='wrap')
+        @classmethod
+        def _wrap(cls, value: Any, handler: Any) -> 'Outer':
+            wrap_calls.append('before')
+            result = handler(value)
+            wrap_calls.append('after')
+            return result
+
+    data = {'item': {'id': 1}}
+
+    for construct in (
+        lambda: Outer.model_validate(data),
+        lambda: Outer(**data),
+        lambda: TypeAdapter(Outer).validate_python(data),
+    ):
+        after_calls.clear()
+        wrap_calls.clear()
+        construct()
+        assert after_calls == ['inner']
+        assert wrap_calls == ['before', 'after']
+
+    after_calls.clear()
+    Inner(id=1)
+    assert after_calls == ['inner']
+
+
+def test_custom_init_without_super_skips_model_validators():
+    """A custom `__init__` that never calls `super().__init__()` performs no validation at all -
+    including outer (`mode='after'`/`mode='wrap'`) model validators - matching the documented
+    behavior that validation is entirely delegated to `super().__init__()`.
+    """
+    calls: list[str] = []
+
+    class Model(BaseModel):
+        x: int = 0
+
+        def __init__(self, **kwargs: Any) -> None:
+            # deliberately never calls super().__init__()
+            built = Model.model_construct(**kwargs)
+            object.__setattr__(self, '__dict__', built.__dict__)
+            object.__setattr__(self, '__pydantic_fields_set__', built.__pydantic_fields_set__)
+            object.__setattr__(self, '__pydantic_extra__', built.__pydantic_extra__)
+            object.__setattr__(self, '__pydantic_private__', built.__pydantic_private__)
+
+        @model_validator(mode='after')
+        def _after(self) -> 'Model':
+            calls.append('after')
+            return self
+
+    m = Model(x=1)
+    assert calls == []
+    assert m.x == 1
+
+
+def test_custom_init_model_validator_and_serializer():
+    """A `@model_serializer` alongside an outer `@model_validator` on a custom-`__init__` model
+    should be unaffected by moving outer model validators to be applied by `ModelValidator`
+    itself (https://github.com/pydantic/pydantic/issues/13471) - `_apply_model_serializers` sets
+    `schema['serialization']` directly on the `model` schema node, not via a wrapping node.
+    """
+    calls: list[str] = []
+
+    class Model(BaseModel):
+        x: int
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+        @model_validator(mode='after')
+        def _after(self) -> 'Model':
+            calls.append('after')
+            return self
+
+        @model_serializer
+        def _ser(self) -> dict[str, Any]:
+            return {'x': self.x, 'serialized': True}
+
+    m = Model.model_validate({'x': 1})
+    assert calls == ['after']
+    assert m.model_dump() == {'x': 1, 'serialized': True}
+
+
 def test_init_inspection():
     calls = []
 


### PR DESCRIPTION
## Summary

Fixes duplicate execution of `@model_validator(mode="after")` and `@model_validator(mode="wrap")` when validating models with a custom `__init__`.

This is primarily a **pydantic-core architecture change**: model validators used to be compiled as schema nodes wrapping the entire model schema from the outside. When a model has a custom `__init__`, validation bounces through `BaseModel.__init__` and re-enters that wrapping schema a second time — so the outer validator ran once before the bounce (uninitialized) and once after (for real), executing the user's validator twice.

The fix moves `mode="after"`/`mode="wrap"` model validators to be applied by `ModelValidator` itself, gated on the same `self_instance` signal that already distinguishes "fresh entry, about to bounce through `__init__`" from "the resumed pass that actually builds the instance." A new `ModelInstanceBuilder` node (a new `CombinedValidator` variant) does the actual field-validation-and-construction step that outer validators wrap; `ModelValidator` itself is now a thin dispatcher.

While fixing this, a second, independent regression was found and fixed: a `mode="wrap"` validator's `handler()` can be called with a different existing model instance than its own input — including one that needs revalidating (`revalidate_instances='always'`/`'subclass-instances'`). That instance-classification logic previously lived only at the top level and was missed in the new internal construction path, causing a `ValidationError` instead of correctly revalidating. This is now centralized in a single helper, `classify_instance_input()`, used by every code path that can receive an existing instance, so this class of bug can't recur independently in each path.

## Behavior Notes for Reviewers

* **Documented behavior, now actually consistent:** if a custom `__init__` never calls `super().__init__()`, model validators (and field validation) are now skipped entirely, matching the documented contract ("a custom `__init__`... performs no validation unless it delegates to `super().__init__()`"). Previously, an outer validator would still run once even without that call.
* **New public API surface:** `core_schema.model_schema()` gains an optional `model_validators` parameter, and three new `TypedDict`s (`ModelAfterValidatorFunctionSchema`, `ModelWrapValidatorFunctionSchema`, `ModelValidatorFunctionSchema`) are added to `pydantic_core.core_schema`. Fully additive and backward compatible — defaults to `None`, with no change to the shape of schemas built without it.
* **Out of scope:** the related issue #8452 (a nested model's after validator re-running under `model_construct`-based revalidation) is a separate bug and is not fixed by this PR; its regression test remains xfail.

## Changes

* `pydantic-core/src/validators/model.rs`: split `ModelValidator` into a dispatcher plus a new `ModelInstanceBuilder` construction step; outer model validators are now compiled as `FunctionAfter`/`FunctionWrap` nodes wrapping the latter, built once in `ModelValidator::build`, instead of as external wrapping schema nodes.
* `pydantic-core/src/validators/{function,validation_state,generator,mod}.rs`: supporting plumbing — direct Rust constructors for `FunctionAfterValidator`/`FunctionWrapValidator` (no schema dict needed), an `existing_fields_set` field threaded through `ValidationState`/`InternalValidator`, and the new `ModelInstanceBuilder` enum variant.
* `pydantic-core/python/pydantic_core/core_schema.py`: new `model_validators` parameter on `model_schema()`.
* `pydantic/_internal/_generate_schema.py`: wires model validators into the new schema shape for both regular models and `RootModel` (TypedDict/create_model and dataclasses are untouched — custom_init doesn't apply to them).
* New regression tests at both the pydantic-core schema level and the pydantic model level, covering after and wrap validators, direct construction, nested custom-init models, and the instance-revalidation-via-wrap-handler case (for both custom-init and non-custom-init models).

## Testing

Verified against the exact reproduction from the issue report — each validator now executes exactly once, where it previously printed twice, across `model_validate()`, direct construction, and nested custom-init models.

* **pydantic-core:** 5798 passed, 123 skipped, 8 xfailed
* **pydantic:** 12410 passed, 455 skipped, 35 xfailed
* **`cargo fmt`:** passed
* **`cargo clippy`:** passed
* **`ruff`:** passed
* **typecheck:** passed
* **codespell:** passed

**Fixes #13472**
