### PR TITLE
Fix #13692: serialize unvalidated None default of SecretStr fields as null

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1751,9 +1751,11 @@ def _secret_display(value: SecretType) -> str:  # type: ignore
 
 
 def _serialize_secret_field(
-    value: _SecretField[SecretType], info: core_schema.SerializationInfo
-) -> str | _SecretField[SecretType]:
+    value: _SecretField[SecretType] | None, info: core_schema.SerializationInfo
+) -> str | _SecretField[SecretType] | None:
     if info.mode == 'json':
+        if value is None:
+            return None
         # we want the output to always be string without the `b'` prefix for bytes,
         # hence we just use `secret_display`
         return _secret_display(value.get_secret_value())


### PR DESCRIPTION
Closes #13692

## What
Implemented per the bounty requirements — see commit(s) for details.

## Verification
Tests run locally on this branch.

_Draft PR created by bounty pipeline; will be marked ready after human review._