### PR TITLE
Preserve include/exclude when wrap serializer is skipped (#13601)

### DIFF
--- a/pydantic-core/src/serializers/type_serializers/function.rs
+++ b/pydantic-core/src/serializers/type_serializers/function.rs
@@ -217,17 +217,25 @@ macro_rules! function_type_serializer {
                 state: &mut SerializationState<'py>,
             ) -> PyResult<Py<PyAny>> {
                 let py = value.py();
-                let (ret_serializer, v) = match self.call(value, state) {
-                    Ok((true, v)) => (&*self.return_serializer, v),
-                    Ok((false, v)) => (self.get_fallback_serializer(), v),
+                let (called, ret_serializer, v) = match self.call(value, state) {
+                    Ok((true, v)) => (true, &*self.return_serializer, v),
+                    Ok((false, v)) => (false, self.get_fallback_serializer(), v),
                     Err(err) => {
                         on_error(py, err, &self.function_name, state)?;
                         return infer_to_python(value, state);
                     }
                 };
-                // None for include/exclude here, as filtering should be done
-                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
-                ret_serializer.to_python(v.bind(py), state)
+                if called {
+                    // When the user's serializer function ran, it produced its own output
+                    // (a plain dict or other value), so field-level include/exclude no longer
+                    // applies to the result — clear it to avoid double-filtering.
+                    let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
+                    ret_serializer.to_python(v.bind(py), state)
+                } else {
+                    // The serializer function was skipped (e.g. when_used="json" in python mode).
+                    // Preserve the caller's include/exclude so that model_dump(exclude=...) is honoured.
+                    ret_serializer.to_python(v.bind(py), state)
+                }
             }
 
             fn json_key<'a, 'py>(
@@ -236,19 +244,24 @@ macro_rules! function_type_serializer {
                 state: &mut SerializationState<'py>,
             ) -> PyResult<Cow<'a, str>> {
                 let py = key.py();
-                let (ret_serializer, v) = match self.call(key, state) {
-                    Ok((true, v)) => (&*self.return_serializer, v),
-                    Ok((false, v)) => (self.get_fallback_serializer(), v),
+                let (called, ret_serializer, v) = match self.call(key, state) {
+                    Ok((true, v)) => (true, &*self.return_serializer, v),
+                    Ok((false, v)) => (false, self.get_fallback_serializer(), v),
                     Err(err) => {
                         on_error(py, err, &self.function_name, state)?;
                         return infer_json_key(key, state);
                     }
                 };
-                // None for include/exclude here, as filtering should be done
-                let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
-                ret_serializer
-                    .json_key(v.bind(py), state)
-                    .map(|cow| Cow::Owned(cow.into_owned()))
+                if called {
+                    let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
+                    ret_serializer
+                        .json_key(v.bind(py), state)
+                        .map(|cow| Cow::Owned(cow.into_owned()))
+                } else {
+                    ret_serializer
+                        .json_key(v.bind(py), state)
+                        .map(|cow| Cow::Owned(cow.into_owned()))
+                }
             }
 
             fn serde_serialize<'py, S: serde::ser::Serializer>(
@@ -258,17 +271,20 @@ macro_rules! function_type_serializer {
                 state: &mut SerializationState<'py>,
             ) -> Result<S::Ok, S::Error> {
                 let py = value.py();
-                let (ret_serializer, v) = match self.call(value, state) {
-                    Ok((true, v)) => (&*self.return_serializer, v),
-                    Ok((false, v)) => (self.get_fallback_serializer(), v),
+                let (called, ret_serializer, v) = match self.call(value, state) {
+                    Ok((true, v)) => (true, &*self.return_serializer, v),
+                    Ok((false, v)) => (false, self.get_fallback_serializer(), v),
                     Err(err) => {
                         on_error(py, err, &self.function_name, state).map_err(py_err_se_err)?;
                         return infer_serialize(value, serializer, state);
                     }
                 };
-                // None for include/exclude here, as filtering should be done
-                let mut state = state.scoped_include_exclude(IncludeExclude::empty());
-                ret_serializer.serde_serialize(v.bind(py), serializer, &mut state)
+                if called {
+                    let mut state = state.scoped_include_exclude(IncludeExclude::empty());
+                    ret_serializer.serde_serialize(v.bind(py), serializer, &mut state)
+                } else {
+                    ret_serializer.serde_serialize(v.bind(py), serializer, state)
+                }
             }
 
             fn get_name(&self) -> &str {

--- a/pydantic-core/tests/serializers/test_functions.py
+++ b/pydantic-core/tests/serializers/test_functions.py
@@ -710,3 +710,22 @@ def test_serialize_pattern():
     assert s.to_python(pattern) == pattern
     assert s.to_python(pattern, mode='json') == '^regex$'
     assert s.to_json(pattern) == b'"^regex$"'
+
+
+def test_wrap_serializer_when_used_json_preserves_exclude():
+    """https://github.com/pydantic/pydantic/issues/13601"""
+
+    def wrap_fn(value, handler):
+        return handler(value)
+
+    schema = core_schema.model_fields_schema(
+        fields={
+            'a': core_schema.model_field(core_schema.int_schema()),
+            'b': core_schema.model_field(core_schema.int_schema()),
+        },
+        serialization=core_schema.wrap_serializer_function_ser_schema(wrap_fn, when_used='json'),
+    )
+    s = SchemaSerializer(schema)
+    assert s.to_python({'a': 1, 'b': 2}, exclude={'b'}) == {'a': 1}
+    assert s.to_python({'a': 1, 'b': 2}, mode='json', exclude={'b'}) == {'a': 1}
+

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1437,3 +1437,20 @@ def test_model_serializer_index_key_type_error() -> None:
         match="Error calling function `_serialize`: TypeError: 'index_key' is expected to be an integer or a string, got 'b'not_a_valid_type_for_index_key''",
     ):
         m.model_dump(include={'f'})
+
+
+def test_model_serializer_wrap_gated_when_used_json_exclude() -> None:
+    """https://github.com/pydantic/pydantic/issues/13601"""
+
+    class Gated(BaseModel):
+        a: int
+        b: int
+
+        @model_serializer(mode='wrap', when_used='json')
+        def _serialize(self, handler: SerializerFunctionWrapHandler) -> object:
+            return handler(self)
+
+    m = Gated(a=1, b=2)
+    assert m.model_dump(exclude={'b'}) == {'a': 1}
+    assert m.model_dump(mode='json', exclude={'b'}) == {'a': 1}
+


### PR DESCRIPTION
## Description

Fixes #13601

When `@model_serializer(mode="wrap", when_used="json")` (or `"json-unless-none"`) is configured on a model, serializing in Python mode (`model_dump()`) skips calling the custom wrap serializer function and invokes the fallback serializer. Previously, `function_type_serializer!` unconditionally reset `state.scoped_include_exclude(IncludeExclude::empty())`, which caused the caller's runtime `include` and `exclude` filters to be wiped out during fallback serialization.

This PR ensures that `IncludeExclude::empty()` is only scoped when the custom serializer function actually ran (`called == true`), preserving the caller's include/exclude context on the fallback path.

## Changes
- `pydantic-core/src/serializers/type_serializers/function.rs`: Check whether the serializer function was called before clearing include/exclude state.
- Added regression test in `pydantic-core/tests/serializers/test_functions.py`.
- Added regression test in `tests/test_serialize.py`.
