### PR TITLE
Allow `None` to serialize against secret fields

### DIFF
--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -1795,7 +1795,7 @@ class _SecretField(_SecretBase[SecretType]):
                 serialization=core_schema.plain_serializer_function_ser_schema(
                     _serialize_secret_field,
                     info_arg=True,
-                    when_used='always',
+                    when_used='unless-none',
                 ),
             )
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2432,5 +2432,5 @@ def test_secret_str_none() -> None:
     class Model(BaseModel):
         f: SecretStr = None
 
-    assert Model.model_dump() == {'f': None}
-    assert Model.model_dump_json() == '{"f":null}'
+    assert Model().model_dump() == {'f': None}
+    assert Model().model_dump_json() == '{"f":null}'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -2424,3 +2424,13 @@ def test_custom_serializer_override_secret_str() -> None:
 
     u = User(name='sam', password='hi')
     assert u.model_dump()['password'] == 'secret: **********'
+
+
+def test_secret_str_none() -> None:
+    """https://github.com/pydantic/pydantic/issues/13692"""
+
+    class Model(BaseModel):
+        f: SecretStr = None
+
+    assert Model.model_dump() == {'f': None}
+    assert Model.model_dump_json() == '{"f":null}'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/13692.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
