### PR TITLE
fix: emit minItems/minProperties for deque, Counter, and OrderedDict constraints

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -256,13 +256,20 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after', 'lax-or-strict'}:
+                    if inner_schema['type'] == 'lax-or-strict':
+                        inner_schema = inner_schema['lax_schema']  # type: ignore
+                    else:
+                        inner_schema = inner_schema['schema']  # type: ignore
                 inner_schema_type = inner_schema['type']
                 if inner_schema_type == 'list' or (
                     inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
                 ):
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type == 'dict' or (
+                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'dict'  # type: ignore
+                ):
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7417,3 +7417,25 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_container_length_constraints_schema() -> None:
+    from collections import Counter, OrderedDict, deque
+
+    class ContainerModel(BaseModel):
+        d: deque[int] = Field(min_length=2, max_length=5)
+        c: Counter[str] = Field(min_length=1, max_length=3)
+        o: OrderedDict[str, int] = Field(min_length=1, max_length=4)
+
+    schema = ContainerModel.model_json_schema()
+    assert schema["properties"]["d"]["minItems"] == 2
+    assert schema["properties"]["d"]["maxItems"] == 5
+    assert "minLength" not in schema["properties"]["d"]
+
+    assert schema["properties"]["c"]["minProperties"] == 1
+    assert schema["properties"]["c"]["maxProperties"] == 3
+    assert "minLength" not in schema["properties"]["c"]
+
+    assert schema["properties"]["o"]["minProperties"] == 1
+    assert schema["properties"]["o"]["maxProperties"] == 4
+    assert "minLength" not in schema["properties"]["o"]


### PR DESCRIPTION
## Problem

Fixes #13704.

Applying length constraints (`min_length`, `max_length`) to `deque`, `Counter`, or `OrderedDict` fields generated JSON Schema string keywords (`minLength`/`maxLength`) instead of `minItems`/`maxItems` (for `deque`) or `minProperties`/`maxProperties` (for `Counter`/`OrderedDict`).

## Cause

In `pydantic/_internal/_known_annotated_metadata.py`, the loop unwrapping container inner schemas to determine the target keyword did not unwrap `lax-or-strict` schemas (which wrap `deque`, `Counter`, and `OrderedDict`), causing them to fall through to the default string keyword branch (`minLength`/`maxLength`). Furthermore, dictionary-like structures had no branch for `minProperties`/`maxProperties`.

## Fix

- Support unwrapping `lax-or-strict` schemas (following `lax_schema`) when inspecting inner schema types in `apply_known_metadata`.
- Emit `minProperties`/`maxProperties` when the resolved inner schema type is `dict` or `json-or-python` with `dict`.
- Add regression tests in `tests/test_json_schema.py`.

## Testing

- Verified schema generation and assertions across `deque`, `Counter`, and `OrderedDict`.