### PR TITLE
Fix typos, phrasing, and missing imports in SKILL.md

### DIFF
--- a/.agents/skills/pydantic/SKILL.md
+++ b/.agents/skills/pydantic/SKILL.md
@@ -10,8 +10,8 @@ to understand how validation (and serialization) should be performed. It is most
 when dealing with external untrusted data, for example when defining an HTTP API.
 
 It is generally *not* recommended to use Pydantic to define classes that are instantiated within the user code.
-By doing so, you will lose flexibility (e.g. can't use types not supported by Pydantic, harder to perform
-post init changes). It is usually better to use vanilla classes (or standard library dataclasses) in this case,
+By doing so, you will lose flexibility (e.g. you cannot use types not supported by Pydantic, and it is harder to perform
+post-init changes). It is usually better to use vanilla classes (or standard library dataclasses) in this case,
 as a static type checker will already catch type mismatches.
 
 ## Basic usage
@@ -30,22 +30,27 @@ class Person(BaseModel):
     birthdate: date | None = None
 
 
-p = Person(name='John', age=20, birthdate='1970-01-01')
+p: Person = Person(name='John', age=20, birthdate='1970-01-01')
 ```
+
+Pydantic coerces compatible input: the ISO date string `'1970-01-01'` is parsed into a `date`.
 
 ## Constraints and field metadata
 
 The `Field()` function is used to provide metadata and constraints.
-You need to distinguish two types of of metadata:
+You need to distinguish two types of metadata:
 
-* *field specific* metadata: metadata such as `deprecated`, `alias`, that only
-  has a meaning when attached to a field.
+* *field specific* metadata: metadata such as `deprecated` and `alias`, that only
+  have meaning when attached to a field.
 * *type specific* metadata: this includes constraints such as `gt`, `max_length`,
   and also metadata that affects the JSON Schema (e.g. `description`, `title`).
 
-The `Field()` function can be attached to model fields using the assignment form:
+Model fields are declared with `Field()` using the assignment form:
 
 ```python
+from pydantic import BaseModel, Field
+
+
 class User(BaseModel):
     first_name: str = Field(alias='name')
 ```
@@ -53,15 +58,20 @@ class User(BaseModel):
 or using the annotated pattern:
 
 ```python
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
 class Model(BaseModel):
     value: Annotated[int, Field(deprecated=True)] = 1
 ```
 
 The annotated pattern has some advantages:
 
-* Using the `f: <type> = Field(...)` form can be confusing and might trick users into thinking `f`
-  has a default value, while in reality it is still required.
-* You can provide an arbitrary amount of metadata elements for a field. As shown in the example above.
+* Using the `f: <type> = Field()` form (no default) can be confusing and might trick users into thinking `f`
+  has a default value, while in reality the field is still required.
+* You can provide an arbitrary amount of metadata elements for a field. As shown in the example above,
   the `Field()` function only supports a limited set of constraints/metadata,
   and you may have to use different Pydantic utilities such as `WithJsonSchema`
   in some cases.
@@ -73,6 +83,11 @@ But note that:
   is to do the following:
 
     ```python
+    from typing import Annotated
+
+    from pydantic import BaseModel, Field
+
+
     class Model(BaseModel):
         field_bad: Annotated[int, Field(deprecated=True)] | None = None
         field_ok: Annotated[int | None, Field(deprecated=True)] = None
@@ -86,7 +101,11 @@ As much as possible, use the "built-in" validation constraints, instead of defin
 custom validators:
 
 ```python
+from typing import Annotated
+
 from annotated_types import Gt  # annotated_types is an alternative to the `Field()` function.
+from pydantic import BaseModel, field_validator
+
 
 class Model(BaseModel):
     constrained_int_ok: Annotated[int, Gt(1)]  # This is good
@@ -95,9 +114,10 @@ class Model(BaseModel):
 
     @field_validator('constrained_int_bad')  # This is bad
     @classmethod
-    def validate(cls, v: int):
+    def validate(cls, v: int) -> int:
         if not v > 1:
             raise ValueError('Value is not greater than 1')
+        return v
 ```
 
 Sometimes, constraints can't be expressed using the `Field()` function. For example, string constraints such
@@ -120,20 +140,22 @@ supported standard library types and their constraints.
 ### Validators
 
 In some cases, you may have to use custom validators. As much as possible, use *after* validators. Because they run after
-the Pydantic validation, you are guaranteed to work with the type of the field being validated. If you use *before* validators,
+Pydantic validation, the value is already the field's type. If you use *before* validators,
 the input data can literally be anything, so it is more error-prone (especially for model validators, the input isn't
 necessarily a dict, it can also be an arbitrary object).
 
 If possible, prefer using the annotated pattern for validators:
 
 ```python
-from pydantic import BaseModel, ValidationError, field_validator
+from typing import Annotated
+
+from pydantic import AfterValidator, BaseModel, field_validator
 
 
 def is_even(value: int) -> int:
     if value % 2 == 1:
-          raise ValueError(f'{value} is not an even number')
-      return value
+        raise ValueError(f'{value} is not an even number')
+    return value
 
 
 class Model(BaseModel):
@@ -150,19 +172,19 @@ class Model(BaseModel):
         return value
 ```
 
-Using the decorator pattern can lead to unclear behavior, especially when considering the order in which they run
-(in particular when using subclasses).
+Using the decorator pattern can lead to unclear behavior, especially regarding the order in which validators run
+(in particular on subclasses).
 
 ### Type coercion, collections and unions
 
 Unless you are using [strict mode](https://pydantic.dev/docs/validation/latest/concepts/strict_mode/), Pydantic applies
 type coercion in most cases. For instance, for a field typed as `int`, strings like `'123'` will be accepted. This also
-applies to collections types: `list[str]` also accepts tuples, sets etc.
+applies to collection types: `list[str]` also accepts tuples, sets etc.
 
-This is way you should avoid:
+This is why you should avoid:
 
 * using unions such as `int | str`, if your goal is to coerce the `str` to an `int` via a validator.
-* using abstract collections such as `collections.abc.Sequence`, if your goal is to accept both list and tuples.
+* using abstract collections such as `collections.abc.Sequence`, if your goal is to accept both lists and tuples.
   Using these abstract collections is inefficient.
 
 In the general case, unions are best avoided because every use of the field will need to check for each type before
@@ -177,22 +199,27 @@ If you are defining Pydantic models in a module, avoid using `from __future__ im
 (which stringifies all annotations by default). Only add explicit quotes to annotations that aren't defined yet, e.g.:
 
 ```python
+from pydantic import BaseModel
+
+
 class Model(BaseModel):
     self_ref: 'Model'
 ```
 
-Also note that in Python >= 3.14, annotations evaluation is deferred, so you should not use string annotations at all.
+Also note that in Python >= 3.14, annotation evaluation is deferred, so you should not use string annotations at all.
 
 #### Recursive type aliases
 
 You might be tempted to define aliases like this:
 
 ```python
+from typing import TypeAlias
+
 JsonValue: TypeAlias = 'list[JsonValue] | dict[str, JsonValue] | str | bool | int | float | None'
 ```
 
-The alias needs to be quoted because it is a recursive one. Pydantic will generally *not* be able to evaluate the alias.
-Instead, use an explicit type alias:
+The alias needs to be quoted because it is recursive. Pydantic will generally *not* be able to evaluate a quoted `TypeAlias`.
+Instead, use an explicit type alias (`type` on Python 3.12+, or `TypeAliasType`), which Pydantic can resolve:
 
 ```python
 type JsonValue = list[JsonValue] | dict[str, JsonValue] | str | bool | int | float | None
@@ -207,10 +234,13 @@ JsonValue = TypeAliasType('JsonValue', 'list[JsonValue] | dict[str, JsonValue] |
 Subclassing is a really common Python pattern, but can be a footgun in Pydantic. You might be tempted to do:
 
 ```python
+from pydantic import BaseModel
+
+
 class Base(BaseModel):
     base_field: int
 
-    def common_method(self): ...
+    def common_method(self) -> None: ...
 
 
 class Sub1(Base):
@@ -225,7 +255,7 @@ class Main(BaseModel):
     model: Base
 
 
-m = Main(model=Sub1(base_field=1, sub1_field='test'))
+m: Main = Main(model=Sub1(base_field=1, sub1_field='test'))
 ```
 
 This example works, but will not behave as expected when serializing `m`:
@@ -235,12 +265,18 @@ m.model_dump()
 #> {'model': {'base_field': 1}} -> sub1_field missing
 ```
 
-This is because Pydantic serializes the model according to the defined type (`Base`), not the runtime value.
-Validation will also be unexpected if doing `Main(model={'base_field': 1, 'sub1_field': 'test'})`.
+This is because Pydantic serializes according to the declared type (`Base`), not the runtime subclass.
+Validation follows the same rule: `Main(model={'base_field': 1, 'sub1_field': 'test'})` validates against `Base`,
+so `sub1_field` is ignored rather than producing a `Sub1` instance.
 
 Instead, try to use discriminated unions (provided that you can set a `type` field to distinguish models):
 
 ```python
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import BaseModel, Field
+
+
 class Sub1(Base):
     type: Literal['sub1']
     sub1_field: str
@@ -250,7 +286,9 @@ class Sub2(Base):
     type: Literal['sub2']
     sub2_field: bool
 
-Subs = Annotated[Sub1 | Sub2, Field(discriminator='type')]
+
+Subs: TypeAlias = Annotated[Sub1 | Sub2, Field(discriminator='type')]
+
 
 class Main(BaseModel):
     model: Subs
@@ -259,12 +297,16 @@ class Main(BaseModel):
 or generics:
 
 ```python
+from pydantic import BaseModel
+
+
 class Main[BaseT: Base](BaseModel):
     model: BaseT
 
-m = Main[Sub1](model={'base_field': 1, 'sub1_field': 'test'})  # Will work
+
+m: Main[Sub1] = Main[Sub1](model={'base_field': 1, 'sub1_field': 'test'})  # Will work
 ```
 
-using [polymorphic serialization](https://pydantic.dev/docs/validation/latest/concepts/serialization/#polymorphic-serialization) (in Pydantic >=2.13)
+If neither discriminated unions nor generics fit, [polymorphic serialization](https://pydantic.dev/docs/validation/latest/concepts/serialization/#polymorphic-serialization) (in Pydantic >=2.13)
 or [*serialize as any*](https://pydantic.dev/docs/validation/latest/concepts/serialization/#serializing-as-any) (in Pydantic <2.13)
-can be used as last resort.
+can be used as a last resort.

--- a/.agents/skills/pydantic/SKILL.md
+++ b/.agents/skills/pydantic/SKILL.md
@@ -30,7 +30,7 @@ class Person(BaseModel):
     birthdate: date | None = None
 
 
-p: Person = Person(name='John', age=20, birthdate='1970-01-01')
+p = Person(name='John', age=20, birthdate='1970-01-01')
 ```
 
 Pydantic coerces compatible input: the ISO date string `'1970-01-01'` is parsed into a `date`.


### PR DESCRIPTION
## Change Summary
Fixed grammatical errors, improved awkward phrasing, and added missing imports and return type hints across code examples in `.agents/skills/pydantic/SKILL.md`.

## Related issue number
N/A (Documentation & typing fix)

## Checklist
* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**