### PR TITLE
Emit `minItems`/`minProperties` for length constraints on `deque`, `Counter` and `OrderedDict`

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -106,6 +106,41 @@ def as_jsonable_value(v: Any) -> Any:
     return v
 
 
+# Core schema types that render as a JSON array or a JSON object, and so take the
+# `*Items` / `*Properties` length keywords rather than the string `*Length` ones.
+ARRAY_SCHEMA_TYPES = frozenset({'list', 'tuple', 'set', 'frozenset', 'generator'})
+OBJECT_SCHEMA_TYPES = frozenset({'dict'})
+
+# Wrappers a length constraint may sit outside of, mapped to the key holding the schema
+# that determines the JSON representation.
+_WRAPPER_SCHEMA_KEYS = {
+    'function-before': 'schema',
+    'function-wrap': 'schema',
+    'function-after': 'schema',
+    'lax-or-strict': 'lax_schema',
+    'json-or-python': 'json_schema',
+}
+
+
+def _length_constraint_js_key(schema: CoreSchema, constraint: str) -> str:
+    """Pick the JSON Schema keyword for a length constraint enforced by a wrapper validator.
+
+    When a schema does not support `min_length`/`max_length` natively the constraint is
+    applied as a validator function wrapped around it, so the keyword has to be chosen
+    from whatever the wrapped schema renders as: `minItems`/`maxItems` for an array,
+    `minProperties`/`maxProperties` for an object, `minLength`/`maxLength` for a string.
+    """
+    while (key := _WRAPPER_SCHEMA_KEYS.get(schema['type'])) is not None:
+        schema = schema[key]  # type: ignore[literal-required]
+
+    is_min = constraint == 'min_length'
+    if schema['type'] in ARRAY_SCHEMA_TYPES:
+        return 'minItems' if is_min else 'maxItems'
+    if schema['type'] in OBJECT_SCHEMA_TYPES:
+        return 'minProperties' if is_min else 'maxProperties'
+    return 'minLength' if is_min else 'maxLength'
+
+
 def expand_grouped_metadata(annotations: Iterable[Any]) -> Iterable[Any]:
     """Expand the annotations.
 
@@ -255,16 +290,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             )
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
-                inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
-                inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
-                ):
-                    js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
-                else:
-                    js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
+                js_constraint_key = _length_constraint_js_key(schema, constraint)
             else:
                 js_constraint_key = constraint
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4,7 +4,7 @@ import math
 import re
 import sys
 import typing
-from collections import deque
+from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -5421,6 +5421,56 @@ def test_sequence_schema_with_min_length(sequence_type):
         'title': 'Model',
         'type': 'object',
     }
+
+
+@pytest.mark.parametrize(
+    'container_type',
+    [list, Sequence, Iterable, set, frozenset, deque],
+)
+def test_array_length_constraints_use_items_keywords(container_type):
+    """Length constraints on any array-like container use `minItems`/`maxItems`.
+
+    Containers whose core schema is wrapped — `deque` in particular — used to
+    get the string keywords `minLength`/`maxLength` on a schema of type
+    `array`, which JSON Schema validators ignore.
+    """
+
+    class Model(BaseModel):
+        field: container_type[int] = Field(min_length=1, max_length=5)
+
+    field_schema = Model.model_json_schema()['properties']['field']
+    assert field_schema['type'] == 'array'
+    assert field_schema['minItems'] == 1
+    assert field_schema['maxItems'] == 5
+    assert 'minLength' not in field_schema
+    assert 'maxLength' not in field_schema
+
+
+@pytest.mark.parametrize('container_type', [dict, Counter, OrderedDict])
+def test_mapping_length_constraints_use_properties_keywords(container_type):
+    """Length constraints on any mapping use `minProperties`/`maxProperties`."""
+    annotation = container_type[str] if container_type is Counter else container_type[str, int]
+
+    class Model(BaseModel):
+        field: annotation = Field(min_length=1, max_length=5)
+
+    field_schema = Model.model_json_schema()['properties']['field']
+    assert field_schema['type'] == 'object'
+    assert field_schema['minProperties'] == 1
+    assert field_schema['maxProperties'] == 5
+    assert 'minLength' not in field_schema
+    assert 'maxLength' not in field_schema
+
+
+@pytest.mark.parametrize('scalar_type', [str, bytes])
+def test_string_length_constraints_still_use_length_keywords(scalar_type):
+    class Model(BaseModel):
+        field: scalar_type = Field(min_length=1, max_length=5)
+
+    field_schema = Model.model_json_schema()['properties']['field']
+    assert field_schema['type'] == 'string'
+    assert field_schema['minLength'] == 1
+    assert field_schema['maxLength'] == 5
 
 
 @pytest.mark.parametrize(('sequence_type',), [pytest.param(list), pytest.param(Sequence)])


### PR DESCRIPTION
## Change Summary

`min_length`/`max_length` on `deque`, `Counter` and `OrderedDict` emit the string JSON Schema keywords `minLength`/`maxLength` on schemas of type `array` and `object`, where those keywords have no defined meaning. Any external consumer of the schema silently drops the constraint:

```python
class M(BaseModel):
    items: deque[int] = Field(min_length=2)

M.model_json_schema()['properties']['items']
# {'items': {'type': 'integer'}, 'minLength': 2, 'title': 'Items', 'type': 'array'}

M.model_validate({'items': [1]})                        # pydantic: rejects, too_short
jsonschema.validate({'items': [1]}, M.model_json_schema())  # jsonschema: ACCEPTS
```

Every other container is already correct — `list`, `set`, `frozenset`, `tuple`, `Sequence`, `Iterable` get `minItems`; `dict` gets `minProperties`; `str`/`bytes` get `minLength`. Only these three are wrong, in both the `min` and `max` directions.

### Cause

When a schema does not support a length constraint natively, the constraint is applied as a validator function wrapped around the schema, so `apply_known_metadata` has to infer the JSON representation from the wrapped schema. The existing loop unwraps only `function-before`/`function-wrap`/`function-after`, then tests for a bare `list` or a `json-or-python` around one.

These three types sit behind a wrapper that loop does not descend through:

```text
deque       : function-after -> lax-or-strict -> [lax_schema] function-wrap  -> list
Counter     : function-after -> lax-or-strict -> [lax_schema] function-after -> dict
OrderedDict : function-after -> lax-or-strict -> [lax_schema] function-after -> dict
```

There are two separate defects:

1. **Unwrapping gap** — `lax-or-strict` is not unwrapped. Its `lax_schema` side holds the real container schema; `strict_schema` is a `chain`, which has no single type to read.
2. **Missing mapping branch** — even after unwrapping, the keyword choice is binary (`*Items` or `*Length`), so there is no way to reach `minProperties`/`maxProperties` for a `dict`-shaped inner schema. Fixing only the unwrap would leave `Counter`/`OrderedDict` emitting *array* keywords on *object* schemas.

This is why the earlier patch in #9303 covered `Sequence` (a bare `function-* -> list`) but not these types.

### Fix

Replace the inline block with `_length_constraint_js_key()`, which unwraps through `lax-or-strict` and `json-or-python` as well, then maps the resulting schema type to the right keyword family: `minItems`/`maxItems` for arrays, `minProperties`/`maxProperties` for objects, `minLength`/`maxLength` otherwise. The wrapper set and the two schema-type sets are named constants so a future container type is a one-line addition rather than another special case.

## Related issue number

Reported in #13704, which I filed.

Deliberately **not** written as `fix #13704`, despite the template asking for that form — flagging it explicitly rather than leaving it to look like an oversight. `enforce-issue-assignment.yml` closes any PR whose *closing* reference points at an issue the author is not assigned to, and it has no reopen path, so a `fix #` line here would close this PR on open. I am the reporter, not an assignee. Please feel free to assign #13704 to me, or to edit this line to `fix #13704` yourself — either way it links normally and closes on merge.

For context: PR #13706 referenced the same issue with a closing keyword and was closed by that workflow 11 seconds after opening.

(The bot also closed this PR on its first open, correctly: an earlier draft of this description happened to contain the prose phrase `... #9303 fixed #9256 ...`, which parses as a closing reference. That was my wording slip, now reworded — apologies for the noise in the timeline.)

Thanks to @CAOShurong, who independently reproduced this on main and separated the two defects above in their analysis on #13704.

## Test results

Three parametrized regression tests in `tests/test_json_schema.py` covering array-like containers, mappings, and the `str`/`bytes` case that must keep the string keywords.

Against `main` with the fix reverted:

```
tests/test_json_schema.py::test_array_length_constraints_use_items_keywords[deque]         KeyError: 'minItems'
tests/test_json_schema.py::test_mapping_length_constraints_use_properties_keywords[Counter]     KeyError: 'minProperties'
tests/test_json_schema.py::test_mapping_length_constraints_use_properties_keywords[OrderedDict] KeyError: 'minProperties'

Results (0.37s):
         3 failed
         8 passed
```

With the fix:

```
Results (0.40s):
        11 passed
```

Full suite, `uv run pytest tests/`:

```
Results (20.22s):
         1 failed
     11781 passed
      1092 skipped
        36 xfailed
```

The single failure is `tests/test_generics.py::test_generic_recursive_models_separate_parameters` (`IndexError` at line 1072, a `subprocess.run` helper); it fails identically on unpatched `main` in this environment and is unrelated to this change.

`uv run ruff check`, `uv run ruff format --check` and `uv run pyright pydantic` are all clean (`0 errors, 0 warnings, 0 informations`).

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable — no docs change needed; the documented behaviour was already that these keywords match the JSON type
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
