### PR TITLE
Don't apply serialization temporal formats to validation JSON schemas

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -871,7 +871,10 @@ class GenerateJsonSchema:
     def _common_temporal_schema(
         self, format: str, temporal_format: Literal['iso8601', 'seconds', 'milliseconds']
     ) -> JsonSchemaValue:
-        if temporal_format != 'iso8601':
+        # `ser_json_temporal` and `ser_json_timedelta` only change what is emitted; validation keeps
+        # accepting ISO 8601 strings whatever they are set to, so a validation schema built from them
+        # would forbid input the model takes.
+        if self.mode == 'serialization' and temporal_format != 'iso8601':
             # Both `'seconds'` and `'milliseconds'` serialize to a number:
             return {'type': 'number'}
         return {'type': 'string', 'format': format}

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -871,9 +871,6 @@ class GenerateJsonSchema:
     def _common_temporal_schema(
         self, format: str, temporal_format: Literal['iso8601', 'seconds', 'milliseconds']
     ) -> JsonSchemaValue:
-        # `ser_json_temporal` and `ser_json_timedelta` only change what is emitted; validation keeps
-        # accepting ISO 8601 strings whatever they are set to, so a validation schema built from them
-        # would forbid input the model takes.
         if self.mode == 'serialization' and temporal_format != 'iso8601':
             # Both `'seconds'` and `'milliseconds'` serialize to a number:
             return {'type': 'number'}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -854,6 +854,7 @@ def test_date_types_ser_json_temporal(field_type, iso8601_format, ser_json_tempo
         expected_schema = {'title': 'A', 'type': 'number'}
 
     assert Model.model_json_schema(mode='serialization')['properties']['a'] == expected_schema
+    assert Model.model_json_schema(mode='validation')['properties']['a']['type'] == 'string'
 
 
 @pytest.mark.parametrize('ser_json_temporal', ['iso8601', 'seconds', 'milliseconds'])
@@ -2045,37 +2046,6 @@ def test_typeddict_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], prop
         'title': 'MyTypedDict',
         'type': 'object',
     }
-
-
-@pytest.mark.parametrize(
-    'config',
-    [
-        {'ser_json_temporal': 'seconds'},
-        {'ser_json_temporal': 'milliseconds'},
-        {'ser_json_timedelta': 'float'},
-    ],
-)
-def test_temporal_validation_json_schema_ignores_serialization_config(config: dict[str, Any]):
-    class Model(BaseModel):
-        model_config = ConfigDict(**config)
-
-        d: date
-        t: time
-        dt: datetime
-        td: timedelta
-
-    properties = Model.model_json_schema(mode='validation')['properties']
-    assert {name: (prop['type'], prop['format']) for name, prop in properties.items()} == {
-        'd': ('string', 'date'),
-        't': ('string', 'time'),
-        'dt': ('string', 'date-time'),
-        'td': ('string', 'duration'),
-    }
-
-    # Which is the right description only because validation keeps taking ISO 8601 either way:
-    assert Model.model_validate_json(
-        '{"d": "2032-01-02", "t": "03:04:05", "dt": "2032-01-02T03:04:05", "td": "PT5M"}'
-    ) == Model(d=date(2032, 1, 2), t=time(3, 4, 5), dt=datetime(2032, 1, 2, 3, 4, 5), td=timedelta(minutes=5))
 
 
 def test_model_subclass_metadata():

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -2047,6 +2047,37 @@ def test_typeddict_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], prop
     }
 
 
+@pytest.mark.parametrize(
+    'config',
+    [
+        {'ser_json_temporal': 'seconds'},
+        {'ser_json_temporal': 'milliseconds'},
+        {'ser_json_timedelta': 'float'},
+    ],
+)
+def test_temporal_validation_json_schema_ignores_serialization_config(config: dict[str, Any]):
+    class Model(BaseModel):
+        model_config = ConfigDict(**config)
+
+        d: date
+        t: time
+        dt: datetime
+        td: timedelta
+
+    properties = Model.model_json_schema(mode='validation')['properties']
+    assert {name: (prop['type'], prop['format']) for name, prop in properties.items()} == {
+        'd': ('string', 'date'),
+        't': ('string', 'time'),
+        'dt': ('string', 'date-time'),
+        'td': ('string', 'duration'),
+    }
+
+    # Which is the right description only because validation keeps taking ISO 8601 either way:
+    assert Model.model_validate_json(
+        '{"d": "2032-01-02", "t": "03:04:05", "dt": "2032-01-02T03:04:05", "td": "PT5M"}'
+    ) == Model(d=date(2032, 1, 2), t=time(3, 4, 5), dt=datetime(2032, 1, 2, 3, 4, 5), td=timedelta(minutes=5))
+
+
 def test_model_subclass_metadata():
     class A(BaseModel):
         """A Model docstring"""


### PR DESCRIPTION
## Change Summary

`ser_json_temporal` and `ser_json_timedelta` only change what is *emitted*. Validation keeps accepting ISO 8601 strings whatever they are set to. But `_common_temporal_schema` consults them in both modes, so a validation JSON schema built under `ser_json_temporal='seconds'` declares `{'type': 'number'}` for a `datetime` — describing input the model would take *and* forbidding input it actually accepts.

On `main`:

```python
from datetime import datetime

from pydantic import BaseModel, ConfigDict

class Model(BaseModel):
    model_config = ConfigDict(ser_json_temporal='seconds')

    dt: datetime

Model.model_json_schema()['properties']['dt']
#> {'title': 'Dt', 'type': 'number'}

Model.model_validate_json('{"dt": "2032-01-02T03:04:05"}')
#> Model(dt=datetime.datetime(2032, 1, 2, 3, 4, 5))
```

The schema says the field is a number; the model parses the string happily. There is no `val_json_temporal` — `val_temporal_unit` only decides how a *number* is read, it does not stop ISO strings being accepted — so the validation schema should stay `{'type': 'string', 'format': 'date-time'}`, which is what it has always been.

The fix gates the numeric branch on the mode:

```python
if self.mode == 'serialization' and temporal_format != 'iso8601':
```

Serialization schemas are unchanged.

## Scope

Two parts, one line of code between them:

- `date`, `time` and `datetime` picked this up in #13665, which is on `main` but not in a release, so this is a regression that has not shipped.
- `timedelta` had it already, from the older `if self._config.ser_json_timedelta == 'float'` branch that #13665 folded into the same helper. That part is a real behaviour change on released versions: a validation schema for `timedelta` under `ser_json_timedelta='float'` goes from `{'type': 'number'}` back to `{'type': 'string', 'format': 'duration'}`. That seems right to me for the same reason — `model_validate_json` takes `"PT5M"` either way — but it is a visible change and I would rather flag it than have it noticed in review.

## Related issue number

No issue; found while comparing generated schemas against what the validators actually accept. #13665 is where the `date`/`time`/`datetime` half came from.

## Something adjacent I did not touch

`bytes` has the mirror-image version of this: `bytes_schema` reads `ser_json_bytes` in both modes, so a model configured with `val_json_bytes='base64'` accepts only base64 while its validation schema says `format: 'binary'`, and one configured with `ser_json_bytes='base64'` still accepts UTF-8 while its validation schema says `format: 'base64url'`. `'hex'` is not handled at all on either side.

I left it out of this PR because #12841 is already rewriting exactly those lines to use `contentMediaType`/`contentEncoding`, and #12104 is still open on what the `base64`/`base64url` labels should be. It seemed unhelpful to move the same code in a third direction while that is being decided. Happy to open a follow-up once #12841 lands, or to fold it in here if you would rather.

`ser_json_inf_nan` is a third member of the family — with `'strings'` a float serializes to `"Infinity"` while the serialization schema still says `{'type': 'number'}` — but unlike the temporal case there is no obvious right answer for what the schema should say instead, so that one needs a decision rather than a patch.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## How I checked it

`test_temporal_validation_json_schema_ignores_serialization_config` covers all three configs across `date`, `time`, `datetime` and `timedelta`, and then round-trips an actual ISO payload through `model_validate_json` — so the test asserts the schema against real behaviour rather than against itself. With only the test applied, `main` fails all three parameter sets; with the fix, they pass.

Full suite locally: `5907 passed, 334 skipped, 27 xfailed`, plus 3 failures (`test_generic_model_pickle_different_module`, `test_model_serializer_when_used_fallback_respects_include_exclude`, `test_wrap_validator_forwards_by_alias_by_name`) that also fail on an unmodified `main` here — I am building against the released `pydantic-core==2.48.0` wheel rather than the workspace crate, which I assume is the cause. `ruff check` and `ruff format --check` are clean.

## AI policy

Per the AI policy in `CONTRIBUTING.md`: I used AI for this contribution — the investigation, the fix and this description were produced with Claude Opus 5 in Claude Code, directed by me. I have read the diff and I understand what it changes and why; the reasoning above about `val_temporal_unit` and about the released-versus-unreleased halves is mine to defend in review.
