### PR TITLE
Fix length constraints JSON schema generation for complex wrappers

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -256,13 +256,27 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while inner_schema['type'] in {
+                    'function-before',
+                    'function-wrap',
+                    'function-after',
+                    'lax-or-strict',
+                    'chain',
+                }:
+                    if inner_schema['type'] == 'lax-or-strict':
+                        inner_schema = inner_schema['lax_schema']
+                    elif inner_schema['type'] == 'chain':
+                        inner_schema = inner_schema['steps'][-1]
+                    else:
+                        inner_schema = inner_schema['schema']  # type: ignore
                 inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
-                ):
+                if inner_schema_type == 'json-or-python':
+                    inner_schema_type = inner_schema['json_schema']['type']
+
+                if inner_schema_type in {'list', 'set', 'frozenset', 'tuple', 'generator'}:
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type == 'dict':
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7417,3 +7417,28 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_json_schema_collection_length_constraints() -> None:
+    from collections import Counter, OrderedDict, deque
+    from typing import Annotated
+
+    from pydantic import Field, TypeAdapter
+
+    assert TypeAdapter(Annotated[deque[int], Field(min_length=1)]).json_schema() == {
+        'items': {'type': 'integer'},
+        'minItems': 1,
+        'type': 'array',
+    }
+
+    assert TypeAdapter(Annotated[Counter[str], Field(min_length=1)]).json_schema() == {
+        'additionalProperties': {'type': 'integer'},
+        'minProperties': 1,
+        'type': 'object',
+    }
+
+    assert TypeAdapter(Annotated[OrderedDict[str, int], Field(min_length=1)]).json_schema() == {
+        'additionalProperties': {'type': 'integer'},
+        'minProperties': 1,
+        'type': 'object',
+    }


### PR DESCRIPTION
Fixes #13704

This PR un-wraps `lax-or-strict` and `chain` schemas to properly determine if a type like `deque`, `Counter`, or `OrderedDict` should emit `minItems`, `minProperties`, or `minLength` in the generated JSON schema.