### PR TITLE
Treat a class attribute set to `None` as existing when assigning with `extra='allow'`

### DIFF
--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -31,7 +31,7 @@ from typing import (
 import pydantic_core
 import typing_extensions
 from pydantic_core import PydanticUndefined, ValidationError
-from typing_extensions import Self, TypeAlias, Unpack
+from typing_extensions import Self, Sentinel, TypeAlias, Unpack
 
 from . import PydanticDeprecatedSince20, PydanticDeprecatedSince211
 from ._internal import (
@@ -119,6 +119,14 @@ def _private_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
         # the `model_post_init()` call. Ideally we should find a better way to init private attrs.
         object.__setattr__(model, '__pydantic_private__', {})
     model.__pydantic_private__[name] = val  # pyright: ignore[reportOptionalSubscript]
+
+
+_ATTRIBUTE_MISSING = Sentinel('_ATTRIBUTE_MISSING')
+"""Sentinel used as the default of `getattr()` calls looking up class attributes.
+
+Using `None` instead would make it impossible to tell a missing attribute apart from
+an attribute that is present and legitimately set to `None`.
+"""
 
 
 _SIMPLE_SETATTR_HANDLERS: Mapping[str, Callable[[BaseModel, str, Any], None]] = {
@@ -1137,7 +1145,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                     _object_setattr(self, name, value)
                     return None  # Can not return memoized handler with possibly freeform attr names
 
-            attr = getattr(cls, name, None)
+            attr = getattr(cls, name, _ATTRIBUTE_MISSING)
             # NOTE: We currently special case properties and `cached_property`, but we might need
             # to generalize this to all data/non-data descriptors at some point. For non-data descriptors
             # (such as `cached_property`), it isn't obvious though. `cached_property` caches the value
@@ -1157,7 +1165,7 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                 if cls.model_config.get('extra') != 'allow':
                     # TODO - matching error
                     raise ValueError(f'"{cls.__name__}" object has no field "{name}"')
-                elif attr is None:
+                elif attr is _ATTRIBUTE_MISSING:
                     # attribute does not exist, so put it in extra
                     self.__pydantic_extra__[name] = value
                     self.__pydantic_fields_set__.add(name)

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -122,11 +122,6 @@ def _private_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
 
 
 _ATTRIBUTE_MISSING = Sentinel('_ATTRIBUTE_MISSING')
-"""Sentinel used as the default of `getattr()` calls looking up class attributes.
-
-Using `None` instead would make it impossible to tell a missing attribute apart from
-an attribute that is present and legitimately set to `None`.
-"""
 
 
 _SIMPLE_SETATTR_HANDLERS: Mapping[str, Callable[[BaseModel, str, Any], None]] = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -401,6 +401,31 @@ def test_reassign_instance_method_with_extra_allow():
     assert 'not_extra_func' in m.__dict__
 
 
+def test_set_class_attribute_set_to_none_with_extra_allow():
+    class Mixin:
+        # Plain class attributes, not Pydantic fields. `None` is a legitimate value here.
+        a = None
+        b = 'b'
+
+    class Model(Mixin, BaseModel):
+        model_config = ConfigDict(extra='allow')
+
+    m = Model()
+
+    # `b` exists on the class, so the assignment shadows it on the instance:
+    m.b = 'set'
+    assert m.b == 'set'
+    assert m.__dict__ == {'b': 'set'}
+    assert m.model_extra == {}
+
+    # `a` exists on the class as well and must behave the same, even though it is `None`
+    # (otherwise the class attribute keeps shadowing the assigned value on reads):
+    m.a = 'set'
+    assert m.a == 'set'
+    assert m.__dict__ == {'a': 'set', 'b': 'set'}
+    assert m.model_extra == {}
+
+
 def test_extra_ignored():
     class Model(BaseModel):
         model_config = ConfigDict(extra='ignore')


### PR DESCRIPTION
## Change Summary

`BaseModel._setattr_handler()` looks up the class attribute with `getattr(cls, name, None)` and then uses `attr is None` as its "the attribute does not exist" test:

```python
attr = getattr(cls, name, None)
...
elif name not in cls.__pydantic_fields__:
    if cls.model_config.get('extra') != 'allow':
        raise ValueError(f'"{cls.__name__}" object has no field "{name}"')
    elif attr is None:
        # attribute does not exist, so put it in extra
        self.__pydantic_extra__[name] = value
```

That conflates *missing* with *present and legitimately `None`*. A class attribute whose value is `None` is taken to be absent, so on a model with `extra='allow'` the assignment is routed into `__pydantic_extra__` instead of shadowing the class attribute on the instance. The class attribute then still wins on attribute lookup, and the value that was just assigned is not readable back:

```python
from pydantic import BaseModel, ConfigDict


class Mixin:
    tag = None      # plain class attribute, `None` is a legitimate value
    other = 'x'


class Model(Mixin, BaseModel):
    model_config = ConfigDict(extra='allow')


m = Model()
m.other = 'set'
m.tag = 'set'

print(m.other)     # 'set'   -> stored in `m.__dict__`
print(m.tag)       # None    -> stored in `m.__pydantic_extra__`, class attribute still shadows it
print(m.model_dump())  # {'tag': 'set'}
```

`m.tag` reads back `None` after being assigned `'set'`, while `model_dump()` reports `{'tag': 'set'}`. The only difference to the `other` case, which behaves correctly, is that the class attribute happens to hold `None`.

This PR introduces an `_ATTRIBUTE_MISSING` sentinel and uses it as the `getattr()` default, so a genuinely absent attribute is distinguished from one whose value is `None`. With the fix, `tag` and `other` behave identically: the value lands in the instance `__dict__` and reads back as assigned.

The sentinel is also correct for the two `isinstance()` checks above it (`cached_property` and `property`), which previously relied on `None` not being an instance of either.

## Related issue number

None - reported and fixed here.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
