### PR TITLE
Fix JSON schema length keywords for wrapped collections

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -256,13 +256,23 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after', 'lax-or-strict'}:
+                    if inner_schema['type'] == 'lax-or-strict':
+                        inner_schema = inner_schema[
+                            'strict_schema' if inner_schema.get('strict', False) else 'lax_schema'
+                        ]
+                    else:
+                        inner_schema = inner_schema['schema']  # type: ignore
                 inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
+                if inner_schema_type in {'list', 'tuple', 'set', 'frozenset', 'generator'} or (
+                    inner_schema_type == 'json-or-python'
+                    and inner_schema['json_schema']['type'] in {'list', 'tuple', 'set', 'frozenset', 'generator'}  # type: ignore
                 ):
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type == 'dict' or (
+                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'dict'  # type: ignore
+                ):
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4,7 +4,7 @@ import math
 import re
 import sys
 import typing
-from collections import deque
+from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -693,6 +693,20 @@ def test_deque():
         'properties': {'a': {'title': 'A', 'type': 'array', 'items': {'type': 'string'}}},
         'required': ['a'],
     }
+
+
+@pytest.mark.parametrize(
+    'field_type,expected_length_keys',
+    [
+        pytest.param(deque[int], {'minItems': 2, 'maxItems': 3}, id='deque'),
+        pytest.param(Counter[str], {'minProperties': 2, 'maxProperties': 3}, id='Counter'),
+        pytest.param(OrderedDict[str, int], {'minProperties': 2, 'maxProperties': 3}, id='OrderedDict'),
+    ],
+)
+def test_wrapped_collection_length_constraints_json_schema(field_type, expected_length_keys):
+    ta = TypeAdapter(Annotated[field_type, Field(min_length=2, max_length=3)])
+
+    assert ta.json_schema().items() >= expected_length_keys.items()
 
 
 def test_bool():


### PR DESCRIPTION
### Problem

`min_length` and `max_length` constraints on `deque`, `Counter`, and `OrderedDict` validate correctly at runtime, but the generated JSON Schema used the *string* keywords `minLength`/`maxLength`.

JSON Schema validators ignore `minLength`/`maxLength` for arrays and objects, so the emitted schema silently failed to express the constraint that Pydantic actually enforces. A consumer validating against the exported schema would accept documents that Pydantic itself rejects.

### Reproducer

```python
from collections import Counter, OrderedDict, deque
from typing import Annotated

from pydantic import Field, TypeAdapter

for annotation in [deque[int], Counter[str], OrderedDict[str, int]]:
    print(TypeAdapter(Annotated[annotation, Field(min_length=2)]).json_schema())
```

Before this change:

```
{'items': {'type': 'integer'}, 'minLength': 2, 'type': 'array'}          # deque
{'additionalProperties': {'type': 'integer'}, 'minLength': 2, ...}       # Counter
{'additionalProperties': {'type': 'integer'}, 'minLength': 2, ...}       # OrderedDict
```

After this change:

```
{'items': {'type': 'integer'}, 'minItems': 2, 'type': 'array'}           # deque
{'additionalProperties': {'type': 'integer'}, 'minProperties': 2, ...}   # Counter
{'additionalProperties': {'type': 'integer'}, 'minProperties': 2, ...}   # OrderedDict
```

### Fix

These collections are built as an inner array/dict schema wrapped in an after-validator, and for `deque` the wrapper is a `lax-or-strict` schema. When length metadata was applied, the keyword was chosen from the outer wrapper rather than the underlying collection, so it fell back to the string keywords.

The fix unwraps `lax-or-strict` the same way JSON Schema generation already selects the active branch, then maps array-like schemas to `minItems`/`maxItems` and dict-like schemas to `minProperties`/`maxProperties`.

### Testing

- Added `test_wrapped_collection_length_constraints_json_schema` in `tests/test_json_schema.py`, which fails before this change and passes after.
- `pytest tests/test_json_schema.py` -> 556 passed, 5 skipped, 1 xfailed.
- Full suite shows only the same two pre-existing unrelated failures as the baseline on `main`.
- `ruff format` and `ruff check` clean on both changed files.
