### PR TITLE
fix(json_schema): emit minItems/minProperties instead of minLength for collection types

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -256,13 +256,21 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after', 'lax-or-strict'}:
+                    if inner_schema['type'] == 'lax-or-strict':
+                        inner_schema = inner_schema['lax_schema']  # type: ignore
+                    else:
+                        inner_schema = inner_schema['schema']  # type: ignore
                 inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
+                if inner_schema_type in {'list', 'set', 'frozenset', 'tuple', 'generator'} or (
+                    inner_schema_type == 'json-or-python'
+                    and inner_schema['json_schema']['type'] in {'list', 'set', 'frozenset', 'tuple', 'generator'}  # type: ignore
                 ):
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type == 'dict' or (
+                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'dict'  # type: ignore
+                ):
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -6876,6 +6876,19 @@ def test_min_and_max_in_schema() -> None:
     TSeq = TypeAdapter(Annotated[Sequence[int], Field(min_length=2, max_length=5)])
     assert TSeq.json_schema() == {'items': {'type': 'integer'}, 'maxItems': 5, 'minItems': 2, 'type': 'array'}
 
+    from collections import Counter, OrderedDict, deque
+    from typing import Deque, Mapping
+
+    TDeque = TypeAdapter(Annotated[Deque[int], Field(min_length=2, max_length=5)])
+    assert TDeque.json_schema() == {'items': {'type': 'integer'}, 'maxItems': 5, 'minItems': 2, 'type': 'array'}
+
+    TCounter = TypeAdapter(Annotated[Counter[str], Field(min_length=1)])
+    assert TCounter.json_schema() == {'additionalProperties': {'type': 'integer'}, 'minProperties': 1, 'type': 'object'}
+
+    TMapping = TypeAdapter(Annotated[Mapping[str, int], Field(min_length=1, max_length=10)])
+    assert TMapping.json_schema() == {'additionalProperties': {'type': 'integer'}, 'maxProperties': 10, 'minProperties': 1, 'type': 'object'}
+
+
 
 def test_plain_field_validator_serialization() -> None:
     """`PlainValidator` internally creates a wrap ser. schema. This tests that we can


### PR DESCRIPTION
## Description
Maps length constraints (`min_length`, `max_length`) in `_known_annotated_metadata.py` to `minItems`/`maxItems` for sequence types (`list`, `set`, `frozenset`, `tuple`, `generator`, `deque`) and `minProperties`/`maxProperties` for mapping types (`dict`, `Counter`, `Mapping`) rather than defaulting to string-specific `minLength`/`maxLength`.

Fixes #13704
