### PR TITLE
fix: respect MRO when merging fields and private attributes in multiple inheritance

### DIFF
--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -311,11 +311,15 @@ def collect_model_fields(  # noqa: C901
 
     from ..fields import ModelPrivateAttr, PrivateAttr
 
-    bases = cls.__bases__
+    BaseModel = import_cached_base_model()
+
     parent_fields_lookup: dict[str, FieldInfo] = {}
-    for base in reversed(bases):
-        if model_fields := getattr(base, '__pydantic_fields__', None):
-            parent_fields_lookup.update(model_fields)
+    for base in reversed(cls.__mro__):
+        if issubclass(base, BaseModel) and base is not BaseModel:
+            if model_fields := getattr(base, '__pydantic_fields__', None):
+                for name, field_info in model_fields.items():
+                    if name in getattr(base, '__annotations__', {}) or name in base.__dict__:
+                        parent_fields_lookup[name] = field_info
 
     type_hints = _typing_extra.get_model_type_hints(cls, ns_resolver=ns_resolver)
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -312,12 +312,15 @@ class ModelMetaclass(ABCMeta):
         field_names: set[str] = set()
         class_vars: set[str] = set()
         private_attributes: dict[str, ModelPrivateAttr] = {}
-        for base in bases:
+        for base in reversed(bases):
             if issubclass(base, BaseModel) and base is not BaseModel:
-                # model_fields might not be defined yet in the case of generics, so we use getattr here:
-                field_names.update(getattr(base, '__pydantic_fields__', {}).keys())
-                class_vars.update(base.__class_vars__)
-                private_attributes.update(base.__private_attributes__)
+                for ancestor in reversed(base.__mro__):
+                    if issubclass(ancestor, BaseModel) and ancestor is not BaseModel:
+                        field_names.update(getattr(ancestor, '__pydantic_fields__', {}).keys())
+                        class_vars.update(ancestor.__class_vars__)
+                        for name, private_attr in ancestor.__private_attributes__.items():
+                            if name in getattr(ancestor, '__annotations__', {}) or name in ancestor.__dict__:
+                                private_attributes[name] = private_attr
         return field_names, class_vars, private_attributes
 
     @property

--- a/tests/test_private_attributes.py
+++ b/tests/test_private_attributes.py
@@ -661,3 +661,30 @@ def test_private_attribute_from_annotated_metadata_set_name() -> None:
 
     assert set_name_calls == [(Model, '_priv')]
     assert Model()._priv == 1
+
+
+def test_multiple_inheritance_mro_shadowing() -> None:
+    """Verify that a base class that only inherits a field does not shadow an override in another base (issue #13678)."""
+
+    class Base(BaseModel):
+        f: str = 'base'
+        _knob: str = 'base'
+
+    class Override(Base):
+        f: str = 'override'
+        _knob: str = 'override'
+
+    class Plain(Base):
+        pass
+
+    class Swapped(Plain, Override):
+        pass
+
+    class Composed(Override, Plain):
+        pass
+
+    assert Swapped().f == 'override'
+    assert Swapped()._knob == 'override'
+    assert Composed().f == 'override'
+    assert Composed()._knob == 'override'
+


### PR DESCRIPTION
## Summary

Fixes #13678

In multiple inheritance where one base class merely inherits a field or private attribute from a common ancestor while a second base class explicitly overrides it, the non-overriding base class could shadow the override depending on base order (e.g. class Swapped(Plain, Override): pass resolving  = 'base' instead of  = 'override').

## Changes

- In pydantic/_internal/_fields.py, iterate over eversed(cls.__mro__) when constructing parent_fields_lookup, and only collect fields defined directly in ase.__annotations__ or ase.__dict__.
- In pydantic/_internal/_model_construction.py, traverse the reversed ancestor MRO in _collect_bases_data and only collect private attributes defined directly on the ancestor.
- In 	ests/test_private_attributes.py, added unit test 	est_multiple_inheritance_mro_shadowing verifying both (Plain, Override) and (Override, Plain) base orderings.
