### PR TITLE
Fix PydanticOmit handling for duplicated union fields

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -305,6 +305,7 @@ class GenerateJsonSchema:
         #  the reference) so instead of failing altogether if we can't build a definition we
         # store the error raised and re-throw it if we end up needing that def
         self._core_defs_invalid_for_json_schema: dict[DefsRef, PydanticInvalidForJsonSchema] = {}
+        self._core_defs_omitted_from_json_schema: set[DefsRef] = set()
 
         # This changes to True after generating a schema, to prevent issues caused by accidental reuse
         # of a single instance of a schema generator
@@ -2222,13 +2223,32 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        for definition in schema['definitions']:
-            try:
-                self.generate_inner(definition)
-            except PydanticInvalidForJsonSchema as e:  # noqa: PERF203
+        definitions = schema['definitions']
+        while True:
+            omitted_defs_before = self._core_defs_omitted_from_json_schema.copy()
+            for definition in definitions:
                 core_ref: CoreRef = CoreRef(definition['ref'])  # type: ignore
-                self._core_defs_invalid_for_json_schema[self.get_defs_ref((core_ref, self.mode))] = e
-                continue
+                defs_ref = self.get_defs_ref((core_ref, self.mode))
+                if defs_ref in self._core_defs_omitted_from_json_schema:
+                    continue
+                try:
+                    self.generate_inner(definition)
+                except PydanticInvalidForJsonSchema as e:  # noqa: PERF203
+                    self._core_defs_invalid_for_json_schema[defs_ref] = e
+                    continue
+                except PydanticOmit:
+                    self._core_defs_omitted_from_json_schema.add(defs_ref)
+                    continue
+
+            if self._core_defs_omitted_from_json_schema == omitted_defs_before:
+                break
+
+            # Definitions generated before an omitted dependency was discovered can contain a dangling reference.
+            # Regenerate them with the complete omission information so containers can propagate the omission and
+            # unions can retain their other choices.
+            for definition in definitions:
+                core_ref = CoreRef(definition['ref'])  # type: ignore
+                self.definitions.pop(self.get_defs_ref((core_ref, self.mode)), None)
         return self.generate_inner(schema['schema'])
 
     def definition_ref_schema(self, schema: core_schema.DefinitionReferenceSchema) -> JsonSchemaValue:
@@ -2241,7 +2261,9 @@ class GenerateJsonSchema:
             The generated JSON schema.
         """
         core_ref = CoreRef(schema['schema_ref'])
-        _, ref_json_schema = self.get_cache_defs_ref_schema(core_ref)
+        defs_ref, ref_json_schema = self.get_cache_defs_ref_schema(core_ref)
+        if defs_ref in self._core_defs_omitted_from_json_schema:
+            raise PydanticOmit
         return ref_json_schema
 
     def ser_schema(

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -29,7 +29,7 @@ from uuid import UUID
 import pytest
 from annotated_types import Interval
 from dirty_equals import HasRepr
-from pydantic_core import CoreSchema, SchemaValidator, core_schema, to_jsonable_python
+from pydantic_core import CoreSchema, PydanticOmit, SchemaValidator, core_schema, to_jsonable_python
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 from typing_extensions import TypeAliasType, TypedDict, deprecated
 
@@ -5966,6 +5966,114 @@ def test_skip_json_schema_annotation() -> None:
         'title': 'Model',
         'type': 'object',
     }
+
+
+def test_omit_json_schema_definition_used_by_multiple_fields() -> None:
+    """https://github.com/pydantic/pydantic/issues/11553"""
+
+    class OmittedModel(BaseModel):
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            raise PydanticOmit
+
+    class Model(BaseModel):
+        first: list[float | OmittedModel]
+        second: list[float | OmittedModel]
+
+    assert Model.model_json_schema() == {
+        'properties': {
+            'first': {'items': {'type': 'number'}, 'title': 'First', 'type': 'array'},
+            'second': {'items': {'type': 'number'}, 'title': 'Second', 'type': 'array'},
+        },
+        'required': ['first', 'second'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
+def test_omit_json_schema_definition_propagates_to_dependent_definition() -> None:
+    def omit_json_schema(core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        raise PydanticOmit
+
+    omitted = core_schema.none_schema(
+        ref='omitted',
+        metadata={'pydantic_js_functions': [omit_json_schema]},
+    )
+    container = core_schema.list_schema(
+        core_schema.definition_reference_schema('omitted'),
+        ref='container',
+    )
+    root = core_schema.typed_dict_schema(
+        {
+            'field': core_schema.typed_dict_field(core_schema.definition_reference_schema('container')),
+        }
+    )
+    schema = core_schema.definitions_schema(root, [container, omitted])
+
+    assert GenerateJsonSchema().generate(schema) == {'properties': {}, 'type': 'object'}
+
+
+def test_omit_json_schema_definition_preserves_valid_union_choice() -> None:
+    def omit_json_schema(core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        raise PydanticOmit
+
+    omitted = core_schema.none_schema(
+        ref='omitted',
+        metadata={'pydantic_js_functions': [omit_json_schema]},
+    )
+    container = core_schema.list_schema(
+        core_schema.union_schema(
+            [core_schema.str_schema(), core_schema.definition_reference_schema('omitted')],
+        ),
+        ref='container',
+    )
+    root = core_schema.typed_dict_schema(
+        {
+            'field': core_schema.typed_dict_field(core_schema.definition_reference_schema('container')),
+        }
+    )
+    schema = core_schema.definitions_schema(root, [container, omitted])
+
+    assert GenerateJsonSchema().generate(schema) == {
+        '$defs': {'container': {'items': {'type': 'string'}, 'type': 'array'}},
+        'properties': {'field': {'$ref': '#/$defs/container'}},
+        'required': ['field'],
+        'type': 'object',
+    }
+
+
+def test_omit_json_schema_definition_propagates_from_nested_definitions() -> None:
+    def omit_json_schema(core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
+        raise PydanticOmit
+
+    omitted = core_schema.none_schema(
+        ref='omitted',
+        metadata={'pydantic_js_functions': [omit_json_schema]},
+    )
+    container = core_schema.list_schema(
+        core_schema.definition_reference_schema('omitted'),
+        ref='container',
+    )
+    wrapper = core_schema.with_default_schema(
+        core_schema.definitions_schema(
+            core_schema.union_schema(
+                [core_schema.str_schema(), core_schema.definition_reference_schema('omitted')],
+            ),
+            [omitted],
+        ),
+        ref='wrapper',
+    )
+    root = core_schema.typed_dict_schema(
+        {
+            'field': core_schema.typed_dict_field(core_schema.definition_reference_schema('container')),
+        }
+    )
+    schema = core_schema.definitions_schema(root, [container, wrapper])
+
+    SchemaValidator(schema)
+    assert GenerateJsonSchema().generate(schema) == {'properties': {}, 'type': 'object'}
 
 
 def test_skip_json_schema_exclude_default():


### PR DESCRIPTION
  Fixes #11553.

  Correct the JSON Schema handling of omitted definitions when the same custom type appears in multiple union fields. Previously, the first omitted schema could leave state that caused a later reference to propagate `PydanticOmit`.

  This change ensures omitted definitions remain consistently omitted when referenced more than once.

  ## Validation

  - Added focused regression coverage for duplicated union fields.
  - Added coverage for the relevant omission and definition-reference cases.
  - `4 passed`
  - Ruff lint checks passed.
  - Ruff formatting checks passed.
  - `git diff --check` passed.