### PR TITLE
Use the field name in `__signature__` when `validate_by_alias` is`False`

### DIFF
--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -156,9 +156,9 @@ def complete_dataclass(
             init=original_init,
             fields=cls.__pydantic_fields__,  # type: ignore
             validate_by_name=config_wrapper.validate_by_name,
+            validate_by_alias=config_wrapper.validate_by_alias,
             extra=config_wrapper.extra,
             is_dataclass=True,
-            validate_by_alias=config_wrapper.validate_by_alias,
         ),
     )
 

--- a/pydantic/_internal/_dataclasses.py
+++ b/pydantic/_internal/_dataclasses.py
@@ -158,6 +158,7 @@ def complete_dataclass(
             validate_by_name=config_wrapper.validate_by_name,
             extra=config_wrapper.extra,
             is_dataclass=True,
+            validate_by_alias=config_wrapper.validate_by_alias,
         ),
     )
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -670,8 +670,8 @@ def complete_model_class(
             init=cls.__init__,
             fields=cls.__pydantic_fields__,
             validate_by_name=config_wrapper.validate_by_name,
-            extra=config_wrapper.extra,
             validate_by_alias=config_wrapper.validate_by_alias,
+            extra=config_wrapper.extra,
         ),
     )
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -671,6 +671,7 @@ def complete_model_class(
             fields=cls.__pydantic_fields__,
             validate_by_name=config_wrapper.validate_by_name,
             extra=config_wrapper.extra,
+            validate_by_alias=config_wrapper.validate_by_alias,
         ),
     )
 

--- a/pydantic/_internal/_signature.py
+++ b/pydantic/_internal/_signature.py
@@ -24,14 +24,11 @@ class _HAS_DEFAULT_FACTORY_CLASS:
 _HAS_DEFAULT_FACTORY = _HAS_DEFAULT_FACTORY_CLASS()
 
 
-def _field_name_for_signature(field_name: str, field_info: FieldInfo, validate_by_alias: bool = True) -> str:
+def _field_name_for_signature(field_name: str, field_info: FieldInfo, validate_by_alias: bool) -> str:
     """Extract the correct name to use for the field when generating a signature.
 
     Assuming the field has a valid alias, this will return the alias. Otherwise, it will return the field name.
     First priority is given to the alias, then the validation_alias, then the field name.
-
-    If `validate_by_alias` is `False`, aliases are not accepted by validation at all, so the field name
-    is always used.
 
     Args:
         field_name: The name of the field
@@ -50,7 +47,7 @@ def _field_name_for_signature(field_name: str, field_info: FieldInfo, validate_b
     return field_name
 
 
-def _process_param_defaults(param: Parameter, validate_by_alias: bool = True) -> Parameter:
+def _process_param_defaults(param: Parameter, validate_by_alias: bool) -> Parameter:
     """Modify the signature for a parameter in a dataclass where the default value is a FieldInfo instance.
 
     Args:
@@ -92,7 +89,7 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
     fields: dict[str, FieldInfo],
     validate_by_name: bool,
     extra: ExtraValues | None,
-    validate_by_alias: bool = True,
+    validate_by_alias: bool,
 ) -> dict[str, Parameter]:
     """Generate a mapping of parameter names to Parameter objects for a pydantic BaseModel or dataclass."""
     from itertools import islice
@@ -173,12 +170,13 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
 
 
 def generate_pydantic_signature(
+    *,
     init: Callable[..., None],
     fields: dict[str, FieldInfo],
     validate_by_name: bool,
+    validate_by_alias: bool,
     extra: ExtraValues | None,
     is_dataclass: bool = False,
-    validate_by_alias: bool = True,
 ) -> Signature:
     """Generate signature for a pydantic BaseModel or dataclass.
 
@@ -186,9 +184,9 @@ def generate_pydantic_signature(
         init: The class init.
         fields: The model fields.
         validate_by_name: The `validate_by_name` value of the config.
+        validate_by_alias: The `validate_by_alias` value of the config.
         extra: The `extra` value of the config.
         is_dataclass: Whether the model is a dataclass.
-        validate_by_alias: The `validate_by_alias` value of the config.
 
     Returns:
         The dataclass/BaseModel subclass signature.

--- a/pydantic/_internal/_signature.py
+++ b/pydantic/_internal/_signature.py
@@ -24,32 +24,38 @@ class _HAS_DEFAULT_FACTORY_CLASS:
 _HAS_DEFAULT_FACTORY = _HAS_DEFAULT_FACTORY_CLASS()
 
 
-def _field_name_for_signature(field_name: str, field_info: FieldInfo) -> str:
+def _field_name_for_signature(field_name: str, field_info: FieldInfo, validate_by_alias: bool = True) -> str:
     """Extract the correct name to use for the field when generating a signature.
 
     Assuming the field has a valid alias, this will return the alias. Otherwise, it will return the field name.
     First priority is given to the alias, then the validation_alias, then the field name.
 
+    If `validate_by_alias` is `False`, aliases are not accepted by validation at all, so the field name
+    is always used.
+
     Args:
         field_name: The name of the field
         field_info: The corresponding FieldInfo object.
+        validate_by_alias: The `validate_by_alias` value of the config.
 
     Returns:
         The correct name to use when generating a signature.
     """
-    if isinstance(field_info.alias, str) and is_valid_identifier(field_info.alias):
-        return field_info.alias
-    if isinstance(field_info.validation_alias, str) and is_valid_identifier(field_info.validation_alias):
-        return field_info.validation_alias
+    if validate_by_alias:
+        if isinstance(field_info.alias, str) and is_valid_identifier(field_info.alias):
+            return field_info.alias
+        if isinstance(field_info.validation_alias, str) and is_valid_identifier(field_info.validation_alias):
+            return field_info.validation_alias
 
     return field_name
 
 
-def _process_param_defaults(param: Parameter) -> Parameter:
+def _process_param_defaults(param: Parameter, validate_by_alias: bool = True) -> Parameter:
     """Modify the signature for a parameter in a dataclass where the default value is a FieldInfo instance.
 
     Args:
         param (Parameter): The parameter
+        validate_by_alias: The `validate_by_alias` value of the config.
 
     Returns:
         Parameter: The custom processed parameter
@@ -74,7 +80,9 @@ def _process_param_defaults(param: Parameter) -> Parameter:
                 # this is used by dataclasses to indicate a factory exists:
                 default = dataclasses._HAS_DEFAULT_FACTORY  # type: ignore
         return param.replace(
-            annotation=annotation, name=_field_name_for_signature(param.name, param_default), default=default
+            annotation=annotation,
+            name=_field_name_for_signature(param.name, param_default, validate_by_alias),
+            default=default,
         )
     return param
 
@@ -84,6 +92,7 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
     fields: dict[str, FieldInfo],
     validate_by_name: bool,
     extra: ExtraValues | None,
+    validate_by_alias: bool = True,
 ) -> dict[str, Parameter]:
     """Generate a mapping of parameter names to Parameter objects for a pydantic BaseModel or dataclass."""
     from itertools import islice
@@ -100,7 +109,7 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
             # exclude params with init=False
             if getattr(fields[param.name], 'init', True) is False:
                 continue
-            param = param.replace(name=_field_name_for_signature(param.name, fields[param.name]))
+            param = param.replace(name=_field_name_for_signature(param.name, fields[param.name], validate_by_alias))
         if param.annotation == 'Any':
             param = param.replace(annotation=Any)
         if param.kind is param.VAR_KEYWORD:
@@ -112,13 +121,13 @@ def _generate_signature_parameters(  # noqa: C901 (ignore complexity, could use 
         allow_names = validate_by_name
         for field_name, field in fields.items():
             # when alias is a str it should be used for signature generation
-            param_name = _field_name_for_signature(field_name, field)
+            param_name = _field_name_for_signature(field_name, field, validate_by_alias)
 
             if field_name in merged_params or param_name in merged_params:
                 continue
 
             if not is_valid_identifier(param_name):
-                if allow_names:
+                if allow_names and is_valid_identifier(field_name):
                     param_name = field_name
                 else:
                     use_var_kw = True
@@ -169,6 +178,7 @@ def generate_pydantic_signature(
     validate_by_name: bool,
     extra: ExtraValues | None,
     is_dataclass: bool = False,
+    validate_by_alias: bool = True,
 ) -> Signature:
     """Generate signature for a pydantic BaseModel or dataclass.
 
@@ -178,13 +188,14 @@ def generate_pydantic_signature(
         validate_by_name: The `validate_by_name` value of the config.
         extra: The `extra` value of the config.
         is_dataclass: Whether the model is a dataclass.
+        validate_by_alias: The `validate_by_alias` value of the config.
 
     Returns:
         The dataclass/BaseModel subclass signature.
     """
-    merged_params = _generate_signature_parameters(init, fields, validate_by_name, extra)
+    merged_params = _generate_signature_parameters(init, fields, validate_by_name, extra, validate_by_alias)
 
     if is_dataclass:
-        merged_params = {k: _process_param_defaults(v) for k, v in merged_params.items()}
+        merged_params = {k: _process_param_defaults(v, validate_by_alias) for k, v in merged_params.items()}
 
     return Signature(parameters=list(merged_params.values()), return_annotation=None)

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -2784,6 +2784,23 @@ def test_signature():
     )
 
 
+def test_signature_validate_by_alias_false():
+    @pydantic.dataclasses.dataclass(config=ConfigDict(validate_by_alias=False, validate_by_name=True))
+    class Model:
+        x: int = Field(alias='xAlias')
+        y: int = Field(default=1, alias='yAlias')
+
+    sig = inspect.signature(Model)
+    assert str(sig) == '(x: int, y: int = 1) -> None'
+
+    # The signature must describe the arguments `__init__` actually accepts:
+    sig.bind(x=1)
+    with pytest.raises(TypeError):
+        sig.bind(xAlias=1)
+
+    assert Model(x=1) == Model(x=1, y=1)
+
+
 def test_inherited_dataclass_signature():
     @pydantic.dataclasses.dataclass
     class A:

--- a/tests/test_model_signature.py
+++ b/tests/test_model_signature.py
@@ -93,6 +93,17 @@ def test_invalid_identifiers_signature():
     assert _equals(str(signature(model)), '(*, yeah: int = 0, **extra_data: Any) -> None')
 
 
+def test_invalid_identifiers_signature_falls_back_to_var_kw():
+    # Neither the alias nor the field name can be used as a parameter name, so the
+    # field is only reachable through the var-keyword parameter.
+    model = create_model(
+        'Model',
+        __config__=ConfigDict(validate_by_name=True),
+        **{'123 invalid identifier!': (int, Field(0, alias='also invalid!'))},
+    )
+    assert _equals(str(signature(model)), '(**extra_data: Any) -> None')
+
+
 def test_use_field_name():
     class Foo(BaseModel):
         foo: str = Field(alias='this is invalid')
@@ -109,6 +120,62 @@ def test_does_not_use_reserved_word():
         model_config = ConfigDict(validate_by_name=True)
 
     assert _equals(str(signature(Foo)), '(*, from_: str) -> None')
+
+
+def test_validate_by_alias_false_uses_field_name():
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_by_alias=False, validate_by_name=True)
+
+        my_field: int = Field(alias='myAlias')
+
+    sig = signature(Model)
+    assert _equals(str(sig), '(*, my_field: int) -> None')
+
+    # The signature must describe the arguments `__init__` actually accepts:
+    sig.bind(my_field=1)
+    with pytest.raises(TypeError):
+        sig.bind(myAlias=1)
+
+
+def test_validate_by_alias_false_uses_field_name_with_validation_alias():
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_by_alias=False, validate_by_name=True)
+
+        my_field: int = Field(validation_alias='myAlias')
+
+    assert _equals(str(signature(Model)), '(*, my_field: int) -> None')
+
+
+def test_validate_by_alias_false_uses_field_name_with_extra_allow():
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_by_alias=False, validate_by_name=True, extra='allow')
+
+        my_field: int = Field(alias='myAlias')
+
+    assert _equals(str(signature(Model)), '(*, my_field: int, **extra_data: Any) -> None')
+
+
+def test_validate_by_alias_true_still_uses_alias():
+    class Model(BaseModel):
+        model_config = ConfigDict(validate_by_name=True)
+
+        my_field: int = Field(alias='myAlias')
+
+    assert _equals(str(signature(Model)), '(*, myAlias: int) -> None')
+
+
+def test_validate_by_alias_false_is_not_inherited_by_outer_model():
+    class Inner(BaseModel):
+        model_config = ConfigDict(validate_by_alias=False, validate_by_name=True)
+
+        inner_field: int = Field(alias='innerAlias')
+
+    class Outer(BaseModel):
+        outer_field: int = Field(alias='outerAlias')
+        inner: Inner
+
+    assert _equals(str(signature(Inner)), '(*, inner_field: int) -> None')
+    assert signature(Outer).parameters['outerAlias'].name == 'outerAlias'
 
 
 def test_extra_allow_no_conflict():


### PR DESCRIPTION
## Change Summary

With `validate_by_alias=False`, a field's alias is never accepted by validation. The generated `__signature__` ignored that and still named the parameter after the alias, so it advertised the one keyword `__init__` rejects and omitted the one it requires:

```python
class Model(BaseModel):
    model_config = ConfigDict(validate_by_alias=False, validate_by_name=True)
    my_field: int = Field(alias='myAlias')

inspect.signature(Model)   #> (*, myAlias: int) -> None
Model(myAlias=1)           #> ValidationError: my_field  Field required
Model(my_field=1)          #> my_field=1
```

`inspect.signature(Model).bind(my_field=1)` raises `TypeError` for a call the model accepts, and binds a call it rejects. This affects `alias` and `validation_alias`, on both `BaseModel` and pydantic dataclasses. `serialization_alias` was already handled correctly.

`_field_name_for_signature()` now consults `validate_by_alias` and falls back to the field name when aliases are off; the flag is threaded through from both call sites. This matches what the mypy plugin already does when it synthesizes `__init__` (`use_alias = ... and config.validate_by_alias is not False` in `pydantic/mypy.py`), so the runtime signature and the static plugin now agree.

One related guard: the invalid-identifier fallback did `param_name = field_name` without checking that the field name is itself a valid identifier, which raises `ValueError` from `inspect.Parameter`. It now falls through to the var-keyword parameter in that case, as the neighbouring branch already does.

Behaviour is unchanged for the default config, `populate_by_name`, `serialization_alias`, `AliasChoices`/`AliasPath`, and plain dataclasses; there is a test pinning each.

## Related issue number

None — this has not been reported. It is the `__signature__` counterpart of the JSON schema problem in #13716 / #13717, but a different code path (`_internal/_signature.py`), so the two do not overlap.

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable

<sub>AI assistance was used in preparing this patch.</sub>
