### PR TITLE
Count validated model fields once in smart unions

### DIFF
--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -179,7 +179,6 @@ impl Validator for ModelFieldsValidator {
             };
             self.validate_by_get_item(py, input, dict, state)?
         };
-        state.add_fields_set(fields_set.len());
 
         // if we have extra=allow, but we didn't create a dict because we were validating
         // from attributes, set it now so __pydantic_extra__ is always a dict if extra=allow
@@ -560,6 +559,7 @@ impl ModelFieldsValidator {
             (0..self.fields.len()).map(|_| None).collect();
         let mut errors: Vec<ValLineError> = Vec::new();
         let fields_set = PySet::empty(py)?;
+        let mut fields_set_count: usize = 0;
 
         let state = &mut state.scoped_set_data(Some(model_dict.clone()));
         let state = &mut state.scoped_clear_field_error();
@@ -636,6 +636,7 @@ impl ModelFieldsValidator {
                 match field.validator.validate(py, field_json_value, state) {
                     Ok(value) => {
                         fields_set.add(&field.name)?;
+                        fields_set_count += 1;
                         value
                     }
                     Err(ValError::Omit) => continue,
@@ -697,6 +698,7 @@ impl ModelFieldsValidator {
             return Err(ValError::LineErrors(errors));
         }
 
+        state.add_fields_set(fields_set_count);
         Ok((model_dict, model_extra_dict_op, fields_set))
     }
 }

--- a/pydantic-core/tests/validators/test_union.py
+++ b/pydantic-core/tests/validators/test_union.py
@@ -10,7 +10,7 @@ from dirty_equals import IsFloat, IsInt
 
 from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema
 
-from ..conftest import plain_repr
+from ..conftest import PyAndJson, plain_repr
 
 
 @pytest.mark.parametrize(
@@ -856,6 +856,42 @@ class TestSmartUnionWithSubclass:
         assert isinstance(validator.validate_python({'a': '1', 'b': '2'}), self.ModelB)
         assert isinstance(validator.validate_python({'a': '1', 'b': 2}), self.ModelB)
         assert isinstance(validator.validate_python({'a': 1, 'b': '2'}), self.ModelB)
+
+
+@pytest.mark.parametrize('extra_behavior', ['ignore', 'allow'])
+@pytest.mark.parametrize('reverse_choices', [False, True])
+def test_smart_union_before_validator_field_count(
+    py_and_json: PyAndJson, extra_behavior: core_schema.ExtraBehavior, reverse_choices: bool
+) -> None:
+    class ModelA:
+        a: int
+        b: int
+
+    class ModelB(ModelA):
+        c: int
+
+    model_a_schema = core_schema.model_schema(
+        ModelA,
+        core_schema.no_info_before_validator_function(
+            lambda value: value,
+            core_schema.model_fields_schema(
+                fields={name: core_schema.model_field(core_schema.int_schema()) for name in ('a', 'b')},
+                extra_behavior=extra_behavior,
+            ),
+        ),
+    )
+    model_b_schema = core_schema.model_schema(
+        ModelB,
+        core_schema.model_fields_schema(
+            fields={name: core_schema.model_field(core_schema.int_schema()) for name in ('a', 'b', 'c')}
+        ),
+    )
+    choices = [model_a_schema, model_b_schema]
+    if reverse_choices:
+        choices.reverse()
+    validator = py_and_json(core_schema.union_schema(choices))
+
+    assert isinstance(validator.validate_test({'a': 1, 'b': 2, 'c': 3}), ModelB)
 
 
 class TestSmartUnionWithDefaults:

--- a/pydantic-core/tests/validators/test_union.py
+++ b/pydantic-core/tests/validators/test_union.py
@@ -10,7 +10,7 @@ from dirty_equals import IsFloat, IsInt
 
 from pydantic_core import CoreConfig, SchemaError, SchemaValidator, ValidationError, core_schema
 
-from ..conftest import PyAndJson, plain_repr
+from ..conftest import plain_repr
 
 
 @pytest.mark.parametrize(
@@ -856,42 +856,6 @@ class TestSmartUnionWithSubclass:
         assert isinstance(validator.validate_python({'a': '1', 'b': '2'}), self.ModelB)
         assert isinstance(validator.validate_python({'a': '1', 'b': 2}), self.ModelB)
         assert isinstance(validator.validate_python({'a': 1, 'b': '2'}), self.ModelB)
-
-
-@pytest.mark.parametrize('extra_behavior', ['ignore', 'allow'])
-@pytest.mark.parametrize('reverse_choices', [False, True])
-def test_smart_union_before_validator_field_count(
-    py_and_json: PyAndJson, extra_behavior: core_schema.ExtraBehavior, reverse_choices: bool
-) -> None:
-    class ModelA:
-        a: int
-        b: int
-
-    class ModelB(ModelA):
-        c: int
-
-    model_a_schema = core_schema.model_schema(
-        ModelA,
-        core_schema.no_info_before_validator_function(
-            lambda value: value,
-            core_schema.model_fields_schema(
-                fields={name: core_schema.model_field(core_schema.int_schema()) for name in ('a', 'b')},
-                extra_behavior=extra_behavior,
-            ),
-        ),
-    )
-    model_b_schema = core_schema.model_schema(
-        ModelB,
-        core_schema.model_fields_schema(
-            fields={name: core_schema.model_field(core_schema.int_schema()) for name in ('a', 'b', 'c')}
-        ),
-    )
-    choices = [model_a_schema, model_b_schema]
-    if reverse_choices:
-        choices.reverse()
-    validator = py_and_json(core_schema.union_schema(choices))
-
-    assert isinstance(validator.validate_test({'a': 1, 'b': 2, 'c': 3}), ModelB)
 
 
 class TestSmartUnionWithDefaults:

--- a/tests/types/unions/test_union.py
+++ b/tests/types/unions/test_union.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import IntEnum
-from typing import Annotated, ClassVar, Literal
+from typing import Annotated, Any, ClassVar, Literal
 from uuid import UUID
 
 import pytest
@@ -14,6 +14,7 @@ from pydantic import (
     Strict,
     TypeAdapter,
     ValidationError,
+    model_validator,
 )
 
 
@@ -233,6 +234,54 @@ def test_union_typeddict():
     ta = TypeAdapter(Dict2 | Dict1)
 
     assert ta.validate_python(dict(foo='baz')) == {'foo': 'baz'}
+
+
+@pytest.mark.parametrize('extra', ['ignore', 'allow'])
+@pytest.mark.parametrize('reverse_members', [False, True])
+def test_smart_union_fields_set_count_consistent_between_json_and_python(
+    extra: Literal['ignore', 'allow'], reverse_members: bool
+) -> None:
+    """https://github.com/pydantic/pydantic/issues/13729"""
+
+    class Smaller(BaseModel):
+        model_config = ConfigDict(extra=extra)
+
+        a: int
+        b: int
+
+        @model_validator(mode='before')
+        @classmethod
+        def keep_input(cls, value: Any) -> Any:
+            return value
+
+    class Larger(BaseModel):
+        a: int
+        b: int
+        c: int
+
+    ta = TypeAdapter(Larger | Smaller if reverse_members else Smaller | Larger)
+
+    assert isinstance(ta.validate_python({'a': 1, 'b': 2, 'c': 3}), Larger)
+    assert isinstance(ta.validate_json('{"a": 1, "b": 2, "c": 3}'), Larger)
+
+
+@pytest.mark.parametrize('reverse_members', [False, True])
+def test_smart_union_fields_set_count_ignores_extra(reverse_members: bool) -> None:
+    """https://github.com/pydantic/pydantic/issues/13729"""
+
+    class WithExtra(BaseModel):
+        model_config = ConfigDict(extra='allow')
+
+        a: int
+
+    class Explicit(BaseModel):
+        a: int
+        b: int
+
+    ta = TypeAdapter(Explicit | WithExtra if reverse_members else WithExtra | Explicit)
+
+    assert isinstance(ta.validate_python({'a': 1, 'b': 2}), Explicit)
+    assert isinstance(ta.validate_json('{"a": 1, "b": 2}'), Explicit)
 
 
 def test_union_respects_local_strict() -> None:


### PR DESCRIPTION
## Change Summary

A model before validator converts JSON input to Python values. The Python-input helper counted supplied fields, then the outer validator counted them again. This let a smaller union member with a before validator outrank a larger member using the plain JSON path.

Count successfully validated, explicitly supplied known fields once in each input-specific helper. Preserve nested counts without counting extra keys or defaults as local fields.

The regression covers Python and JSON input, both union orders, and ignored or allowed extras.

Edit by @Viicos: this also does not count extra fields anymore, this was most likely a regression too and doesn't really make sense. 

## Related issue number

Fixes #13729.

## Checklist

* [x] The pull request title is a good summary of the changes
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable (the documented smart-union ranking is unchanged)
* [x] My PR is ready to review

Prepared with AI assistance.
