### PR TITLE
Handle `PydanticOmit` for definitions referenced more than once

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -306,6 +306,10 @@ class GenerateJsonSchema:
         # store the error raised and re-throw it if we end up needing that def
         self._core_defs_invalid_for_json_schema: dict[DefsRef, PydanticInvalidForJsonSchema] = {}
 
+        # Same idea for definitions that asked to be omitted: the omission has to be re-raised
+        # where the definition is referenced, so the surrounding union or field can drop it.
+        self._core_defs_omitted_from_json_schema: set[DefsRef] = set()
+
         # This changes to True after generating a schema, to prevent issues caused by accidental reuse
         # of a single instance of a schema generator
         self._used = False
@@ -478,6 +482,7 @@ class GenerateJsonSchema:
                 if json_schema.get('$ref', None) != json_ref:
                     self.definitions[defs_ref] = json_schema
                     self._core_defs_invalid_for_json_schema.pop(defs_ref, None)
+                    self._core_defs_omitted_from_json_schema.discard(defs_ref)
                 json_schema = ref_json_schema
             return json_schema
 
@@ -2229,6 +2234,10 @@ class GenerateJsonSchema:
                 core_ref: CoreRef = CoreRef(definition['ref'])  # type: ignore
                 self._core_defs_invalid_for_json_schema[self.get_defs_ref((core_ref, self.mode))] = e
                 continue
+            except PydanticOmit:
+                omitted_ref: CoreRef = CoreRef(definition['ref'])  # type: ignore
+                self._core_defs_omitted_from_json_schema.add(self.get_defs_ref((omitted_ref, self.mode)))
+                continue
         return self.generate_inner(schema['schema'])
 
     def definition_ref_schema(self, schema: core_schema.DefinitionReferenceSchema) -> JsonSchemaValue:
@@ -2241,7 +2250,11 @@ class GenerateJsonSchema:
             The generated JSON schema.
         """
         core_ref = CoreRef(schema['schema_ref'])
-        _, ref_json_schema = self.get_cache_defs_ref_schema(core_ref)
+        defs_ref, ref_json_schema = self.get_cache_defs_ref_schema(core_ref)
+        if defs_ref in self._core_defs_omitted_from_json_schema:
+            # Raise here rather than at the definition, so that whatever holds the reference —
+            # a union member, a field — gets to decide what an omission means for it.
+            raise PydanticOmit
         return ref_json_schema
 
     def ser_schema(

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -29,7 +29,7 @@ from uuid import UUID
 import pytest
 from annotated_types import Interval
 from dirty_equals import HasRepr
-from pydantic_core import CoreSchema, SchemaValidator, core_schema, to_jsonable_python
+from pydantic_core import CoreSchema, PydanticOmit, SchemaValidator, core_schema, to_jsonable_python
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 from typing_extensions import TypeAliasType, TypedDict, deprecated
 
@@ -5981,6 +5981,59 @@ def test_skip_json_schema_exclude_default():
         'title': 'Model',
         'type': 'object',
     }
+
+
+def test_skip_json_schema_referenced_twice() -> None:
+    """https://github.com/pydantic/pydantic/issues/11553"""
+
+    class Inner(BaseModel):
+        x: int
+
+    class Model(BaseModel):
+        first: list[float | SkipJsonSchema[Inner]]
+        second: list[float | SkipJsonSchema[Inner]]
+
+    # Referencing it twice moves `Inner` into the core schema definitions, which used to let the
+    # omission escape instead of dropping the union member.
+    assert Model.model_json_schema() == {
+        'properties': {
+            'first': {'items': {'type': 'number'}, 'title': 'First', 'type': 'array'},
+            'second': {'items': {'type': 'number'}, 'title': 'Second', 'type': 'array'},
+        },
+        'required': ['first', 'second'],
+        'title': 'Model',
+        'type': 'object',
+    }
+
+
+def test_omitted_definition_referenced_twice() -> None:
+    """https://github.com/pydantic/pydantic/issues/11553"""
+
+    class Omitted(BaseModel):
+        @classmethod
+        def __get_pydantic_json_schema__(cls, core_schema, handler):
+            raise PydanticOmit
+
+    class Model(BaseModel):
+        first: list[float | Omitted]
+        second: list[float | Omitted]
+
+    schema = Model.model_json_schema()
+    assert list(schema['properties']) == ['first', 'second']
+    assert schema['properties']['first'] == {
+        'items': {'type': 'number'},
+        'title': 'First',
+        'type': 'array',
+    }
+    assert '$defs' not in schema
+
+    # A field that is nothing but the omitted type is dropped, as it is with a single reference.
+    class WithBareField(BaseModel):
+        kept: int
+        first: Omitted
+        second: Omitted
+
+    assert list(WithBareField.model_json_schema()['properties']) == ['kept']
 
 
 def test_typeddict_field_required_missing() -> None:


### PR DESCRIPTION
## Change Summary

A type that raises `PydanticOmit` from `__get_pydantic_json_schema__` works when it is referenced once and blows up when it is referenced twice, because the second reference makes pydantic-core hoist it into the schema definitions.

`definitions_schema` catches `PydanticInvalidForJsonSchema` while walking the definitions but has nothing for `PydanticOmit`, so the omission escapes `model_json_schema()` entirely. With a single reference there is no definitions entry, the omission is raised inside the union instead, and the handler already in `union_schema` drops that member. Hence the two cases diverging.

This adds the omit counterpart of the machinery that is already there for invalid definitions: record the ref while walking the definitions, then re-raise `PydanticOmit` in `definition_ref_schema`, where whatever holds the reference gets to decide what an omission means for it. The existing handlers in `union_schema` and `_named_required_fields_schema` then behave exactly as they do for a single reference.

## Related issue number

Reported in #11553. No `closes` keyword since I am not assigned to it.

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## How I checked it

`test_omitted_definition_referenced_twice` covers the report: the same omitting type in two union fields, plus two bare fields of that type to check they are dropped the way a single reference is. It fails on `main` with `PydanticOmit()` escaping.

`test_skip_json_schema_referenced_twice` is the same shape through `SkipJsonSchema`. That one already passes on `main` — the workaround suggested in the issue does work now — so it is there to keep the two routes agreeing rather than as a regression test.

Full suite is 5960 passed, and `pyright pydantic`, `ruff check` and `ruff format --check` are clean.
