### PR TITLE
Handle any exception when trying to compute JSON Schema default

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -54,7 +54,7 @@ from ._internal import (
 )
 from .annotated_handlers import GetJsonSchemaHandler
 from .config import JsonDict, JsonValue
-from .errors import PydanticInvalidForJsonSchema, PydanticSchemaGenerationError, PydanticUserError
+from .errors import PydanticInvalidForJsonSchema, PydanticUserError
 
 if TYPE_CHECKING:
     from . import ConfigDict
@@ -2480,12 +2480,14 @@ class GenerateJsonSchema:
                     dft, by_alias=self.by_alias, mode='json'
                 )
             )
-        except PydanticSchemaGenerationError:
-            raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}')
-
-        return pydantic_core.to_jsonable_python(
-            default, timedelta_mode=config.ser_json_timedelta, bytes_mode=config.ser_json_bytes, by_alias=self.by_alias
-        )
+            return pydantic_core.to_jsonable_python(
+                default,
+                timedelta_mode=config.ser_json_timedelta,
+                bytes_mode=config.ser_json_bytes,
+                by_alias=self.by_alias,
+            )
+        except Exception as e:
+            raise pydantic_core.PydanticSerializationError(f'Unable to encode default value {dft}') from e
 
     def update_with_validations(
         self, json_schema: JsonSchemaValue, core_schema: CoreSchema, mapping: dict[str, str]

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1506,23 +1506,28 @@ def test_byte_size_type():
 
 
 @pytest.mark.parametrize(
-    'type_,default_value,properties',
+    ['type_', 'default_value', 'properties'],
     (
         (
             dict[Any, Any],
             {(lambda x: x): 1},
-            {'callback': {'title': 'Callback', 'type': 'object', 'additionalProperties': True}},
+            {'field': {'title': 'Field', 'type': 'object', 'additionalProperties': True}},
         ),
         (
             int | Callable[[int], int],
             lambda x: x,
-            {'callback': {'title': 'Callback', 'type': 'integer'}},
+            {'field': {'title': 'Field', 'type': 'integer'}},
+        ),
+        (
+            bytes,
+            b'\xff\xfe',
+            {'field': {'title': 'Field', 'format': 'binary', 'type': 'string'}},
         ),
     ),
 )
 def test_non_serializable_default(type_, default_value, properties):
     class Model(BaseModel):
-        callback: type_ = default_value
+        field: type_ = default_value
 
     with pytest.warns(
         PydanticJsonSchemaWarning,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Replaces https://github.com/pydantic/pydantic/pull/13416. Generally, there's an issue with `dump_python()` with `mode='json'`, as several exceptions are just raised as is instead of being reraised as a `PydanticSerializationError`:

```python
>>> TypeAdapter(bytes).dump_json(b'\xff\xfe')
  pydantic_core._pydantic_core.PydanticSerializationError: Error serializing to JSON: invalid utf-8 sequence of 1 bytes from index 0
>>> TypeAdapter(bytes).dump_python(b'\xff\xfe', mode='json')
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid utf-8
```

But even if this were to be fixed, we can still in theory encounter any exception when serializing (even though we try very hard not to).

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
