### PR TITLE
fix(json_schema): emit minItems/minProperties for deque, Counter, OrderedDict length constraints

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -256,13 +256,20 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while True:
+                    if inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
+                        inner_schema = inner_schema['schema']  # type: ignore
+                    elif inner_schema['type'] == 'lax-or-strict':
+                        inner_schema = inner_schema['lax_schema']  # type: ignore
+                    elif inner_schema['type'] == 'json-or-python':
+                        inner_schema = inner_schema['json_schema']  # type: ignore
+                    else:
+                        break
                 inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
-                ):
+                if inner_schema_type in {'list', 'set', 'frozenset', 'tuple', 'generator'}:
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type in {'dict', 'typed-dict', 'frozendict'}:
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -7474,3 +7474,55 @@ def test_nested_model_deduplication() -> None:
     assert 'Level1' in definitions
     assert 'Level1-Input' not in definitions
     assert 'Level1-Output' not in definitions
+
+
+def test_container_length_constraints_json_schema() -> None:
+    from collections import Counter, OrderedDict, deque
+
+    class DequeModel(BaseModel):
+        items: deque[int] = Field(min_length=2, max_length=5)
+
+    assert DequeModel.model_json_schema() == {
+        'properties': {
+            'items': {'items': {'type': 'integer'}, 'maxItems': 5, 'minItems': 2, 'title': 'Items', 'type': 'array'},
+        },
+        'required': ['items'],
+        'title': 'DequeModel',
+        'type': 'object',
+    }
+
+    class CounterModel(BaseModel):
+        items: Counter[str] = Field(min_length=1, max_length=10)
+
+    assert CounterModel.model_json_schema() == {
+        'properties': {
+            'items': {
+                'additionalProperties': {'type': 'integer'},
+                'maxProperties': 10,
+                'minProperties': 1,
+                'title': 'Items',
+                'type': 'object',
+            },
+        },
+        'required': ['items'],
+        'title': 'CounterModel',
+        'type': 'object',
+    }
+
+    class OrderedDictModel(BaseModel):
+        items: OrderedDict[str, int] = Field(min_length=1)
+
+    assert OrderedDictModel.model_json_schema() == {
+        'properties': {
+            'items': {
+                'additionalProperties': {'type': 'integer'},
+                'minProperties': 1,
+                'title': 'Items',
+                'type': 'object',
+            },
+        },
+        'required': ['items'],
+        'title': 'OrderedDictModel',
+        'type': 'object',
+    }
+


### PR DESCRIPTION
Fixes #13704

### Selected Reviewer
@Viicos or @sydney-runkle

### Description
When `min_length` / `max_length` constraints are applied to container types like `deque`, `Counter`, or `OrderedDict`, they are wrapped in `lax-or-strict` schemas before reaching `function-wrap` / `function-after`.
Previously, `_known_annotated_metadata.py` did not unwrap `lax-or-strict` / `json-or-python` wrappers when inspecting the inner schema type, causing these container types to fall through to the string constraint branch and emit `minLength` / `maxLength` instead of the appropriate JSON Schema keywords.

### Changes
- Updated `apply_known_metadata()` in `pydantic/_internal/_known_annotated_metadata.py` to unwrap `lax-or-strict` and `json-or-python` schemas.
- Mapped sequence/array container types (`list`, `set`, `frozenset`, `tuple`, `generator`) to `minItems` / `maxItems`.
- Mapped mapping/dict container types (`dict`, `typed-dict`, `frozendict`) to `minProperties` / `maxProperties`.
- Added tests in `tests/test_json_schema.py` verifying JSON Schema generation for `deque`, `Counter`, and `OrderedDict`.