### PR TITLE
Use `contentEncoding`/`contentMediaType` instead of `format: binary` for `bytes` JSON Schema

### DIFF
--- a/docs/plugins/schema_mappings.toml
+++ b/docs/plugins/schema_mappings.toml
@@ -198,11 +198,11 @@ format = "regex"
 [bytes]
 py_type = "bytes"
 json_type = "string"
-defined_in = "OpenAPI"
-notes = ""
+defined_in = "JSON Schema Validation"
+notes = "`\"contentEncoding\": \"base64\"` is also added if `ser_json_bytes` (in serialization mode) or `val_json_bytes` (in validation mode) is set to `'base64'`."
 
 [bytes.additional]
-format = "binary"
+contentMediaType = "application/octet-stream"
 
 [Decimal]
 py_type = "Decimal"

--- a/docs/why.md
+++ b/docs/why.md
@@ -314,7 +314,7 @@ Pydantic provides four ways to create schemas and perform validation and seriali
     {
         'properties': {
             'when': {'format': 'date-time', 'title': 'When', 'type': 'string'},
-            'where': {'format': 'binary', 'title': 'Where', 'type': 'string'},
+            'where': {'contentMediaType': 'application/octet-stream', 'title': 'Where', 'type': 'string'},
             'why': {'title': 'Why', 'type': 'string'},
         },
         'required': ['when', 'where'],

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -818,7 +818,10 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        json_schema = {'type': 'string', 'format': 'base64url' if self._config.ser_json_bytes == 'base64' else 'binary'}
+        json_schema: JsonSchemaValue = {'type': 'string', 'contentMediaType': 'application/octet-stream'}
+        bytes_mode = self._config.val_json_bytes if self.mode == 'validation' else self._config.ser_json_bytes
+        if bytes_mode == 'base64':
+            json_schema['contentEncoding'] = 'base64'
         self.update_with_validations(json_schema, schema, self.ValidationsMapping.bytes)
         return json_schema
 

--- a/pydantic/types.py
+++ b/pydantic/types.py
@@ -2432,6 +2432,15 @@ class EncoderProtocol(Protocol):
         """
         ...
 
+    @classmethod
+    def get_content_encoding(cls) -> str | None:
+        """Get the JSON Schema `contentEncoding` value for the encoded data.
+
+        Returns:
+            The content encoding, or `None` if no `contentEncoding` keyword should be set.
+        """
+        ...
+
 
 class Base64Encoder(EncoderProtocol):
     """Standard (non-URL-safe) Base64 encoder."""
@@ -2469,6 +2478,15 @@ class Base64Encoder(EncoderProtocol):
 
         Returns:
             The JSON format for the encoded data.
+        """
+        return 'base64'
+
+    @classmethod
+    def get_content_encoding(cls) -> Literal['base64']:
+        """Get the JSON Schema `contentEncoding` value for the encoded data.
+
+        Returns:
+            The content encoding for the encoded data.
         """
         return 'base64'
 
@@ -2520,6 +2538,15 @@ class Base64UrlEncoder(EncoderProtocol):
 
         Returns:
             The JSON format for the encoded data.
+        """
+        return 'base64url'
+
+    @classmethod
+    def get_content_encoding(cls) -> Literal['base64url']:
+        """Get the JSON Schema `contentEncoding` value for the encoded data.
+
+        Returns:
+            The content encoding for the encoded data.
         """
         return 'base64url'
 
@@ -2586,6 +2613,9 @@ class EncodedBytes:
     ) -> JsonSchemaValue:
         field_schema = handler(core_schema)
         field_schema.update(type='string', format=self.encoder.get_json_format())
+        content_encoding = self.encoder.get_content_encoding()
+        if content_encoding is not None:
+            field_schema['contentEncoding'] = content_encoding
         return field_schema
 
     def __get_pydantic_core_schema__(self, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
@@ -2685,6 +2715,9 @@ class EncodedStr:
     ) -> JsonSchemaValue:
         field_schema = handler(core_schema)
         field_schema.update(type='string', format=self.encoder.get_json_format())
+        content_encoding = self.encoder.get_content_encoding()
+        if content_encoding is not None:
+            field_schema['contentEncoding'] = content_encoding
         return field_schema
 
     def __get_pydantic_core_schema__(self, source: type[Any], handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -558,7 +558,7 @@ def test_decimal_json_schema():
 
     assert model_json_schema_validation == {
         'properties': {
-            'a': {'default': 'foobar', 'format': 'binary', 'title': 'A', 'type': 'string'},
+            'a': {'contentMediaType': 'application/octet-stream', 'default': 'foobar', 'title': 'A', 'type': 'string'},
             'b': {
                 'anyOf': [
                     {'type': 'number'},
@@ -576,7 +576,7 @@ def test_decimal_json_schema():
     }
     assert model_json_schema_serialization == {
         'properties': {
-            'a': {'default': 'foobar', 'format': 'binary', 'title': 'A', 'type': 'string'},
+            'a': {'contentMediaType': 'application/octet-stream', 'default': 'foobar', 'title': 'A', 'type': 'string'},
             'b': {
                 'default': '12.34',
                 'title': 'B',
@@ -970,13 +970,29 @@ def test_complex_types():
         (str | None, {'properties': {'a': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'title': 'A'}}}),
         (
             bytes | None,
-            {'properties': {'a': {'title': 'A', 'anyOf': [{'type': 'string', 'format': 'binary'}, {'type': 'null'}]}}},
+            {
+                'properties': {
+                    'a': {
+                        'title': 'A',
+                        'anyOf': [
+                            {'type': 'string', 'contentMediaType': 'application/octet-stream'},
+                            {'type': 'null'},
+                        ],
+                    }
+                }
+            },
         ),
         (
             str | bytes,
             {
                 'properties': {
-                    'a': {'title': 'A', 'anyOf': [{'type': 'string'}, {'type': 'string', 'format': 'binary'}]}
+                    'a': {
+                        'title': 'A',
+                        'anyOf': [
+                            {'type': 'string'},
+                            {'type': 'string', 'contentMediaType': 'application/octet-stream'},
+                        ],
+                    }
                 },
             },
         ),
@@ -986,7 +1002,11 @@ def test_complex_types():
                 'properties': {
                     'a': {
                         'title': 'A',
-                        'anyOf': [{'type': 'string'}, {'type': 'string', 'format': 'binary'}, {'type': 'null'}],
+                        'anyOf': [
+                            {'type': 'string'},
+                            {'type': 'string', 'contentMediaType': 'application/octet-stream'},
+                            {'type': 'null'},
+                        ],
                     }
                 }
             },
@@ -1091,6 +1111,8 @@ def test_secret_types(field_type, inner_type):
         'properties': {'a': {'title': 'A', 'type': inner_type, 'writeOnly': True, 'format': 'password'}},
         'required': ['a'],
     }
+    if field_type is SecretBytes:
+        base_schema['properties']['a']['contentMediaType'] = 'application/octet-stream'
 
     assert Model.model_json_schema() == base_schema
 
@@ -1981,8 +2003,29 @@ def test_model_default_timedelta(ser_json_timedelta: Literal['float', 'iso8601']
 @pytest.mark.parametrize(
     'ser_json_bytes,properties',
     [
-        ('base64', {'data': {'default': 'Zm9vYmFy', 'format': 'base64url', 'title': 'Data', 'type': 'string'}}),
-        ('utf8', {'data': {'default': 'foobar', 'format': 'binary', 'title': 'Data', 'type': 'string'}}),
+        (
+            'base64',
+            {
+                'data': {
+                    'default': 'Zm9vYmFy',
+                    'contentEncoding': 'base64',
+                    'contentMediaType': 'application/octet-stream',
+                    'title': 'Data',
+                    'type': 'string',
+                }
+            },
+        ),
+        (
+            'utf8',
+            {
+                'data': {
+                    'contentMediaType': 'application/octet-stream',
+                    'default': 'foobar',
+                    'title': 'Data',
+                    'type': 'string',
+                }
+            },
+        ),
     ],
 )
 def test_model_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], properties: dict[str, Any]):
@@ -2022,8 +2065,29 @@ def test_dataclass_default_timedelta(ser_json_timedelta: Literal['float', 'iso86
 @pytest.mark.parametrize(
     'ser_json_bytes,properties',
     [
-        ('base64', {'data': {'default': 'Zm9vYmFy', 'format': 'base64url', 'title': 'Data', 'type': 'string'}}),
-        ('utf8', {'data': {'default': 'foobar', 'format': 'binary', 'title': 'Data', 'type': 'string'}}),
+        (
+            'base64',
+            {
+                'data': {
+                    'default': 'Zm9vYmFy',
+                    'contentEncoding': 'base64',
+                    'contentMediaType': 'application/octet-stream',
+                    'title': 'Data',
+                    'type': 'string',
+                }
+            },
+        ),
+        (
+            'utf8',
+            {
+                'data': {
+                    'contentMediaType': 'application/octet-stream',
+                    'default': 'foobar',
+                    'title': 'Data',
+                    'type': 'string',
+                }
+            },
+        ),
     ],
 )
 def test_dataclass_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], properties: dict[str, Any]):
@@ -2063,8 +2127,29 @@ def test_typeddict_default_timedelta(ser_json_timedelta: Literal['float', 'iso86
 @pytest.mark.parametrize(
     'ser_json_bytes,properties',
     [
-        ('base64', {'data': {'default': 'Zm9vYmFy', 'format': 'base64url', 'title': 'Data', 'type': 'string'}}),
-        ('utf8', {'data': {'default': 'foobar', 'format': 'binary', 'title': 'Data', 'type': 'string'}}),
+        (
+            'base64',
+            {
+                'data': {
+                    'default': 'Zm9vYmFy',
+                    'contentEncoding': 'base64',
+                    'contentMediaType': 'application/octet-stream',
+                    'title': 'Data',
+                    'type': 'string',
+                }
+            },
+        ),
+        (
+            'utf8',
+            {
+                'data': {
+                    'contentMediaType': 'application/octet-stream',
+                    'default': 'foobar',
+                    'title': 'Data',
+                    'type': 'string',
+                }
+            },
+        ),
     ],
 )
 def test_typeddict_default_bytes(ser_json_bytes: Literal['base64', 'utf8'], properties: dict[str, Any]):
@@ -2146,7 +2231,7 @@ def test_docstring(docstring, description):
         ({'max_length': 5}, str, {'type': 'string', 'maxLength': 5}),
         ({}, constr(max_length=6), {'type': 'string', 'maxLength': 6}),
         ({'min_length': 2}, str, {'type': 'string', 'minLength': 2}),
-        ({'max_length': 5}, bytes, {'type': 'string', 'maxLength': 5, 'format': 'binary'}),
+        ({'max_length': 5}, bytes, {'contentMediaType': 'application/octet-stream', 'type': 'string', 'maxLength': 5}),
         ({'pattern': '^foo$'}, str, {'type': 'string', 'pattern': '^foo$'}),
         ({'gt': 2}, int, {'type': 'integer', 'exclusiveMinimum': 2}),
         ({'lt': 5}, int, {'type': 'integer', 'exclusiveMaximum': 5}),
@@ -2250,7 +2335,7 @@ def test_constraints_schema_validation(kwargs, type_, expected_extra):
         ({'max_length': 5}, str, {'type': 'string', 'maxLength': 5}),
         ({}, constr(max_length=6), {'type': 'string', 'maxLength': 6}),
         ({'min_length': 2}, str, {'type': 'string', 'minLength': 2}),
-        ({'max_length': 5}, bytes, {'type': 'string', 'maxLength': 5, 'format': 'binary'}),
+        ({'max_length': 5}, bytes, {'contentMediaType': 'application/octet-stream', 'type': 'string', 'maxLength': 5}),
         ({'pattern': '^foo$'}, str, {'type': 'string', 'pattern': '^foo$'}),
         ({'gt': 2}, int, {'type': 'integer', 'exclusiveMinimum': 2}),
         ({'lt': 5}, int, {'type': 'integer', 'exclusiveMaximum': 5}),
@@ -2420,10 +2505,16 @@ def test_schema_dict_constr():
 @pytest.mark.parametrize(
     'field_type,expected_schema',
     [
-        # (ConstrainedBytes, {'title': 'A', 'type': 'string', 'format': 'binary'}),
+        # (ConstrainedBytes, {'title': 'A', 'type': 'string', 'contentMediaType': 'application/octet-stream'}),
         (
             conbytes(min_length=3, max_length=5),
-            {'title': 'A', 'type': 'string', 'format': 'binary', 'minLength': 3, 'maxLength': 5},
+            {
+                'title': 'A',
+                'contentMediaType': 'application/octet-stream',
+                'type': 'string',
+                'minLength': 3,
+                'maxLength': 5,
+            },
         ),
     ],
 )
@@ -4814,12 +4905,20 @@ def test_secrets_schema(secret_cls, field_kw, schema_kw):
     class Foobar(BaseModel):
         password: secret_cls = Field(**field_kw)
 
+    expected_password_schema = {
+        'title': 'Password',
+        'type': 'string',
+        'writeOnly': True,
+        'format': 'password',
+        **schema_kw,
+    }
+    if secret_cls is SecretBytes:
+        expected_password_schema['contentMediaType'] = 'application/octet-stream'
+
     assert Foobar.model_json_schema() == {
         'title': 'Foobar',
         'type': 'object',
-        'properties': {
-            'password': {'title': 'Password', 'type': 'string', 'writeOnly': True, 'format': 'password', **schema_kw}
-        },
+        'properties': {'password': expected_password_schema},
         'required': ['password'],
     }
 

--- a/tests/test_type_adapter.py
+++ b/tests/test_type_adapter.py
@@ -558,7 +558,10 @@ def test_ta_config_with_annotated_type() -> None:
 def test_ta_config_used_for_json_schema() -> None:
     """https://github.com/pydantic/pydantic/issues/13675"""
     ta = TypeAdapter(list[bytes], config=ConfigDict(ser_json_bytes='base64'))
-    assert ta.json_schema() == {'type': 'array', 'items': {'type': 'string', 'format': 'base64url'}}
+    assert ta.json_schema(mode='serialization') == {
+        'type': 'array',
+        'items': {'type': 'string', 'contentMediaType': 'application/octet-stream', 'contentEncoding': 'base64'},
+    }
 
 
 def defer_build_test_models(config: ConfigDict) -> list[Any]:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1418,15 +1418,24 @@ def test_base64(field_type, input_data, expected_value, serialized_data):
         'base64_value_or_none': None,
     }
 
+    if field_type is Base64Bytes:
+        base64_schema = {
+            'contentEncoding': 'base64',
+            'contentMediaType': 'application/octet-stream',
+            'format': 'base64',
+            'type': 'string',
+        }
+    else:
+        base64_schema = {'contentEncoding': 'base64', 'format': 'base64', 'type': 'string'}
+
     assert Model.model_json_schema() == {
         'properties': {
             'base64_value': {
-                'format': 'base64',
+                **base64_schema,
                 'title': 'Base64 Value',
-                'type': 'string',
             },
             'base64_value_or_none': {
-                'anyOf': [{'type': 'string', 'format': 'base64'}, {'type': 'null'}],
+                'anyOf': [base64_schema, {'type': 'null'}],
                 'default': None,
                 'title': 'Base64 Value Or None',
             },
@@ -1511,15 +1520,24 @@ def test_base64url(field_type, input_data, expected_value, serialized_data):
         'base64url_value_or_none': None,
     }
 
+    if field_type is Base64UrlBytes:
+        base64url_schema = {
+            'contentEncoding': 'base64url',
+            'contentMediaType': 'application/octet-stream',
+            'format': 'base64url',
+            'type': 'string',
+        }
+    else:
+        base64url_schema = {'contentEncoding': 'base64url', 'format': 'base64url', 'type': 'string'}
+
     assert Model.model_json_schema() == {
         'properties': {
             'base64url_value': {
-                'format': 'base64url',
+                **base64url_schema,
                 'title': 'Base64Url Value',
-                'type': 'string',
             },
             'base64url_value_or_none': {
-                'anyOf': [{'type': 'string', 'format': 'base64url'}, {'type': 'null'}],
+                'anyOf': [base64url_schema, {'type': 'null'}],
                 'default': None,
                 'title': 'Base64Url Value Or None',
             },

--- a/tests/types/test_path.py
+++ b/tests/types/test_path.py
@@ -69,7 +69,12 @@ def test_path_like_extra_subtype():
     assert Model.model_json_schema() == {
         'properties': {
             'str_type': {'format': 'path', 'title': 'Str Type', 'type': 'string'},
-            'byte_type': {'format': 'path', 'title': 'Byte Type', 'type': 'string'},
+            'byte_type': {
+                'contentMediaType': 'application/octet-stream',
+                'format': 'path',
+                'title': 'Byte Type',
+                'type': 'string',
+            },
             'any_type': {'format': 'path', 'title': 'Any Type', 'type': 'string'},
         },
         'required': ['str_type', 'byte_type', 'any_type'],


### PR DESCRIPTION
Closes #13737.

`"format": "binary"` for `bytes` comes from OpenAPI 3.0.x and isn't part of the JSON Schema Validation vocabulary. This switches to the JSON Schema keywords `contentMediaType` (always `application/octet-stream`) and `contentEncoding` (set to `base64`/`base64url` when the relevant `val_json_bytes`/`ser_json_bytes` config is `'base64'`).

This follows the same approach already sketched by @tiangolo on the `vp/bytes-contentencoding` branch linked from the issue — reimplemented here, rebased on current `main`, with updated tests and docs.

`EncodedBytes`/`EncodedStr` (and therefore `Base64Bytes`/`Base64Str`/`Base64UrlBytes`/`Base64UrlStr`) gain an optional `contentEncoding` via a new `EncoderProtocol.get_content_encoding()` hook, keeping their existing `format` for backwards compatibility.

All existing tests pass with expectations updated accordingly; ruff lint/format are clean.