### PR TITLE
fix(json-schema): emit correct keywords for deque, Counter, OrderedDict

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -256,13 +256,26 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while inner_schema['type'] in {
+                    'function-before',
+                    'function-wrap',
+                    'function-after',
+                    'lax-or-strict',
+                }:
+                    if inner_schema['type'] == 'lax-or-strict':
+                        inner_schema = inner_schema['lax_schema']  # type: ignore
+                    else:
+                        inner_schema = inner_schema['schema']  # type: ignore
                 inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
-                ):
+                json_or_python_inner = (
+                    inner_schema['json_schema']['type']  # type: ignore
+                    if inner_schema_type == 'json-or-python'
+                    else None
+                )
+                if inner_schema_type == 'list' or json_or_python_inner == 'list':
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type == 'dict' or json_or_python_inner == 'dict':
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4,7 +4,7 @@ import math
 import re
 import sys
 import typing
-from collections import deque
+from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -6908,6 +6908,35 @@ def test_ta_and_bm_same_json_schema() -> None:
 def test_min_and_max_in_schema() -> None:
     TSeq = TypeAdapter(Annotated[Sequence[int], Field(min_length=2, max_length=5)])
     assert TSeq.json_schema() == {'items': {'type': 'integer'}, 'maxItems': 5, 'minItems': 2, 'type': 'array'}
+
+
+def test_deque_min_max_in_schema() -> None:
+    ta = TypeAdapter(Annotated[deque[int], Field(min_length=2, max_length=5)])
+    schema = ta.json_schema()
+    assert schema['minItems'] == 2
+    assert schema['maxItems'] == 5
+    assert 'minLength' not in schema
+    assert 'maxLength' not in schema
+
+
+def test_counter_min_max_in_schema() -> None:
+    ta = TypeAdapter(Annotated[Counter[str], Field(min_length=1, max_length=10)])
+    schema = ta.json_schema()
+    assert schema['type'] == 'object'
+    assert schema['minProperties'] == 1
+    assert schema['maxProperties'] == 10
+    assert 'minLength' not in schema
+    assert 'maxLength' not in schema
+
+
+def test_ordered_dict_min_max_in_schema() -> None:
+    ta = TypeAdapter(Annotated[OrderedDict[str, int], Field(min_length=1, max_length=10)])
+    schema = ta.json_schema()
+    assert schema['type'] == 'object'
+    assert schema['minProperties'] == 1
+    assert schema['maxProperties'] == 10
+    assert 'minLength' not in schema
+    assert 'maxLength' not in schema
 
 
 def test_plain_field_validator_serialization() -> None:


### PR DESCRIPTION
Fixes #13704

when you use `min_length`/`max_length` on `deque`, `Counter` or `OrderedDict`, the json schema emits `minLength`/`maxLength` (string keywords) insted of the correct ones like `minItems`/`maxItems` for lists or `minProperties`/`maxProperties` for dicts.

the problem is in `apply_known_metadata` — theres a loop that unwraps function wrappers to find the inner schema type, but it didnt handle `lax-or-strict` wrappers. `deque`, `Counter`, `OrderedDict` all use lax-or-strict internally so the unwrap stopped early and fell through to the string keyword branch.

fix: added `lax-or-strict` to the unwrap loop (follows `lax_schema` path) and also made the `json-or-python` check work for dict types not just list.

tested with deque, Counter, OrderedDict — all emit correct keywords now.