### PR TITLE
Report string-only constraints applied to `bytes` instead of silently ignoring them

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -66,13 +66,24 @@ URL_CONSTRAINTS = {
 }
 
 TEXT_SCHEMA_TYPES = ('str', 'bytes', 'url', 'multi-host-url')
+# The schema types that accept the string-only constraints in `STR_CONSTRAINTS`.
+# `bytes` is deliberately absent: the `bytes` validator implements none of them, so
+# listing it here made `pattern`, `to_lower`, `to_upper`, `strip_whitespace`,
+# `coerce_numbers_to_str` and `ascii_only` silent no-ops on `bytes` fields.
+# `BYTES_CONSTRAINTS` is what `bytes` accepts.
+STR_SCHEMA_TYPES = ('str', 'url', 'multi-host-url')
+# Schema types whose validated value must not be re-validated as a string. The fallback in
+# `apply_known_metadata()` chains a `str_schema(...)` step to enforce a string-only constraint,
+# but in lax mode that step decodes `bytes` to `str`, which would silently change the type of
+# the field. These constraints have no meaning for `bytes`, so report them instead.
+CHAIN_INCOMPATIBLE_SCHEMA_TYPES = frozenset({'bytes'})
 SEQUENCE_SCHEMA_TYPES = ('list', 'tuple', 'set', 'frozenset', 'generator', *TEXT_SCHEMA_TYPES)
 NUMERIC_SCHEMA_TYPES = ('float', 'int', 'date', 'time', 'timedelta', 'datetime')
 
 CONSTRAINTS_TO_ALLOWED_SCHEMAS: dict[str, set[str]] = defaultdict(set)
 
 constraint_schema_pairings: list[tuple[set[str], tuple[str, ...]]] = [
-    (STR_CONSTRAINTS, TEXT_SCHEMA_TYPES),
+    (STR_CONSTRAINTS, STR_SCHEMA_TYPES),
     (BYTES_CONSTRAINTS, ('bytes',)),
     (LIST_CONSTRAINTS, ('list',)),
     (TUPLE_CONSTRAINTS, ('tuple',)),
@@ -228,7 +239,7 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
             continue
 
         #  else, apply a function after validator to the schema to enforce the corresponding constraint
-        if constraint in chain_schema_constraints:
+        if constraint in chain_schema_constraints and schema_type not in CHAIN_INCOMPATIBLE_SCHEMA_TYPES:
 
             def _apply_constraint_with_incompatibility_info(
                 value: Any, handler: cs.ValidatorFunctionWrapHandler

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -16,6 +16,7 @@ from pydantic import (
     Field,
     GetCoreSchemaHandler,
     PydanticUserError,
+    StringConstraints,
     TypeAdapter,
     ValidationError,
 )
@@ -614,6 +615,38 @@ def test_incompatible_metadata_error() -> None:
     ta = TypeAdapter(Annotated[list[int], Field(pattern='abc')])
     with pytest.raises(TypeError, match="Unable to apply constraint 'pattern'"):
         ta.validate_python([1, 2, 3])
+
+
+@pytest.mark.parametrize(
+    'constraint',
+    [
+        {'pattern': 'abc'},
+        {'strip_whitespace': True},
+        {'to_lower': True},
+        {'to_upper': True},
+        {'ascii_only': True},
+    ],
+)
+def test_str_only_metadata_on_bytes_is_reported(constraint: dict[str, Any]) -> None:
+    """String-only constraints have no `bytes` implementation, so they must be reported, not ignored."""
+    (name,) = constraint
+    with pytest.raises(RuntimeError, match=f"Unable to apply constraint '{name}' to schema of type 'bytes'"):
+        TypeAdapter(Annotated[bytes, StringConstraints(**constraint)])
+
+
+@pytest.mark.parametrize(
+    'constraint,valid,invalid',
+    [
+        ({'min_length': 2}, b'ab', b'a'),
+        ({'max_length': 2}, b'ab', b'abc'),
+        ({'strict': True}, b'ab', 'ab'),
+    ],
+)
+def test_bytes_metadata_still_applies(constraint: dict[str, Any], valid: bytes, invalid: Any) -> None:
+    ta = TypeAdapter(Annotated[bytes, StringConstraints(**constraint)])
+    assert ta.validate_python(valid) == valid
+    with pytest.raises(ValidationError):
+        ta.validate_python(invalid)
 
 
 def test_compatible_metadata_raises_correct_validation_error() -> None:


### PR DESCRIPTION
## Change Summary

`Annotated[bytes, StringConstraints(pattern=...)]` (and `to_lower`, `to_upper`, `strip_whitespace`, `ascii_only`) builds without complaint and then validates nothing:

```python
TypeAdapter(Annotated[bytes, StringConstraints(pattern='^ZZZZ$')]).validate_python(b'abcde')
#> b'abcde'          # on main; the same annotation on `str` raises string_pattern_mismatch
```

`CONSTRAINTS_TO_ALLOWED_SCHEMAS` pairs `STR_CONSTRAINTS` with `TEXT_SCHEMA_TYPES`, which contains `'bytes'`, so the constraint is written onto the `bytes` core schema — which implements none of them — and dropped. The constraint is also absent from the emitted JSON Schema, so nothing downstream shows it either.

The fix pairs `STR_CONSTRAINTS` with the schema types that implement them, so these fall through to the existing report path: `RuntimeError: Unable to apply constraint 'pattern' to schema of type 'bytes'`, the same message `Annotated[list[int], Field(pattern='abc')]` already produces. `min_length`, `max_length` and `strict` on `bytes` are unaffected — they come from `BYTES_CONSTRAINTS`.

- **The one-line version of this fix is not enough, and I checked.** With only the pairing changed, these route into the `str_schema(...)` chain fallback, which in lax mode *decodes* bytes: `to_lower` on a `bytes` field then returns `'abc'` — a `str`. `ascii_only` gives `TypeError: str_schema() got an unexpected keyword argument 'ascii_only'`. Hence the second half of the change. Run against the added tests, that one-line variant fails 5 of them.
- **Origin.** `TEXT_SCHEMA_TYPES` arrived in #5883 as the dispatch list for *length* constraints, where `bytes` belongs; #6951 reused it as the allow-list for *all* string constraints while, three lines later, giving `bytes` its own narrower `BYTES_CONSTRAINTS` loop. Two answers to "what does `bytes` accept" in one file, and the wider one wins by union.
- **Why the suite doesn't catch it.** `test_invalid_schema_constraints` is the table for exactly this class of mistake, and it has rows for `int`, `list[int]`, `set`, `frozenset`, `Decimal` and `float` — no `bytes` row. Across `tests/`, `StringConstraints` and `bytes` never appear together.
- **Left alone:** `min_length` is likewise declared for `'url'`/`'multi-host-url'`, which don't implement it, but it isn't reachable through the public URL types (their schema is `function-wrap`, so it takes the functional-validator path and works).

Behaviour change: code that passes one of these constraints on a `bytes` field gets an error where it previously got silence. That code was already not being validated.

## Related issue number

None — I didn't find an existing issue for this (searched open and closed). Happy to open one first if you'd prefer that order.

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

---

Tests: 6011 passed / 851 skipped / 28 xfailed, against 6003 / 851 / 28 on an unmodified checkout in the same env (the 8 are the added cases). Reverting only the source change fails 5 of them. `ruff check` and `ruff format --check` clean at the locked 0.15.10.

Drafted with AI assistance (Claude Opus 5, `claude-opus-5`). Every number above was measured on this branch, not estimated.
