### PR TITLE
Fix duplicate word 'it it' in fields docstring

### DIFF
--- a/pydantic/v1/fields.py
+++ b/pydantic/v1/fields.py
@@ -539,7 +539,7 @@ class ModelField(Representation):
         Prepare the field but inspecting self.default, self.type_ etc.
 
         Note: this method is **not** idempotent (because _type_analysis is not idempotent),
-        e.g. calling it it multiple times may modify the field and configure it incorrectly.
+        e.g. calling it multiple times may modify the field and configure it incorrectly.
         """
         self._set_default_and_type()
         if self.type_.__class__ is ForwardRef or self.type_.__class__ is DeferredType:


### PR DESCRIPTION
## Change Summary

Fix a duplicate word in the `ModelField.prepare` docstring in `pydantic/v1/fields.py`: "calling it it multiple times" → "calling it multiple times".

This file is the pydantic v1 compatibility layer shipped in v2 (`pydantic.v1`), so the fix applies to the v2 branch.

## Related issue number

N/A — trivial docs typo (explicitly welcomed per CONTRIBUTING: "Unless your change is trivial (typo, docs tweak etc.)...").

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**

## Verification

- `git diff --check` — clean
- `python3 -m py_compile pydantic/v1/fields.py` — OK (docstring-only change)
- Diff: 1 file, 1 line changed (1 insertion, 1 deletion)
- Grep for `it it` in the file — no remaining matches
