### PR TITLE
Use the field name in serialization JSON schemas when serialize_by_alias is False

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1618,11 +1618,11 @@ class GenerateJsonSchema:
 
     def _get_alias_name(self, field: CoreSchemaField, name: str) -> str:
         if field['type'] == 'computed-field':
-            alias: Any = field.get('alias', name)
+            alias: Any = name if not self._config.serialize_by_alias else field.get('alias', name)
         elif self.mode == 'validation':
             alias = name if not self._config.validate_by_alias else field.get('validation_alias', name)
         else:
-            alias = field.get('serialization_alias', name)
+            alias = name if not self._config.serialize_by_alias else field.get('serialization_alias', name)
         if isinstance(alias, str):
             name = alias
         elif isinstance(alias, list):

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -146,8 +146,8 @@ def test_validate_by_alias_false_uses_the_field_name():
         my_field: str = Field(alias='myAlias')
 
     assert list(Model.model_json_schema()['properties']) == ['my_field']
-    # Serialization is governed by `serialize_by_alias`, which this leaves alone:
-    assert list(Model.model_json_schema(mode='serialization')['properties']) == ['myAlias']
+    # Serialization is governed by `serialize_by_alias` (default `False`), so the field name is used:
+    assert list(Model.model_json_schema(mode='serialization')['properties']) == ['my_field']
 
     @pydantic.dataclasses.dataclass(config=ConfigDict(validate_by_alias=False, validate_by_name=True))
     class Dataclass:
@@ -171,6 +171,63 @@ def test_validate_by_alias_false_is_scoped_to_its_own_model():
     assert list(json_schema['$defs']['Inner']['properties']) == ['inner_field']
 
     assert Outer.model_validate({'outerAlias': 'x', 'inner': {'inner_field': 'y'}}).outer_field == 'x'
+
+
+def test_serialize_by_alias_false_uses_the_field_name():
+    class Model(BaseModel):
+        model_config = ConfigDict(serialize_by_alias=False)
+        my_field: str = Field(serialization_alias='myAlias')
+
+    assert list(Model.model_json_schema(mode='serialization')['properties']) == ['my_field']
+    # Validation mode is unaffected (there is no validation alias, so the field name is used):
+    assert list(Model.model_json_schema()['properties']) == ['my_field']
+
+    @pydantic.dataclasses.dataclass(config=ConfigDict(serialize_by_alias=False))
+    class Dataclass:
+        my_field: str = Field(serialization_alias='myAlias')
+
+    adapter = TypeAdapter(Dataclass)
+    assert list(adapter.json_schema(mode='serialization')['properties']) == ['my_field']
+
+
+def test_serialize_by_alias_false_applies_to_plain_alias_and_computed_fields():
+    class Model(BaseModel):
+        my_field: str = Field(alias='myAlias')
+
+        @computed_field(alias='computedAlias')
+        @property
+        def computed(self) -> str:
+            return 'v'
+
+    assert list(Model.model_json_schema(mode='serialization')['properties']) == ['my_field', 'computed']
+    assert list(Model.model_validate({'myAlias': 'x'}).model_dump().keys()) == ['my_field', 'computed']
+
+
+def test_serialize_by_alias_true_uses_the_serialization_alias():
+    class Model(BaseModel):
+        model_config = ConfigDict(serialize_by_alias=True)
+        my_field: str = Field(serialization_alias='myAlias')
+
+        @computed_field(alias='computedAlias')
+        @property
+        def computed(self) -> str:
+            return 'v'
+
+    assert list(Model.model_json_schema(mode='serialization')['properties']) == ['myAlias', 'computedAlias']
+
+
+def test_serialize_by_alias_false_is_scoped_to_its_own_model():
+    class Inner(BaseModel):
+        model_config = ConfigDict(serialize_by_alias=False)
+        inner_field: str = Field(serialization_alias='innerAlias')
+
+    class Outer(BaseModel):
+        outer_field: str = Field(serialization_alias='outerAlias')
+        inner: Inner
+
+    json_schema = Outer.model_json_schema(mode='serialization')
+    assert list(json_schema['properties']) == ['outer_field', 'inner']
+    assert list(json_schema['$defs']['Inner']['properties']) == ['inner_field']
 
 
 def test_ref_template():
@@ -3429,11 +3486,11 @@ def test_mode_name_causes_no_conflict():
             'OrganizationOutput': {'properties': {}, 'title': 'OrganizationOutput', 'type': 'object'},
         },
         'properties': {
-            'x_serialization': {'$ref': '#/$defs/Organization'},
+            'x': {'$ref': '#/$defs/Organization'},
             'y': {'$ref': '#/$defs/OrganizationInput'},
             'z': {'$ref': '#/$defs/OrganizationOutput'},
         },
-        'required': ['x_serialization', 'y', 'z'],
+        'required': ['x', 'y', 'z'],
         'title': 'Model',
         'type': 'object',
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

With `serialize_by_alias=False` (the default since v2.11), `model_dump()` emits the field name, but `model_json_schema(mode='serialization')` still keyed the properties by the `serialization_alias`, so the serialization schema named keys the model would never emit. This keys serialization schemas by the field name when `serialize_by_alias` is `False`, and keeps the alias when it is `True`, so the serialization schema matches the actual `model_dump()` output.

This is the serialization-side mirror of #13717 (which fixed the same mismatch for the validation schema via `validate_by_alias`). The fix gates the serialization branch of `GenerateJsonSchema._get_alias_name()` on `self._config.serialize_by_alias`, and applies the same gate to the computed-field branch (which uses `field.get('alias', name)`).

## Related issue number

fix #13754

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
