### PR TITLE
fix: valid JSON schema propertyNames for non-string enum dict keys

### DIFF
--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1175,7 +1175,21 @@ class GenerateJsonSchema:
         else:  # for `dict[str, Any]`, we allow any key and any value, since `str` is the default key type
             json_schema['additionalProperties'] = True
 
+        keys_core_schema = schema.get('keys_schema')
         if (
+            keys_core_schema is not None
+            and keys_core_schema['type'] == 'enum'
+            and keys_core_schema.get('sub_type') != 'str'
+        ):
+            # JSON object keys are always strings, and pydantic serializes a non-string enum
+            # key to the string form of its value, so `propertyNames` must describe those
+            # stringified values instead of referencing the (non-string) enum schema.
+            json_schema['propertyNames'] = {
+                'enum': [
+                    str(member.value if isinstance(member, Enum) else member) for member in keys_core_schema['members']
+                ]
+            }
+        elif (
             # The len check indicates that constraints are probably present:
             (keys_schema.get('type') == 'string' and len(keys_schema) > 1)
             # If this is a definition reference schema, it most likely has constraints:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1894,6 +1894,35 @@ def test_enum_dict():
     }
 
 
+def test_enum_dict_non_string_keys():
+    # https://github.com/pydantic/pydantic/issues/11967
+    # JSON object keys are always strings, so a non-string enum used as a dict key must be
+    # described in `propertyNames` by the string form of its values, not the integer enum schema.
+    class MyEnum(IntEnum):
+        FOO = 1
+        BAR = 2
+
+    class MyModel(BaseModel):
+        enum_dict: dict[MyEnum, str]
+
+    assert MyModel.model_json_schema() == {
+        'title': 'MyModel',
+        'type': 'object',
+        'properties': {
+            'enum_dict': {
+                'title': 'Enum Dict',
+                'type': 'object',
+                'additionalProperties': {'type': 'string'},
+                'propertyNames': {'enum': ['1', '2']},
+            }
+        },
+        'required': ['enum_dict'],
+    }
+
+    dumped = MyModel(enum_dict={MyEnum.FOO: 'a', MyEnum.BAR: 'b'}).model_dump(mode='json')
+    assert set(dumped['enum_dict']) == {'1', '2'}
+
+
 def test_property_names_constraint():
     class MyModel(BaseModel):
         my_dict: dict[Annotated[str, StringConstraints(max_length=1)], str]


### PR DESCRIPTION
## Change Summary

A `dict` keyed by a non-string enum generated an invalid JSON schema. `propertyNames` referenced the enum definition, so for an `IntEnum` (or any enum whose values are not strings) the schema constrained object keys to `type: integer`. JSON object keys are always strings, and pydantic serializes such a key to the string form of its value (`IntEnum` member `1` becomes `"1"`), so the schema did not match pydantic's own serialization.

This describes `propertyNames` with the stringified enum values instead. For example, `dict[SomeIntEnum, float]` now produces `"propertyNames": {"enum": ["1", "2"]}`. String enums are unaffected: their `$ref` schema is already valid, so behavior there is unchanged.

## Related issue number

fix #11967

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
