### PR TITLE
Apply `multiple_of` natively for temporal core schemas in the pipeline API

### DIFF
--- a/pydantic/experimental/pipeline.py
+++ b/pydantic/experimental/pipeline.py
@@ -485,6 +485,8 @@ _ORDERING_SCHEMA_TYPES = frozenset({'int', 'float', 'decimal', 'fraction', 'date
 _LENGTH_SCHEMA_TYPES = frozenset(
     {'str', 'bytes', 'list', 'tuple', 'set', 'frozenset', 'dict', 'frozendict', 'generator'}
 )
+# Core schema types with native support for the `multiple_of` constraint:
+_MULTIPLE_OF_SCHEMA_TYPES = frozenset({'int', 'float', 'decimal', 'date', 'time', 'datetime', 'timedelta'})
 
 
 def _apply_constraint(  # noqa: C901
@@ -561,7 +563,7 @@ def _apply_constraint(  # noqa: C901
             s = _check_func(check_len, predicate_err, s)
     elif isinstance(constraint, annotated_types.MultipleOf):
         multiple_of = constraint.multiple_of
-        if s and s['type'] in {'int', 'float', 'decimal'}:
+        if s and s['type'] in _MULTIPLE_OF_SCHEMA_TYPES:
             s = s.copy()
             s['multiple_of'] = multiple_of  # pyright: ignore[reportGeneralTypeIssues]
         else:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,7 +13,7 @@ import pytest
 import pytz
 from annotated_types import Interval, Len
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import Field, TypeAdapter, ValidationError
 from pydantic.experimental.pipeline import _Pipeline, transform, validate_as  # pyright: ignore[reportPrivateUsage]
 
 
@@ -131,6 +131,16 @@ def test_ge_le_gt_lt(
             [Decimal('1.5'), Decimal('3.0'), Decimal('4.5')],
             [Decimal('1.4'), Decimal('2.1')],
         ),
+        # Temporal core schemas accept the `multiple_of` key, which `pydantic-core` does not
+        # enforce. The constraint must still be applied natively rather than falling back to a
+        # Python predicate, which never holds for `timedelta` (`timedelta(0) == 0` is `False`).
+        # `date`, `time` and `datetime` are covered by `test_multiple_of_temporal_parity()`.
+        (
+            datetime.timedelta,
+            validate_as(datetime.timedelta).multiple_of(datetime.timedelta(seconds=5)),
+            [datetime.timedelta(seconds=10), datetime.timedelta(seconds=7)],
+            [],
+        ),
     ],
 )
 def test_parse_multipleOf(type_: Any, pipeline: Any, valid_cases: list[Any], invalid_cases: list[Any]) -> None:
@@ -140,6 +150,29 @@ def test_parse_multipleOf(type_: Any, pipeline: Any, valid_cases: list[Any], inv
     for y in invalid_cases:
         with pytest.raises(ValueError):
             ta.validate_python(y)
+
+
+@pytest.mark.parametrize(
+    'type_, multiple_of, value',
+    [
+        (datetime.timedelta, datetime.timedelta(seconds=5), datetime.timedelta(seconds=10)),
+        (datetime.timedelta, datetime.timedelta(seconds=5), datetime.timedelta(seconds=7)),
+        (datetime.date, 2, datetime.date(2020, 1, 1)),
+        (datetime.time, 2, datetime.time(1, 0, 0)),
+        (datetime.datetime, 2, datetime.datetime(2020, 1, 1)),
+    ],
+)
+def test_multiple_of_temporal_parity(type_: Any, multiple_of: Any, value: Any) -> None:
+    """The pipeline API must apply `multiple_of` to temporal types as the `Field()` API does.
+
+    Previously the constraint fell back to a Python predicate evaluating `v % multiple_of == 0`,
+    which is never true for `timedelta` (`timedelta(0) == 0` is `False`) and raises `TypeError`
+    for `date`, `time` and `datetime`.
+    """
+    field_ta = TypeAdapter[Any](Annotated[type_, Field(multiple_of=multiple_of)])
+    pipeline_ta = TypeAdapter[Any](Annotated[type_, validate_as(type_).multiple_of(multiple_of)])
+
+    assert pipeline_ta.validate_python(value) == field_ta.validate_python(value) == value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Change Summary

In the pipeline API, `multiple_of()` is broken for every temporal type: `timedelta` rejects **every** value including exact multiples, and `date`/`time`/`datetime` raise a bare `TypeError` that escapes instead of a `ValidationError`.

`_apply_constraint()` applied `multiple_of` natively only for a hardcoded `{'int', 'float', 'decimal'}`, so temporal types fell through to the Python predicate `v % multiple_of == 0`. That predicate cannot work for them:

* `timedelta(seconds=10) % timedelta(seconds=5)` is `timedelta(0)`, and `timedelta(0) == 0` is `False` in Python, so the check never holds for any input.
* `date`, `time` and `datetime` do not support `%` at all, so the predicate raises `TypeError: unsupported operand type(s) for %`.

#13659 generalised exactly this pattern for the other constraints in the same function, introducing `_ORDERING_SCHEMA_TYPES` and `_LENGTH_SCHEMA_TYPES`, both covering the temporal types. `MultipleOf` was left on its old hardcoded set.

This adds `_MULTIPLE_OF_SCHEMA_TYPES`, whose members are exactly the schema types that pydantic already records as accepting the constraint:

```python
>>> from pydantic._internal._known_annotated_metadata import CONSTRAINTS_TO_ALLOWED_SCHEMAS
>>> sorted(CONSTRAINTS_TO_ALLOWED_SCHEMAS['multiple_of'])
['date', 'datetime', 'decimal', 'float', 'int', 'time', 'timedelta']
```

`fraction` is correctly absent there and stays on the predicate path: `fraction_schema()` takes no `multiple_of` argument, and `Fraction` supports `%` correctly.

### Behaviour after the change

The pipeline API now agrees with `Field(multiple_of=...)` for every type, which is the position taken in #13564 (the pipeline API should match the non-experimental API):

| annotation | before | after | `Field(multiple_of=...)` |
|---|---|---|---|
| `int` / `float` / `Decimal` | `multiple_of` error | unchanged | `multiple_of` error |
| `Fraction` | predicate check | unchanged | n/a |
| `timedelta` | **rejects everything** | accepts | accepts |
| `date` / `time` / `datetime` | **uncaught `TypeError`** | accepts | accepts |

Worth calling out explicitly: this makes `multiple_of` a silent no-op on temporal types, because `pydantic-core` accepts the key but does not enforce it there — which is precisely what `Field(multiple_of=...)` already does today. I deliberately scoped this to removing the divergence rather than adding enforcement; enforcing it would be a `pydantic-core` change and a separate discussion. Happy to follow up there if you'd prefer that instead.

No existing behaviour can regress: the previous path was unconditionally broken for these types, so there is no working behaviour to lose.

### Verification

* New tests fail without the fix and pass with it.
* Full suite passes (the one unrelated failure, `test_generic_model_pickle_different_module`, reproduces identically on unmodified `main` here).
* `ruff check` / `ruff format --check` clean; `pyright pydantic` unchanged from baseline.
* Schemas verified to build under a strict `SchemaValidator`, and the emitted JSON Schema is identical to the `Field()` equivalent for every type.

## Related issue number

Related to #13764 (I am not assigned, so this intentionally avoids a closing reference — please feel free to close this in favour of assigning the issue first if that suits your process better).

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
