### PR TITLE
Fix than/that typo and sharpen `ConfigDict` docs anchor targets

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -1734,4 +1734,4 @@ print(f'{id(c1.arr) == id(c2.arr)=}')
 !!! note
     There are some situations where Pydantic does not copy attributes, such as when passing models &mdash; we use the
     model as is. You can override this behaviour by setting
-    [`model_config['revalidate_instances'] = 'always'`](../api/config.md#pydantic.config.ConfigDict).
+    [`model_config['revalidate_instances'] = 'always'`](../api/config.md#pydantic.config.ConfigDict.revalidate_instances).

--- a/docs/concepts/validators.md
+++ b/docs/concepts/validators.md
@@ -608,7 +608,7 @@ Both the field and model validators callables (in all modes) can optionally take
 ### Validation data
 
 For field validators, the already validated data can be accessed using the [`data`][pydantic.ValidationInfo.data]
-property. Here is an example than can be used as an alternative to the [*after* model validator](#model-after-validator)
+property. Here is an example that can be used as an alternative to the [*after* model validator](#model-after-validator)
 example:
 
 ```python

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -326,7 +326,7 @@ like `class MyModel(Model1, Model2)`, the non-default settings in the `model_con
 will be merged, and for any settings defined in both, those from `Model2` will override those from `Model1`.
 
 * The following config settings have been removed:
-    * `allow_mutation` — this has been removed. You should be able to use [frozen](api/config.md#pydantic.config.ConfigDict) equivalently (inverse of current use).
+    * `allow_mutation` — this has been removed. You should be able to use [`frozen`](api/config.md#pydantic.config.ConfigDict.frozen) equivalently (inverse of current use).
     * `error_msg_templates`
     * `fields` — this was the source of various bugs, so has been removed.
       You should be able to use `Annotated` on fields to modify them as desired.


### PR DESCRIPTION
Three small docs fixes:

1. `docs/concepts/validators.md`: "an example **than** can be used" → "**that**".
2. `docs/migration.md`: the `allow_mutation` migration bullet linked the whole `ConfigDict` class anchor while recommending the `frozen` key; repointed at `#pydantic.config.ConfigDict.frozen`.
3. `docs/concepts/models.md`: the `revalidate_instances` link went to the class top; repointed at `#pydantic.config.ConfigDict.revalidate_instances` (both key anchors follow the exact per-key convention already used in the same docs, e.g. `#pydantic.config.ConfigDict.regex_engine`).