### PR TITLE
Prefer exact types in smart union serialization

### DIFF
--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -86,6 +86,8 @@ Because of the potentially surprising results of `union_mode='left_to_right'`, i
 
 In this mode, pydantic attempts to select the best match for the input from the union members. The exact algorithm may change between Pydantic minor releases to allow for improvements in both performance and accuracy.
 
+The same `union_mode` is used for serialization. In `smart` mode, if no union member matches during strict serialization, the lax retry prefers members whose type exactly matches the value (for example a `Child` instance against `Parent | Child`) over isinstance/base-class matches. This avoids serializing a subclass as its parent and dropping subclass-only fields.
+
 !!! note
 
     We reserve the right to tweak the internal `smart` matching algorithm in future versions of Pydantic. If you rely on very specific

--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -2809,8 +2809,11 @@ def union_schema(
         custom_error_message: The custom error message to use if the validation fails
         custom_error_context: The custom error context to use if the validation fails
         mode: How to select which choice to return
-            * `smart` (default) will try to return the choice which is the closest match to the input value
+            * `smart` (default) will try to return the choice which is the closest match to the input value.
+              For serialization, this prefers exact type matches (for example the exact model or dataclass
+              class) over isinstance/base-class matches when retrying in lax mode.
             * `left_to_right` will return the first choice in `choices` which succeeds validation
+              (and, for serialization, the first choice which succeeds in schema order)
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema

--- a/pydantic-core/src/serializers/polymorphism_trampoline.rs
+++ b/pydantic-core/src/serializers/polymorphism_trampoline.rs
@@ -91,4 +91,8 @@ impl TypeSerializer for PolymorphismTrampoline {
     fn retry_with_lax_check(&self) -> bool {
         self.serializer.retry_with_lax_check()
     }
+
+    fn exact_type_match(&self, value: &Bound<'_, PyAny>) -> bool {
+        value.get_type().is(&self.class)
+    }
 }

--- a/pydantic-core/src/serializers/prebuilt.rs
+++ b/pydantic-core/src/serializers/prebuilt.rs
@@ -75,4 +75,8 @@ impl TypeSerializer for PrebuiltSerializer {
     fn retry_with_lax_check(&self) -> bool {
         self.schema_serializer.get().serializer.retry_with_lax_check()
     }
+
+    fn exact_type_match(&self, value: &Bound<'_, PyAny>) -> bool {
+        self.schema_serializer.get().serializer.exact_type_match(value)
+    }
 }

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -446,6 +446,14 @@ pub(crate) trait TypeSerializer: Send + Sync + Debug {
         false
     }
 
+    /// Whether this serializer's expected type exactly matches `value`'s runtime type.
+    ///
+    /// Used by smart union serialization during the Lax retry to prefer exact
+    /// model/dataclass class matches over isinstance/base-class matches.
+    fn exact_type_match(&self, _value: &Bound<'_, PyAny>) -> bool {
+        false
+    }
+
     fn get_default(&self, _py: Python) -> PyResult<Option<Py<PyAny>>> {
         Ok(None)
     }

--- a/pydantic-core/src/serializers/type_serializers/dataclass.rs
+++ b/pydantic-core/src/serializers/type_serializers/dataclass.rs
@@ -206,6 +206,10 @@ impl TypeSerializer for DataclassSerializer {
     fn retry_with_lax_check(&self) -> bool {
         true
     }
+
+    fn exact_type_match(&self, value: &Bound<'_, PyAny>) -> bool {
+        value.get_type().is(self.class.bind(value.py()))
+    }
 }
 
 fn known_dataclass_iter<'a, 'py>(

--- a/pydantic-core/src/serializers/type_serializers/definitions.rs
+++ b/pydantic-core/src/serializers/type_serializers/definitions.rs
@@ -116,4 +116,8 @@ impl TypeSerializer for DefinitionRefSerializer {
             .retry_with_lax_check
             .get_or_init(|| self.definition.read(|s| s.unwrap().retry_with_lax_check()), &false)
     }
+
+    fn exact_type_match(&self, value: &Bound<'_, PyAny>) -> bool {
+        self.definition.read(|s| s.unwrap().exact_type_match(value))
+    }
 }

--- a/pydantic-core/src/serializers/type_serializers/model.rs
+++ b/pydantic-core/src/serializers/type_serializers/model.rs
@@ -292,4 +292,8 @@ impl TypeSerializer for ModelSerializer {
     fn retry_with_lax_check(&self) -> bool {
         true
     }
+
+    fn exact_type_match(&self, value: &Bound<'_, PyAny>) -> bool {
+        value.get_type().is(&self.class)
+    }
 }

--- a/pydantic-core/src/serializers/type_serializers/nullable.rs
+++ b/pydantic-core/src/serializers/type_serializers/nullable.rs
@@ -74,4 +74,8 @@ impl TypeSerializer for NullableSerializer {
     fn retry_with_lax_check(&self) -> bool {
         self.serializer.retry_with_lax_check()
     }
+
+    fn exact_type_match(&self, value: &Bound<'_, PyAny>) -> bool {
+        self.serializer.exact_type_match(value)
+    }
 }

--- a/pydantic-core/src/serializers/type_serializers/union.rs
+++ b/pydantic-core/src/serializers/type_serializers/union.rs
@@ -1,6 +1,6 @@
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyTuple};
+use pyo3::types::{PyDict, PyList, PyString, PyTuple};
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -20,10 +20,18 @@ use super::{
     BuildSerializer, CombinedSerializer, SerCheck, TypeSerializer, infer_json_key, infer_serialize, infer_to_python,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum UnionMode {
+    #[default]
+    Smart,
+    LeftToRight,
+}
+
 #[derive(Debug)]
 pub struct UnionSerializer {
     choices: UnionChoices,
     name: String,
+    mode: UnionMode,
 }
 
 impl BuildSerializer for UnionSerializer {
@@ -51,6 +59,14 @@ impl BuildSerializer for UnionSerializer {
             FromChoicesOutput::Multiple(m) => m,
         };
 
+        let mode = schema
+            .get_as::<Bound<'_, PyString>>(intern!(py, "mode"))?
+            .map_or(Ok(UnionMode::Smart), |mode| match mode.to_str()? {
+                "smart" => Ok(UnionMode::Smart),
+                "left_to_right" => Ok(UnionMode::LeftToRight),
+                s => py_schema_err!("Invalid union mode: `{s}`, expected `smart` or `left_to_right`"),
+            })?;
+
         let descr = choices
             .choices
             .iter()
@@ -61,6 +77,7 @@ impl BuildSerializer for UnionSerializer {
         Ok(CombinedSerializer::Union(Self {
             choices,
             name: format!("Union[{descr}]"),
+            mode,
         })
         .into())
     }
@@ -71,7 +88,12 @@ impl_py_gc_traverse!(UnionSerializer { choices });
 impl TypeSerializer for UnionSerializer {
     fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         self.choices
-            .serialize(|comb_serializer, state| comb_serializer.to_python(value, state), state)?
+            .serialize(
+                value,
+                self.mode,
+                |comb_serializer, state| comb_serializer.to_python(value, state),
+                state,
+            )?
             .map_or_else(|| infer_to_python(value, state), Ok)
     }
 
@@ -81,7 +103,12 @@ impl TypeSerializer for UnionSerializer {
         state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
         self.choices
-            .serialize(|comb_serializer, state| comb_serializer.json_key(key, state), state)?
+            .serialize(
+                key,
+                self.mode,
+                |comb_serializer, state| comb_serializer.json_key(key, state),
+                state,
+            )?
             .map_or_else(|| infer_json_key(key, state), Ok)
     }
 
@@ -91,10 +118,12 @@ impl TypeSerializer for UnionSerializer {
         serializer: S,
         state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
-        match self
-            .choices
-            .serialize(|comb_serializer, state| comb_serializer.to_python(value, state), state)
-        {
+        match self.choices.serialize(
+            value,
+            self.mode,
+            |comb_serializer, state| comb_serializer.to_python(value, state),
+            state,
+        ) {
             Ok(Some(v)) => {
                 let state = &mut state.scoped_include_exclude(IncludeExclude::empty());
                 infer_serialize(v.bind(value.py()), serializer, state)
@@ -275,7 +304,7 @@ impl TaggedUnionSerializer {
             if in_top_level_union(state) {
                 register_tagged_union_fallback_warning(value, state);
             }
-            return self.choices.serialize(selector, state);
+            return self.choices.serialize(value, UnionMode::Smart, selector, state);
         };
 
         // Try a first pass with the appropriate checking level
@@ -354,9 +383,16 @@ impl UnionChoices {
         self.choices.iter().any(|c| c.retry_with_lax_check())
     }
 
-    /// Try to serialize using the union choices from left to right
+    /// Try to serialize using the union choices.
+    ///
+    /// Strict pass is always left-to-right. For the Lax retry:
+    /// - `smart` (default): prefer choices whose type exactly matches `value`
+    ///   (e.g. exact model/dataclass class) before isinstance/base-class matches.
+    /// - `left_to_right`: keep trying choices in schema order.
     fn serialize<'py, S>(
         &self,
+        value: &Bound<'py, PyAny>,
+        mode: UnionMode,
         mut selector: impl FnMut(&CombinedSerializer, &mut SerializationState<'py>) -> PyResult<S>,
         state: &mut SerializationState<'py>,
     ) -> PyResult<Option<S>> {
@@ -385,7 +421,20 @@ impl UnionChoices {
         // otherwise, in a top level union, we retry with lax checking if any choice supports it
         if self.retry_with_lax_check() {
             let state = &mut scoped_check_level(state, SerCheck::Lax);
+            let prefer_exact_type = mode == UnionMode::Smart;
+            if prefer_exact_type {
+                for comb_serializer in &self.choices {
+                    if comb_serializer.exact_type_match(value)
+                        && let Ok(v) = selector(comb_serializer, state)
+                    {
+                        return Ok(Some(v));
+                    }
+                }
+            }
             for comb_serializer in &self.choices {
+                if prefer_exact_type && comb_serializer.exact_type_match(value) {
+                    continue;
+                }
                 if let Ok(v) = selector(comb_serializer, state) {
                     return Ok(Some(v));
                 }

--- a/pydantic-core/src/serializers/type_serializers/with_default.rs
+++ b/pydantic-core/src/serializers/type_serializers/with_default.rs
@@ -68,6 +68,10 @@ impl TypeSerializer for WithDefaultSerializer {
         self.serializer.retry_with_lax_check()
     }
 
+    fn exact_type_match(&self, value: &Bound<'_, PyAny>) -> bool {
+        self.serializer.exact_type_match(value)
+    }
+
     fn get_default(&self, py: Python) -> PyResult<Option<Py<PyAny>>> {
         if let DefaultType::DefaultFactory(_, _takes_data @ true) = self.default {
             // We currently don't compute the default if the default factory takes

--- a/pydantic-core/tests/serializers/test_union.py
+++ b/pydantic-core/tests/serializers/test_union.py
@@ -1116,3 +1116,86 @@ def test_discriminated_union_ser_with_typed_dict() -> None:
 
     assert v.to_python({'type': 'a', 'a': 1}, warnings='error') == {'type': 'a', 'a': 1}
     assert v.to_python({'type': 'b', 'b': 'foo'}, warnings='error') == {'type': 'b', 'b': 'foo'}
+
+
+def test_union_smart_prefers_exact_model_type_with_int_as_float_field():
+    """https://github.com/pydantic/pydantic/issues/12099
+
+    Child with an inherited ``a: float`` field holding an int fails Strict float
+    serialization. The Lax retry must prefer the exact Child class over Parent's
+    isinstance match, otherwise Child-only fields are dropped.
+    """
+
+    class Parent:
+        def __init__(self, a=0):
+            self.a = a
+
+    class Child(Parent):
+        def __init__(self, a=0, b=0):
+            super().__init__(a)
+            self.b = b
+
+    parent_schema = core_schema.model_schema(
+        Parent,
+        core_schema.model_fields_schema(
+            {
+                'a': core_schema.model_field(core_schema.float_schema()),
+            }
+        ),
+    )
+    child_schema = core_schema.model_schema(
+        Child,
+        core_schema.model_fields_schema(
+            {
+                'a': core_schema.model_field(core_schema.float_schema()),
+                'b': core_schema.model_field(core_schema.int_schema()),
+            }
+        ),
+    )
+
+    s = SchemaSerializer(core_schema.union_schema([parent_schema, child_schema]))
+    child = Child(a=0, b=3)
+    assert s.to_python(child) == {'a': 0, 'b': 3}
+    assert json.loads(s.to_json(child)) == {'a': 0.0, 'b': 3}
+    assert s.to_python(Parent(a=1.5)) == {'a': 1.5}
+
+    s_ltr = SchemaSerializer(core_schema.union_schema([parent_schema, child_schema], mode='left_to_right'))
+    # left-to-right Lax still picks Parent first via isinstance and drops ``b``
+    assert s_ltr.to_python(child) == {'a': 0}
+
+
+def test_union_smart_prefers_exact_dataclass_type_with_int_as_float_field():
+    """Same as the model case in #12099, for dataclasses."""
+
+    @dataclasses.dataclass
+    class Parent:
+        a: float = 0
+
+    @dataclasses.dataclass
+    class Child(Parent):
+        b: int = 0
+
+    parent_schema = core_schema.dataclass_schema(
+        Parent,
+        core_schema.dataclass_args_schema(
+            'Parent',
+            [core_schema.dataclass_field(name='a', schema=core_schema.float_schema())],
+        ),
+        ['a'],
+    )
+    child_schema = core_schema.dataclass_schema(
+        Child,
+        core_schema.dataclass_args_schema(
+            'Child',
+            [
+                core_schema.dataclass_field(name='a', schema=core_schema.float_schema()),
+                core_schema.dataclass_field(name='b', schema=core_schema.int_schema()),
+            ],
+        ),
+        ['a', 'b'],
+    )
+
+    s = SchemaSerializer(core_schema.union_schema([parent_schema, child_schema]))
+    child = Child(a=0, b=3)
+    assert s.to_python(child) == {'a': 0, 'b': 3}
+    assert json.loads(s.to_json(child)) == {'a': 0.0, 'b': 3}

--- a/pydantic/fields.py
+++ b/pydantic/fields.py
@@ -1421,7 +1421,7 @@ def Field(  # noqa: C901
         allow_inf_nan: Allow `inf`, `-inf`, `nan`. Only applicable to float and [`Decimal`][decimal.Decimal] numbers.
         max_digits: Maximum number of allowed digits for [`Decimal`][decimal.Decimal] numbers.
         decimal_places: Maximum number of decimal places allowed for numbers.
-        union_mode: The strategy to apply when validating a union. Can be `smart` (the default), or `left_to_right`.
+        union_mode: The strategy to apply when validating or serializing a union. Can be `smart` (the default), or `left_to_right`.
             See [Union Mode](../concepts/unions.md#union-modes) for details.
         fail_fast: If `True`, validation will stop on the first error. If `False`, all validation errors will be collected.
             This option can be applied only to iterable types (list, tuple, set, and frozenset).

--- a/tests/types/unions/test_union.py
+++ b/tests/types/unions/test_union.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABC, abstractmethod
 from enum import IntEnum
 from typing import Annotated, Any, ClassVar, Literal
@@ -324,3 +325,38 @@ def test_union_abc() -> None:
 
     X(x=a1)
     X(x=a2)
+
+
+def test_union_serialization_prefers_exact_subclass_with_int_float_default() -> None:
+    """https://github.com/pydantic/pydantic/issues/12099
+
+    ``Parent | Child`` must serialize a Child instance as Child even when Parent has
+    ``a: float = 0`` (int default). Strict float serialization rejects that int, and
+    the Lax retry must not pick Parent first via isinstance (which drops Child-only fields).
+    """
+
+    class Parent(BaseModel):
+        a: float = 0
+
+    class Child(Parent):
+        b: int
+
+    class Container(BaseModel):
+        union: Parent | Child
+
+    container = Container(union=Child(b=3))
+    assert container.model_dump() == {'union': {'a': 0.0, 'b': 3}}
+    assert json.loads(container.model_dump_json()) == {'union': {'a': 0.0, 'b': 3}}
+
+    assert Container(union=Parent()).model_dump() == {'union': {'a': 0.0}}
+
+    class ContainerReversed(BaseModel):
+        union: Child | Parent
+
+    assert ContainerReversed(union=Child(b=3)).model_dump() == {'union': {'a': 0.0, 'b': 3}}
+
+    class ContainerLeftToRight(BaseModel):
+        union: Annotated[Parent | Child, Field(union_mode='left_to_right')]
+
+    # left-to-right keeps schema order; Parent still wins via isinstance
+    assert ContainerLeftToRight(union=Child(b=3)).model_dump() == {'union': {'a': 0.0}}


### PR DESCRIPTION
Related to https://github.com/pydantic/pydantic/issues/12099. Smart union serialization prefers exact model/dataclass matches in Lax retry so Child is not serialized as Parent when int-as-float fields fail Strict. Tests fail on unpatched main and pass with this patch. AI-generated; please review.