### PR TITLE
fix: respect MRO when base merely inherits a field or private attribute (#13678)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,8 +525,7 @@ jobs:
       matrix:
         python-version:
           - '3.13'
-          # Segmentation fault on pypy3.11.15 (latest), see https://github.com/pypy/pypy/issues/5400
-          - 'pypy3.11.13'
+          - 'pypy3.11'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -645,8 +644,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Segmentation fault on pypy3.11.15 (latest), see https://github.com/pypy/pypy/issues/5400
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy3.11.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy3.11']
         include:
           # test macos intel just with latest python version
           - os: macos-15-intel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   core-build:
     name: core / Build on ${{ matrix.os }} (${{ matrix.target }} - ${{ matrix.interpreter || 'all' }}${{ matrix.os == 'linux' && format(' - {0}', matrix.manylinux == 'auto' && 'manylinux' || matrix.manylinux) || '' }})
     # only run on push to main, if a full build was requested or on release:
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'full build')
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'full build')
     strategy:
       fail-fast: false
       matrix:
@@ -187,7 +187,7 @@ jobs:
   core-build-pgo:
     name: core / Build PGO-optimized on ${{ matrix.platform.os }} / ${{ matrix.interpreter }}
     # only run on push to main, if a full build was requested or on release:
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'full build')
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'full build')
     strategy:
       fail-fast: false
       matrix:
@@ -559,7 +559,7 @@ jobs:
 
   build-pydantic:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/v')
     outputs:
       pydantic-version: ${{ steps.check-tag.outputs.VERSION }}
 
@@ -882,7 +882,7 @@ jobs:
 
   release-pydantic-core:
     needs: [core-test-builds-arch, core-test-builds-os, core-build-sdist, check]
-    if: needs.check.outputs.result == 'success' && startsWith(github.ref, 'refs/tags/')
+    if: needs.check.outputs.result == 'success' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: release
 
@@ -941,7 +941,7 @@ jobs:
 
   release-pydantic:
     needs: [build-pydantic, release-pydantic-core]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: release
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,5 +44,5 @@ keywords:
   - hints
   - typing
 license: MIT
-version: v2.13.2
-date-released: 2026-04-17
+version: v2.13.3
+date-released: 2026-04-20

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,5 +44,5 @@ keywords:
   - hints
   - typing
 license: MIT
-version: v2.13.3
-date-released: 2026-04-20
+version: v2.13.4
+date-released: 2026-05-06

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,5 +44,5 @@ keywords:
   - hints
   - typing
 license: MIT
-version: v2.13.1
-date-released: 2026-04-15
+version: v2.13.2
+date-released: 2026-04-17

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,5 +44,5 @@ keywords:
   - hints
   - typing
 license: MIT
-version: v2.13.0
-date-released: 2026-04-13
+version: v2.13.1
+date-released: 2026-04-15

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,16 @@
 <!-- markdownlint-disable descriptive-link-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 
+## v2.13.1 (2026-04-15)
+
+[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.1)
+
+### What's Changed
+
+#### Fixes
+
+* Fix `ValidationInfo.data` missing with `model_validate_json()` by @davidhewitt in [#13079](https://github.com/pydantic/pydantic/pull/13079)
+
 ## v2.13.0 (2026-04-13)
 
 [GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.0)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,16 @@
 <!-- markdownlint-disable descriptive-link-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 
+## v2.13.3 (2026-04-20)
+
+[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.3)
+
+### What's Changed
+
+#### Fixes
+
+* Handle `AttributeError` subclasses with `from_attributes` by @Viicos in [#13096](https://github.com/pydantic/pydantic/pull/13096)
+
 ## v2.13.2 (2026-04-17)
 
 [GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.2)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,16 @@
 <!-- markdownlint-disable descriptive-link-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 
+## v2.13.2 (2026-04-17)
+
+[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.2)
+
+### What's Changed
+
+#### Fixes
+
+* Fix `ValidationInfo.field_name` missing with `model_validate_json()` by @Viicos in [#13084](https://github.com/pydantic/pydantic/pull/13084)
+
 ## v2.13.1 (2026-04-15)
 
 [GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.1)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,21 @@
 <!-- markdownlint-disable descriptive-link-text -->
 <!-- markdownlint-disable-next-line first-line-heading -->
 
+## v2.13.4 (2026-05-06)
+
+[GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.4)
+
+### What's Changed
+
+#### Packaging
+
+* Bump libc from 0.2.155 to 0.2.185 by @Viicos in [#13109](https://github.com/pydantic/pydantic/pull/13109)
+* Adapt `pydantic-core` linker flags on macOS by @washingtoneg and @Viicos in [#13147](https://github.com/pydantic/pydantic/pull/13147)
+
+#### Fixes
+
+* Preserve `RootModel` core metadata by @Viicos in [#13129](https://github.com/pydantic/pydantic/pull/13129)
+
 ## v2.13.3 (2026-04-20)
 
 [GitHub release](https://github.com/pydantic/pydantic/releases/tag/v2.13.3)

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,67 +14,25 @@ Pydantic is the most widely used data validation library for Python.
 
 Fast and extensible, Pydantic plays nicely with your linters/IDE/brain. Define how data should be in pure, canonical Python 3.9+; validate it with Pydantic.
 
-!!! logfire "Monitor Pydantic with Pydantic Logfire :fire:"
-    **[Pydantic Logfire](https://pydantic.dev/logfire)** is a production-grade observability platform for AI and general applications. See LLM interactions, agent behavior, API requests, and database queries in one unified trace. With SDKs for Python, JavaScript/TypeScript, and Rust, Logfire works with all OpenTelemetry-compatible languages.
+**Sign up for our newsletter, *The Pydantic Stack*, with updates & tutorials on Pydantic, Logfire, and Pydantic AI:**
 
-    Logfire integrates with many popular Python libraries including FastAPI, OpenAI and Pydantic itself, so you can use Logfire to monitor Pydantic validations and understand why some inputs fail validation:
-
-    ```python {title="Monitoring Pydantic with Logfire" test="skip"}
-    from datetime import datetime
-
-    import logfire
-
-    from pydantic import BaseModel
-
-    logfire.configure()
-    logfire.instrument_pydantic()  # (1)!
-
-
-    class Delivery(BaseModel):
-        timestamp: datetime
-        dimensions: tuple[int, int]
-
-
-    # this will record details of a successful validation to logfire
-    m = Delivery(timestamp='2020-01-02T03:04:05Z', dimensions=['10', '20'])
-    print(repr(m.timestamp))
-    #> datetime.datetime(2020, 1, 2, 3, 4, 5, tzinfo=TzInfo(UTC))
-    print(m.dimensions)
-    #> (10, 20)
-
-    Delivery(timestamp='2020-01-02T03:04:05Z', dimensions=['10'])  # (2)!
-    ```
-
-    1. Set logfire record all both successful and failed validations, use `record='failure'` to only record failed validations, [learn more](https://logfire.pydantic.dev/docs/integrations/pydantic/).
-    2. This will raise a `ValidationError` since there are too few `dimensions`, details of the input data and validation errors will be recorded in Logfire.
-
-    Would give you a view like this in the Logfire platform:
-
-    [![Logfire Pydantic Integration](img/logfire-pydantic-integration.png)](https://logfire.pydantic.dev/docs/guides/web-ui/live/)
-
-    This is just a toy example, but hopefully makes clear the potential value of instrumenting a more complex application.
-
-    **[Learn more about Pydantic Logfire](https://logfire.pydantic.dev/docs/)**
-
-    **Sign up for our newsletter, *The Pydantic Stack*, with updates & tutorials on Pydantic, Logfire, and Pydantic AI:**
-
-      <form method="POST" action="https://eu.customerioforms.com/forms/submit_action?site_id=53d2086c3c4214eaecaa&form_id=14b22611745b458&success_url=https://docs.pydantic.dev/" class="md-typeset" style="display: flex; align-items: center; gap: 0.5rem; max-width: 100%;">
-          <input
-          type="email"
-          id="email_input"
-          name="email"
-          class="md-input md-input--stretch"
-          style="flex: 1; background: var(--md-default-bg-color); color: var(--md-default-fg-color);"
-          required
-          placeholder="Email"
-          data-1p-ignore
-          data-lpignore="true"
-          data-protonpass-ignore="true"
-          data-bwignore="true"
-          />
-          <input type="hidden" id="source_input" name="source" value="pydantic" />
-          <button type="submit" class="md-button md-button--primary">Subscribe</button>
-      </form>
+<form method="POST" action="https://eu.customerioforms.com/forms/submit_action?site_id=53d2086c3c4214eaecaa&form_id=14b22611745b458&success_url=https://docs.pydantic.dev/" class="md-typeset" style="display: flex; align-items: center; gap: 0.5rem; max-width: 100%;">
+    <input
+    type="email"
+    id="email_input"
+    name="email"
+    class="md-input md-input--stretch"
+    style="flex: 1; background: var(--md-default-bg-color); color: var(--md-default-fg-color);"
+    required
+    placeholder="Email"
+    data-1p-ignore
+    data-lpignore="true"
+    data-protonpass-ignore="true"
+    data-bwignore="true"
+    />
+    <input type="hidden" id="source_input" name="source" value="pydantic" />
+    <button type="submit" class="md-button md-button--primary">Subscribe</button>
+</form>
 
 ## Why use Pydantic?
 

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -34,7 +34,16 @@ In all cases we will aim to minimize churn and do so only when justified by the 
 
 ## Pydantic V3 and beyond
 
-We expect to make new major releases roughly once a year going forward, although as mentioned above, any associated breaking changes should be trivial to fix compared to the V1-to-V2 transition.
+Any associated breaking changes in the V3 release will be introduced with care. This will include bug fixes that can't be solved in V2 without introducing a change in behavior
+(e.g. [fixing configuration not following the MRO](https://github.com/pydantic/pydantic/issues/9992)), or changes that don't remove existing functionality or doesn't provide
+proper alternatives.
+
+In V3, it is expected to merged `pydantic-core` as an internal sub-module of Pydantic, meaning it won't be published as a standalone library anymore.
+
+## Tagging conventions
+
+Pydantic uses Git tags to identify all published versions on PyPI (including alpha and beta releases), prefixed with the `v` character. Since v2.13, `pydantic-core`
+has been merged as a workspace member inside the `pydantic` repository, and subsequent `pydantic-core` releases are tagged as `core-vx.y.z`.
 
 ## Experimental Features
 

--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.3"
+version = "2.46.4"
 dependencies = [
  "ahash",
  "base64",

--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "litemap"

--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.2"
+version = "2.46.3"
 dependencies = [
  "ahash",
  "base64",

--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.0"
+version = "2.46.1"
 dependencies = [
  "ahash",
  "base64",

--- a/pydantic-core/Cargo.lock
+++ b/pydantic-core/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.1"
+version = "2.46.2"
 dependencies = [
  "ahash",
  "base64",

--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "2.46.0"
+version = "2.46.1"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic"

--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "2.46.2"
+version = "2.46.3"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic"

--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "2.46.3"
+version = "2.46.4"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic"

--- a/pydantic-core/Cargo.toml
+++ b/pydantic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydantic-core"
-version = "2.46.1"
+version = "2.46.2"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/pydantic/pydantic"

--- a/pydantic-core/build.rs
+++ b/pydantic-core/build.rs
@@ -13,4 +13,13 @@ fn main() {
     }
     println!("cargo:rustc-check-cfg=cfg(specified_profile_use)");
     println!("cargo:rustc-env=PROFILE={}", std::env::var("PROFILE").unwrap());
+
+    // The macOS `ld_prime` new Linker (used in macOS 15 GitHub CI runners),
+    // reserves significantly less Mach-O header padding than the old linker.
+    // Tools like Homebrew use install_name_tool to rewrite dylib paths post-install,
+    // and that requires spare space in the header. Without this flag the relink
+    // fails with "updated load commands do not fit in the header".
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-link-arg=-Wl,-headerpad_max_install_names");
+    }
 }

--- a/pydantic-core/src/lookup_key.rs
+++ b/pydantic-core/src/lookup_key.rs
@@ -3,7 +3,7 @@ use std::convert::Infallible;
 use std::fmt;
 
 use pyo3::IntoPyObjectExt;
-use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::exceptions::{PyAttributeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyList, PyMapping, PyString};
@@ -111,7 +111,7 @@ impl LookupPath {
     }
 
     pub fn simple_py_get_attr<'py>(&self, obj: &Bound<'py, PyAny>) -> PyResult<Option<Bound<'py, PyAny>>> {
-        self.get_impl(obj, PyAnyMethods::getattr_opt, |d, loc| loc.py_get_attrs(&d))
+        self.get_impl(obj, py_get_attrs, |d, loc| loc.py_get_attrs(&d))
     }
 
     pub fn py_get_attr<'py>(
@@ -366,7 +366,7 @@ impl PathItemString {
             // FIXME: should this instance check be for Mapping instead of Dict, and use `mapping_get`?
             Ok(obj.get_item(self).ok())
         } else {
-            obj.getattr_opt(self)
+            py_get_attrs(obj, self)
         }
     }
 }
@@ -452,5 +452,22 @@ impl LookupType {
 
     pub fn matches(self, other: LookupType) -> bool {
         (self as u8 & other as u8) != 0
+    }
+}
+
+// TODO replace with `PyAnyMethods::getattr_opt` once https://github.com/PyO3/pyo3/pull/5985 is merged:
+fn py_get_attrs<'py, N>(obj: &Bound<'py, PyAny>, attr_name: N) -> PyResult<Option<Bound<'py, PyAny>>>
+where
+    N: IntoPyObject<'py, Target = PyString>,
+{
+    match obj.getattr(attr_name) {
+        Ok(attr) => Ok(Some(attr)),
+        Err(err) => {
+            if err.get_type(obj.py()).is_subclass_of::<PyAttributeError>()? {
+                Ok(None)
+            } else {
+                Err(err)
+            }
+        }
     }
 }

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -20,7 +20,7 @@ use crate::lookup_key::LookupPathCollection;
 use crate::lookup_key::LookupType;
 use crate::tools::SchemaDict;
 use crate::tools::new_py_string;
-use crate::validators::shared::lookup_tree::LookupFieldPriority;
+use crate::validators::shared::lookup_tree::LookupFieldInfo;
 use crate::validators::shared::lookup_tree::LookupTree;
 
 use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
@@ -555,17 +555,19 @@ impl ModelFieldsValidator {
 
         let model_dict = PyDict::new(py);
         let mut model_extra_dict_op: Option<Bound<PyDict>> = None;
-        let mut field_results: Vec<Option<(ValResult<Py<PyAny>>, LookupFieldPriority)>> =
+        let mut field_results: Vec<Option<(LookupFieldInfo, &JsonValue)>> =
             (0..self.fields.len()).map(|_| None).collect();
         let mut errors: Vec<ValLineError> = Vec::new();
         let fields_set = PySet::empty(py)?;
+
+        let state = &mut state.rebind_extra(|extra| extra.data = Some(model_dict.clone()));
+        let state = &mut state.scoped_set(|state| &mut state.has_field_error, false);
 
         let model_extra_dict = PyDict::new(py);
         for (key, value) in &**json_object {
             let mut handled = false;
             let key = key.as_ref();
-            let mut matches = self.lookup.iter_matches(key, value);
-            while let Some((field_info, field_value, lookup_path)) = matches.next_match() {
+            for (field_info, field_value) in self.lookup.iter_matches(key, value) {
                 handled = true;
 
                 if !field_info.matches_lookup(lookup_type) {
@@ -575,37 +577,15 @@ impl ModelFieldsValidator {
                 let field_result = &mut field_results[field_info.field_index];
 
                 // later results are preferred unless the existing result has come from a higher priority alias
-                if let Some((_, existing_lookup_priority)) = &field_result
-                    && existing_lookup_priority.is_higher_priority_than(&field_info.lookup_priority)
+                if let Some((existing_field_info, _)) = &field_result
+                    && existing_field_info
+                        .lookup_priority
+                        .is_higher_priority_than(&field_info.lookup_priority)
                 {
                     continue;
                 }
 
-                let field = &self.fields[field_info.field_index];
-
-                let result = field.validator.validate(py, field_value, state).map_err(|e| match e {
-                    ValError::LineErrors(line_errors) => {
-                        // for line errors, apply the actual lookup path used
-                        ValError::LineErrors(
-                            line_errors
-                                .into_iter()
-                                .map(|mut err| {
-                                    if self.loc_by_alias {
-                                        for loc in lookup_path.iter_loc_items().rev() {
-                                            err = err.with_outer_location(loc);
-                                        }
-                                    } else {
-                                        err = err.with_outer_location(field.name.clone());
-                                    }
-                                    err
-                                })
-                                .collect(),
-                        )
-                    }
-                    other => other,
-                });
-
-                *field_result = Some((result, field_info.lookup_priority));
+                *field_result = Some((*field_info, field_value));
             }
 
             if handled {
@@ -649,15 +629,30 @@ impl ModelFieldsValidator {
         // dict, and try to set defaults for any missing fields
 
         for (field, field_result) in std::iter::zip(&self.fields, field_results) {
-            let field_value = if let Some((validation_result, _)) = field_result {
-                match validation_result {
+            let field_value = if let Some((field_info, field_json_value)) = field_result {
+                match field.validator.validate(py, field_json_value, state) {
                     Ok(value) => {
                         fields_set.add(&field.name)?;
                         value
                     }
                     Err(ValError::Omit) => continue,
                     Err(ValError::LineErrors(line_errors)) => {
-                        errors.extend(line_errors);
+                        state.has_field_error = true;
+                        // for line errors, apply the actual lookup path used
+                        errors.extend(line_errors.into_iter().map(|mut err| {
+                            if self.loc_by_alias
+                                && let Some(alias_index) = field_info.alias_index()
+                            {
+                                err = field.lookup_path_collection.by_alias[alias_index].apply_error_loc(
+                                    err,
+                                    self.loc_by_alias,
+                                    &field.name,
+                                );
+                            } else {
+                                err = err.with_outer_location(field.name.clone());
+                            }
+                            err
+                        }));
                         continue;
                     }
                     Err(err) => return Err(err),
@@ -674,6 +669,7 @@ impl ModelFieldsValidator {
                     }
                     Err(ValError::Omit) => continue,
                     Err(ValError::LineErrors(line_errors)) => {
+                        state.has_field_error = true;
                         for err in line_errors {
                             // Note: this will always use the field name even if there is an alias
                             // However, we don't mind so much because this error can only happen if the

--- a/pydantic-core/src/validators/model_fields.rs
+++ b/pydantic-core/src/validators/model_fields.rs
@@ -629,6 +629,8 @@ impl ModelFieldsValidator {
         // dict, and try to set defaults for any missing fields
 
         for (field, field_result) in std::iter::zip(&self.fields, field_results) {
+            let state = &mut state.scoped_set_field_name(Some(field.name.as_py_str().bind(py).clone()));
+
             let field_value = if let Some((field_info, field_json_value)) = field_result {
                 match field.validator.validate(py, field_json_value, state) {
                     Ok(value) => {

--- a/pydantic-core/src/validators/shared/lookup_tree.rs
+++ b/pydantic-core/src/validators/shared/lookup_tree.rs
@@ -5,7 +5,6 @@ use ahash::AHashMap;
 use jiter::{JsonArray, JsonValue};
 use smallvec::SmallVec;
 
-use crate::errors::LocItem;
 use crate::lookup_key::{LookupPath, LookupPathCollection, LookupType, PathItem, PathItemString};
 
 /// A tree of paths for lookups when trying to find fields from input.
@@ -68,7 +67,7 @@ impl LookupTree {
         json_value: &'a JsonValue<'j>,
     ) -> LookupMatchesIter<'a, 'j> {
         let node = self.inner.get(root_key);
-        LookupMatchesIter::new(root_key, node, json_value)
+        LookupMatchesIter::new(node, json_value)
     }
 }
 
@@ -110,6 +109,15 @@ impl LookupFieldInfo {
     /// Whether this lookup should be used for the given lookup type (i.e. when validating by_name / by_alias)
     pub fn matches_lookup(&self, lookup_type: LookupType) -> bool {
         self.lookup_priority.lookup_type.matches(lookup_type)
+    }
+
+    /// The alias index for this lookup, if it is an alias lookup, or `None` if it is a name lookup.
+    pub fn alias_index(&self) -> Option<usize> {
+        if self.lookup_priority.lookup_type == LookupType::Alias {
+            Some(self.lookup_priority.alias_index)
+        } else {
+            None
+        }
     }
 }
 
@@ -182,27 +190,14 @@ fn add_path_to_map(map: &mut AHashMap<PathItemString, LookupTreeNode>, path: &Lo
 /// This isn't a typical `Iterator` because `next_match` returns data which borrows from the iterator itself,
 /// not yet supported by Rust's `Iterator` trait.
 pub struct LookupMatchesIter<'a, 'j> {
-    stack: LookupMatchesStack<'a, 'j>,
+    stack: SmallVec<[NestedFrame<'a, 'j>; 1]>,
 }
-
-/// Current stack of the `LookupMatches` iterator
-pub struct LookupMatchesStack<'a, 'j>(
-    // uses SmallVec to avoid allocating if there are no `AliasPath` lookups
-    SmallVec<[NestedFrame<'a, 'j>; 1]>,
-);
 
 /// State of the iterator at a given depth in the lookup tree
 struct NestedFrame<'a, 'j> {
     json_value: &'a JsonValue<'j>,
-    lookup_path: LookupPathItem<'a>,
     node: &'a LookupTreeNode,
     state: FrameState<'a, 'j>,
-}
-
-#[derive(Clone, Copy)]
-enum LookupPathItem<'a> {
-    Key(&'a str),
-    Index(i64),
 }
 
 enum FrameState<'a, 'j> {
@@ -223,11 +218,10 @@ enum FrameState<'a, 'j> {
 }
 
 impl<'a, 'j> LookupMatchesIter<'a, 'j> {
-    fn new(root_key: &'a str, node: Option<&'a LookupTreeNode>, json_value: &'a JsonValue<'j>) -> Self {
+    fn new(node: Option<&'a LookupTreeNode>, json_value: &'a JsonValue<'j>) -> Self {
         let stack = if let Some(node) = node {
             SmallVec::from_buf([NestedFrame {
                 json_value,
-                lookup_path: LookupPathItem::Key(root_key),
                 node,
                 state: FrameState::Fields {
                     fields: node.fields.iter(),
@@ -237,18 +231,20 @@ impl<'a, 'j> LookupMatchesIter<'a, 'j> {
             SmallVec::new()
         };
 
-        Self {
-            stack: LookupMatchesStack(stack),
-        }
+        Self { stack }
     }
+}
 
-    pub fn next_match(&mut self) -> Option<(&'_ LookupFieldInfo, &'_ JsonValue<'j>, &'_ LookupMatchesStack<'a, 'j>)> {
-        'top_level: while let Some(frame) = self.stack.0.last_mut() {
+impl<'a, 'j> Iterator for LookupMatchesIter<'a, 'j> {
+    type Item = (&'a LookupFieldInfo, &'a JsonValue<'j>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        'top_level: while let Some(frame) = self.stack.last_mut() {
             // Initialize exploration state if needed
             match &mut frame.state {
                 FrameState::Fields { fields } => {
                     if let Some(field_info) = fields.next() {
-                        return Some((field_info, frame.json_value, &self.stack));
+                        return Some((field_info, frame.json_value));
                     }
 
                     // no more fields, possibly explore nested structures if there are complex aliases
@@ -263,7 +259,7 @@ impl<'a, 'j> LookupMatchesIter<'a, 'j> {
                             };
                         }
                         _ => {
-                            self.stack.0.pop();
+                            self.stack.pop();
                         }
                     }
                 }
@@ -272,18 +268,17 @@ impl<'a, 'j> LookupMatchesIter<'a, 'j> {
                         let nested_node = frame.node.map.get(key.as_ref())?;
                         Some(NestedFrame {
                             json_value: value,
-                            lookup_path: LookupPathItem::Key(key.as_ref()),
                             node: nested_node,
                             state: FrameState::Fields {
                                 fields: nested_node.fields.iter(),
                             },
                         })
                     }) {
-                        self.stack.0.push(next_frame);
+                        self.stack.push(next_frame);
                         continue 'top_level;
                     }
 
-                    self.stack.0.pop();
+                    self.stack.pop();
                 }
                 FrameState::NestedArray { json_array, iter } => {
                     if let Some(next_frame) = iter.by_ref().find_map(|(list_item, nested_node)| {
@@ -296,31 +291,20 @@ impl<'a, 'j> LookupMatchesIter<'a, 'j> {
                         let value = json_array.get(index as usize)?;
                         Some(NestedFrame {
                             json_value: value,
-                            lookup_path: LookupPathItem::Index(*list_item),
                             node: nested_node,
                             state: FrameState::Fields {
                                 fields: nested_node.fields.iter(),
                             },
                         })
                     }) {
-                        self.stack.0.push(next_frame);
+                        self.stack.push(next_frame);
                         continue 'top_level;
                     }
 
-                    self.stack.0.pop();
+                    self.stack.pop();
                 }
             }
         }
         None
-    }
-}
-
-impl LookupMatchesStack<'_, '_> {
-    /// Iterate the location items representing the path taken to reach the current match
-    pub fn iter_loc_items(&self) -> impl DoubleEndedIterator<Item = LocItem> + use<'_> {
-        self.0.iter().map(|frame| match frame.lookup_path {
-            LookupPathItem::Key(s) => s.into(),
-            LookupPathItem::Index(i) => i.into(),
-        })
     }
 }

--- a/pydantic-core/tests/validators/test_arguments.py
+++ b/pydantic-core/tests/validators/test_arguments.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 from functools import wraps
 from inspect import Parameter, signature
 from typing import Any, Union, get_type_hints

--- a/pydantic-core/tests/validators/test_arguments.py
+++ b/pydantic-core/tests/validators/test_arguments.py
@@ -1,7 +1,5 @@
 import os
-import platform
 import re
-import sys
 from functools import wraps
 from inspect import Parameter, signature
 from typing import Any, Union, get_type_hints
@@ -1139,9 +1137,6 @@ def test_invalid_schema():
         )
 
 
-@pytest.mark.xfail(
-    platform.python_implementation() == 'PyPy' and sys.version_info[:2] == (3, 11), reason='pypy 3.11 type formatting'
-)
 def test_error_display(pydantic_version):
     v = SchemaValidator(
         core_schema.arguments_schema(

--- a/pydantic-core/tests/validators/test_definitions_recursive.py
+++ b/pydantic-core/tests/validators/test_definitions_recursive.py
@@ -1,6 +1,5 @@
 import datetime
 import platform
-import sys
 from dataclasses import dataclass
 from typing import Optional
 
@@ -753,9 +752,6 @@ def test_many_uses_of_ref():
     assert v.validate_python(long_input) == long_input
 
 
-@pytest.mark.xfail(
-    platform.python_implementation() == 'PyPy' and sys.version_info[:2] == (3, 11), reason='pypy 3.11 type formatting'
-)
 def test_error_inside_definition_wrapper():
     with pytest.raises(SchemaError) as exc_info:
         SchemaValidator(

--- a/pydantic-core/tests/validators/test_string.py
+++ b/pydantic-core/tests/validators/test_string.py
@@ -348,9 +348,6 @@ def test_coerce_numbers_to_str_from_json(number: str, expected_str: str) -> None
 
 
 @pytest.mark.parametrize('mode', (None, 'schema', 'config'))
-@pytest.mark.xfail(
-    platform.python_implementation() == 'PyPy' and sys.version_info[:2] == (3, 11), reason='pypy 3.11 type formatting'
-)
 def test_backtracking_regex_rust_unsupported(mode) -> None:
     pattern = r'r(#*)".*?"\1'
 

--- a/pydantic-core/tests/validators/test_union.py
+++ b/pydantic-core/tests/validators/test_union.py
@@ -1,5 +1,3 @@
-import platform
-import sys
 from dataclasses import dataclass
 from datetime import date, time
 from enum import Enum, IntEnum
@@ -233,9 +231,6 @@ def test_union_list_bool_int():
     ]
 
 
-@pytest.mark.xfail(
-    platform.python_implementation() == 'PyPy' and sys.version_info[:2] == (3, 11), reason='pypy 3.11 type formatting'
-)
 def test_empty_choices():
     msg = r'Error building "union" validator:\s+SchemaError: One or more union choices required'
     with pytest.raises(SchemaError, match=msg):

--- a/pydantic/_internal/_fields.py
+++ b/pydantic/_internal/_fields.py
@@ -258,9 +258,35 @@ def collect_model_fields(  # noqa: C901
 
     bases = cls.__bases__
     parent_fields_lookup: dict[str, FieldInfo] = {}
-    for base in reversed(bases):
-        if model_fields := getattr(base, '__pydantic_fields__', None):
-            parent_fields_lookup.update(model_fields)
+
+    # Find all fields declared across parent classes in MRO order.
+    # The first class in MRO to explicitly declare a field is the winning declarer (see #13678, #11700).
+    declared_fields: dict[str, type[Any]] = {}
+    for base in cls.__mro__[1:]:
+        if not issubclass(base, BaseModel_) or base is BaseModel_:
+            continue
+        for name in _typing_extra.safe_get_annotations(base):
+            if name not in declared_fields and name in getattr(base, '__pydantic_fields__', {}):
+                declared_fields[name] = base
+
+    # For each declared field, check if an intervening parameterized generic submodel
+    # specialized the field (e.g. `Model[int]`), preserving concrete type arguments:
+    for name, declarer in declared_fields.items():
+        found = False
+        for base in cls.__mro__[1:]:
+            if base is declarer:
+                break
+            if not issubclass(base, BaseModel_) or base is BaseModel_:
+                continue
+            origin = getattr(base, '__pydantic_generic_metadata__', {}).get('origin')
+            if origin is not None and issubclass(origin, declarer):
+                model_fields = getattr(base, '__pydantic_fields__', {})
+                if name in model_fields:
+                    parent_fields_lookup[name] = model_fields[name]
+                    found = True
+                    break
+        if not found:
+            parent_fields_lookup[name] = getattr(declarer, '__pydantic_fields__')[name]
 
     type_hints = _typing_extra.get_model_type_hints(cls, ns_resolver=ns_resolver)
 

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -840,8 +840,17 @@ class GenerateSchema:
                 generic_origin: type[BaseModel] | None = getattr(cls, '__pydantic_generic_metadata__', {}).get('origin')
 
                 if cls.__pydantic_root_model__:
-                    # FIXME: should the common field metadata be used here?
-                    inner_schema, _ = self._common_field_schema('root', fields['root'], decorators)
+                    inner_schema, metadata = self._common_field_schema('root', fields['root'], decorators)
+                    if cls.__doc__ and metadata.get('pydantic_js_updates', {}).get('description'):
+                        # This is a bit of a leaky abstraction, but as the model docstring takes priority
+                        # over the root field's description, we need to override it here. This can't be done
+                        # in the JSON Schema generation logic because the metadata's `pydantic_js_updates` are
+                        # applied last, and overrides any value previously set (so the description set from the
+                        # docstring in `GenerateJsonSchema._update_class_schema()` is overridden):
+                        update_core_metadata(
+                            metadata, pydantic_js_updates={'description': inspect.cleandoc(cls.__doc__)}
+                        )
+
                     inner_schema = apply_model_validators(inner_schema, model_validators, 'inner')
                     model_schema = core_schema.model_schema(
                         cls,
@@ -852,6 +861,7 @@ class GenerateSchema:
                         post_init=getattr(cls, '__pydantic_post_init__', None),
                         config=core_config,
                         ref=model_ref,
+                        metadata=metadata,
                     )
                 else:
                     fields_schema: core_schema.CoreSchema = core_schema.model_fields_schema(

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -20,7 +20,7 @@ from ..errors import PydanticUndefinedAnnotation, PydanticUserError
 from ..plugin._schema_validator import create_schema_validator
 from ..warnings import GenericBeforeBaseModelWarning, PydanticDeprecatedSince20
 from ._config import ConfigWrapper
-from ._decorators import DecoratorInfos, PydanticDescriptorProxy, get_attribute_from_bases, unwrap_wrapped_function
+from ._decorators import DecoratorInfos, PydanticDescriptorProxy, get_attribute_from_bases, mro_for_bases, unwrap_wrapped_function
 from ._fields import collect_model_fields, is_valid_field_name, is_valid_privateattr_name, rebuild_model_fields
 from ._generate_schema import GenerateSchema, InvalidSchemaError
 from ._generics import PydanticGenericMetadata, get_model_typevars_map
@@ -312,15 +312,31 @@ class ModelMetaclass(ABCMeta):
     def _collect_bases_data(bases: tuple[type[Any], ...]) -> tuple[set[str], set[str], dict[str, ModelPrivateAttr]]:
         BaseModel = import_cached_base_model()
 
+        def _is_declared(base: type[Any], name: str, attr: ModelPrivateAttr) -> bool:
+            # A base that merely inherits a private attribute re-exposes its ancestor's
+            # `ModelPrivateAttr` instance through its flattened `__private_attributes__`
+            # (identical object); only a new object counts as a declaration (see #13678).
+            for ancestor in base.__mro__[1:]:
+                ancestor_attrs = ancestor.__dict__.get('__private_attributes__')
+                if ancestor_attrs and name in ancestor_attrs:
+                    return ancestor_attrs[name] is not attr
+            return True
+
         field_names: set[str] = set()
         class_vars: set[str] = set()
         private_attributes: dict[str, ModelPrivateAttr] = {}
-        for base in bases:
+        for base in reversed(mro_for_bases(bases)):
             if issubclass(base, BaseModel) and base is not BaseModel:
                 # model_fields might not be defined yet in the case of generics, so we use getattr here:
                 field_names.update(getattr(base, '__pydantic_fields__', {}).keys())
                 class_vars.update(base.__class_vars__)
-                private_attributes.update(base.__private_attributes__)
+                # Only private attributes *declared* on a base may shadow other bases. Merging in
+                # reverse MRO order means the MRO-earliest declarer wins (see #13678, #11700):
+                inherited = getattr(base, '__private_attributes__', None)
+                if inherited:
+                    private_attributes.update(
+                        {name: attr for name, attr in inherited.items() if _is_declared(base, name, attr)}
+                    )
         return field_names, class_vars, private_attributes
 
     @property

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -1636,7 +1636,6 @@ class GenerateJsonSchema:
         """
         from ._internal._dataclasses import is_stdlib_dataclass
         from .main import BaseModel
-        from .root_model import RootModel
 
         if (config_title := config.get('title')) is not None:
             json_schema.setdefault('title', config_title)
@@ -1664,8 +1663,6 @@ class GenerateJsonSchema:
 
         if docstring:
             json_schema.setdefault('description', inspect.cleandoc(docstring))
-        elif issubclass(cls, RootModel) and (root_description := cls.__pydantic_fields__['root'].description):
-            json_schema.setdefault('description', root_description)
 
         extra = config.get('extra')
         if 'additionalProperties' not in json_schema:  # This check is particularly important for `typed_dict_schema()`

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -8,7 +8,7 @@ from pydantic_core import __version__ as __pydantic_core_version__
 
 __all__ = 'VERSION', 'version_info'
 
-VERSION = '2.13.1'
+VERSION = '2.13.2'
 """The version of Pydantic.
 
 This version specifier is guaranteed to be compliant with the [specification],
@@ -19,7 +19,7 @@ introduced by [PEP 440].
 """
 
 # Keep this in sync with the version constraint in the `pyproject.toml` dependencies:
-_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.1'
+_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.2'
 
 
 def version_short() -> str:

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -8,7 +8,7 @@ from pydantic_core import __version__ as __pydantic_core_version__
 
 __all__ = 'VERSION', 'version_info'
 
-VERSION = '2.13.0'
+VERSION = '2.13.1'
 """The version of Pydantic.
 
 This version specifier is guaranteed to be compliant with the [specification],
@@ -19,7 +19,7 @@ introduced by [PEP 440].
 """
 
 # Keep this in sync with the version constraint in the `pyproject.toml` dependencies:
-_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.0'
+_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.1'
 
 
 def version_short() -> str:

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -8,7 +8,7 @@ from pydantic_core import __version__ as __pydantic_core_version__
 
 __all__ = 'VERSION', 'version_info'
 
-VERSION = '2.13.2'
+VERSION = '2.13.3'
 """The version of Pydantic.
 
 This version specifier is guaranteed to be compliant with the [specification],
@@ -19,7 +19,7 @@ introduced by [PEP 440].
 """
 
 # Keep this in sync with the version constraint in the `pyproject.toml` dependencies:
-_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.2'
+_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.3'
 
 
 def version_short() -> str:

--- a/pydantic/version.py
+++ b/pydantic/version.py
@@ -8,7 +8,7 @@ from pydantic_core import __version__ as __pydantic_core_version__
 
 __all__ = 'VERSION', 'version_info'
 
-VERSION = '2.13.3'
+VERSION = '2.13.4'
 """The version of Pydantic.
 
 This version specifier is guaranteed to be compliant with the [specification],
@@ -19,7 +19,7 @@ introduced by [PEP 440].
 """
 
 # Keep this in sync with the version constraint in the `pyproject.toml` dependencies:
-_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.3'
+_COMPATIBLE_PYDANTIC_CORE_VERSION = '2.46.4'
 
 
 def version_short() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'typing-extensions>=4.14.1',
     'annotated-types>=0.6.0',
     # Keep this in sync with the version in the `check_pydantic_core_version()` function:
-    'pydantic-core==2.46.1',
+    'pydantic-core==2.46.2',
     'typing-inspection>=0.4.2',
 ]
 dynamic = ['version', 'readme']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'typing-extensions>=4.14.1',
     'annotated-types>=0.6.0',
     # Keep this in sync with the version in the `check_pydantic_core_version()` function:
-    'pydantic-core==2.46.0',
+    'pydantic-core==2.46.1',
     'typing-inspection>=0.4.2',
 ]
 dynamic = ['version', 'readme']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'typing-extensions>=4.14.1',
     'annotated-types>=0.6.0',
     # Keep this in sync with the version in the `check_pydantic_core_version()` function:
-    'pydantic-core==2.46.2',
+    'pydantic-core==2.46.3',
     'typing-inspection>=0.4.2',
 ]
 dynamic = ['version', 'readme']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'typing-extensions>=4.14.1',
     'annotated-types>=0.6.0',
     # Keep this in sync with the version in the `check_pydantic_core_version()` function:
-    'pydantic-core==2.46.3',
+    'pydantic-core==2.46.4',
     'typing-inspection>=0.4.2',
 ]
 dynamic = ['version', 'readme']

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -3170,3 +3170,148 @@ def test_model_fields_set_includes_extra_after_assignment():
     m.extra_after_init = 3
     assert m.model_fields_set == {'field', 'extra_at_init', 'extra_after_init'}
     assert m.model_extra == {'extra_at_init': 2, 'extra_after_init': 3}
+
+
+def test_multiple_inheritance_merely_inherited_field_does_not_shadow_override():
+    """Regression test for https://github.com/pydantic/pydantic/issues/13678.
+
+    A base that merely inherits a field/private attribute (re-exposed through its
+    flattened `__pydantic_fields__`/`__private_attributes__`) must not shadow another
+    base's override; the winner follows the MRO in both base orders.
+    """
+
+    class Base(BaseModel):
+        f: str = 'base'
+        _knob: str = 'base'
+
+    class Override(Base):
+        f: str = 'override'
+        _knob: str = 'override'
+
+    class Plain(Base):
+        pass
+
+    class Swapped(Plain, Override):
+        pass
+
+    class Composed(Override, Plain):
+        pass
+
+    assert Swapped().f == 'override'
+    assert Swapped()._knob == 'override'
+    assert Composed().f == 'override'
+    assert Composed()._knob == 'override'
+
+
+def test_multiple_inheritance_mro_adversarial_cases():
+    """Comprehensive tests for multiple inheritance MRO resolution with fields and private attrs.
+
+    Covers:
+    - Issue #11700: both bases declare the same field / private attr (first base in MRO wins)
+    - Deep pass-through inheritance chains
+    - Diamond inheritance with override on one branch
+    - Parameterized generic submodels in multiple inheritance
+    """
+    from typing import Generic, TypeVar
+
+    # 1. Both bases declare: first in MRO must win (#11700)
+    class DeclA(BaseModel):
+        x: str = 'a'
+        _p: str = 'priv_a'
+
+    class DeclB(BaseModel):
+        x: str = 'b'
+        _p: str = 'priv_b'
+
+    class SubAB(DeclA, DeclB):
+        pass
+
+    class SubBA(DeclB, DeclA):
+        pass
+
+    assert SubAB().x == 'a'
+    assert SubAB()._p == 'priv_a'
+    assert SubBA().x == 'b'
+    assert SubBA()._p == 'priv_b'
+
+    # 2. Deep pass-through inheritance chain
+    class Grandparent(BaseModel):
+        f: str = 'grandparent'
+        _k: str = 'grandparent'
+
+    class Parent(Grandparent):
+        pass
+
+    class Child(Parent):
+        pass
+
+    class GrandparentOverride(Grandparent):
+        f: str = 'override'
+        _k: str = 'override'
+
+    class DeepMix1(Child, GrandparentOverride):
+        pass
+
+    class DeepMix2(GrandparentOverride, Child):
+        pass
+
+    assert DeepMix1().f == 'override'
+    assert DeepMix1()._k == 'override'
+    assert DeepMix2().f == 'override'
+    assert DeepMix2()._k == 'override'
+
+    # 3. Diamond inheritance: Root -> (LeftOverride, RightPlain) -> Diamond
+    class Root(BaseModel):
+        f: str = 'root'
+        _k: str = 'root'
+
+    class LeftOverride(Root):
+        f: str = 'left'
+        _k: str = 'left'
+
+    class RightPlain(Root):
+        pass
+
+    class DiamondRightLeft(RightPlain, LeftOverride):
+        pass
+
+    class DiamondLeftRight(LeftOverride, RightPlain):
+        pass
+
+    assert DiamondRightLeft().f == 'left'
+    assert DiamondRightLeft()._k == 'left'
+    assert DiamondLeftRight().f == 'left'
+    assert DiamondLeftRight()._k == 'left'
+
+    # 4. Parameterized generic submodel with multiple inheritance
+    T = TypeVar('T')
+
+    class GenBase(BaseModel, Generic[T]):
+        val: T = 'base'
+
+    class GenPlain(GenBase[T], Generic[T]):
+        pass
+
+    class ValOverride(GenBase[str]):
+        val: str = 'override'
+
+    # GenPlain merely inherits val; ValOverride overrides it
+    class GenDerived(GenPlain[int], ValOverride):
+        pass
+
+    assert GenDerived().val == 'override'
+
+    # And direct subclassing of a parameterized generic preserves concrete type substitution
+    class DirectGenSub(GenBase[int]):
+        pass
+
+    assert DirectGenSub(val=42).val == 42
+
+    # Subclassing a parameterized generic child that merely inherited from a generic root
+    # must preserve the concrete type substitution on the inherited field:
+    class SubGenChild(GenPlain[int]):
+        pass
+    assert SubGenChild(val=123).val == 123
+    assert SubGenChild.model_fields['val'].annotation is int
+    with pytest.raises(ValidationError):
+        SubGenChild(val='not_an_int')

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5391,6 +5391,38 @@ def test_root_model():
     }
 
 
+def test_root_model_annotated_root_type_parameterized() -> None:
+    """https://github.com/pydantic/pydantic/issues/13123"""
+
+    MyType = Annotated[str, Field(examples=['hello'], description='desc', deprecated=True)]
+
+    class MyModel(RootModel[MyType]):
+        pass
+
+    assert MyModel.model_json_schema() == {
+        'deprecated': True,
+        'description': 'desc',
+        'examples': ['hello'],
+        'title': 'MyModel',
+        'type': 'string',
+    }
+
+
+def test_root_model_annotated_root_type() -> None:
+    """https://github.com/pydantic/pydantic/issues/13123"""
+
+    class MyModel(RootModel):
+        root: Annotated[str, Field(examples=['hello'], description='desc', deprecated=True)]
+
+    assert MyModel.model_json_schema() == {
+        'deprecated': True,
+        'description': 'desc',
+        'examples': ['hello'],
+        'title': 'MyModel',
+        'type': 'string',
+    }
+
+
 def test_type_adapter_json_schemas_title_description():
     class Model(BaseModel):
         a: str

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3063,7 +3063,7 @@ def test_from_attributes_attributeerror_subclass() -> None:
         pass
 
     class Model(BaseModel, from_attributes=True):
-        field: int | None = None
+        field: Union[int, None] = None
 
     class Obj:
         @property

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2010,11 +2010,7 @@ def test_class_kwargs_config_and_attr_conflict():
 
 
 def test_class_kwargs_custom_config():
-    if platform.python_implementation() == 'PyPy':
-        msg = r"__init_subclass__\(\) got an unexpected keyword argument 'some_config'"
-    else:
-        msg = r'__init_subclass__\(\) takes no keyword arguments'
-    with pytest.raises(TypeError, match=msg):
+    with pytest.raises(TypeError, match=r'__init_subclass__\(\) takes no keyword arguments'):
 
         class Model(BaseModel, some_config='new_value'):
             a: int

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3056,6 +3056,25 @@ def test_validate_python_from_attributes() -> None:
     assert res == ModelFromAttributesFalse(x=1)
 
 
+def test_from_attributes_attributeerror_subclass() -> None:
+    """https://github.com/pydantic/pydantic/issues/13092"""
+
+    class SubAttributeError(AttributeError):
+        pass
+
+    class Model(BaseModel, from_attributes=True):
+        field: int | None = None
+
+    class Obj:
+        @property
+        def child(self):
+            raise SubAttributeError()
+
+    m = Model.model_validate(Obj())
+
+    assert m.field is None
+
+
 @pytest.mark.parametrize(
     'field_type,input_value,expected,raises_match,strict',
     [

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -2,6 +2,7 @@ import pickle
 from typing import Annotated, Union
 
 import pytest
+import typing_extensions
 from annotated_types import Ge
 from pydantic_core import MISSING, PydanticSerializationUnexpectedValue
 
@@ -53,7 +54,11 @@ class ModelPickle(BaseModel):
     f: Union[int, MISSING] = MISSING
 
 
-@pytest.mark.xfail(reason="PEP 661 sentinels aren't picklable yet in the experimental typing-extensions implementation")
+@pytest.mark.xfail(
+    # Unreleased typing-extensions has the final sentinel implementation with pickle support:
+    condition=not hasattr(typing_extensions, 'sentinel'),
+    reason="PEP 661 sentinels aren't picklable yet in the experimental typing-extensions implementation",
+)
 def test_missing_sentinel_pickle() -> None:
     m = ModelPickle()
     m_reconstructed = pickle.loads(pickle.dumps(m))

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import pytest
 
@@ -15,17 +15,31 @@ from pydantic import BaseModel, PositiveFloat, ValidationError
 from pydantic._internal._model_construction import _PydanticWeakRef
 from pydantic.config import ConfigDict
 
-try:
+IS_PYPY = sys.implementation.name == 'pypy' and sys.version_info >= (3, 11)
+
+if TYPE_CHECKING:
     import cloudpickle
-except ImportError:
-    cloudpickle = None
+else:
+    if not IS_PYPY:
+        try:
+            import cloudpickle
+        except ImportError:
+            cloudpickle = None
+    else:
+        cloudpickle = None
 
 TEST_DATA_DIR = Path(__file__).parent / 'test_data'
 
-pytestmark = pytest.mark.skipif(cloudpickle is None, reason='cloudpickle is not installed')
+pytestmark = pytest.mark.skipif(
+    cloudpickle is None,
+    reason='cloudpickle is not installed, or tests are running with PyPy (https://github.com/cloudpipe/cloudpickle/issues/592).',
+)
 
+# Note: this xfail marker was used when cloudpickle was partially compatible with PyPy. Since PyPy 7.3.22, it isn't compatible
+# at all (importing it fails), so all tests are skipped as per the module's `pytestmark`. We keep the xfail marker if this ever
+# changes:
 cloudpickle_pypy_xfail = pytest.mark.xfail(
-    condition=sys.implementation.name == 'pypy' and sys.version_info >= (3, 11),
+    condition=IS_PYPY,
     reason='Cloudpickle issue: - possibly https://github.com/cloudpipe/cloudpickle/issues/557',
 )
 
@@ -99,7 +113,10 @@ def model_factory() -> type:
         # Importable model can be pickled with either pickle or cloudpickle.
         (ImportableModel, False),
         (ImportableModel, True),
-        # Locally-defined model can only be pickled with cloudpickle.
+        # Locally-defined model can only be pickle
+        # # Note: this xfail marker was used when cloudpickle was partially compatible with PyPy. Since PyPy 7.3.22, it is completelyisn't compatible
+        # # at all (importing it fails), so all tests are skipped as per the module's `pytestmark`. We keep the xfail marker if this ever
+        # # changes:d with cloudpickle.
         pytest.param(model_factory(), True, marks=cloudpickle_pypy_xfail),
     ],
 )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3145,3 +3145,45 @@ def test_nested_model_validator_not_reexecuted():
     )  # Create a Sub instance without triggering validation (e.g., using model_construct)
     # Attempt to create Base with the Sub instance. This line should succeed if the bug is fixed, but currently raises ValidationError.
     Base(sub=sub)  # <-- This throws AssertionError because Sub's 'after' validator runs again.
+
+
+def test_model_validate_by_json_field_validator_with_validation_info() -> None:
+    """https://github.com/pydantic/pydantic/issues/13074"""
+
+    class Foo(BaseModel):
+        field1: int
+        field2: int
+
+        @field_validator('field2')
+        @classmethod
+        def _validate_field2(cls, v: int, info: ValidationInfo) -> int:
+            assert info.field_name in ('field1', 'field2')
+            assert info.context == 'context'
+
+            return v + info.data['field1']
+
+    f1 = Foo.model_validate({'field1': 1, 'field2': 2}, context='context')
+    f2 = Foo.model_validate_json('{"field1": 1, "field2": 2}', context='context')
+
+    assert f1.field1 == f2.field1 == 1
+    assert f1.field2 == f2.field2 == 3
+
+
+def test_model_validate_json_default_value_validator_with_validation_info() -> None:
+    """https://github.com/pydantic/pydantic/issues/13074"""
+
+    class Foo(BaseModel, validate_default=True):
+        field: int = 1
+
+        @field_validator('field')
+        @classmethod
+        def _validate_field(cls, v: int, info: ValidationInfo) -> int:
+            assert info.field_name == 'field'
+            assert info.context == 'context'
+
+            return v + 1
+
+    f1 = Foo.model_validate({'field': 1}, context='context')
+    f2 = Foo.model_validate_json('{"field1": 1}', context='context')
+
+    assert f1.field == f2.field == 2

--- a/tests/types/test_model.py
+++ b/tests/types/test_model.py
@@ -2,7 +2,15 @@ from typing import Union
 
 import pytest
 
-from pydantic import BaseModel, ConfigDict, SerializationInfo, TypeAdapter, model_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    SerializationInfo,
+    TypeAdapter,
+    ValidationInfo,
+    field_validator,
+    model_serializer,
+)
 
 
 @pytest.mark.parametrize('config', [True, False, None])
@@ -77,3 +85,22 @@ def test_polymorphic_serialization_with_model_serializer(config: bool, runtime: 
     else:
         assert serializer.to_python(ModelB(a=123, b='test'), **kwargs) == 'ModelA'
         assert serializer.to_json(ModelB(a=123, b='test'), **kwargs) == b'"ModelA"'
+
+
+def test_model_validate_by_json_with_validation_info_data():
+    """https://github.com/pydantic/pydantic/issues/13074"""
+
+    class Foo(BaseModel):
+        field1: int
+        field2: int
+
+        @field_validator('field2')
+        @classmethod
+        def _validate_field2(cls, v: str, info: ValidationInfo) -> int:
+            return v + info.data['field1']
+
+    f1 = Foo.model_validate({'field1': 1, 'field2': 2})
+    f2 = Foo.model_validate_json('{"field1": 1, "field2": 2}')
+
+    assert f1.field1 == f2.field1 == 1
+    assert f1.field2 == f2.field2 == 3

--- a/tests/types/test_model.py
+++ b/tests/types/test_model.py
@@ -7,8 +7,6 @@ from pydantic import (
     ConfigDict,
     SerializationInfo,
     TypeAdapter,
-    ValidationInfo,
-    field_validator,
     model_serializer,
 )
 
@@ -85,22 +83,3 @@ def test_polymorphic_serialization_with_model_serializer(config: bool, runtime: 
     else:
         assert serializer.to_python(ModelB(a=123, b='test'), **kwargs) == 'ModelA'
         assert serializer.to_json(ModelB(a=123, b='test'), **kwargs) == b'"ModelA"'
-
-
-def test_model_validate_by_json_with_validation_info_data():
-    """https://github.com/pydantic/pydantic/issues/13074"""
-
-    class Foo(BaseModel):
-        field1: int
-        field2: int
-
-        @field_validator('field2')
-        @classmethod
-        def _validate_field2(cls, v: str, info: ValidationInfo) -> int:
-            return v + info.data['field1']
-
-    f1 = Foo.model_validate({'field1': 1, 'field2': 2})
-    f2 = Foo.model_validate_json('{"field1": 1, "field2": 2}')
-
-    assert f1.field1 == f2.field1 == 1
-    assert f1.field2 == f2.field2 == 3


### PR DESCRIPTION
## Problem

In multiple inheritance hierarchies with Pydantic models, when one base class merely inherits a field or private attribute from a common ancestor without re-declaring it, and another base class explicitly overrides that field/private attribute, the merely-inheriting base improperly shadows the override depending on base order (e.g. `Swapped(Plain, Override)` where `Plain(Base)` declares `pass` and `Override(Base)` overrides `f`).

This violates Python's Method Resolution Order (MRO), where the first class in the MRO defining an attribute in its own namespace should take precedence.

## Root Cause

Two separate lookup mechanisms were affected:
1. In `pydantic._internal._fields.collect_model_fields`, `parent_fields_lookup` was built by iterating `reversed(bases)` and updating with each base's flattened `__pydantic_fields__`. Because a base that merely inherits a field re-exposes its ancestor's `FieldInfo` in `__pydantic_fields__`, an earlier base in `bases` would overwrite an explicit override declared on a later base.
2. In `pydantic._internal._model_construction.ModelMetaclass._collect_bases_data`, `private_attributes` was built by iterating `bases` forward and updating with each base's flattened `__private_attributes__`. This caused the last base to win instead of the MRO-earliest declarer (also causing issue #11700 where `C(A, B)` took `B`'s private attribute instead of `A`'s).

## Solution

1. In `collect_model_fields`:
   - Inspect parent classes along `cls.__mro__[1:]` in forward order to identify the MRO-winning declarer for each field (`name in safe_get_annotations(base)`).
   - If an intervening parameterized generic submodel specialized that declarer (e.g. `Model[int]`), copy the specialized `FieldInfo` from that submodel so concrete type arguments are preserved.
   - If no generic specialization occurred, copy the `FieldInfo` from the winning declarer.
2. In `_collect_bases_data`:
   - Walk `reversed(mro_for_bases(bases))` and filter inherited private attributes using an ancestor identity check (`_is_declared`). Because a class that merely inherits a private attribute re-exposes an identical `ModelPrivateAttr` object from its ancestor's `__dict__`, only newly assigned private attributes count as declarations, ensuring the MRO-earliest declarer wins.

## Testing

Added comprehensive regression tests in `tests/test_edge_cases.py`:
- `test_multiple_inheritance_merely_inherited_field_does_not_shadow_override`: Directly reproduces #13678, asserting that both fields and private attributes resolve to `'override'` for both `Swapped(Plain, Override)` and `Composed(Override, Plain)`. (Fails pre-fix on `Swapped.f` and `Composed._knob`, passes post-fix).
- `test_multiple_inheritance_mro_adversarial_cases`: Adversarial coverage including:
  - Both bases declaring the same field and private attribute (#11700).
  - Deep pass-through inheritance chains (`Grandparent -> Parent -> Child` mixed with `GrandparentOverride`).
  - Diamond inheritance hierarchies.
  - Parameterized generic submodels with multiple inheritance and direct generic subclassing with type substitution and `ValidationError` enforcement.

## Verification

- Targeted: `pytest tests/test_edge_cases.py -k test_multiple_inheritance` (2 passed).
- Module: `pytest tests/test_edge_cases.py` (197 passed, 1 skipped).
- Integration: `pytest tests/test_private_attributes.py tests/test_generics.py tests/test_main.py tests/test_fields.py tests/test_construction.py` (518 passed, 27 skipped, 5 xfailed).
- Repro script: 4/4 assertions pass.

## Impact

Fields and private attributes in multiple inheritance now consistently follow Python's MRO. Single-inheritance and existing multi-inheritance models without competing inherited fields are unaffected.

## Compatibility

Backwards compatible. Closes #13678 and aligns with #11700.
