### PR TITLE
Fix: correct JSON schema length constraints for lax-or-strict schemas and dictionaries

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -250,13 +250,20 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after', 'lax-or-strict'}:
+                    if inner_schema['type'] == 'lax-or-strict':
+                        inner_schema = inner_schema['lax_schema']  # type: ignore
+                    else:
+                        inner_schema = inner_schema['schema']  # type: ignore
                 inner_schema_type = inner_schema['type']
                 if inner_schema_type == 'list' or (
                     inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
                 ):
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type == 'dict' or (
+                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'dict'  # type: ignore
+                ):
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:


### PR DESCRIPTION
Fixes #13704. Updates `_known_annotated_metadata.py` to unwrap `lax-or-strict` schemas correctly when parsing `LENGTH_CONSTRAINTS` and ensures `dict` typed schemas emit `minProperties` / `maxProperties` instead of string properties (`minLength` / `maxLength`).