### PR TITLE
Document that val_json_bytes applies in Python mode

### DIFF
--- a/docs/api/standard_library_types.md
+++ b/docs/api/standard_library_types.md
@@ -130,7 +130,8 @@ See also: [`ByteSize`][pydantic.types.ByteSize].
 <h3>Validation</h3>
 
 * [`bytes`][] instances are validated as is.
-* Strings and [`bytearray`][] instances are converted as bytes, following the [`val_json_bytes`][pydantic.ConfigDict.val_json_bytes] configuration value
+* [`bytearray`][] instances are converted to bytes as is.
+* Strings are decoded following the [`val_json_bytes`][pydantic.ConfigDict.val_json_bytes] configuration value
   (despite its name, it applies to both Python and JSON modes).
 
 <h3>Constraints</h3>

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -633,12 +633,28 @@ class ConfigDict(TypedDict, total=False):
     /// version-added | v2.9
     ///
 
-    The encoding of JSON serialized bytes to decode. Defaults to `'utf8'`.
+    The encoding to assume when decoding a string into [`bytes`][]. Defaults to `'utf8'`.
     Set equal to `ser_json_bytes` to get back an equal value after serialization round trip.
 
-    - `'utf8'` will deserialize UTF-8 strings to bytes.
-    - `'base64'` will deserialize URL safe base64 strings to bytes.
-    - `'hex'` will deserialize hexadecimal strings to bytes.
+    - `'utf8'` will decode UTF-8 strings to bytes.
+    - `'base64'` will decode URL safe base64 strings to bytes.
+    - `'hex'` will decode hexadecimal strings to bytes.
+
+    Despite the name, this applies in Python mode as well as JSON mode: any [`str`][] input to a
+    `bytes` field is decoded this way. [`bytes`][] and [`bytearray`][] inputs are used as is.
+
+    ```python
+    from pydantic import TypeAdapter
+
+    ta = TypeAdapter(bytes, config={'val_json_bytes': 'base64'})
+
+    print(ta.validate_json('"YWJj"'))
+    #> b'abc'
+    print(ta.validate_python('YWJj'))
+    #> b'abc'
+    print(ta.validate_python(b'YWJj'))
+    #> b'YWJj'
+    ```
     """
 
     ser_json_inf_nan: Literal['null', 'constants', 'strings']


### PR DESCRIPTION
## Change Summary

`val_json_bytes` is documented as "the encoding of JSON serialized bytes to decode", which reads as if it only applies to `validate_json`. It applies to any `str` input, so `TypeAdapter(bytes, config={'val_json_bytes': 'base64'}).validate_python('abc')` decodes rather than accepting the string as-is — and where the string happens to be valid base64 that is silently wrong rather than an error.

`docs/api/standard_library_types.md` already carries the "despite its name" note since #12287; this adds it to the `ConfigDict.val_json_bytes` reference, which is where people land from the config, and gives a short example.

The same bullet in `standard_library_types.md` says strings *and* `bytearray` instances are decoded following the setting. Only strings are:

```python
from pydantic import TypeAdapter

ta = TypeAdapter(bytes, config={'val_json_bytes': 'base64'})
ta.validate_python('YWJj')             # b'abc'
ta.validate_python(bytearray(b'YWJj')) # b'YWJj'
ta.validate_python(b'YWJj')            # b'YWJj'
```

So I split that bullet in two. Happy to drop that part if you would rather keep this to the config reference.

## Related issue number

fix #12297

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist — documentation only; the example in the docstring is covered by `tests/test_docs.py`
* [x] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
