### PR TITLE
Do not mention `MISSING` as a valid value in validation errors

### DIFF
--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -1442,18 +1442,40 @@ def enum_schema(
 
 class MissingSentinelSchema(TypedDict, total=False):
     type: Required[Literal['missing-sentinel']]
+    schema: CoreSchema
     metadata: dict[str, Any]
     serialization: SerSchema
 
 
 def missing_sentinel_schema(
+    schema: CoreSchema | None = None,
+    *,
     metadata: dict[str, Any] | None = None,
     serialization: SerSchema | None = None,
 ) -> MissingSentinelSchema:
-    """Returns a schema for the `MISSING` sentinel."""
+    """
+    Returns a schema that matches the `MISSING` sentinel, or, if provided, the wrapped schema, e.g.:
+
+    ```py
+    from pydantic_core import MISSING, SchemaValidator, core_schema
+
+    schema = core_schema.missing_sentinel_schema(core_schema.int_schema())
+    v = SchemaValidator(schema)
+    assert v.validate_python(MISSING) is MISSING
+    assert v.validate_python(1) == 1
+    ```
+
+    If no schema is provided, only the `MISSING` sentinel is a valid input.
+
+    Args:
+        schema: The schema to wrap
+        metadata: Any other information you want to include with the schema, not used by pydantic-core
+        serialization: Custom serialization schema
+    """
 
     return _dict_not_none(
         type='missing-sentinel',
+        schema=schema,
         metadata=metadata,
         serialization=serialization,
     )

--- a/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
+++ b/pydantic-core/src/serializers/type_serializers/missing_sentinel.rs
@@ -1,13 +1,13 @@
-// This serializer is defined so that building a schema serializer containing an
-// 'missing-sentinel' core schema doesn't crash. In practice, the serializer isn't
-// used for model-like classes, as the 'fields' serializer takes care of omitting
-// the fields from the output (the serializer can still be used if the 'missing-sentinel'
-// core schema is used standalone (e.g. with a Pydantic type adapter), but this isn't
-// something we explicitly support.
+// When the 'missing-sentinel' core schema has no inner 'schema', this serializer is only defined
+// so that building a schema serializer containing it doesn't crash. In practice, the serializer
+// isn't used for model-like classes, as the 'fields' serializer takes care of omitting the fields
+// from the output (the serializer can still be used if the 'missing-sentinel' core schema is used
+// standalone (e.g. with a Pydantic type adapter), but this isn't something we explicitly support).
 
 use std::borrow::Cow;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -17,40 +17,48 @@ use crate::PydanticSerializationUnexpectedValue;
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::definitions::DefinitionsBuilder;
 use crate::serializers::SerializationState;
+use crate::tools::SchemaDict;
 
 use super::{BuildSerializer, CombinedSerializer, TypeSerializer};
 
 #[derive(Debug)]
-pub struct MissingSentinelSerializer {}
-
-static MISSING_SENTINEL_SERIALIZER: LazyLock<Arc<CombinedSerializer>> =
-    LazyLock::new(|| Arc::new(MissingSentinelSerializer {}.into()));
+pub struct MissingSentinelSerializer {
+    /// The serializer of the inner schema (if any). If not set, only the `MISSING` sentinel can be serialized.
+    serializer: Option<Arc<CombinedSerializer>>,
+}
 
 impl BuildSerializer for MissingSentinelSerializer {
     const EXPECTED_TYPE: &'static str = "missing-sentinel";
 
     fn build(
-        _schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
+        schema: &Bound<'_, PyDict>,
+        config: Option<&Bound<'_, PyDict>>,
+        definitions: &mut DefinitionsBuilder<Arc<CombinedSerializer>>,
     ) -> PyResult<Arc<CombinedSerializer>> {
-        Ok(MISSING_SENTINEL_SERIALIZER.clone())
+        let serializer = match schema.get_as::<Bound<'_, PyDict>>(intern!(schema.py(), "schema"))? {
+            Some(inner_schema) => Some(CombinedSerializer::build(&inner_schema, config, definitions)?),
+            None => None,
+        };
+        Ok(CombinedSerializer::MissingSentinel(Self { serializer }).into())
     }
 }
 
-impl_py_gc_traverse!(MissingSentinelSerializer {});
+impl_py_gc_traverse!(MissingSentinelSerializer { serializer });
 
 impl TypeSerializer for MissingSentinelSerializer {
-    fn to_python(&self, value: &Bound<'_, PyAny>, _state: &mut SerializationState<'_>) -> PyResult<Py<PyAny>> {
+    fn to_python<'py>(&self, value: &Bound<'py, PyAny>, state: &mut SerializationState<'py>) -> PyResult<Py<PyAny>> {
         let missing_sentinel = get_missing_sentinel_object(value.py());
 
         if value.is(missing_sentinel) {
-            Ok(missing_sentinel.to_owned().into())
-        } else {
-            Err(
-                PydanticSerializationUnexpectedValue::new_from_msg(Some("Expected 'MISSING' sentinel".to_string()))
-                    .to_py_err(),
-            )
+            return Ok(missing_sentinel.to_owned().into());
+        }
+
+        match &self.serializer {
+            Some(serializer) => serializer.to_python(value, state),
+            None => Err(PydanticSerializationUnexpectedValue::new_from_msg(Some(
+                "Expected 'MISSING' sentinel".to_string(),
+            ))
+            .to_py_err()),
         }
     }
 
@@ -59,19 +67,35 @@ impl TypeSerializer for MissingSentinelSerializer {
         key: &'a Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
     ) -> PyResult<Cow<'a, str>> {
-        self.invalid_as_json_key(key, state, Self::EXPECTED_TYPE)
+        let missing_sentinel = get_missing_sentinel_object(key.py());
+
+        match &self.serializer {
+            Some(serializer) if !key.is(missing_sentinel) => serializer.json_key(key, state),
+            _ => self.invalid_as_json_key(key, state, Self::EXPECTED_TYPE),
+        }
     }
 
-    fn serde_serialize<S: serde::ser::Serializer>(
+    fn serde_serialize<'py, S: serde::ser::Serializer>(
         &self,
-        _value: &Bound<'_, PyAny>,
-        _serializer: S,
-        _state: &mut SerializationState<'_>,
+        value: &Bound<'py, PyAny>,
+        serializer: S,
+        state: &mut SerializationState<'py>,
     ) -> Result<S::Ok, S::Error> {
-        Err(Error::custom("'MISSING' can't be serialized to JSON".to_string()))
+        let missing_sentinel = get_missing_sentinel_object(value.py());
+
+        match &self.serializer {
+            Some(inner_serializer) if !value.is(missing_sentinel) => {
+                inner_serializer.serde_serialize(value, serializer, state)
+            }
+            _ => Err(Error::custom("'MISSING' can't be serialized to JSON".to_string())),
+        }
     }
 
     fn get_name(&self) -> &str {
         Self::EXPECTED_TYPE
+    }
+
+    fn retry_with_lax_check(&self) -> bool {
+        self.serializer.as_ref().is_some_and(|s| s.retry_with_lax_check())
     }
 }

--- a/pydantic-core/src/validators/missing_sentinel.rs
+++ b/pydantic-core/src/validators/missing_sentinel.rs
@@ -1,51 +1,69 @@
 use core::fmt::Debug;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::common::missing_sentinel::get_missing_sentinel_object;
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::Input;
+use crate::tools::SchemaDict;
 
-use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator};
+use super::{BuildValidator, CombinedValidator, DefinitionsBuilder, ValidationState, Validator, build_validator};
 
-#[derive(Debug, Clone)]
-pub struct MissingSentinelValidator {}
-
-static MISSING_SENTINEL_VALIDATOR: LazyLock<Arc<CombinedValidator>> =
-    LazyLock::new(|| CombinedValidator::MissingSentinel(MissingSentinelValidator {}).into());
+#[derive(Debug)]
+pub struct MissingSentinelValidator {
+    /// The validator of the inner schema (if any). If not set, only the `MISSING` sentinel is a valid input.
+    validator: Option<Arc<CombinedValidator>>,
+    name: String,
+}
 
 impl BuildValidator for MissingSentinelValidator {
     const EXPECTED_TYPE: &'static str = "missing-sentinel";
 
     fn build(
-        _schema: &Bound<'_, PyDict>,
-        _config: Option<&Bound<'_, PyDict>>,
-        _definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
+        schema: &Bound<'_, PyDict>,
+        config: Option<&Bound<'_, PyDict>>,
+        definitions: &mut DefinitionsBuilder<Arc<CombinedValidator>>,
     ) -> PyResult<Arc<CombinedValidator>> {
-        Ok(MISSING_SENTINEL_VALIDATOR.clone())
+        let py = schema.py();
+        let (validator, name) = match schema.get_as::<Bound<'_, PyDict>>(intern!(py, "schema"))? {
+            Some(inner_schema) => {
+                let validator = build_validator(&inner_schema, config, definitions)?;
+                let name = format!("{}[{}]", Self::EXPECTED_TYPE, validator.get_name());
+                (Some(validator), name)
+            }
+            None => (None, Self::EXPECTED_TYPE.to_string()),
+        };
+        Ok(CombinedValidator::MissingSentinel(Self { validator, name }).into())
     }
 }
 
-impl_py_gc_traverse!(MissingSentinelValidator {});
+impl_py_gc_traverse!(MissingSentinelValidator { validator });
 
 impl Validator for MissingSentinelValidator {
     fn validate<'py>(
         &self,
         py: Python<'py>,
         input: &(impl Input<'py> + ?Sized),
-        _state: &mut ValidationState<'_, 'py>,
+        state: &mut ValidationState<'_, 'py>,
     ) -> ValResult<Py<PyAny>> {
         let missing_sentinel = get_missing_sentinel_object(py);
 
-        match input.as_python() {
-            Some(v) if v.is(missing_sentinel) => Ok(v.to_owned().into()),
-            _ => Err(ValError::new(ErrorType::MissingSentinelError { context: None }, input)),
+        if let Some(v) = input.as_python()
+            && v.is(missing_sentinel)
+        {
+            return Ok(v.to_owned().into());
+        }
+
+        match &self.validator {
+            Some(validator) => validator.validate(py, input, state),
+            None => Err(ValError::new(ErrorType::MissingSentinelError { context: None }, input)),
         }
     }
 
     fn get_name(&self) -> &str {
-        Self::EXPECTED_TYPE
+        &self.name
     }
 }

--- a/pydantic-core/tests/serializers/test_missing_sentinel.py
+++ b/pydantic-core/tests/serializers/test_missing_sentinel.py
@@ -1,0 +1,74 @@
+import pytest
+
+from pydantic_core import (
+    MISSING,
+    PydanticSerializationError,
+    PydanticSerializationUnexpectedValue,
+    SchemaSerializer,
+    core_schema,
+)
+
+
+def test_missing_sentinel_no_inner_schema() -> None:
+    s = SchemaSerializer(core_schema.missing_sentinel_schema())
+
+    assert s.to_python(MISSING) is MISSING
+
+    with pytest.raises(PydanticSerializationUnexpectedValue, match="Expected 'MISSING' sentinel"):
+        s.to_python(1)
+
+    with pytest.raises(ValueError, match="'MISSING' can't be serialized to JSON"):
+        s.to_json(MISSING)
+
+
+def test_missing_sentinel_inner_schema() -> None:
+    s = SchemaSerializer(core_schema.missing_sentinel_schema(core_schema.int_schema()))
+
+    assert s.to_python(MISSING) is MISSING
+    assert s.to_python(1) == 1
+    assert s.to_python(1, mode='json') == 1
+    assert s.to_json(1) == b'1'
+
+    with pytest.raises(ValueError, match="'MISSING' can't be serialized to JSON"):
+        s.to_json(MISSING)
+
+
+def test_missing_sentinel_inner_schema_serialization_warning() -> None:
+    s = SchemaSerializer(core_schema.missing_sentinel_schema(core_schema.int_schema()))
+
+    with pytest.warns(UserWarning, match='Expected `int`'):
+        s.to_python('hello')
+
+
+def test_missing_sentinel_dict_key() -> None:
+    s = SchemaSerializer(
+        core_schema.dict_schema(
+            keys_schema=core_schema.missing_sentinel_schema(core_schema.int_schema()),
+            values_schema=core_schema.int_schema(),
+        )
+    )
+
+    assert s.to_python({1: 2}, mode='json') == {'1': 2}
+    assert s.to_json({1: 2}) == b'{"1":2}'
+
+    with pytest.raises(PydanticSerializationError, match='Unable to serialize unknown type'):
+        s.to_json({MISSING: 2})
+
+
+def test_missing_sentinel_typed_dict_field_omitted() -> None:
+    s = SchemaSerializer(
+        core_schema.typed_dict_schema(
+            {
+                'f': core_schema.typed_dict_field(
+                    core_schema.with_default_schema(
+                        core_schema.missing_sentinel_schema(core_schema.int_schema()), default=MISSING
+                    )
+                ),
+                'g': core_schema.typed_dict_field(core_schema.int_schema()),
+            }
+        )
+    )
+
+    assert s.to_python({'f': MISSING, 'g': 1}) == {'g': 1}
+    assert s.to_python({'f': 1, 'g': 1}) == {'f': 1, 'g': 1}
+    assert s.to_json({'f': MISSING, 'g': 1}) == b'{"g":1}'

--- a/pydantic-core/tests/test_schema_functions.py
+++ b/pydantic-core/tests/test_schema_functions.py
@@ -88,6 +88,11 @@ all_schema_functions = [
     ),
     (core_schema.literal_schema, args(['a', 'b']), {'type': 'literal', 'expected': ['a', 'b']}),
     (core_schema.missing_sentinel_schema, args(), {'type': 'missing-sentinel'}),
+    (
+        core_schema.missing_sentinel_schema,
+        args({'type': 'int'}),
+        {'type': 'missing-sentinel', 'schema': {'type': 'int'}},
+    ),
     (core_schema.ellipsis_schema, args(), {'type': 'ellipsis'}),
     (
         core_schema.enum_schema,

--- a/pydantic-core/tests/validators/test_missing_sentinel.py
+++ b/pydantic-core/tests/validators/test_missing_sentinel.py
@@ -1,0 +1,94 @@
+import pytest
+
+from pydantic_core import MISSING, SchemaValidator, ValidationError, core_schema
+
+
+def test_missing_sentinel_no_inner_schema() -> None:
+    v = SchemaValidator(core_schema.missing_sentinel_schema())
+
+    assert v.validate_python(MISSING) is MISSING
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python(1)
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'missing_sentinel_error',
+            'loc': (),
+            'msg': "Input should be the 'MISSING' sentinel",
+            'input': 1,
+        }
+    ]
+
+
+def test_missing_sentinel_inner_schema() -> None:
+    v = SchemaValidator(core_schema.missing_sentinel_schema(core_schema.int_schema()))
+
+    assert v.validate_python(MISSING) is MISSING
+    assert v.validate_python(1) == 1
+    assert v.validate_python('123') == 123
+    assert v.validate_json('123') == 123
+
+    # The `MISSING` sentinel shouldn't be mentioned as a valid input:
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python('hello')
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_parsing',
+            'loc': (),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'hello',
+        }
+    ]
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_json('"hello"')
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_parsing',
+            'loc': (),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'hello',
+        }
+    ]
+
+
+def test_missing_sentinel_inner_schema_none_not_allowed() -> None:
+    v = SchemaValidator(core_schema.missing_sentinel_schema(core_schema.int_schema()))
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python(None)
+
+    assert exc_info.value.errors(include_url=False)[0]['type'] == 'int_type'
+
+
+def test_missing_sentinel_model_field() -> None:
+    v = SchemaValidator(
+        core_schema.model_fields_schema(
+            {
+                'f': core_schema.model_field(
+                    core_schema.with_default_schema(
+                        core_schema.missing_sentinel_schema(core_schema.int_schema()), default=MISSING
+                    )
+                )
+            }
+        )
+    )
+
+    assert v.validate_python({}) == ({'f': MISSING}, None, set())
+    assert v.validate_python({'f': MISSING}) == ({'f': MISSING}, None, {'f'})
+    assert v.validate_python({'f': 1}) == ({'f': 1}, None, {'f'})
+
+    with pytest.raises(ValidationError) as exc_info:
+        v.validate_python({'f': 'hello'})
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_parsing',
+            'loc': ('f',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'hello',
+        }
+    ]

--- a/pydantic/_internal/_discriminated_union.py
+++ b/pydantic/_internal/_discriminated_union.py
@@ -124,6 +124,11 @@ class _ApplyInferredDiscriminator:
         # to the possible presence of other wrapper schemas such as DefinitionsSchema, WithDefaultSchema, etc.
         self._is_nullable = False
 
+        # `_should_allow_missing` and `_is_allowing_missing` play the same role as `_should_be_nullable`
+        # and `_is_nullable`, for the `MISSING` sentinel (represented by the 'missing-sentinel' wrapper schema).
+        self._should_allow_missing = False
+        self._is_allowing_missing = False
+
         # `_choices_to_handle` serves as a stack of choices to add to the tagged union. Initially, choices
         # from the union in the wrapped schema will be appended to this list, and the recursive choice-handling
         # algorithm may add more choices to this stack as (nested) unions are encountered.
@@ -163,6 +168,8 @@ class _ApplyInferredDiscriminator:
         schema = self._apply_to_root(schema)
         if self._should_be_nullable and not self._is_nullable:
             schema = core_schema.nullable_schema(schema)
+        if self._should_allow_missing and not self._is_allowing_missing:
+            schema = core_schema.missing_sentinel_schema(schema)
         self._used = True
         return schema
 
@@ -177,6 +184,13 @@ class _ApplyInferredDiscriminator:
             nullable_wrapper = schema.copy()
             nullable_wrapper['schema'] = wrapped
             return nullable_wrapper
+
+        if schema['type'] == 'missing-sentinel' and 'schema' in schema:
+            self._is_allowing_missing = True
+            wrapped = self._apply_to_root(schema['schema'])
+            missing_sentinel_wrapper = schema.copy()
+            missing_sentinel_wrapper['schema'] = wrapped
+            return missing_sentinel_wrapper
 
         if schema['type'] == 'definitions':
             wrapped = self._apply_to_root(schema['schema'])
@@ -255,6 +269,10 @@ class _ApplyInferredDiscriminator:
         elif choice['type'] == 'nullable':
             self._should_be_nullable = True
             self._handle_choice(choice['schema'])  # unwrap the nullable schema
+        elif choice['type'] == 'missing-sentinel':
+            self._should_allow_missing = True
+            if (inner_schema := choice.get('schema')) is not None:
+                self._handle_choice(inner_schema)  # unwrap the missing-sentinel schema
         elif choice['type'] == 'union':
             # Reverse the choices list before extending the stack so that they get handled in the order they occur
             choices_schemas = [v[0] if isinstance(v, tuple) else v for v in choice['choices'][::-1]]
@@ -341,6 +359,10 @@ class _ApplyInferredDiscriminator:
         elif choice['type'] == 'nullable':
             self._should_be_nullable = True
             return self._infer_discriminator_values_for_choice(choice['schema'], source_name=None)
+
+        elif choice['type'] == 'missing-sentinel' and (inner_schema := choice.get('schema')) is not None:
+            self._should_allow_missing = True
+            return self._infer_discriminator_values_for_choice(inner_schema, source_name=None)
 
         elif choice['type'] == 'model':
             return self._infer_discriminator_values_for_choice(choice['schema'], source_name=choice['cls'].__name__)

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -1356,7 +1356,11 @@ class GenerateSchema:
             else:
                 choices.append(self.generate_schema(arg))
 
-        if len(choices) == 1:
+        if not choices:
+            # Only `None` and `MISSING` were present in the union (e.g. `None | MISSING`):
+            s = core_schema.none_schema()
+            nullable = False
+        elif len(choices) == 1:
             s = choices[0]
         else:
             choices_with_tags: list[CoreSchema | tuple[CoreSchema, str]] = []

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -236,6 +236,9 @@ def apply_each_item_validators(
     if schema['type'] == 'nullable':
         schema['schema'] = apply_each_item_validators(schema['schema'], each_item_validators)
         return schema
+    elif schema['type'] == 'missing-sentinel' and 'schema' in schema:
+        schema['schema'] = apply_each_item_validators(schema['schema'], each_item_validators)
+        return schema
     elif schema['type'] == 'tuple':
         if (variadic_item_index := schema.get('variadic_item_index')) is not None:
             schema['items_schema'][variadic_item_index] = apply_validators(
@@ -1344,9 +1347,12 @@ class GenerateSchema:
         args = self._get_args_resolving_forward_refs(union_type, required=True)
         choices: list[CoreSchema] = []
         nullable = False
+        allow_missing = False
         for arg in args:
             if arg is None or arg is NoneType:
                 nullable = True
+            elif arg is MISSING:
+                allow_missing = True
             else:
                 choices.append(self.generate_schema(arg))
 
@@ -1364,6 +1370,8 @@ class GenerateSchema:
 
         if nullable:
             s = core_schema.nullable_schema(s)
+        if allow_missing:
+            s = core_schema.missing_sentinel_schema(s)
         return s
 
     def _type_alias_type_schema(self, obj: TypeAliasType) -> CoreSchema:
@@ -2352,47 +2360,12 @@ class GenerateSchema:
                 schema['schema'] = inner
             return schema
 
-        if schema['type'] == 'union' and any(
-            choice['type'] == 'missing-sentinel' for choice in core_schema.iter_union_choices(schema)
-        ):
-            # Same behavior as for nullable schemas. This is a bit gross, but we have to support the same pattern
-            filtered_choices = [
-                choice
-                for choice in schema['choices']
-                if (choice[0] if isinstance(choice, tuple) else choice)['type'] != 'missing-sentinel'
-            ]
-            if len(filtered_choices) >= 2:
-                # e.g. `Annotated[int | str | MISSING, Constraint(...)]`. We apply `Constraint(...)` to `int | str`,
-                # and create a new union semantically equivalent to `Annotated[int | str, Constraint(...)] | MISSING`:
-                filtered_union = core_schema.union_schema(filtered_choices)
-                filtered_union = self._apply_single_annotation(filtered_union, metadata)
-                new_union = schema.copy()
-                new_union['choices'] = [
-                    filtered_union,
-                    next(
-                        choice
-                        for choice in schema['choices']
-                        if (choice[0] if isinstance(choice, tuple) else choice)['type'] == 'missing-sentinel'
-                    ),
-                ]
-                return new_union
-            elif len(filtered_choices) == 1:
-                # e.g. `Annotated[int | MISSING, Constraint(...)]`. We apply `Constraint(...)` to `int`, and reconstruct
-                # a new union preserving the order.
-                inner = filtered_choices[0][0] if isinstance(filtered_choices[0], tuple) else filtered_choices[0]
-                inner = self._apply_single_annotation(inner, metadata)
-
-                # Create a new union schema, preserving the order of the union:
-                new_union = schema.copy()
-                new_union['choices'] = [
-                    (inner, choice[1])
-                    if isinstance(choice, tuple) and choice[0]['type'] != 'missing-sentinel'
-                    else inner
-                    if not isinstance(choice, tuple) and choice['type'] != 'missing-sentinel'
-                    else choice
-                    for choice in schema['choices']
-                ]
-                return new_union
+        if schema['type'] == 'missing-sentinel' and (inner := schema.get('schema')) is not None:
+            # Same behavior as for nullable schemas: metadata is automatically applied to the inner schema
+            inner = self._apply_single_annotation(inner, metadata)
+            if inner:
+                schema['schema'] = inner
+            return schema
 
         original_schema = schema
         ref = schema.get('ref')

--- a/pydantic/json_schema.py
+++ b/pydantic/json_schema.py
@@ -913,7 +913,7 @@ class GenerateJsonSchema:
         return result
 
     def missing_sentinel_schema(self, schema: core_schema.MissingSentinelSchema) -> JsonSchemaValue:
-        """Generates a JSON schema that matches the `MISSING` sentinel value.
+        """Generates a JSON schema that matches a schema that allows the `MISSING` sentinel value.
 
         Args:
             schema: The core schema.
@@ -921,7 +921,10 @@ class GenerateJsonSchema:
         Returns:
             The generated JSON schema.
         """
-        raise PydanticOmit
+        inner_schema = schema.get('schema')
+        if inner_schema is None:
+            raise PydanticOmit
+        return self.generate_inner(inner_schema)
 
     def ellipsis_schema(self, schema: core_schema.EllipsisSchema) -> JsonSchemaValue:
         """Handles JSON schema generation for a core schema that checks if a value is the [`Ellipsis`][] literal.
@@ -2322,6 +2325,8 @@ class GenerateJsonSchema:
                 return False
             if schema['type'] in {'default', 'nullable', 'definitions'}:
                 return self.field_title_should_be_set(schema['schema'])  # type: ignore[typeddict-item]
+            if schema['type'] == 'missing-sentinel' and (inner_schema := schema.get('schema')) is not None:
+                return self.field_title_should_be_set(inner_schema)
             if _core_utils.is_function_with_inner_schema(schema):
                 return self.field_title_should_be_set(schema['schema'])
             if schema['type'] == 'definition-ref':

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -1,12 +1,12 @@
 import pickle
-from typing import Annotated
+from typing import Annotated, Literal, Union
 
 import pytest
 import typing_extensions
 from annotated_types import Ge
 from pydantic_core import MISSING, PydanticSerializationUnexpectedValue
 
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 
 def test_missing_sentinel_model() -> None:
@@ -146,3 +146,104 @@ def test_missing_sentinel_child_fields() -> None:
     result = TypeAdapter(Container).dump_python(container)
 
     assert result == {'item': {'parent_field': 'p'}}
+
+
+def test_missing_sentinel_validation_error_not_mentioned() -> None:
+    class Model(BaseModel):
+        f1: int | MISSING = MISSING
+        f2: int | None | MISSING = MISSING
+        f3: int | str | MISSING = MISSING
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(f1='not_an_int', f2='not_an_int', f3=[])
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_parsing',
+            'loc': ('f1',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'not_an_int',
+        },
+        {
+            'type': 'int_parsing',
+            'loc': ('f2',),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'not_an_int',
+        },
+        {
+            'type': 'int_type',
+            'loc': ('f3', 'int'),
+            'msg': 'Input should be a valid integer',
+            'input': [],
+        },
+        {
+            'type': 'string_type',
+            'loc': ('f3', 'str'),
+            'msg': 'Input should be a valid string',
+            'input': [],
+        },
+    ]
+
+
+def test_missing_sentinel_discriminated_union() -> None:
+    class Cat(BaseModel):
+        kind: Literal['cat']
+
+    class Dog(BaseModel):
+        kind: Literal['dog']
+
+    class Model(BaseModel):
+        pet1: Annotated[Cat | Dog | MISSING, Field(discriminator='kind')] = MISSING
+        pet2: Annotated[Cat | Dog | None | MISSING, Field(discriminator='kind')] = MISSING
+        pet3: Annotated[Union[Cat | MISSING, Dog], Field(discriminator='kind')] = MISSING  # noqa: UP007
+
+    m = Model(pet1={'kind': 'cat'}, pet2=None, pet3={'kind': 'dog'})
+    assert isinstance(m.pet1, Cat)
+    assert m.pet2 is None
+    assert isinstance(m.pet3, Dog)
+
+    m = Model(pet1=MISSING, pet2=MISSING, pet3=MISSING)
+    assert m.model_dump() == {}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(pet1={'kind': 'fish'})
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'union_tag_invalid',
+            'loc': ('pet1',),
+            'msg': "Input tag 'fish' found using 'kind' does not match any of the expected tags: 'cat', 'dog'",
+            'input': {'kind': 'fish'},
+            'ctx': {'discriminator': "'kind'", 'tag': 'fish', 'expected_tags': "'cat', 'dog'"},
+        },
+    ]
+
+    json_schema = Model.model_json_schema()
+    tagged_union_json_schema = {
+        'discriminator': {'mapping': {'cat': '#/$defs/Cat', 'dog': '#/$defs/Dog'}, 'propertyName': 'kind'},
+        'oneOf': [{'$ref': '#/$defs/Cat'}, {'$ref': '#/$defs/Dog'}],
+    }
+    assert json_schema['properties'] == {
+        'pet1': {**tagged_union_json_schema, 'title': 'Pet1'},
+        'pet2': {'anyOf': [tagged_union_json_schema, {'type': 'null'}], 'title': 'Pet2'},
+        'pet3': {**tagged_union_json_schema, 'title': 'Pet3'},
+    }
+
+
+def test_missing_sentinel_nested_type() -> None:
+    ta = TypeAdapter(list[int | MISSING])
+
+    assert ta.validate_python([1, MISSING]) == [1, MISSING]
+    assert ta.dump_python([1, MISSING]) == [1, MISSING]
+
+    with pytest.raises(ValidationError) as exc_info:
+        ta.validate_python([1, 'not_an_int'])
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'int_parsing',
+            'loc': (1,),
+            'msg': 'Input should be a valid integer, unable to parse string as an integer',
+            'input': 'not_an_int',
+        },
+    ]

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -192,17 +192,27 @@ def test_missing_sentinel_discriminated_union() -> None:
     class Dog(BaseModel):
         kind: Literal['dog']
 
+    MissingCat = typing_extensions.TypeAliasType('MissingCat', Cat | MISSING)
+
     class Model(BaseModel):
         pet1: Annotated[Cat | Dog | MISSING, Field(discriminator='kind')] = MISSING
         pet2: Annotated[Cat | Dog | None | MISSING, Field(discriminator='kind')] = MISSING
-        pet3: Annotated[Union[Cat | MISSING, Dog], Field(discriminator='kind')] = MISSING  # noqa: UP007
+        # The inner `Annotated` form prevents the union from being flattened, so that the
+        # 'missing-sentinel' schema is a choice of the outer union:
+        pet3: Annotated[
+            Union[Annotated[Cat | MISSING, Field(title='Cat')], Dog],  # noqa: UP007
+            Field(discriminator='kind'),
+        ] = MISSING
+        # The 'missing-sentinel' schema is referenced through a 'definition-ref' schema:
+        pet4: Annotated[Union[MissingCat, Dog], Field(discriminator='kind')] = MISSING  # noqa: UP007
 
-    m = Model(pet1={'kind': 'cat'}, pet2=None, pet3={'kind': 'dog'})
+    m = Model(pet1={'kind': 'cat'}, pet2=None, pet3={'kind': 'dog'}, pet4={'kind': 'cat'})
     assert isinstance(m.pet1, Cat)
     assert m.pet2 is None
     assert isinstance(m.pet3, Dog)
+    assert isinstance(m.pet4, Cat)
 
-    m = Model(pet1=MISSING, pet2=MISSING, pet3=MISSING)
+    m = Model(pet1=MISSING, pet2=MISSING, pet3=MISSING, pet4=MISSING)
     assert m.model_dump() == {}
 
     with pytest.raises(ValidationError) as exc_info:
@@ -227,7 +237,36 @@ def test_missing_sentinel_discriminated_union() -> None:
         'pet1': {**tagged_union_json_schema, 'title': 'Pet1'},
         'pet2': {'anyOf': [tagged_union_json_schema, {'type': 'null'}], 'title': 'Pet2'},
         'pet3': {**tagged_union_json_schema, 'title': 'Pet3'},
+        'pet4': {
+            'discriminator': {'mapping': {'cat': '#/$defs/MissingCat', 'dog': '#/$defs/Dog'}, 'propertyName': 'kind'},
+            'oneOf': [{'$ref': '#/$defs/MissingCat'}, {'$ref': '#/$defs/Dog'}],
+            'title': 'Pet4',
+        },
     }
+
+
+def test_missing_sentinel_none_union() -> None:
+    class Model(BaseModel):
+        f: None | MISSING = MISSING
+
+    assert Model(f=None).f is None
+    assert Model(f=MISSING).f is MISSING
+    assert Model().model_dump() == {}
+    assert Model(f=None).model_dump() == {'f': None}
+
+    with pytest.raises(ValidationError) as exc_info:
+        Model(f=1)
+
+    assert exc_info.value.errors(include_url=False) == [
+        {
+            'type': 'none_required',
+            'loc': ('f',),
+            'msg': 'Input should be None',
+            'input': 1,
+        },
+    ]
+
+    assert Model.model_json_schema()['properties']['f'] == {'title': 'F', 'type': 'null'}
 
 
 def test_missing_sentinel_nested_type() -> None:

--- a/tests/typechecking/uv.lock
+++ b/tests/typechecking/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"


### PR DESCRIPTION
To achieve this, we refactor the `'missing-sentinel'` schema to have an inner core schema, like `'nullable'` schemas. 

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Part of https://github.com/pydantic/pydantic/issues/12090.

