### PR TITLE
Derive alias config on a copy, not in the caller's ConfigDict

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -209,6 +209,13 @@ class ConfigWrapper:
                 stacklevel=2,
             )
 
+        # The backwards-compatibility patches below write derived values back into
+        # `config`, which is the very same mapping the caller handed us: a model's own
+        # `model_config`, or the `ConfigDict` passed to `TypeAdapter`/`validate_call`/
+        # `@dataclass`. Derive them on a copy instead, so a value pydantic worked out
+        # cannot later be read back as one the user set.
+        config = cast(ConfigDict, dict(config))
+
         if (populate_by_name := config.get('populate_by_name')) is not None:
             # We include this patch for backwards compatibility purposes, but this config setting will be deprecated in v3.0, and likely removed in v4.0.
             # Thus, the above warning and this patch can be removed then as well.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1000,4 +1000,62 @@ def test_dynamic_default() -> None:
     class Model(BaseModel):
         model_config = ConfigDict(validate_by_alias=False)
 
-    assert Model.model_config == {'validate_by_alias': False, 'validate_by_name': True}
+        a: int = Field(alias='A')
+
+    # model_config holds the configuration as given. A value pydantic derives from it
+    # cannot be stored alongside: subclass config is merged over the parent's, so the
+    # derived value would outrank an explicit setting made by a subclass.
+    assert Model.model_config == {'validate_by_alias': False}
+
+    # The derived validate_by_name=True is still what makes this model usable at all.
+    assert Model(a=1).a == 1
+    with pytest.raises(ValidationError):
+        Model.model_validate({'A': 1})
+
+
+def test_derived_alias_config_is_not_inherited_as_explicit() -> None:
+    class Parent(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+
+    class Child(Parent):
+        model_config = ConfigDict(populate_by_name=False)
+
+        a: int = Field(alias='A')
+
+    class Standalone(BaseModel):
+        model_config = ConfigDict(populate_by_name=False)
+
+        a: int = Field(alias='A')
+
+    assert Child.model_config == {'populate_by_name': False}
+
+    # Child and Standalone declare the same configuration and the same field, so they
+    # have to validate the same way.
+    for model in (Child, Standalone):
+        assert model.model_validate({'A': 1}).a == 1
+        with pytest.raises(ValidationError):
+            model.model_validate({'a': 1})
+
+
+def test_config_argument_is_not_mutated() -> None:
+    config = ConfigDict(populate_by_name=True)
+    TypeAdapter(int, config=config)
+    assert config == {'populate_by_name': True}
+
+    config = ConfigDict(populate_by_name=True)
+
+    @validate_call(config=config)
+    def func(a: int) -> int:
+        return a
+
+    func(1)
+    assert config == {'populate_by_name': True}
+
+    config = ConfigDict(populate_by_name=True)
+
+    @pydantic_dataclass(config=config)
+    class Dc:
+        a: int
+
+    Dc(a=1)
+    assert config == {'populate_by_name': True}


### PR DESCRIPTION
Discussion in #13786 — deliberately not using a closing keyword, since I am not assigned to it.

### The bug

Two models that declare the same configuration and the same field validate differently, depending on what a base class declared:

```python
class Parent(BaseModel):
    model_config = ConfigDict(populate_by_name=True)
    p: int = 0

class Child(Parent):
    model_config = ConfigDict(populate_by_name=False)
    x: int = Field(alias='X')

class Standalone(BaseModel):
    model_config = ConfigDict(populate_by_name=False)
    x: int = Field(alias='X')

Standalone(x=1)  # ValidationError, alias required
Child(x=1)       # Child(p=0, x=1)  -- alias requirement silently bypassed
```

### Cause

`core_config()` patches the deprecated settings into their replacements by writing into `self.config_dict`, which is the very mapping it was given:

```python
config = self.config_dict
...
if config.get('validate_by_name') is None:
    config['validate_by_alias'] = True
    config['validate_by_name'] = populate_by_name
```

For a model that mapping is `model_config`, so a value pydantic derived ends up stored next to the ones the user declared:

```
Parent.model_config    : {'populate_by_name': True,  'validate_by_alias': True, 'validate_by_name': True}
Child.model_config     : {'populate_by_name': False, 'validate_by_alias': True, 'validate_by_name': True}
Standalone.model_config: {'populate_by_name': False, 'validate_by_alias': True, 'validate_by_name': False}
```

Subclass config is merged over the parent's, so `Child` inherits the derived `validate_by_name=True`, and the `is None` guard then declines to derive again from `Child`'s own `populate_by_name=False`. The derived value outranks the explicit one.

`docs/concepts/config.md` describes `model_config` as the merge of what was declared, and its inheritance example prints exactly the keys the user set — so this is also what the documented merge is defined over.

The same write reaches user-owned mappings through the direct-config entry points, where `config_dict` really is the caller's object:

```
TypeAdapter(config=...)   : before {'populate_by_name': True} after {..., 'validate_by_alias': True, 'validate_by_name': True}
validate_call(config=...) : before {'populate_by_name': True} after {..., 'validate_by_alias': True, 'validate_by_name': True}
@dataclass(config=...)    : same
```

### Fix

Derive on a copy. The derived values are only ever read back by `core_config` itself on the way to `CoreConfig`: the sole runtime reader of either name outside this function is `json_schema.py:1659`, and it reads `validate_by_alias`, which the patch only ever sets to `True` — already the default. So nothing downstream sees a change.

### The one existing test this changes

`test_dynamic_default` asserted the derived value was visible on `model_config`:

```python
assert Model.model_config == {'validate_by_alias': False, 'validate_by_name': True}
```

That assertion and correct merging cannot both hold. While `model_config` is a plain dict there is nothing to distinguish a derived value from a declared one, so anything stored there participates in the merge and wins over a subclass's explicit setting. The test now asserts the derived default is *applied* — `Model(a=1)` works and `{'A': 1}` is rejected — rather than where it is kept, which is what it was really about.

If you would rather keep it visible and re-derive during the merge instead, I am glad to rework it that way; that route needs a way to mark derived keys, which seemed like your call to make rather than mine.

### Tests

- `test_dynamic_default` — rewritten as above.
- `test_derived_alias_config_is_not_inherited_as_explicit` — `Child` and `Standalone` must validate identically.
- `test_config_argument_is_not_mutated` — `TypeAdapter`, `validate_call` and `@dataclass` leave the caller's `ConfigDict` alone.

Full suite (`pytest tests/ --ignore=tests/benchmarks`): **5864 passed, 226 skipped, 4 failed** — the same 4 failures the tree has without this change (`test_validate_call.py:262`, `test_json_schema.py:1025`, `test_main.py:1442`, `test_types.py:3182`), so no new failures.

Reverting only `_config.py` and keeping the tests fails exactly the three above, 83 others in `test_config.py` passing either way.

A note on how that was run: `main` currently imports `_schema_gather` from `pydantic-core`, which the published 2.48.0 wheel does not export, so the suite cannot run against a released core. I ran it at `585c994~1` (the commit before "Move schema gathering logic to `pydantic-core`"), where `_config.py` and `tests/test_config.py` are byte-identical to `main` — `git diff main 585c994~1 --` on both files is empty.
