### PR TITLE
Fix JSON Schema length keywords for mapping wrappers

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -250,13 +250,25 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while True:
+                    inner_schema_type = inner_schema['type']
+                    if inner_schema_type in {'function-before', 'function-wrap', 'function-after'}:
+                        inner_schema = inner_schema['schema']  # type: ignore
+                    elif inner_schema_type == 'lax-or-strict':
+                        inner_schema = (
+                            inner_schema['strict_schema']
+                            if inner_schema.get('strict', False)
+                            else inner_schema['lax_schema']
+                        )  # type: ignore
+                    elif inner_schema_type == 'json-or-python':
+                        inner_schema = inner_schema['json_schema']  # type: ignore
+                    else:
+                        break
                 inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
-                ):
+                if inner_schema_type == 'list':
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type == 'dict':
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/types/test_counter.py
+++ b/tests/types/test_counter.py
@@ -1,8 +1,9 @@
 from collections import Counter
+from typing import Annotated
 
 import pytest
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import Field, TypeAdapter, ValidationError
 
 
 def test_typing_coercion_counter():
@@ -28,3 +29,14 @@ def test_typing_counter_value_validation():
             'input': 'a',
         }
     ]
+
+
+def test_typing_counter_json_schema_with_length_constraints() -> None:
+    ta = TypeAdapter(Annotated[Counter[str], Field(min_length=1, max_length=3)])
+
+    assert ta.json_schema() == {
+        'type': 'object',
+        'additionalProperties': {'type': 'integer'},
+        'minProperties': 1,
+        'maxProperties': 3,
+    }

--- a/tests/types/test_ordered_dict.py
+++ b/tests/types/test_ordered_dict.py
@@ -1,10 +1,11 @@
 import collections
 import typing
 from collections import OrderedDict
+from typing import Annotated
 
 import pytest
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import Field, TypeAdapter, ValidationError
 
 
 def test_ordered_dict():
@@ -59,6 +60,17 @@ def test_ordered_dict_from_ordered_dict_typed():
     assert ta.json_schema() == {
         'type': 'object',
         'additionalProperties': {'type': 'integer'},
+    }
+
+
+def test_ordered_dict_json_schema_with_length_constraints() -> None:
+    ta = TypeAdapter(Annotated[OrderedDict[str, int], Field(min_length=1, max_length=3)])
+
+    assert ta.json_schema() == {
+        'type': 'object',
+        'additionalProperties': {'type': 'integer'},
+        'minProperties': 1,
+        'maxProperties': 3,
     }
 
 


### PR DESCRIPTION
## Change Summary

`Counter` and `OrderedDict` schemas wrap their underlying `dict` schema in `lax-or-strict` and `function-after` schemas. The known-metadata handling only inspected the outer schema, so `min_length` and `max_length` were emitted as `minLength` and `maxLength` even though the JSON Schema type was `object`.

This change unwraps the relevant schema wrappers before choosing the JSON Schema keyword and emits `minProperties` and `maxProperties` for mappings while preserving `minItems` and `maxItems` for arrays.

## Related issue number

Fixes #13704

## Checklist

- [x] The pull request title is a good summary of the changes
- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- [x] Documentation reflects the changes where applicable
- [x] My PR is ready to review — please review

Focused Counter and OrderedDict tests pass locally, along with Ruff checks and `git diff --check`.