### PR TITLE
Call enum constructors in both validation modes

### DIFF
--- a/pydantic-core/python/pydantic_core/core_schema.py
+++ b/pydantic-core/python/pydantic_core/core_schema.py
@@ -12,7 +12,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from fractions import Fraction
 from re import Pattern
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal, Union, overload
 
 from typing_extensions import TypeVar, deprecated
 
@@ -1390,6 +1390,34 @@ class EnumSchema(TypedDict, total=False):
     serialization: SerSchema
 
 
+@overload
+@deprecated('The `missing` argument on `enum_schema()` is deprecated and no longer used.')
+def enum_schema(
+    cls: Any,
+    members: list[Any],
+    *,
+    sub_type: Literal['str', 'int', 'float'] | None = None,
+    missing: Callable[[Any], Any] | None,
+    strict: bool | None = None,
+    ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> EnumSchema: ...
+
+
+@overload
+def enum_schema(
+    cls: Any,
+    members: list[Any],
+    *,
+    sub_type: Literal['str', 'int', 'float'] | None = None,
+    strict: bool | None = None,
+    ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> EnumSchema: ...
+
+
 def enum_schema(
     cls: Any,
     members: list[Any],
@@ -1422,12 +1450,19 @@ def enum_schema(
         cls: The enum class
         members: The members of the enum, generally `list(MyEnum.__members__.values())`
         sub_type: The type of the enum, either 'str' or 'int' or None for plain enums
-        missing: A function to use when the value is not found in the enum, from `_missing_`
+        missing: Deprecated and no longer used, the `_missing_` hook of the enum class is now called by the enum validator
         strict: Whether to use strict mode, defaults to False
         ref: optional unique identifier of the schema, used to reference the schema in other places
         metadata: Any other information you want to include with the schema, not used by pydantic-core
         serialization: Custom serialization schema
     """
+    if missing is not None:
+        warnings.warn(
+            'The `missing` argument on `enum_schema()` is deprecated and no longer used.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     return _dict_not_none(
         type='enum',
         cls=cls,
@@ -2338,6 +2373,35 @@ def no_info_before_validator_function(
     )
 
 
+@overload
+@deprecated(
+    'The `field_name` argument on `with_info_before_validator_function` is deprecated, '
+    'it will be passed to the function through `ValidationState` instead.'
+)
+def with_info_before_validator_function(
+    function: WithInfoValidatorFunction,
+    schema: CoreSchema,
+    *,
+    field_name: str | None,
+    ref: str | None = None,
+    json_schema_input_schema: CoreSchema | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> BeforeValidatorFunctionSchema: ...
+
+
+@overload
+def with_info_before_validator_function(
+    function: WithInfoValidatorFunction,
+    schema: CoreSchema,
+    *,
+    ref: str | None = None,
+    json_schema_input_schema: CoreSchema | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> BeforeValidatorFunctionSchema: ...
+
+
 def with_info_before_validator_function(
     function: WithInfoValidatorFunction,
     schema: CoreSchema,
@@ -2442,6 +2506,33 @@ def no_info_after_validator_function(
         metadata=metadata,
         serialization=serialization,
     )
+
+
+@overload
+@deprecated(
+    'The `field_name` argument on `with_info_after_validator_function` is deprecated, '
+    'it will be passed to the function through `ValidationState` instead.'
+)
+def with_info_after_validator_function(
+    function: WithInfoValidatorFunction,
+    schema: CoreSchema,
+    *,
+    field_name: str | None,
+    ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> AfterValidatorFunctionSchema: ...
+
+
+@overload
+def with_info_after_validator_function(
+    function: WithInfoValidatorFunction,
+    schema: CoreSchema,
+    *,
+    ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> AfterValidatorFunctionSchema: ...
 
 
 def with_info_after_validator_function(
@@ -2585,6 +2676,35 @@ def no_info_wrap_validator_function(
     )
 
 
+@overload
+@deprecated(
+    'The `field_name` argument on `with_info_wrap_validator_function` is deprecated, '
+    'it will be passed to the function through `ValidationState` instead.'
+)
+def with_info_wrap_validator_function(
+    function: WithInfoWrapValidatorFunction,
+    schema: CoreSchema,
+    *,
+    field_name: str | None,
+    json_schema_input_schema: CoreSchema | None = None,
+    ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> WrapValidatorFunctionSchema: ...
+
+
+@overload
+def with_info_wrap_validator_function(
+    function: WithInfoWrapValidatorFunction,
+    schema: CoreSchema,
+    *,
+    json_schema_input_schema: CoreSchema | None = None,
+    ref: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> WrapValidatorFunctionSchema: ...
+
+
 def with_info_wrap_validator_function(
     function: WithInfoWrapValidatorFunction,
     schema: CoreSchema,
@@ -2691,6 +2811,33 @@ def no_info_plain_validator_function(
         metadata=metadata,
         serialization=serialization,
     )
+
+
+@overload
+@deprecated(
+    'The `field_name` argument on `with_info_plain_validator_function` is deprecated, '
+    'it will be passed to the function through `ValidationState` instead.'
+)
+def with_info_plain_validator_function(
+    function: WithInfoValidatorFunction,
+    *,
+    field_name: str | None,
+    ref: str | None = None,
+    json_schema_input_schema: CoreSchema | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> PlainValidatorFunctionSchema: ...
+
+
+@overload
+def with_info_plain_validator_function(
+    function: WithInfoValidatorFunction,
+    *,
+    ref: str | None = None,
+    json_schema_input_schema: CoreSchema | None = None,
+    metadata: dict[str, Any] | None = None,
+    serialization: SerSchema | None = None,
+) -> PlainValidatorFunctionSchema: ...
 
 
 def with_info_plain_validator_function(
@@ -4733,37 +4880,21 @@ def iter_union_choices(union_schema: UnionSchema) -> Generator[CoreSchema]:
 
 @deprecated('`field_before_validator_function` is deprecated, use `with_info_before_validator_function` instead.')
 def field_before_validator_function(function: WithInfoValidatorFunction, field_name: str, schema: CoreSchema, **kwargs):
-    warnings.warn(
-        '`field_before_validator_function` is deprecated, use `with_info_before_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_before_validator_function(function, schema, field_name=field_name, **kwargs)
 
 
 @deprecated('`general_before_validator_function` is deprecated, use `with_info_before_validator_function` instead.')
 def general_before_validator_function(*args, **kwargs):
-    warnings.warn(
-        '`general_before_validator_function` is deprecated, use `with_info_before_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_before_validator_function(*args, **kwargs)
 
 
 @deprecated('`field_after_validator_function` is deprecated, use `with_info_after_validator_function` instead.')
 def field_after_validator_function(function: WithInfoValidatorFunction, field_name: str, schema: CoreSchema, **kwargs):
-    warnings.warn(
-        '`field_after_validator_function` is deprecated, use `with_info_after_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_after_validator_function(function, schema, field_name=field_name, **kwargs)
 
 
 @deprecated('`general_after_validator_function` is deprecated, use `with_info_after_validator_function` instead.')
 def general_after_validator_function(*args, **kwargs):
-    warnings.warn(
-        '`general_after_validator_function` is deprecated, use `with_info_after_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_after_validator_function(*args, **kwargs)
 
 
@@ -4771,37 +4902,21 @@ def general_after_validator_function(*args, **kwargs):
 def field_wrap_validator_function(
     function: WithInfoWrapValidatorFunction, field_name: str, schema: CoreSchema, **kwargs
 ):
-    warnings.warn(
-        '`field_wrap_validator_function` is deprecated, use `with_info_wrap_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_wrap_validator_function(function, schema, field_name=field_name, **kwargs)
 
 
 @deprecated('`general_wrap_validator_function` is deprecated, use `with_info_wrap_validator_function` instead.')
 def general_wrap_validator_function(*args, **kwargs):
-    warnings.warn(
-        '`general_wrap_validator_function` is deprecated, use `with_info_wrap_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_wrap_validator_function(*args, **kwargs)
 
 
 @deprecated('`field_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.')
 def field_plain_validator_function(function: WithInfoValidatorFunction, field_name: str, **kwargs):
-    warnings.warn(
-        '`field_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_plain_validator_function(function, field_name=field_name, **kwargs)
 
 
 @deprecated('`general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.')
 def general_plain_validator_function(*args, **kwargs):
-    warnings.warn(
-        '`general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.',
-        DeprecationWarning,
-    )
     return with_info_plain_validator_function(*args, **kwargs)
 
 

--- a/pydantic-core/src/validators/enum_.rs
+++ b/pydantic-core/src/validators/enum_.rs
@@ -2,7 +2,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use pyo3::exceptions::PyTypeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyType};
@@ -10,7 +10,7 @@ use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyType};
 use crate::build_tools::{is_strict, py_schema_err};
 use crate::errors::{ErrorType, ValError, ValResult};
 use crate::input::{Input, InputType};
-use crate::tools::{SchemaDict, safe_repr};
+use crate::tools::SchemaDict;
 use crate::validators::literal::expected_repr;
 
 use super::is_instance::class_repr;
@@ -54,7 +54,6 @@ impl BuildValidator for BuildEnumValidator {
                     phantom: PhantomData::<$vv>,
                     class: class.clone().into(),
                     lookup,
-                    missing: schema.get_as(intern!(py, "missing"))?,
                     expected_repr,
                     strict: is_strict(schema, config)?,
                     class_repr: class_repr.clone(),
@@ -88,7 +87,6 @@ pub struct EnumValidator<T: EnumValidateValue> {
     phantom: PhantomData<T>,
     class: Py<PyType>,
     lookup: Box<LiteralLookup<Py<PyAny>>>,
-    missing: Option<Py<PyAny>>,
     expected_repr: String,
     strict: bool,
     class_repr: String,
@@ -122,42 +120,23 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
 
         if let Some(v) = T::validate_value(py, input, &self.lookup, strict)? {
             return Ok(v);
-        } else if let Ok(res) = class.as_unbound().call1(py, (input.as_python(),)) {
-            return Ok(res);
-        } else if let Some(ref missing) = self.missing {
-            let enum_value = missing.bind(py).call1((input.to_object(py)?,)).map_err(|_| {
-                ValError::new(
-                    ErrorType::Enum {
-                        expected: self.expected_repr.clone(),
-                        context: None,
-                    },
-                    input,
-                )
-            })?;
-            // check enum_value is an instance of the class like
-            // https://github.com/python/cpython/blob/v3.12.2/Lib/enum.py#L1148
-            if enum_value.is_instance(class)? {
-                return Ok(enum_value.into());
-            } else if !enum_value.is(py.None()) {
-                let type_error = PyTypeError::new_err(format!(
-                    "error in {}._missing_: returned {} instead of None or a valid member",
-                    class
-                        .name()
-                        .and_then(|name| name.extract::<String>())
-                        .unwrap_or_else(|_| "<Unknown>".into()),
-                    safe_repr(&enum_value)
-                ));
-                return Err(type_error.into());
-            }
         }
 
-        Err(ValError::new(
-            ErrorType::Enum {
-                expected: self.expected_repr.clone(),
-                context: None,
-            },
-            input,
-        ))
+        // Fall back to calling the enum class (it handles calling `_missing_()` and such).
+        // A `ValueError` means the value is not a valid member. Any other exception is propagated
+        // as is (e.g. a `TypeError` if `_missing_()` returns something else than an enum value,
+        // meaning the `_missing_()` definition is invalid):
+        match class.call1((input.to_object(py)?,)) {
+            Ok(res) => Ok(res.unbind()),
+            Err(err) if err.is_instance_of::<PyValueError>(py) => Err(ValError::new(
+                ErrorType::Enum {
+                    expected: self.expected_repr.clone(),
+                    context: None,
+                },
+                input,
+            )),
+            Err(err) => Err(err.into()),
+        }
     }
 
     fn get_name(&self) -> &str {
@@ -168,7 +147,7 @@ impl<T: EnumValidateValue> Validator for EnumValidator<T> {
 #[derive(Debug, Clone)]
 pub struct PlainEnumValidator;
 
-impl_py_gc_traverse!(EnumValidator<PlainEnumValidator> { class, lookup, missing });
+impl_py_gc_traverse!(EnumValidator<PlainEnumValidator> { class, lookup });
 
 impl EnumValidateValue for PlainEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(
@@ -200,7 +179,7 @@ impl EnumValidateValue for PlainEnumValidator {
 #[derive(Debug, Clone)]
 pub struct IntEnumValidator;
 
-impl_py_gc_traverse!(EnumValidator<IntEnumValidator> { class, lookup, missing });
+impl_py_gc_traverse!(EnumValidator<IntEnumValidator> { class, lookup });
 
 impl EnumValidateValue for IntEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(
@@ -216,7 +195,7 @@ impl EnumValidateValue for IntEnumValidator {
 #[derive(Debug, Clone)]
 pub struct StrEnumValidator;
 
-impl_py_gc_traverse!(EnumValidator<StrEnumValidator> { class, lookup, missing });
+impl_py_gc_traverse!(EnumValidator<StrEnumValidator> { class, lookup });
 
 impl EnumValidateValue for StrEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(
@@ -232,7 +211,7 @@ impl EnumValidateValue for StrEnumValidator {
 #[derive(Debug, Clone)]
 pub struct FloatEnumValidator;
 
-impl_py_gc_traverse!(EnumValidator<FloatEnumValidator> { class, lookup, missing });
+impl_py_gc_traverse!(EnumValidator<FloatEnumValidator> { class, lookup });
 
 impl EnumValidateValue for FloatEnumValidator {
     fn validate_value<'py, I: Input<'py> + ?Sized>(

--- a/pydantic-core/tests/test_schema_functions.py
+++ b/pydantic-core/tests/test_schema_functions.py
@@ -427,3 +427,11 @@ def test_deprecation_warning() -> None:
         match='The `field_name` argument on `with_info_before_validator_function` is deprecated'
     ):
         core_schema.with_info_before_validator_function(val_function, schema={'type': 'int'}, field_name='foo')
+
+
+def test_enum_schema_missing_deprecation_warning() -> None:
+    class MyEnum(Enum):
+        a = 1
+
+    with pytest.deprecated_call(match=r'The `missing` argument on `enum_schema\(\)` is deprecated and no longer used'):
+        core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values()), missing=MyEnum._missing_)

--- a/pydantic-core/tests/validators/test_enums.py
+++ b/pydantic-core/tests/validators/test_enums.py
@@ -169,7 +169,7 @@ def test_enum_missing():
     assert MyEnum(2) is MyEnum.b
     assert MyEnum(3) is MyEnum.b
 
-    v = SchemaValidator(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values()), missing=MyEnum._missing_))
+    v = SchemaValidator(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values())))
 
     # debug(v)
     assert v.validate_python(MyEnum.a) is MyEnum.a
@@ -195,7 +195,7 @@ def test_enum_missing_none():
     with pytest.raises(ValueError, match='3 is not a valid'):
         MyEnum(3)
 
-    v = SchemaValidator(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values()), missing=MyEnum._missing_))
+    v = SchemaValidator(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values())))
 
     # debug(v)
     assert v.validate_python(MyEnum.a) is MyEnum.a
@@ -227,9 +227,11 @@ def test_enum_missing_wrong():
     with pytest.raises(TypeError, match=e):
         MyEnum(3)
 
-    v = SchemaValidator(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values()), missing=MyEnum._missing_))
+    v = SchemaValidator(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values())))
     with pytest.raises(TypeError, match=e):
         v.validate_python(3)
+    with pytest.raises(TypeError, match=e):
+        v.validate_json('3')
 
 
 def test_enum_exactness():
@@ -240,7 +242,7 @@ def test_enum_exactness():
     v = SchemaValidator(
         core_schema.union_schema(
             [
-                core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values()), missing=MyEnum._missing_),
+                core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values())),
                 core_schema.int_schema(),
             ],
         )

--- a/pydantic/_internal/_generate_schema.py
+++ b/pydantic/_internal/_generate_schema.py
@@ -527,13 +527,10 @@ class GenerateSchema:
                 original_schema.update(js_updates)
                 return json_schema
 
-            # we don't want to add the missing to the schema if it's the default one
-            default_missing = getattr(enum_type._missing_, '__func__', None) is Enum._missing_.__func__  # pyright: ignore[reportFunctionMemberAccess]
             enum_schema = core_schema.enum_schema(
                 enum_type,
                 cases,
                 sub_type=sub_type,
-                missing=None if default_missing else enum_type._missing_,
                 ref=enum_ref,
                 metadata={'pydantic_js_functions': [get_json_schema]},
             )

--- a/tests/types/test_enum.py
+++ b/tests/types/test_enum.py
@@ -1,4 +1,3 @@
-import re
 from enum import Enum, IntEnum
 from typing import Annotated, Any, NamedTuple
 
@@ -157,12 +156,12 @@ def test_enum_missing_default():
         a = 1
 
     ta = TypeAdapter(MyEnum)
-    missing_value = re.search(r'missing: (\w+)', repr(ta.validator)).group(1)
-    assert missing_value == 'None'
 
     assert ta.validate_python(1) is MyEnum.a
     with pytest.raises(ValidationError):
         ta.validate_python(2)
+    with pytest.raises(ValidationError):
+        ta.validate_json('2')
 
 
 def test_enum_missing_custom():
@@ -174,11 +173,59 @@ def test_enum_missing_custom():
             return MyEnum.a
 
     ta = TypeAdapter(MyEnum)
-    missing_value = re.search(r'missing: (\w+)', repr(ta.validator)).group(1)
-    assert missing_value == 'Some'
 
     assert ta.validate_python(1) is MyEnum.a
     assert ta.validate_python(2) is MyEnum.a
+    assert ta.validate_json('2') is MyEnum.a
+
+
+def test_enum_missing_receives_input_value() -> None:
+    """https://github.com/pydantic/pydantic/issues/12960"""
+    seen = []
+
+    class MyEnum(Enum):
+        a = 1
+        b = 2
+
+        @classmethod
+        def _missing_(cls, value):
+            seen.append(value)
+            return cls.b
+
+    ta = TypeAdapter(MyEnum)
+
+    assert ta.validate_python(3) is MyEnum.b
+    assert ta.validate_json('3') is MyEnum.b
+    assert ta.validate_json('3', strict=True) is MyEnum.b
+    assert ta.validate_python('3') is MyEnum.b
+    assert ta.validate_json('"3"') is MyEnum.b
+    assert seen == [3, 3, 3, '3', '3']
+
+
+def test_enum_missing_raises() -> None:
+    class MyEnum(Enum):
+        a = 1
+        b = 2
+
+        @classmethod
+        def _missing_(cls, value):
+            if value == 3:
+                raise ValueError('nope')
+            raise KeyError(value)
+
+    ta = TypeAdapter(MyEnum)
+
+    # `ValueError` is converted to a validation error, as in `Enum.__new__()`:
+    with pytest.raises(ValidationError, match=r'Input should be 1 or 2 \[type=enum, input_value=3, input_type=int\]'):
+        ta.validate_python(3)
+    with pytest.raises(ValidationError, match=r'Input should be 1 or 2 \[type=enum, input_value=3, input_type=int\]'):
+        ta.validate_json('3')
+
+    # other exceptions are propagated:
+    with pytest.raises(KeyError):
+        ta.validate_python(4)
+    with pytest.raises(KeyError):
+        ta.validate_json('4')
 
 
 def test_int_enum_type():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Fixes https://github.com/pydantic/pydantic/issues/12960.

When https://github.com/pydantic/pydantic-core/pull/1235 was introduced, it never called the enum class at all, so the `_missing_()` method had to be manually passed in the core schema. https://github.com/pydantic/pydantic-core/pull/1456 then changed the behavior to call the enum constructor as a fallback (but only in Python mode, what this PR fixes by widening to JSON). As the enum constructor takes care of calling `_missing_()` already, there's no need to have it manually set in the core schema anymore.

Also update deprecation warnings for existing deprecations in `core_schema.py`.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
