### PR TITLE
fix: schema keywords for deque/Counter/OrderedDict (fixes #13704)

### DIFF
--- a/pydantic/_internal/_known_annotated_metadata.py
+++ b/pydantic/_internal/_known_annotated_metadata.py
@@ -250,13 +250,24 @@ def apply_known_metadata(annotation: Any, schema: CoreSchema) -> CoreSchema | No
         elif constraint in NUMERIC_VALIDATOR_LOOKUP:
             if constraint in LENGTH_CONSTRAINTS:
                 inner_schema = schema
-                while inner_schema['type'] in {'function-before', 'function-wrap', 'function-after'}:
-                    inner_schema = inner_schema['schema']  # type: ignore
+                while True:
+                    inner_schema_type = inner_schema['type']
+                    if inner_schema_type in {'function-before', 'function-wrap', 'function-after'}:
+                        inner_schema = inner_schema['schema']  # type: ignore
+                        continue
+                    if inner_schema_type == 'lax-or-strict':
+                        inner_schema = inner_schema['lax_schema']  # type: ignore
+                        continue
+                    break
                 inner_schema_type = inner_schema['type']
-                if inner_schema_type == 'list' or (
-                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'list'  # type: ignore
+                if inner_schema_type in {'list', 'deque'} or (
+                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] in {'list', 'deque'}  # type: ignore
                 ):
                     js_constraint_key = 'minItems' if constraint == 'min_length' else 'maxItems'
+                elif inner_schema_type in {'dict'} or (
+                    inner_schema_type == 'json-or-python' and inner_schema['json_schema']['type'] == 'dict'  # type: ignore
+                ):
+                    js_constraint_key = 'minProperties' if constraint == 'min_length' else 'maxProperties'
                 else:
                     js_constraint_key = 'minLength' if constraint == 'min_length' else 'maxLength'
             else:

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -4,7 +4,7 @@ import math
 import re
 import sys
 import typing
-from collections import deque
+from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -6872,6 +6872,15 @@ def test_ta_and_bm_same_json_schema() -> None:
 def test_min_and_max_in_schema() -> None:
     TSeq = TypeAdapter(Annotated[Sequence[int], Field(min_length=2, max_length=5)])
     assert TSeq.json_schema() == {'items': {'type': 'integer'}, 'maxItems': 5, 'minItems': 2, 'type': 'array'}
+
+
+def test_deque_uses_minItems() -> None:
+    assert TypeAdapter(Annotated[deque[int], Field(min_length=1)]).json_schema()['minItems'] == 1
+
+
+def test_counter_ordereddict_use_minProperties() -> None:
+    assert TypeAdapter(Annotated[Counter[str], Field(min_length=1)]).json_schema()['minProperties'] == 1
+    assert TypeAdapter(Annotated[OrderedDict[str, int], Field(min_length=1)]).json_schema()['minProperties'] == 1
 
 
 def test_plain_field_validator_serialization() -> None:


### PR DESCRIPTION
Closes #13704. Mirrors #9303: unwrap lax-or-strict in _known_annotated_metadata to emit minItems/minProperties for deque/Counter/OrderedDict instead of minLength. Tests: focused test_json_schema (deque/Counter/OrderedDict) PASS, full test_json_schema 655 passed, types/test_deque 29 passed. RED: Counter test KeyError minProperties before fix; GREEN after.