### PR TITLE
fix: avoid mutating config_dict in core_config (#13786)

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -196,7 +196,7 @@ class ConfigWrapper:
         Returns:
             A `CoreConfig` object created from config.
         """
-        config = self.config_dict
+        config = self.config_dict.copy()
 
         if not config:
             # Fast path for the common case of an empty (default) config:


### PR DESCRIPTION
### Problem
In ConfigWrapper.core_config(), dynamic backward-compatibility and fallback mutations (alidate_by_alias and alidate_by_name) were applied directly onto self.config_dict. This mutated model_config in-place, causing derived/inherited models to inherit the mutated dictionary instead of their declared configuration.

### Fix
Make a copy config = self.config_dict.copy() in core_config() before performing any modifications so that the original self.config_dict remains unmutated and clean for inheritance.

Closes #13786