### PR TITLE
Fix TypeError instead of using fallback when __pydantic_serializer__ …

### DIFF
--- a/pydantic-core/src/serializers/infer.rs
+++ b/pydantic-core/src/serializers/infer.rs
@@ -510,14 +510,14 @@ pub(crate) fn infer_serialize_known<'py, S: Serializer>(
     }
 }
 
-fn unknown_type_error(value: &Bound<'_, PyAny>) -> PyErr {
+pub(crate) fn unknown_type_error(value: &Bound<'_, PyAny>) -> PyErr {
     PydanticSerializationError::new_err(format!(
         "Unable to serialize unknown type: {}",
         safe_repr(&value.get_type())
     ))
 }
 
-fn serialize_unknown<'py>(value: &Bound<'py, PyAny>) -> Cow<'py, str> {
+pub(crate) fn serialize_unknown<'py>(value: &Bound<'py, PyAny>) -> Cow<'py, str> {
     if let Ok(s) = value.str() {
         s.to_string_lossy().into_owned().into()
     } else if let Ok(name) = value.get_type().qualname() {
@@ -656,7 +656,12 @@ fn serialize_pydantic_serializable<'py, S: DoSerialize>(
 ) -> Result<S::Ok, S::Error> {
     let py = value.py();
     let py_serializer = value.getattr(intern!(py, "__pydantic_serializer__"))?;
-    call_pydantic_serializer(py_serializer.cast().map_err(Into::into)?, value, state, do_serialize)
+    match py_serializer.cast::<SchemaSerializer>() {
+        Ok(serializer) => call_pydantic_serializer(serializer, value, state, do_serialize),
+        // Attribute existed (e.g. via a `__getattr__` override that never raises
+        // `AttributeError`, like `unittest.mock.call`) but wasn't actually a SchemaSerializer.
+        Err(_) => do_serialize.serialize_unknown_fallback(value, state),
+    }
 }
 
 pub(crate) fn call_pydantic_serializer<'py, S: DoSerialize>(

--- a/pydantic-core/src/serializers/shared.rs
+++ b/pydantic-core/src/serializers/shared.rs
@@ -625,6 +625,11 @@ pub(crate) fn to_json_bytes<'py>(
 }
 
 /// Common interface for doing serialization
+use super::infer::{serialize_unknown, unknown_type_error};
+use crate::serializers::errors::SERIALIZATION_ERR_MARKER;
+use crate::tools::safe_repr;
+use serde::ser::Error as _;
+
 pub(crate) trait DoSerialize {
     type Ok;
     type Error: From<PyErr>;
@@ -639,6 +644,17 @@ pub(crate) trait DoSerialize {
     fn serialize_fallback<'py>(
         self,
         name: &str,
+        value: &Bound<'py, PyAny>,
+        state: &mut SerializationState<'py>,
+    ) -> Result<Self::Ok, Self::Error>;
+
+    /// Fallback for when a value looked like it should use a custom serializer
+    /// (e.g. had a `__pydantic_serializer__` attribute) but that turned out not
+    /// to actually be a `SchemaSerializer` - e.g. dynamic mock objects like
+    /// `unittest.mock.call` whose `__getattr__` never raises `AttributeError`.
+    /// Falls through to the same handling as `ObType::Unknown`.
+    fn serialize_unknown_fallback<'py>(
+        self,
         value: &Bound<'py, PyAny>,
         state: &mut SerializationState<'py>,
     ) -> Result<Self::Ok, Self::Error>;
@@ -709,6 +725,21 @@ impl<'s> DoSerialize for SerializeToPython<'s> {
     ) -> PyResult<Py<PyAny>> {
         state.warn_fallback_py(name, value)?;
         infer_to_python(value, state)
+    }
+
+    fn serialize_unknown_fallback<'py>(
+        self,
+        value: &Bound<'py, PyAny>,
+        state: &mut SerializationState<'py>,
+    ) -> PyResult<Py<PyAny>> {
+        if let Some(fallback) = &state.extra.fallback {
+            let next_value = fallback.call1((value,))?;
+            infer_to_python(&next_value, state)
+        } else if state.extra.serialize_unknown {
+            serialize_unknown(value).into_py_any(value.py())
+        } else {
+            Err(unknown_type_error(value))
+        }
     }
 
     fn serialize_str(self, value: &Bound<'_, PyString>) -> Result<Py<PyAny>, PyErr> {
@@ -790,6 +821,28 @@ impl<S: Serializer> DoSerialize for SerializeToJson<S> {
     ) -> Result<S::Ok, WrappedSerError<S::Error>> {
         state.warn_fallback_ser::<S>(name, value).map_err(WrappedSerError)?;
         infer_serialize(value, self.serializer, state).map_err(WrappedSerError)
+    }
+
+    fn serialize_unknown_fallback<'py>(
+        self,
+        value: &Bound<'py, PyAny>,
+        state: &mut SerializationState<'py>,
+    ) -> Result<S::Ok, WrappedSerError<S::Error>> {
+        if let Some(fallback) = &state.extra.fallback {
+            let next_value = fallback.call1((value,)).map_err(WrappedSerError::from)?;
+            infer_serialize(&next_value, self.serializer, state).map_err(WrappedSerError)
+        } else if state.extra.serialize_unknown {
+            self.serializer
+                .serialize_str(&serialize_unknown(value))
+                .map_err(WrappedSerError)
+        } else {
+            let msg = format!(
+                "{}Unable to serialize unknown type: {}",
+                SERIALIZATION_ERR_MARKER,
+                safe_repr(&value.get_type()),
+            );
+            Err(WrappedSerError(S::Error::custom(msg)))
+        }
     }
 
     fn serialize_str(self, value: &Bound<'_, PyString>) -> Result<S::Ok, WrappedSerError<S::Error>> {

--- a/pydantic-core/tests/serializers/test_infer.py
+++ b/pydantic-core/tests/serializers/test_infer.py
@@ -26,3 +26,36 @@ def test_infer_json_key():
 
     v = SchemaSerializer(core_schema.enum_schema(MyEnum, list(MyEnum.__members__.values())))
     assert v.to_json(MyEnum.complex_) == b'{"1+2j":1}'
+
+
+# https://github.com/pydantic/pydantic/issues/13734
+# Objects with a `__getattr__` that never raises AttributeError (e.g.
+# unittest.mock.call) get classified as ObType::PydanticSerializable because
+# `hasattr(value, '__pydantic_serializer__')` returns True, even though the
+# attribute isn't actually a SchemaSerializer. This used to raise a bare
+# TypeError instead of using the `fallback`.
+def test_infer_to_python_fallback_on_fake_pydantic_serializer():
+    from unittest.mock import call
+
+    v = SchemaSerializer(core_schema.any_schema())
+    mock_call = call(1, 2, 3)
+    assert v.to_python(mock_call, fallback=lambda c: list(c.args)) == [1, 2, 3]
+
+
+def test_infer_serialize_fallback_on_fake_pydantic_serializer():
+    from unittest.mock import call
+
+    v = SchemaSerializer(core_schema.any_schema())
+    mock_call = call(1, 2, 3)
+    assert v.to_json(mock_call, fallback=lambda c: list(c.args)) == b'[1,2,3]'
+
+
+def test_infer_to_python_no_fallback_on_fake_pydantic_serializer_raises():
+    from unittest.mock import call
+    import pytest
+    from pydantic_core import PydanticSerializationError
+
+    v = SchemaSerializer(core_schema.any_schema())
+    mock_call = call(1, 2, 3)
+    with pytest.raises(PydanticSerializationError):
+        v.to_python(mock_call)


### PR DESCRIPTION
Fix TypeError instead of using fallback when __pydantic_serializer__ attribute is not a SchemaSerializer

Objects with a `__getattr__` that never raises `AttributeError` (e.g. `unittest.mock.call`) get classified as `ObType::PydanticSerializable` because `hasattr(value, '__pydantic_serializer__')` returns `True`, even though the attribute isn't actually a `SchemaSerializer` instance. Previously this raised a bare `TypeError` from `serialize_pydantic_serializable`, bypassing any user-provided fallback. Now it falls through to the same handling as `ObType::Unknown` (fallback, then `serialize_unknown`, then error).

## Change Summary

`serialize_pydantic_serializable` now checks whether the `__pydantic_serializer__` attribute actually downcasts to a `SchemaSerializer` before calling it. If the downcast fails, serialization falls through to the existing unknown-type handling instead of raising immediately, so a user-supplied `fallback` is respected.

## Related issue number

Fixes #1866
Fixes #13734

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [x] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**