### PR TITLE
add a model_config setting to control field deprecation warnings

### DIFF
--- a/pydantic/_internal/_config.py
+++ b/pydantic/_internal/_config.py
@@ -56,6 +56,7 @@ _config_dict_to_core_config_key: dict[str, str] = {
     'serialize_by_alias': 'serialize_by_alias',
     'url_preserve_empty_path': 'url_preserve_empty_path',
     'polymorphic_serialization': 'polymorphic_serialization',
+    'warn_deprecated': 'warn_deprecated',
 }
 
 
@@ -122,6 +123,7 @@ class ConfigWrapper:
     serialize_by_alias: bool
     url_preserve_empty_path: bool
     polymorphic_serialization: bool
+    warn_deprecated: Literal['get', 'set', 'get_and_set', None]
 
     def __init__(self, config: ConfigDict | dict[str, Any] | type[Any] | None, *, check: bool = True):
         if check:
@@ -318,6 +320,7 @@ config_defaults = ConfigDict(
     serialize_by_alias=False,
     url_preserve_empty_path=False,
     polymorphic_serialization=False,
+    warn_deprecated='get',
 )
 
 

--- a/pydantic/_internal/_model_construction.py
+++ b/pydantic/_internal/_model_construction.py
@@ -644,7 +644,8 @@ def complete_model_class(
     # of the properties are evaluated and the `ComputedFieldInfo` are recreated:
     cls.__pydantic_computed_fields__ = {k: v.info for k, v in cls.__pydantic_decorators__.computed_fields.items()}
 
-    set_deprecated_descriptors(cls)
+    if config_wrapper.warn_deprecated in ('get', 'get_and_set'):
+        set_deprecated_descriptors(cls)
 
     cls.__pydantic_core_schema__ = schema
 

--- a/pydantic/config.py
+++ b/pydantic/config.py
@@ -1210,6 +1210,16 @@ class ConfigDict(TypedDict, total=False):
     Whether to use polymorphic serialization for subclasses of the model or Pydantic dataclass. Defaults to `False`.
     """
 
+    warn_deprecated: Literal['get', 'set', 'get_and_set', None]
+    """
+    How to handle fields marked as deprecated.
+
+    - `'get'`: A `DeprecationWarning` is emitted when accessing the field.
+    - `'set'`: A `DeprecationWarning` is emitted when assigning to the field.
+    - `'get_and_set'`: A `DeprecationWarning` is emitted both when accessing and assigning to the field.
+    - `None`: The deprecation is ignored and no warning is emitted.
+"""
+
 
 _TypeT = TypeVar('_TypeT', bound=type)
 

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -109,19 +109,21 @@ def _check_frozen(model_cls: type[BaseModel], name: str, value: Any) -> None:
 def _model_field_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
     model.__dict__[name] = val  # pyright: ignore[reportIndexIssue] (https://github.com/microsoft/pyright/issues/11548)
     model.__pydantic_fields_set__.add(name)
-    if (msg := model.__pydantic_fields__[name].deprecation_message) is not None and model.model_config.get(
-        'warn_deprecated', 'get'
-    ) in ('set', 'get_and_set'):
+
+
+def _model_field_setattr_handler_deprecation(model: BaseModel, name: str, val: Any) -> None:
+    _model_field_setattr_handler(model, name, val)
+    if (msg := model.__pydantic_fields__[name].deprecation_message) is not None:
         warnings.warn(msg, DeprecationWarning, stacklevel=3)
 
 
 def _validate_assignment_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
     model.__pydantic_validator__.validate_assignment(model, name, val)  # pyright: ignore[reportAssignmentType]
-    if (
-        (field := model.__pydantic_fields__.get(name)) is not None
-        and (msg := field.deprecation_message) is not None
-        and model.model_config.get('warn_deprecated', 'get') in ('set', 'get_and_set')
-    ):
+
+
+def _validate_assignment_setattr_handler_deprecation(model: BaseModel, name: str, val: Any) -> None:
+    _validate_assignment_setattr_handler(model, name, val)
+    if (field := model.__pydantic_fields__.get(name)) is not None and (msg := field.deprecation_message) is not None:
         warnings.warn(msg, DeprecationWarning, stacklevel=3)
 
 
@@ -140,7 +142,9 @@ _ATTRIBUTE_MISSING = Sentinel('_ATTRIBUTE_MISSING')
 
 _SIMPLE_SETATTR_HANDLERS: Mapping[str, Callable[[BaseModel, str, Any], None]] = {
     'model_field': _model_field_setattr_handler,
+    'model_field_deprecation': _model_field_setattr_handler_deprecation,
     'validate_assignment': _validate_assignment_setattr_handler,
+    'validate_assignment_deprecation': _validate_assignment_setattr_handler_deprecation,
     'private': _private_setattr_handler,
     'cached_property': lambda model, name, val: model.__dict__.__setitem__(name, val),  # pyright: ignore[reportAttributeAccessIssue] (https://github.com/microsoft/pyright/issues/11548)
     'extra_known': lambda model, name, val: _object_setattr(model, name, val),
@@ -1165,7 +1169,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
             if isinstance(attr, property):
                 return lambda model, _name, val: attr.__set__(model, val)
             elif cls.model_config.get('validate_assignment'):
-                return _SIMPLE_SETATTR_HANDLERS['validate_assignment']
+                return _SIMPLE_SETATTR_HANDLERS[
+                    'validate_assignment_deprecation'
+                    if cls.model_config.get('warn_deprecated') in ('set', 'get_and_set')
+                    else 'validate_assignment'
+                ]
             elif name not in cls.__pydantic_fields__:
                 if cls.model_config.get('extra') != 'allow':
                     # TODO - matching error
@@ -1179,7 +1187,11 @@ class BaseModel(metaclass=_model_construction.ModelMetaclass):
                     # attribute _does_ exist, and was not in extra, so update it
                     return _SIMPLE_SETATTR_HANDLERS['extra_known']
             else:
-                return _SIMPLE_SETATTR_HANDLERS['model_field']
+                return _SIMPLE_SETATTR_HANDLERS[
+                    'model_field_deprecation'
+                    if cls.model_config.get('warn_deprecated') in ('set', 'get_and_set')
+                    else 'model_field'
+                ]
 
         def __delattr__(self, item: str) -> Any:
             cls = self.__class__

--- a/pydantic/main.py
+++ b/pydantic/main.py
@@ -109,6 +109,20 @@ def _check_frozen(model_cls: type[BaseModel], name: str, value: Any) -> None:
 def _model_field_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
     model.__dict__[name] = val  # pyright: ignore[reportIndexIssue] (https://github.com/microsoft/pyright/issues/11548)
     model.__pydantic_fields_set__.add(name)
+    if (msg := model.__pydantic_fields__[name].deprecation_message) is not None and model.model_config.get(
+        'warn_deprecated', 'get'
+    ) in ('set', 'get_and_set'):
+        warnings.warn(msg, DeprecationWarning, stacklevel=3)
+
+
+def _validate_assignment_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
+    model.__pydantic_validator__.validate_assignment(model, name, val)  # pyright: ignore[reportAssignmentType]
+    if (
+        (field := model.__pydantic_fields__.get(name)) is not None
+        and (msg := field.deprecation_message) is not None
+        and model.model_config.get('warn_deprecated', 'get') in ('set', 'get_and_set')
+    ):
+        warnings.warn(msg, DeprecationWarning, stacklevel=3)
 
 
 def _private_setattr_handler(model: BaseModel, name: str, val: Any) -> None:
@@ -126,7 +140,7 @@ _ATTRIBUTE_MISSING = Sentinel('_ATTRIBUTE_MISSING')
 
 _SIMPLE_SETATTR_HANDLERS: Mapping[str, Callable[[BaseModel, str, Any], None]] = {
     'model_field': _model_field_setattr_handler,
-    'validate_assignment': lambda model, name, val: model.__pydantic_validator__.validate_assignment(model, name, val),  # pyright: ignore[reportAssignmentType]
+    'validate_assignment': _validate_assignment_setattr_handler,
     'private': _private_setattr_handler,
     'cached_property': lambda model, name, val: model.__dict__.__setitem__(name, val),  # pyright: ignore[reportAttributeAccessIssue] (https://github.com/microsoft/pyright/issues/11548)
     'extra_known': lambda model, name, val: _object_setattr(model, name, val),

--- a/tests/test_deprecated_fields.py
+++ b/tests/test_deprecated_fields.py
@@ -1,13 +1,36 @@
-from typing import Annotated
+import warnings
+from contextlib import contextmanager
+from typing import Annotated, Literal
 
 import pytest
 from typing_extensions import Self, deprecated
 
-from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 
-def test_deprecated_fields():
+@contextmanager
+def error_on_deprecationwarning():
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', DeprecationWarning)
+        yield
+
+
+@pytest.fixture(params=(None, 'get', 'set', 'get_and_set'))
+def mode(request: pytest.FixtureRequest) -> Literal[None, 'get', 'set', 'get_and_set']:
+    return request.param
+
+
+@pytest.fixture
+def config(mode) -> ConfigDict:
+    config = ConfigDict()
+    if mode is not None:
+        config['warn_deprecated'] = mode
+    return config
+
+
+def test_deprecated_fields(mode, config):
     class Model(BaseModel):
+        model_config = config
         a: Annotated[int, Field(deprecated='')]
         b: Annotated[int, Field(deprecated='This is deprecated')]
         c: Annotated[int, Field(deprecated=None)]
@@ -25,17 +48,36 @@ def test_deprecated_fields():
 
     instance = Model(a=1, b=1, c=1)
 
-    with pytest.warns(DeprecationWarning, match='^$'):
+    with pytest.warns(DeprecationWarning, match='^$') if mode != 'set' else error_on_deprecationwarning():
         instance.a
 
-    with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
+    with (
+        pytest.warns(DeprecationWarning, match='^$')
+        if mode in ('set', 'get_and_set')
+        else error_on_deprecationwarning()
+    ):
+        instance.a = 2
+
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode != 'set'
+        else error_on_deprecationwarning()
+    ):
         b = instance.b
 
     assert b == 1
 
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode in ('set', 'get_and_set')
+        else error_on_deprecationwarning()
+    ):
+        instance.b = 2
 
-def test_deprecated_fields_deprecated_class():
+
+def test_deprecated_fields_deprecated_class(mode, config):
     class Model(BaseModel):
+        model_config = config
         a: Annotated[int, deprecated('')]
         b: Annotated[int, deprecated('This is deprecated')] = 1
         c: Annotated[int, Field(deprecated=deprecated('This is deprecated'))] = 1
@@ -53,16 +95,43 @@ def test_deprecated_fields_deprecated_class():
 
     instance = Model(a=1)
 
-    with pytest.warns(DeprecationWarning, match='^$'):
+    with pytest.warns(DeprecationWarning, match='^$') if mode != 'set' else error_on_deprecationwarning():
         instance.a
-    with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
+    with (
+        pytest.warns(DeprecationWarning, match='^$')
+        if mode in ('set', 'get_and_set')
+        else error_on_deprecationwarning()
+    ):
+        instance.a = 2
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode != 'set'
+        else error_on_deprecationwarning()
+    ):
         instance.b
-    with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode in ('set', 'get_and_set')
+        else error_on_deprecationwarning()
+    ):
+        instance.b = 2
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode != 'set'
+        else error_on_deprecationwarning()
+    ):
         instance.c
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode in ('set', 'get_and_set')
+        else error_on_deprecationwarning()
+    ):
+        instance.c = 2
 
 
-def test_deprecated_fields_field_validator():
+def test_deprecated_fields_field_validator(mode, config):
     class Model(BaseModel):
+        model_config = config
         x: int = Field(deprecated='x is deprecated')
 
         @field_validator('x')
@@ -72,12 +141,15 @@ def test_deprecated_fields_field_validator():
 
     instance = Model(x=1)
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning) if mode != 'set' else error_on_deprecationwarning():
         assert instance.x == 2
+    with pytest.warns(DeprecationWarning) if mode in ('set', 'get_and_set') else error_on_deprecationwarning():
+        instance.x = 3
 
 
-def test_deprecated_fields_model_validator():
+def test_deprecated_fields_model_validator(mode, config):
     class Model(BaseModel):
+        model_config = config
         x: int = Field(deprecated='x is deprecated')
 
         @model_validator(mode='after')
@@ -87,28 +159,34 @@ def test_deprecated_fields_model_validator():
 
     with pytest.warns(DeprecationWarning):
         instance = Model(x=1)
+    with pytest.warns(DeprecationWarning) if mode != 'set' else error_on_deprecationwarning():
         assert instance.x == 2
+    with pytest.warns(DeprecationWarning) if mode in ('set', 'get_and_set') else error_on_deprecationwarning():
+        instance.x = 3
 
 
-def test_deprecated_fields_validate_assignment():
+def test_deprecated_fields_validate_assignment(mode, config):
     class Model(BaseModel):
         x: int = Field(deprecated='x is deprecated')
 
-        model_config = {'validate_assignment': True}
+        model_config = config | {'validate_assignment': True}
 
     instance = Model(x=1)
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning) if mode != 'set' else error_on_deprecationwarning():
         assert instance.x == 1
 
-    instance.x = 2
+    with pytest.warns(DeprecationWarning) if mode in ('set', 'get_and_set') else error_on_deprecationwarning():
+        instance.x = 2
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning) if mode != 'set' else error_on_deprecationwarning():
         assert instance.x == 2
 
 
-def test_computed_field_deprecated():
+def test_computed_field_deprecated(mode, config):
     class Model(BaseModel):
+        model_config = config
+
         @computed_field
         @property
         @deprecated('This is deprecated')
@@ -158,19 +236,25 @@ def test_computed_field_deprecated():
     # `set_deprecated_descriptors()`):
     with pytest.warns(DeprecationWarning, match=r'^This is deprecated \(this message is the one emitted\)$'):
         instance.p2
-    with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode != 'set'
+        else error_on_deprecationwarning()
+    ):
         instance.p4
     with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
         instance.p5
 
-    with pytest.warns(DeprecationWarning, match='^$'):
+    with pytest.warns(DeprecationWarning, match='^$') if mode != 'set' else error_on_deprecationwarning():
         p3 = instance.p3
 
     assert p3 == 1
 
 
-def test_computed_field_deprecated_deprecated_class():
+def test_computed_field_deprecated_deprecated_class(mode, config):
     class Model(BaseModel):
+        model_config = config
+
         @computed_field(deprecated=deprecated('This is deprecated'))
         @property
         def p1(self) -> int:
@@ -199,13 +283,21 @@ def test_computed_field_deprecated_deprecated_class():
 
     instance = Model()
 
-    with pytest.warns(DeprecationWarning, match='^This is deprecated$'):
+    with (
+        pytest.warns(DeprecationWarning, match='^This is deprecated$')
+        if mode != 'set'
+        else error_on_deprecationwarning()
+    ):
         p1 = instance.p1
 
-    with pytest.warns(DeprecationWarning, match='^deprecated$'):
+    with pytest.warns(DeprecationWarning, match='^deprecated$') if mode != 'set' else error_on_deprecationwarning():
         p2 = instance.p2
 
-    with pytest.warns(DeprecationWarning, match='^This is a deprecated string$'):
+    with (
+        pytest.warns(DeprecationWarning, match='^This is a deprecated string$')
+        if mode != 'set'
+        else error_on_deprecationwarning()
+    ):
         p3 = instance.p3
 
     assert p1 == 1
@@ -213,8 +305,10 @@ def test_computed_field_deprecated_deprecated_class():
     assert p3 == 3
 
 
-def test_deprecated_with_boolean() -> None:
+def test_deprecated_with_boolean(mode, config) -> None:
     class Model(BaseModel):
+        model_config = config
+
         a: Annotated[int, Field(deprecated=True)]
         b: Annotated[int, Field(deprecated=False)]
 
@@ -230,8 +324,14 @@ def test_deprecated_with_boolean() -> None:
 
     instance = Model(a=1, b=1)
 
-    with pytest.warns(DeprecationWarning, match='deprecated'):
+    with pytest.warns(DeprecationWarning, match='deprecated') if mode != 'set' else error_on_deprecationwarning():
         instance.a
+    with (
+        pytest.warns(DeprecationWarning, match='deprecated')
+        if mode in ('set', 'get_and_set')
+        else error_on_deprecationwarning()
+    ):
+        instance.a = 2
 
 
 def test_computed_field_deprecated_class_access() -> None:
@@ -255,10 +355,12 @@ def test_computed_field_deprecated_subclass() -> None:
         pass
 
 
-def test_deprecated_field_forward_annotation() -> None:
+def test_deprecated_field_forward_annotation(mode, config) -> None:
     """https://github.com/pydantic/pydantic/issues/11390"""
 
     class Model(BaseModel):
+        model_config = config
+
         a: "Annotated[Test, deprecated('test')]" = 2
 
     Test = int
@@ -269,8 +371,14 @@ def test_deprecated_field_forward_annotation() -> None:
 
     m = Model()
 
-    with pytest.warns(DeprecationWarning, match='test'):
+    with pytest.warns(DeprecationWarning, match='test') if mode != 'set' else error_on_deprecationwarning():
         m.a
+    with (
+        pytest.warns(DeprecationWarning, match='test')
+        if mode in ('set', 'get_and_set')
+        else error_on_deprecationwarning()
+    ):
+        m.a = 1
 
 
 def test_deprecated_field_with_assignment() -> None:


### PR DESCRIPTION
The user can now choose whether deprecation warnings are emitted on field read, write, both, or never.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The deprecation descriptors are now only created if deprecation warnings should be emitted on read. The setattr hanlders for `model_field` and `validate_assignment` now check the model config whether a warning should be emitted on write and warn if necessary.

This is particularly useful when using `pydantic-settings` to expose settings to users: Deprecation warnings should only be emitted when the user sets a field. Reading a field happens internally within the package and should not warn.

## Related issue number

This is one of the features requested in the discussion for #8922

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Unit tests for the changes exist
* [ ] Tests pass on CI
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
