### PR TITLE
Add an enterprise support guide

### DIFF
--- a/docs/enterprise-support.md
+++ b/docs/enterprise-support.md
@@ -1,0 +1,70 @@
+---
+title: Enterprise support for Pydantic
+description: Get direct support from Pydantic engineers for production incidents, major upgrades, architecture reviews, and performance.
+---
+
+Pydantic often sits between untrusted data and the rest of a production system. When that boundary is critical, a public issue tracker is not the escalation path you want during an incident or a major upgrade.
+
+Enterprise plans include direct access to Pydantic engineers, 24/7 priority support, setup assistance, and an SLA matched to your operating model.
+
+<EnterpriseSupportCta
+  product="validation"
+  href="https://pydantic.dev/contact"
+  label="Discuss enterprise support"
+/>
+
+<EnterpriseSupportPlan product="validation" />
+
+## Where Pydantic engineers can help
+
+Use the public documentation, issue tracker, and community channels for ordinary questions. Enterprise support covers production incidents, major upgrades, and architecture or performance reviews.
+
+<EnterpriseSupportAreas product="validation" />
+
+## How support works
+
+<Steps>
+
+1. **Agree the support boundary**
+
+   Define the packages, release lines, environments, contacts, and initial response targets covered by your agreement.
+
+2. **Prepare useful context**
+
+   Map where Pydantic sits in critical paths and decide how to capture a reproducible example, relevant configuration, and recent changes.
+
+3. **Escalate directly**
+
+   Bring production-impacting issues to Pydantic engineers, who work with your team to isolate the behavior and determine the next action.
+
+</Steps>
+
+## Open source remains the foundation
+
+Pydantic's license, documentation, releases, issue tracker, and community support remain open to everyone. Enterprise support adds a direct escalation path and contractual commitments for teams that depend on Pydantic in production.
+
+## Questions teams ask
+
+<Collapsible title="Is this the same as Logfire support?">
+
+No. This page describes support for the Pydantic validation library. Logfire is a separate product with its own commercial plans and support.
+
+</Collapsible>
+
+<Collapsible title="What can Pydantic engineers help investigate?">
+
+We work with your engineers to reproduce the issue, isolate Pydantic behavior, explain the relevant implementation details, and determine the next action. Your team retains ownership of the surrounding application and infrastructure.
+
+</Collapsible>
+
+<Collapsible title="Can we agree specific versions and initial response targets?">
+
+Yes. Supported versions, severity levels, initial response targets, and other commitments are defined in your commercial agreement. [Contact us](https://pydantic.dev/contact) to discuss your requirements.
+
+</Collapsible>
+
+## Continue reading
+
+* Review the [Pydantic version policy](version-policy.md).
+* Plan an upgrade with the [migration guide](migration.md).
+* Use the [community help channels](help_with_pydantic.md) for questions that do not require a commercial support relationship.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Welcome to Pydantic: index.md
       - Why use Pydantic: why.md
       - Help with Pydantic: help_with_pydantic.md
+      - Enterprise Support: enterprise-support.md
       - Installation: install.md
       - Migration Guide: migration.md
       - Version Policy: version-policy.md


### PR DESCRIPTION
## Change Summary

Add an enterprise-support guide for teams that depend on Pydantic in production, including support boundaries, incident escalation, upgrades, architecture reviews, and response commitments.

Requires [pydantic/unified-docs#266](https://github.com/pydantic/unified-docs/pull/266) for the shared page components.

## Related issue number

None — documentation improvement.

## Verification

* `uv run pre-commit run --files docs/enterprise-support.md mkdocs.yml`
* Exact unified-docs Validation build and responsive browser review at 390x844, 768x1024, and 1440x900

## Checklist

* [x] The pull request title is a good summary of the changes - it will be used in the changelog
* [x] Documentation reflects the changes where applicable
